### PR TITLE
[6.16.z] cherry-pick Gut testing tiers (#17809)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,6 @@ help:
 	@echo "  test-robottelo             to run internal robottelo tests"
 	@echo "  test-robottelo-coverage    to run internal robottelo tests with coverage report."
 	@echo "                             Requires pytest-cov"
-	@echo "  test-foreman-tier1         to run Foreman deployment tier1 tests"
-	@echo "  test-foreman-tier2         to run Foreman deployment tier2 tests"
-	@echo "  test-foreman-tier3         to run Foreman deployment tier3 tests"
-	@echo "  test-foreman-tier4         to run Foreman deployment tier4 tests"
 	@echo "  test-foreman-sys           to run Foreman deployment sys tests"
 	@echo "  test-foreman-api           to test a Foreman deployment API"
 	@echo "  test-foreman-api-threaded  to do the above with threading."
@@ -109,18 +105,6 @@ test-foreman-virtwho:
 test-foreman-endtoend:
 	$(PYTEST) $(PYTEST_OPTS) $(FOREMAN_ENDTOEND_TESTS_PATH)
 
-test-foreman-tier1:
-	$(PYTEST) $(PYTEST_XDIST_OPTS) -m 'not stubbed and tier1' $(FOREMAN_TIERS_TESTS_PATH)
-
-test-foreman-tier2:
-	$(PYTEST) $(PYTEST_XDIST_OPTS) -m 'not stubbed and tier2' $(FOREMAN_TIERS_TESTS_PATH)
-
-test-foreman-tier3:
-	$(PYTEST) $(PYTEST_XDIST_OPTS) -m 'not stubbed and tier3' $(FOREMAN_TIERS_TESTS_PATH)
-
-test-foreman-tier4:
-	$(PYTEST) $(PYTEST_XDIST_OPTS) -m 'not stubbed and tier4' $(join $(FOREMAN_TESTS_PATH), longrun)
-
 test-foreman-sys:
 	$(PYTEST) $(PYTEST_OPTS) -m 'not stubbed and destructive' $(FOREMAN_TESTS_PATH)
 
@@ -185,13 +169,11 @@ vault-logout:
 	@scripts/vault_login.py --logout
 
 
-
 # Special Targets -------------------------------------------------------------
 
 .PHONY: help docs docs-clean test-docstrings test-robottelo \
         test-robottelo-coverage test-foreman-api test-foreman-cli \
-        test-foreman-rhai test-foreman-tier1 \
-        test-foreman-tier2 test-foreman-tier3 test-foreman-tier4 \
+		test-foreman-rhai \
         test-foreman-sys test-foreman-ui test-foreman-ui-xvfb \
         test-foreman-virtwho test-foreman-ui \
         test-foreman-endtoend graph-entities logs-join \

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -6,11 +6,6 @@ def pytest_configure(config):
     markers = [
         "deselect(reason=None): Mark test to be removed from collection.",
         "skip_if_open(issue): Skip test based on issue status.",
-        "tier1: Tier 1 tests",  # CRUD tests
-        "tier2: Tier 2 tests",  # Association tests
-        "tier3: Tier 3 tests",  # Systems integration tests
-        "tier4: Tier 4 tests",  # Long running tests
-        "tier5: Tier 5 tests",  # Deprecated component tests
         "destructive: Destructive tests",
         "upgrade: Upgrade tests",
         "e2e: End to end tests",

--- a/robottelo/utils/report_portal/README.adoc
+++ b/robottelo/utils/report_portal/README.adoc
@@ -80,7 +80,6 @@ Out [5]:
   'parameters': [],
   'attributes': [{'key': 'SnapVersion', 'value': '22.0'},
    {'key': 'SatelliteVersion', 'value': '6.11.0'},
-   {'key': '', 'value': 'tier2'},
    {'key': 'upgrade', 'value': 'None'},
    {'key': 'endpoint', 'value': 'ui'},
    {'key': 'importance', 'value': 'High'},

--- a/tests/foreman/api/test_acs.py
+++ b/tests/foreman/api/test_acs.py
@@ -20,7 +20,6 @@ from robottelo.constants.repos import PULP_FIXTURE_ROOT, PULP_SUBPATHS_COMBINED
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.parametrize('cnt_type', ['yum', 'file'])
 @pytest.mark.parametrize('acs_type', ['custom', 'simplified', 'rhui'])
@@ -107,7 +106,6 @@ def test_positive_CRUD_all_types(
         module_target_sat.api.AlternateContentSource(id=new_acs.id).read()
 
 
-@pytest.mark.tier2
 def test_positive_run_bulk_actions(module_target_sat, module_yum_repo):
     """Perform bulk actions with an ACS.
 

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -42,7 +42,6 @@ def _bad_max_hosts():
     return [gen_integer(-100, -1), 0, gen_string('alpha')]
 
 
-@pytest.mark.tier1
 def test_positive_create_unlimited_hosts(target_sat):
     """Create a plain vanilla activation key.
 
@@ -56,7 +55,6 @@ def test_positive_create_unlimited_hosts(target_sat):
     assert target_sat.api.ActivationKey().create().unlimited_hosts is True
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('max_host', **parametrized(_good_max_hosts()))
 def test_positive_create_limited_hosts(max_host, target_sat):
     """Create an activation key with limited hosts.
@@ -75,7 +73,6 @@ def test_positive_create_limited_hosts(max_host, target_sat):
     assert act_key.unlimited_hosts is False
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('key_name', **parametrized(valid_data_list()))
 def test_positive_create_with_name(key_name, target_sat):
     """Create an activation key providing the initial name.
@@ -92,7 +89,6 @@ def test_positive_create_with_name(key_name, target_sat):
     assert key_name == act_key.name
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
 def test_positive_create_with_description(desc, target_sat):
     """Create an activation key and provide a description.
@@ -107,7 +103,6 @@ def test_positive_create_with_description(desc, target_sat):
     assert desc == act_key.description
 
 
-@pytest.mark.tier2
 def test_negative_create_with_no_host_limit(target_sat):
     """Create activation key without providing limitation for hosts number
 
@@ -121,7 +116,6 @@ def test_negative_create_with_no_host_limit(target_sat):
         target_sat.api.ActivationKey(unlimited_hosts=False).create()
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize('max_host', **parametrized(_bad_max_hosts()))
 def test_negative_create_with_invalid_host_limit(max_host, target_sat):
     """Create activation key with invalid limit values for hosts number.
@@ -138,7 +132,6 @@ def test_negative_create_with_invalid_host_limit(max_host, target_sat):
         target_sat.api.ActivationKey(max_hosts=max_host, unlimited_hosts=False).create()
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
 def test_negative_create_with_invalid_name(name, target_sat):
     """Create activation key providing an invalid name.
@@ -155,7 +148,6 @@ def test_negative_create_with_invalid_name(name, target_sat):
         target_sat.api.ActivationKey(name=name).create()
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('max_host', **parametrized(_good_max_hosts()))
 def test_positive_update_limited_host(max_host, target_sat):
     """Create activation key then update it to limited hosts.
@@ -176,7 +168,6 @@ def test_positive_update_limited_host(max_host, target_sat):
     assert want == actual
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
 def test_positive_update_name(new_name, target_sat, module_org):
     """Create activation key providing the initial name, then update
@@ -196,7 +187,6 @@ def test_positive_update_name(new_name, target_sat, module_org):
     assert new_name == updated.name
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize('max_host', **parametrized(_bad_max_hosts()))
 def test_negative_update_limit(max_host, target_sat):
     """Create activation key then update its limit to invalid value.
@@ -224,7 +214,6 @@ def test_negative_update_limit(max_host, target_sat):
     assert want == actual
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
 def test_negative_update_name(new_name, target_sat, module_org):
     """Create activation key then update its name to an invalid name.
@@ -248,7 +237,6 @@ def test_negative_update_name(new_name, target_sat, module_org):
     assert new_key.name == act_key.name
 
 
-@pytest.mark.tier3
 def test_negative_update_max_hosts(target_sat, module_org):
     """Create an activation key with ``max_hosts == 1``, then update that
     field with a string value.
@@ -267,7 +255,6 @@ def test_negative_update_max_hosts(target_sat, module_org):
     assert act_key.read().max_hosts == 1
 
 
-@pytest.mark.tier2
 def test_positive_get_releases_status_code(target_sat):
     """Get an activation key's releases. Check response format.
 
@@ -284,7 +271,6 @@ def test_positive_get_releases_status_code(target_sat):
     assert 'application/json' in response.headers['content-type']
 
 
-@pytest.mark.tier2
 def test_positive_get_releases_content(target_sat):
     """Get an activation key's releases. Check response contents.
 
@@ -298,7 +284,6 @@ def test_positive_get_releases_content(target_sat):
     assert isinstance(response['results'], list)
 
 
-@pytest.mark.tier2
 def test_positive_add_host_collections(module_org, module_target_sat):
     """Associate an activation key with several host collections.
 
@@ -333,7 +318,6 @@ def test_positive_add_host_collections(module_org, module_target_sat):
     assert len(act_key.host_collection) == 2
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_remove_host_collection(module_org, module_target_sat):
     """Disassociate host collection from the activation key
@@ -366,7 +350,6 @@ def test_positive_remove_host_collection(module_org, module_target_sat):
     assert len(act_key.read().host_collection) == 0
 
 
-@pytest.mark.tier1
 def test_positive_update_auto_attach(target_sat, module_org):
     """Create an activation key, then update the auto_attach
     field with the inverse boolean value.
@@ -384,7 +367,6 @@ def test_positive_update_auto_attach(target_sat, module_org):
     assert act_key.auto_attach != act_key_2.auto_attach
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 def test_positive_delete(name, target_sat):
@@ -404,7 +386,6 @@ def test_positive_delete(name, target_sat):
         target_sat.api.ActivationKey(id=act_key.id).read()
 
 
-@pytest.mark.tier2
 def test_positive_remove_user(target_sat):
     """Delete any user who has previously created an activation key
     and check that activation key still exists
@@ -428,7 +409,6 @@ def test_positive_remove_user(target_sat):
 
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_fetch_product_content(
     module_org, module_lce, module_sca_manifest, module_target_sat
 ):
@@ -467,7 +447,6 @@ def test_positive_fetch_product_content(
     }
 
 
-@pytest.mark.tier1
 def test_positive_search_by_org(target_sat):
     """Search for all activation keys in an organization.
 

--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -109,7 +109,6 @@ class TestAnsibleCfgMgmt:
         assert len(task_details[0].output['result']['created']) == playbooks_count
 
     @pytest.mark.e2e
-    @pytest.mark.tier2
     def test_add_and_remove_ansible_role_hostgroup(self, target_sat):
         """
         Test add and remove functionality for ansible roles in hostgroup via API
@@ -190,7 +189,6 @@ class TestAnsibleCfgMgmt:
         assert len(hg_nested_roles) == 0
 
     @pytest.mark.e2e
-    @pytest.mark.tier2
     def test_positive_ansible_roles_inherited_from_hostgroup(
         self, request, target_sat, module_org, module_location
     ):
@@ -281,7 +279,6 @@ class TestAnsibleCfgMgmt:
         assert ROLE_NAMES[1] == listroles_hg[0]['name']
 
     @pytest.mark.rhel_ver_match('[78]')
-    @pytest.mark.tier2
     def test_positive_read_facts_with_filter(
         self, target_sat, rex_contenthost, filtered_user, module_org, module_location
     ):
@@ -611,7 +608,6 @@ class TestAnsibleREX:
         assert [i['output'] for i in result if i['output'] == 'StandardError: Job execution failed']
         assert [i['output'] for i in result if i['output'] == 'Exit status: 120']
 
-    @pytest.mark.tier2
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_ansible_job_privilege_escalation(

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -23,7 +23,6 @@ from robottelo.utils.datafactory import (
 )
 
 
-@pytest.mark.tier1
 def test_positive_CRUD(default_os, target_sat):
     """Create a new Architecture with several attributes, update the name
     and delete the Architecture itself.
@@ -53,7 +52,6 @@ def test_positive_CRUD(default_os, target_sat):
         arch.read()
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
 def test_negative_create_with_invalid_name(name, target_sat):
     """Create architecture providing an invalid initial name.
@@ -72,7 +70,6 @@ def test_negative_create_with_invalid_name(name, target_sat):
         target_sat.api.Architecture(name=name).create()
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
 def test_negative_update_with_invalid_name(name, module_architecture, module_target_sat):
     """Update architecture's name to an invalid name.

--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -18,7 +18,6 @@ from robottelo.utils.datafactory import gen_string
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 def test_positive_create_by_type(target_sat):
     """Create entities of different types and check audit logs for these
     events using entity type as search criteria
@@ -104,7 +103,6 @@ def test_positive_create_by_type(target_sat):
         assert audit.version == 1
 
 
-@pytest.mark.tier1
 def test_positive_update_by_type(target_sat):
     """Update some entities of different types and check audit logs for
     these events using entity type as search criteria
@@ -139,7 +137,6 @@ def test_positive_update_by_type(target_sat):
         assert audit.version == 2
 
 
-@pytest.mark.tier1
 def test_positive_delete_by_type(target_sat):
     """Delete some entities of different types and check audit logs for
     these events using entity type as search criteria

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -25,7 +25,6 @@ from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 CONTROLLERS = list(dict.fromkeys(entity['controller'] for entity in BOOKMARK_ENTITIES_SELECTION))
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_positive_create_with_name(controller, target_sat):
     """Create a bookmark
@@ -51,7 +50,6 @@ def test_positive_create_with_name(controller, target_sat):
     assert bm.name == name
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_positive_create_with_query(controller, target_sat):
     """Create a bookmark
@@ -77,7 +75,6 @@ def test_positive_create_with_query(controller, target_sat):
     assert bm.query == query
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('public', [True, False])
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_positive_create_public(controller, public, target_sat):
@@ -103,7 +100,6 @@ def test_positive_create_public(controller, public, target_sat):
     assert bm.public == public
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_negative_create_with_invalid_name(controller, target_sat):
     """Create a bookmark with invalid name
@@ -131,7 +127,6 @@ def test_negative_create_with_invalid_name(controller, target_sat):
     assert len(result) == 0
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_negative_create_empty_query(controller, target_sat):
     """Create a bookmark with empty query
@@ -159,7 +154,6 @@ def test_negative_create_empty_query(controller, target_sat):
     assert len(result) == 0
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_negative_create_same_name(controller, target_sat):
     """Create bookmarks with the same names
@@ -189,7 +183,6 @@ def test_negative_create_same_name(controller, target_sat):
     assert len(result) == 1
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_negative_create_null_public(controller, target_sat):
     """Create a bookmark omitting the public parameter
@@ -220,7 +213,6 @@ def test_negative_create_null_public(controller, target_sat):
     assert len(result) == 0
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_positive_update_name(controller, target_sat):
     """Update a bookmark
@@ -247,7 +239,6 @@ def test_positive_update_name(controller, target_sat):
     assert bm.name == new_name
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_negative_update_same_name(controller, target_sat):
     """Update a bookmark with name already taken
@@ -278,7 +269,6 @@ def test_negative_update_same_name(controller, target_sat):
     assert bm.name != name
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_negative_update_invalid_name(controller, target_sat):
     """Update a bookmark with an invalid name
@@ -307,7 +297,6 @@ def test_negative_update_invalid_name(controller, target_sat):
     assert bm.name != new_name
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_positive_update_query(controller, target_sat):
     """Update a bookmark query
@@ -334,7 +323,6 @@ def test_positive_update_query(controller, target_sat):
     assert bm.query == new_query
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_negative_update_empty_query(controller, target_sat):
     """Update a bookmark with an empty query
@@ -362,7 +350,6 @@ def test_negative_update_empty_query(controller, target_sat):
     assert bm.query != ''
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('public', [True, False])
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_positive_update_public(controller, public, target_sat):

--- a/tests/foreman/api/test_capsule.py
+++ b/tests/foreman/api/test_capsule.py
@@ -21,7 +21,6 @@ from robottelo.config import user_nailgun_config
 
 @pytest.mark.e2e
 @pytest.mark.upgrade
-@pytest.mark.tier1
 def test_positive_update_capsule(request, pytestconfig, target_sat, module_capsule_configured):
     """Update various capsule properties
 
@@ -89,7 +88,6 @@ def test_positive_update_capsule(request, pytestconfig, target_sat, module_capsu
 
 
 @pytest.mark.skip_if_not_set('fake_capsules')
-@pytest.mark.tier1
 def test_negative_create_with_url(target_sat):
     """Capsule creation with random URL
 
@@ -104,7 +102,6 @@ def test_negative_create_with_url(target_sat):
 
 
 @pytest.mark.skip_if_not_set('fake_capsules')
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_delete(target_sat):
     """Capsule deletion
@@ -124,7 +121,6 @@ def test_positive_delete(target_sat):
 
 
 @pytest.mark.skip_if_not_set('fake_capsules')
-@pytest.mark.tier1
 def test_positive_update_url(request, target_sat):
     """Capsule url updated
 
@@ -147,7 +143,6 @@ def test_positive_update_url(request, target_sat):
 
 
 @pytest.mark.skip_if_not_set('fake_capsules')
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_import_puppet_classes(
     request,

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -85,7 +85,6 @@ class TestCapsuleContentManagement:
     interactions and use capsule.
     """
 
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_uploaded_content_library_sync(
         self,
@@ -146,7 +145,6 @@ class TestCapsuleContentManagement:
         assert len(caps_files) == 1
         assert caps_files[0] == RPM_TO_UPLOAD
 
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_checksum_sync(
         self, module_capsule_configured, function_org, function_product, function_lce, target_sat
@@ -241,7 +239,6 @@ class TestCapsuleContentManagement:
         assert original_checksum not in checksum_types
 
     @pytest.mark.e2e
-    @pytest.mark.tier4
     @pytest.mark.pit_client
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_updated_repo(
@@ -350,7 +347,6 @@ class TestCapsuleContentManagement:
         assert len(caps_files) == 2
 
     @pytest.mark.e2e
-    @pytest.mark.tier4
     @pytest.mark.pit_client
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_capsule_sync(
@@ -503,7 +499,6 @@ class TestCapsuleContentManagement:
         caps_files = get_repo_files_by_url(caps_repo_url)
         assert sat_files == caps_files
 
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_iso_library_sync(
         self, module_capsule_configured, module_sca_manifest_org, module_target_sat
@@ -570,7 +565,6 @@ class TestCapsuleContentManagement:
         assert len(caps_isos) == 4
         assert set(sat_isos) == set(caps_isos)
 
-    @pytest.mark.tier4
     @pytest.mark.build_sanity
     @pytest.mark.order(after="tests/foreman/installer/test_installer.py::test_capsule_installation")
     @pytest.mark.skip_if_not_set('capsule')
@@ -657,7 +651,6 @@ class TestCapsuleContentManagement:
         # Assert checksums are matching
         assert package_md5 == published_package_md5
 
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_update_with_immediate_sync(
         self,
@@ -758,7 +751,6 @@ class TestCapsuleContentManagement:
         caps_files = get_repo_files_by_url(caps_repo_url)
         assert len(caps_files) == packages_count
 
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_capsule_pub_url_accessible(self, module_capsule_configured):
         """Ensure capsule pub url is accessible
@@ -782,7 +774,6 @@ class TestCapsuleContentManagement:
             assert b'katello-server-ca.crt' in response.content
 
     @pytest.mark.e2e
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     @pytest.mark.parametrize('distro', ['rhel7', 'rhel8_bos', 'rhel9_bos'])
     def test_positive_sync_kickstart_repo(
@@ -876,7 +867,6 @@ class TestCapsuleContentManagement:
         assert len(caps_pkgs)
         assert sat_pkgs == caps_pkgs
 
-    @pytest.mark.tier4
     @pytest.mark.e2e
     @pytest.mark.pit_client
     @pytest.mark.skip_if_not_set('capsule')
@@ -1015,7 +1005,6 @@ class TestCapsuleContentManagement:
             )
             assert result.status == 0
 
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_collection_repo(
         self,
@@ -1102,7 +1091,6 @@ class TestCapsuleContentManagement:
         assert 'foreman' in result.stdout
         assert 'operations' in result.stdout
 
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_file_repo(
         self, target_sat, module_capsule_configured, function_org, function_product, function_lce
@@ -1189,7 +1177,6 @@ class TestCapsuleContentManagement:
             caps_file = target_sat.checksum_by_url(f'{caps_repo_url}{file}')
             assert sat_file == caps_file
 
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_CV_to_multiple_LCEs(
         self, target_sat, module_capsule_configured, module_sca_manifest_org
@@ -1263,7 +1250,6 @@ class TestCapsuleContentManagement:
         cvv = cvv.read()
         assert len(cvv.environment) == 3
 
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_capsule_sync_status_persists(
         self, target_sat, module_capsule_configured, function_org, function_product, function_lce
@@ -1329,7 +1315,6 @@ class TestCapsuleContentManagement:
             datetime.strptime(sync_status['last_sync_time'], '%Y-%m-%d %H:%M:%S UTC') >= timestamp
         )
 
-    @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_remove_capsule_orphans(
         self,

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -72,7 +72,6 @@ def module_puppet(session_puppet_enabled_sat):
     session_puppet_enabled_sat.destroy_custom_environment(env_name)
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.skipif(

--- a/tests/foreman/api/test_computeprofile.py
+++ b/tests/foreman/api/test_computeprofile.py
@@ -23,7 +23,6 @@ from robottelo.utils.datafactory import (
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_name(name, target_sat):
     """Create new Compute Profile using different names
 
@@ -40,7 +39,6 @@ def test_positive_create_with_name(name, target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_create(name, target_sat):
     """Attempt to create Compute Profile using invalid names only
 
@@ -57,7 +55,6 @@ def test_negative_create(name, target_sat):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_update_name(new_name, target_sat):
     """Update selected Compute Profile entity using proper names
 
@@ -76,7 +73,6 @@ def test_positive_update_name(new_name, target_sat):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_update_name(new_name, target_sat):
     """Attempt to update Compute Profile entity using invalid names only
 
@@ -96,7 +92,6 @@ def test_negative_update_name(new_name, target_sat):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_delete(new_name, target_sat):
     """Delete Compute Profile entity
 

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -30,7 +30,6 @@ class TestAzureRMComputeResourceTestCase:
     """Tests for ``api/v2/compute_resources``"""
 
     @pytest.mark.upgrade
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
     )
@@ -86,7 +85,6 @@ class TestAzureRMComputeResourceTestCase:
         )
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
     )
@@ -111,7 +109,6 @@ class TestAzureRMComputeResourceTestCase:
         assert module_azurerm_cloudimg.uuid == AZURERM_RHEL7_UD_IMG_URN
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
     )
@@ -128,7 +125,6 @@ class TestAzureRMComputeResourceTestCase:
         assert len(portal_nws) == len(cr_nws['results'])
 
     @pytest.mark.stubbed
-    @pytest.mark.tier2
     def test_gov_cloud_regions_from_azure_compute_resources(self):
         """Check Azure Gov Cloud for US Cloud region options when creating a compute resource
 
@@ -252,7 +248,6 @@ class TestAzureRMHostProvisioningTestCase:
     @pytest.mark.e2e
     @pytest.mark.upgrade
     @pytest.mark.pit_server
-    @pytest.mark.tier3
     @pytest.mark.parametrize('sat_azure', ['sat'], indirect=True)
     def test_positive_azurerm_host_provisioned(self, class_host_ft, azureclient_host):
         """Host can be provisioned on AzureRM
@@ -283,7 +278,6 @@ class TestAzureRMHostProvisioningTestCase:
         assert self.hostname.lower() == azureclient_host.name
         assert self.vm_size == azureclient_host.type
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize('sat_azure', ['sat'], indirect=True)
     def test_positive_azurerm_host_power_on_off(self, class_host_ft, azureclient_host):
         """Host can be powered on and off
@@ -400,7 +394,6 @@ class TestAzureRMUserDataProvisioning:
         return azurermclient.get_vm(name=class_host_ud.name.split('.')[0])
 
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
     )
@@ -436,7 +429,6 @@ class TestAzureRMUserDataProvisioning:
         assert self.vm_size == azureclient_host.type
 
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
     )
@@ -551,7 +543,6 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
         return azurermclient.get_vm(name=class_host_custom_ft.name.split('.')[0])
 
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     @pytest.mark.parametrize('sat_azure', ['sat'], indirect=True)
     def test_positive_azurerm_custom_image_host_provisioned(
         self, class_host_custom_ft, azureclient_host

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -29,7 +29,6 @@ from robottelo.utils.issue_handlers import is_open
 class TestGCEComputeResourceTestCases:
     """Tests for ``api/v2/compute_resources``."""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('sat_gce', ['sat', 'puppet_sat'], indirect=True)
     def test_positive_crud_gce_cr(self, sat_gce, sat_gce_org, sat_gce_loc, gce_cert):
         """Create, Read, Update and Delete GCE compute resources
@@ -69,7 +68,6 @@ class TestGCEComputeResourceTestCases:
         updated.delete()
         assert not sat_gce.api.GCEComputeResource().search(query={'search': f'name={new_name}'})
 
-    @pytest.mark.tier3
     def test_positive_check_available_images(self, module_gce_compute, googleclient):
         """Verify RHEL images from GCP are available to select in GCE CR
 
@@ -92,7 +90,6 @@ class TestGCEComputeResourceTestCases:
             # Validate only rhel-images exist in GCE_CR
             assert image.startswith('rhel-')
 
-    @pytest.mark.tier3
     def test_positive_check_available_networks(self, module_gce_compute, googleclient):
         """Verify all the networks from GCE are available to select
 
@@ -106,7 +103,6 @@ class TestGCEComputeResourceTestCases:
         gcloudclient_networks = googleclient.list_network()
         assert sorted(satgce_networks) == sorted(gcloudclient_networks)
 
-    @pytest.mark.tier3
     def test_positive_check_available_flavors(self, module_gce_compute):
         """Verify flavors from GCE are available to select
 
@@ -120,7 +116,6 @@ class TestGCEComputeResourceTestCases:
         satgce_flavors = int(module_gce_compute.available_flavors()['total'])
         assert satgce_flavors > 1
 
-    @pytest.mark.tier3
     def test_positive_create_finish_template_image(
         self, module_gce_finishimg, module_gce_compute, gce_latest_rhel_uuid
     ):
@@ -140,7 +135,6 @@ class TestGCEComputeResourceTestCases:
         assert module_gce_finishimg.compute_resource.id == module_gce_compute.id
         assert module_gce_finishimg.uuid == gce_latest_rhel_uuid
 
-    @pytest.mark.tier3
     def test_positive_create_cloud_init_image(
         self, module_gce_cloudimg, module_gce_compute, gce_custom_cloudinit_uuid
     ):
@@ -226,7 +220,6 @@ class TestGCEHostProvisioningTestCase:
         return googleclient.get_vm(name='{}'.format(self.fullhostname.replace('.', '-')))
 
     @pytest.mark.e2e
-    @pytest.mark.tier1
     @pytest.mark.pit_server
     @pytest.mark.build_sanity
     @pytest.mark.skipif(
@@ -257,7 +250,6 @@ class TestGCEHostProvisioningTestCase:
         assert class_host.build_status_label == 'Installed'
         assert class_host.ip == google_host.ip
 
-    @pytest.mark.tier3
     def test_positive_gce_host_power_on_off(self, class_host, google_host):
         """Host can be powered on and off
 

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -92,7 +92,6 @@ def test_positive_crud_libvirt_cr(module_target_sat, module_org, module_location
     )
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 def test_positive_create_with_name_description(
     name, request, module_target_sat, module_org, module_location
@@ -119,7 +118,6 @@ def test_positive_create_with_name_description(
     assert compresource.description == name
 
 
-@pytest.mark.tier2
 def test_positive_create_with_orgs_and_locs(request, module_target_sat):
     """Create a compute resource with multiple organizations and locations
 
@@ -140,7 +138,6 @@ def test_positive_create_with_orgs_and_locs(request, module_target_sat):
     assert {loc.name for loc in locs} == {loc.read().name for loc in compresource.location}
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
 def test_negative_create_with_invalid_name(name, module_target_sat, module_org, module_location):
     """Attempt to create compute resources with invalid names
@@ -162,7 +159,6 @@ def test_negative_create_with_invalid_name(name, module_target_sat, module_org, 
         ).create()
 
 
-@pytest.mark.tier2
 def test_negative_create_with_same_name(request, module_target_sat, module_org, module_location):
     """Attempt to create a compute resource with already existing name
 
@@ -187,7 +183,6 @@ def test_negative_create_with_same_name(request, module_target_sat, module_org, 
         ).create()
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('url', **parametrized({'random': gen_string('alpha'), 'empty': ''}))
 def test_negative_create_with_url(module_target_sat, module_org, module_location, url):
     """Attempt to create compute resources with invalid url
@@ -206,7 +201,6 @@ def test_negative_create_with_url(module_target_sat, module_org, module_location
         ).create()
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
 def test_negative_update_invalid_name(
     request, module_target_sat, module_org, module_location, new_name
@@ -232,7 +226,6 @@ def test_negative_update_invalid_name(
     assert compresource.read().name == name
 
 
-@pytest.mark.tier2
 def test_negative_update_same_name(request, module_target_sat, module_org, module_location):
     """Attempt to update a compute resource with already existing name
 
@@ -257,7 +250,6 @@ def test_negative_update_same_name(request, module_target_sat, module_org, modul
     assert new_compresource.read().name != name
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('url', **parametrized({'random': gen_string('alpha'), 'empty': ''}))
 def test_negative_update_url(url, request, module_target_sat, module_org, module_location):
     """Attempt to update a compute resource with invalid url

--- a/tests/foreman/api/test_computeresource_vmware.py
+++ b/tests/foreman/api/test_computeresource_vmware.py
@@ -131,7 +131,6 @@ def test_positive_provision_end_to_end(
 @pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
-@pytest.mark.tier3
 def test_positive_provision_vmware_pxe_discovery(
     request,
     module_provisioning_rhel_content,

--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -29,7 +29,6 @@ key_content = DataFile.VALID_GPG_KEY_FILE.read_text()
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_name(module_org, name, module_target_sat):
     """Create a GPG key with valid name.
 
@@ -45,7 +44,6 @@ def test_positive_create_with_name(module_org, name, module_target_sat):
     assert name == gpg_key.name
 
 
-@pytest.mark.tier1
 def test_positive_create_with_content(module_org, module_target_sat):
     """Create a GPG key with valid name and valid gpg key text.
 
@@ -60,7 +58,6 @@ def test_positive_create_with_content(module_org, module_target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_create_name(module_org, name, module_target_sat):
     """Attempt to create GPG key with invalid names only.
 
@@ -78,7 +75,6 @@ def test_negative_create_name(module_org, name, module_target_sat):
     assert 'Validation failed:' in error.value.response.text
 
 
-@pytest.mark.tier1
 def test_negative_create_with_same_name(module_org, module_target_sat):
     """Attempt to create a GPG key providing a name of already existent
     entity
@@ -97,7 +93,6 @@ def test_negative_create_with_same_name(module_org, module_target_sat):
     assert 'Validation failed:' in error.value.response.text
 
 
-@pytest.mark.tier1
 def test_negative_create_with_content(module_org, module_target_sat):
     """Attempt to create GPG key with empty content.
 
@@ -114,7 +109,6 @@ def test_negative_create_with_content(module_org, module_target_sat):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_update_name(module_org, new_name, module_target_sat):
     """Update GPG key name to another valid name.
 
@@ -132,7 +126,6 @@ def test_positive_update_name(module_org, new_name, module_target_sat):
     assert new_name == gpg_key.name
 
 
-@pytest.mark.tier1
 def test_positive_update_content(module_org, module_target_sat):
     """Update GPG key content text to another valid one.
 
@@ -152,7 +145,6 @@ def test_positive_update_content(module_org, module_target_sat):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_update_name(module_org, new_name, module_target_sat):
     """Attempt to update GPG key name to invalid one
 
@@ -172,7 +164,6 @@ def test_negative_update_name(module_org, new_name, module_target_sat):
     assert 'Validation failed:' in error.value.response.text
 
 
-@pytest.mark.tier1
 def test_negative_update_same_name(module_org, module_target_sat):
     """Attempt to update GPG key name to the name of existing GPG key
     entity
@@ -193,7 +184,6 @@ def test_negative_update_same_name(module_org, module_target_sat):
     assert 'Validation failed:' in error.value.response.text
 
 
-@pytest.mark.tier1
 def test_negative_update_content(module_org, module_target_sat):
     """Attempt to update GPG key content to invalid one
 
@@ -212,7 +202,6 @@ def test_negative_update_content(module_org, module_target_sat):
     assert 'Validation failed:' in error.value.response.text
 
 
-@pytest.mark.tier1
 def test_positive_delete(module_org, module_target_sat):
     """Create a GPG key with different names and then delete it.
 
@@ -228,7 +217,6 @@ def test_positive_delete(module_org, module_target_sat):
         gpg_key.read()
 
 
-@pytest.mark.tier3
 def test_positive_block_delete_key_in_use(module_org, target_sat):
     """Create a GPG key with valid content. Create a new product and
         associated repository, assigning the GPG key to both. Attempt to delete the

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -102,7 +102,6 @@ def apply_package_filter(content_view, repo, package, target_sat, inclusion=True
 
 class TestContentView:
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     def test_positive_subscribe_host(
         self, class_cv, class_promoted_cv, module_lce, module_org, module_target_sat
     ):
@@ -135,7 +134,6 @@ class TestContentView:
         assert host.content_facet_attributes['lifecycle_environment']['id'] == module_lce.id
         assert class_cv.read().content_host_count == 1
 
-    @pytest.mark.tier2
     def test_positive_clone_within_same_env(self, class_published_cloned_cv, module_lce):
         """attempt to create, publish and promote new content view
         based on existing view within the same environment as the
@@ -151,7 +149,6 @@ class TestContentView:
         class_published_cloned_cv.read().version[0].promote(data={'environment_ids': module_lce.id})
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     def test_positive_clone_with_diff_env(
         self, module_org, class_published_cloned_cv, module_target_sat
     ):
@@ -169,7 +166,6 @@ class TestContentView:
         le_clone = module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
         class_published_cloned_cv.read().version[0].promote(data={'environment_ids': le_clone.id})
 
-    @pytest.mark.tier2
     def test_positive_add_custom_content(self, module_product, module_org, module_target_sat):
         """Associate custom content in a view
 
@@ -188,7 +184,6 @@ class TestContentView:
         assert len(content_view.repository) == 1
         assert content_view.repository[0].read().name == yum_repo.name
 
-    @pytest.mark.tier2
     def test_negative_add_dupe_repos(
         self, content_view, module_product, module_org, module_target_sat
     ):
@@ -209,7 +204,6 @@ class TestContentView:
             content_view.update(['repository'])
         assert len(content_view.read().repository) == 0
 
-    @pytest.mark.tier2
     @pytest.mark.pit_server
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -252,7 +246,6 @@ class TestContentView:
             content_view_version.errata_counts['total'] == CUSTOM_RPM_SHA_512_FEED_COUNT['errata']
         )
 
-    @pytest.mark.tier2
     def test_ccv_promote_registry_name_change(self, module_target_sat, module_sca_manifest_org):
         """Testing CCV promotion scenarios where the registry_name has been changed to some
         specific value.
@@ -314,7 +307,6 @@ class TestContentViewCreate:
     """Create tests for content views."""
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    @pytest.mark.tier1
     def test_positive_create_with_name(self, name, target_sat):
         """Create empty content-view with random names.
 
@@ -329,7 +321,6 @@ class TestContentViewCreate:
         assert target_sat.api.ContentView(name=name).create().name == name
 
     @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-    @pytest.mark.tier1
     def test_positive_create_with_description(self, desc, target_sat):
         """Create empty content view with random description.
 
@@ -343,7 +334,6 @@ class TestContentViewCreate:
         """
         assert target_sat.api.ContentView(description=desc).create().description == desc
 
-    @pytest.mark.tier1
     def test_positive_clone(self, content_view, module_org, module_target_sat):
         """Create a content view by copying an existing one
 
@@ -364,7 +354,6 @@ class TestContentViewCreate:
         assert cv_origin == cloned_cv
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self, name, target_sat):
         """Create content view providing an invalid name.
 
@@ -410,7 +399,6 @@ class TestContentViewPublishPromote:
         composite_cv = composite_cv.update(['component'])
         assert len(composite_cv.component) == cv_amount
 
-    @pytest.mark.tier2
     def test_positive_publish_with_content_multiple(self, content_view, module_org):
         """Give a content view yum packages and publish it repeatedly.
 
@@ -435,7 +423,6 @@ class TestContentViewPublishPromote:
         for cvv in content_view.read().version:
             assert cvv.read_json()['package_count'] > 0
 
-    @pytest.mark.tier2
     def test_positive_publish_composite_multiple_content_once(self, module_org, module_target_sat):
         """Create empty composite view and assign random number of
         normal content views to it. After that publish that composite content
@@ -458,7 +445,6 @@ class TestContentViewPublishPromote:
         composite_cv.publish()
         assert len(composite_cv.read().version) == 1
 
-    @pytest.mark.tier2
     def test_positive_publish_composite_multiple_content_multiple(
         self, module_org, module_target_sat
     ):
@@ -485,7 +471,6 @@ class TestContentViewPublishPromote:
             composite_cv.publish()
             assert len(composite_cv.read().version) == i + 1
 
-    @pytest.mark.tier2
     def test_positive_promote_with_yum_multiple(self, content_view, module_org, module_target_sat):
         """Give a content view a yum repo, publish it once and promote
         the content view version ``REPEAT + 1`` times.
@@ -518,7 +503,6 @@ class TestContentViewPublishPromote:
         assert len(cvv_attrs['environments']) == REPEAT + 1
         assert cvv_attrs['package_count'] > 0
 
-    @pytest.mark.tier2
     def test_negative_publish_during_repo_sync(self, content_view, module_target_sat):
         """Attempt to publish a new version of the content-view,
         while an associated repository is being synced.
@@ -567,7 +551,6 @@ class TestContentViewPublishPromote:
         assert content_view.read().version == existing_versions
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     def test_positive_promote_composite_multiple_content_once(
         self, module_lce, module_org, module_target_sat
     ):
@@ -596,7 +579,6 @@ class TestContentViewPublishPromote:
         assert len(composite_cv.version[0].read().environment) == 2
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     def test_positive_promote_composite_multiple_content_multiple(
         self, module_org, module_target_sat
     ):
@@ -629,7 +611,6 @@ class TestContentViewPublishPromote:
         assert len(composite_cv.version) == 1
         assert len(composite_cv.version[0].read().environment) == envs_amount + 1
 
-    @pytest.mark.tier2
     def test_positive_promote_out_of_sequence(self, content_view, module_org):
         """Try to publish content view few times in a row and then re-promote
         first version to default environment
@@ -663,7 +644,6 @@ class TestContentViewPublishPromote:
         assert len(content_view.version[0].read().environment) == 1
         assert len(content_view.version[-1].read().environment) == 0
 
-    @pytest.mark.tier3
     @pytest.mark.pit_server
     def test_positive_publish_multiple_repos(self, content_view, module_org, module_target_sat):
         """Attempt to publish a content view with multiple YUM repos.
@@ -693,7 +673,6 @@ class TestContentViewPublishPromote:
         content_view.publish()
         assert len(content_view.read().version) == 1
 
-    @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -746,7 +725,6 @@ class TestContentViewPublishPromote:
         assert comp_content_view_info.package_count == 36
 
     @pytest.mark.e2e
-    @pytest.mark.tier2
     def test_ccv_audit_scenarios(self, module_org, target_sat):
         """Check for various scenarios where a composite content view or it's component
         content views needs_publish flags should be set to true and that they properly
@@ -814,7 +792,6 @@ class TestContentViewPublishPromote:
         composite_cv.publish()
         assert not composite_cv.read().needs_publish
 
-    @pytest.mark.tier2
     def test_check_needs_publish_flag(self, target_sat):
         """Check that the publish_only_if_needed option in the API works as intended (defaults to
         false, is able to be overriden to true, and if so gives the appropriate message
@@ -849,7 +826,6 @@ class TestContentViewUpdate:
             {'description': gen_utf8(), 'name': gen_utf8()}
         ),
     )
-    @pytest.mark.tier1
     def test_positive_update_attributes(self, module_cv, key, value):
         """Update a content view and provide valid attributes.
 
@@ -866,7 +842,6 @@ class TestContentViewUpdate:
         assert getattr(content_view, key) == value
 
     @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-    @pytest.mark.tier1
     def test_positive_update_name(self, module_cv, new_name, module_target_sat):
         """Create content view providing the initial name, then update
         its name to another valid name.
@@ -885,7 +860,6 @@ class TestContentViewUpdate:
         assert new_name == updated.name
 
     @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
-    @pytest.mark.tier1
     def test_negative_update_name(self, module_cv, new_name, module_target_sat):
         """Create content view then update its name to an
         invalid name.
@@ -927,7 +901,6 @@ class TestContentViewRedHatContent:
         module_cv.update(['repository'])
         request.cls.yumcv = module_cv.read()
 
-    @pytest.mark.tier2
     def test_positive_add_rh_custom_spin(self, target_sat):
         """Associate Red Hat content in a view and filter it using rule
 
@@ -952,7 +925,6 @@ class TestContentViewRedHatContent:
         ).create()
         assert cv_filter.id == cv_filter_rule.content_view_filter.id
 
-    @pytest.mark.tier2
     def test_positive_publish_rh_custom_spin(self, module_org, content_view, module_target_sat):
         """Attempt to publish a content view containing Red Hat spin - i.e.,
         contains filters.
@@ -971,7 +943,6 @@ class TestContentViewRedHatContent:
         content_view.publish()
         assert len(content_view.read().version) == 1
 
-    @pytest.mark.tier2
     def test_positive_promote_rh(self, module_org, content_view, module_lce):
         """Attempt to promote a content view containing Red Hat content
 
@@ -993,7 +964,6 @@ class TestContentViewRedHatContent:
         assert len(content_view.read().version[0].read().environment) == 2
 
     @pytest.mark.e2e
-    @pytest.mark.tier2
     def test_cv_audit_scenarios(self, module_product, target_sat):
         """Check for various scenarios where a content view's needs_publish flag
         should be set to true and that it properly gets set and unset
@@ -1079,7 +1049,6 @@ class TestContentViewRedHatContent:
         assert not self.yumcv.read().needs_publish
 
 
-@pytest.mark.tier2
 def test_repository_rpms_id_type(target_sat):
     """Katello_repository_rpms_id_seq needs to have the type bigint to allow
     repeated publishing of Content Views by customers.
@@ -1101,7 +1070,6 @@ def test_repository_rpms_id_type(target_sat):
     assert 'integer' not in db_out.stdout
 
 
-@pytest.mark.tier2
 def test_negative_readonly_user_actions(
     target_sat, function_role, content_view, module_org, module_lce
 ):
@@ -1184,7 +1152,6 @@ def test_negative_readonly_user_actions(
         target_sat.api.HostCollection(server_config=cfg).create()
 
 
-@pytest.mark.tier2
 def test_negative_non_readonly_user_actions(target_sat, content_view, function_role, module_org):
     """Attempt to view content views
 
@@ -1261,7 +1228,6 @@ class TestOstreeContentView:
         ).create()
         self.docker_repo.sync()
 
-    @pytest.mark.tier2
     def test_positive_add_custom_ostree_content(self, content_view):
         """Associate custom ostree content in a view
 
@@ -1278,7 +1244,6 @@ class TestOstreeContentView:
         assert len(content_view.repository) == 1
         assert content_view.repository[0].read().name == self.ostree_repo.name
 
-    @pytest.mark.tier2
     def test_positive_publish_custom_ostree(self, content_view):
         """Publish a content view with custom ostree contents
 
@@ -1294,7 +1259,6 @@ class TestOstreeContentView:
         content_view.publish()
         assert len(content_view.read().version) == 1
 
-    @pytest.mark.tier2
     def test_positive_promote_custom_ostree(self, content_view, module_lce):
         """Promote a content view with custom ostree contents
 
@@ -1313,7 +1277,6 @@ class TestOstreeContentView:
         )
         assert len(content_view.read().version[0].read().environment) == 2
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_publish_promote_with_custom_ostree_and_other(self, content_view, module_lce):
         """Publish & Promote a content view with custom ostree and other contents
@@ -1355,7 +1318,6 @@ class TestContentViewRedHatOstreeContent:
         request.cls.repo = class_target_sat.api.Repository(id=repo_id)
         self.repo.sync()
 
-    @pytest.mark.tier2
     def test_positive_add_rh_ostree_content(self, content_view):
         """Associate RH atomic ostree content in a view
 
@@ -1372,7 +1334,6 @@ class TestContentViewRedHatOstreeContent:
         assert len(content_view.repository) == 1
         assert content_view.repository[0].read().name == REPOS['rhaht']['name']
 
-    @pytest.mark.tier2
     def test_positive_publish_RH_ostree(self, content_view):
         """Publish a content view with RH ostree contents
 
@@ -1388,7 +1349,6 @@ class TestContentViewRedHatOstreeContent:
         content_view.publish()
         assert len(content_view.read().version) == 1
 
-    @pytest.mark.tier2
     def test_positive_promote_RH_ostree(self, content_view, module_lce):
         """Promote a content view with RH ostree contents
 
@@ -1407,7 +1367,6 @@ class TestContentViewRedHatOstreeContent:
         )
         assert len(content_view.read().version[0].read().environment) == 2
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_publish_promote_with_RH_ostree_and_other(
         self, content_view, module_org, module_lce, module_target_sat

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -62,7 +62,6 @@ def content_view_module_stream(module_org, sync_repo_module_stream, module_targe
 class TestContentViewFilter:
     """Tests for content view filters."""
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_create_erratum_with_name(self, name, content_view, target_sat):
         """Create new erratum content filter using different inputs as a name
@@ -79,7 +78,6 @@ class TestContentViewFilter:
         assert cvf.name == name
         assert cvf.type == 'erratum'
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_create_pkg_group_with_name(self, name, content_view, target_sat):
         """Create new package group content filter using different inputs as a name
@@ -100,7 +98,6 @@ class TestContentViewFilter:
         assert cvf.name == name
         assert cvf.type == 'package_group'
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_create_rpm_with_name(self, name, content_view, target_sat):
         """Create new RPM content filter using different inputs as a name
@@ -118,7 +115,6 @@ class TestContentViewFilter:
         assert cvf.name == name
         assert cvf.type == 'rpm'
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('inclusion', [True, False])
     def test_positive_create_with_inclusion(self, inclusion, content_view, target_sat):
         """Create new content view filter with different inclusion values
@@ -136,7 +132,6 @@ class TestContentViewFilter:
         ).create()
         assert cvf.inclusion == inclusion
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
     def test_positive_create_with_description(self, description, content_view, target_sat):
         """Create new content filter using different inputs as a description
@@ -156,7 +151,6 @@ class TestContentViewFilter:
         ).create()
         assert cvf.description == description
 
-    @pytest.mark.tier2
     def test_positive_create_with_repo(self, content_view, sync_repo, target_sat):
         """Create new content filter with repository assigned
 
@@ -173,7 +167,6 @@ class TestContentViewFilter:
         ).create()
         assert cvf.repository[0].id == sync_repo.id
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('original_packages', [True, False])
     def test_positive_create_with_original_packages(
         self, original_packages, content_view, sync_repo, target_sat
@@ -198,7 +191,6 @@ class TestContentViewFilter:
         ).create()
         assert cvf.original_packages == original_packages
 
-    @pytest.mark.tier2
     def test_positive_create_with_docker_repos(
         self, module_product, sync_repo, content_view, module_target_sat
     ):
@@ -230,7 +222,6 @@ class TestContentViewFilter:
         for repo in cvf.repository:
             assert repo.id in (sync_repo.id, docker_repository.id)
 
-    @pytest.mark.tier2
     def test_negative_create_without_cv(self, target_sat):
         """Try to create content view filter without providing content
         view
@@ -244,7 +235,6 @@ class TestContentViewFilter:
         with pytest.raises(HTTPError):
             target_sat.api.RPMContentViewFilter(content_view=None).create()
 
-    @pytest.mark.tier2
     def test_negative_create_with_invalid_repo_id(self, content_view, target_sat):
         """Try to create content view filter using incorrect repository
         id
@@ -261,7 +251,6 @@ class TestContentViewFilter:
                 repository=[gen_integer(10000, 99999)],
             ).create()
 
-    @pytest.mark.tier2
     def test_positive_delete_by_id(self, content_view, target_sat):
         """Delete content view filter
 
@@ -276,7 +265,6 @@ class TestContentViewFilter:
         with pytest.raises(HTTPError):
             cvf.read()
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_update_name(self, name, content_view, target_sat):
         """Update content view filter with new name
@@ -293,7 +281,6 @@ class TestContentViewFilter:
         cvf.name = name
         assert cvf.update(['name']).name == name
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
     def test_positive_update_description(self, description, content_view, target_sat):
         """Update content view filter with new description
@@ -312,7 +299,6 @@ class TestContentViewFilter:
         cvf = cvf.update(['description'])
         assert cvf.description == description
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('inclusion', [True, False])
     def test_positive_update_inclusion(self, inclusion, content_view, target_sat):
         """Update content view filter with new inclusion value
@@ -330,7 +316,6 @@ class TestContentViewFilter:
         cvf = cvf.update(['inclusion'])
         assert cvf.inclusion == inclusion
 
-    @pytest.mark.tier2
     def test_positive_update_repo(self, module_product, sync_repo, content_view, target_sat):
         """Update content view filter with new repository
 
@@ -354,7 +339,6 @@ class TestContentViewFilter:
         assert len(cvf.repository) == 1
         assert cvf.repository[0].id == new_repo.id
 
-    @pytest.mark.tier2
     def test_positive_update_repos(self, module_product, sync_repo, content_view, target_sat):
         """Update content view filter with multiple repositories
 
@@ -381,7 +365,6 @@ class TestContentViewFilter:
         cvf = cvf.update(['repository'])
         assert {repo.id for repo in cvf.repository} == {repo.id for repo in repos}
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('original_packages', [True, False])
     def test_positive_update_original_packages(
         self, original_packages, sync_repo, content_view, target_sat
@@ -405,7 +388,6 @@ class TestContentViewFilter:
         cvf = cvf.update(['original_packages'])
         assert cvf.original_packages == original_packages
 
-    @pytest.mark.tier2
     def test_positive_update_repo_with_docker(
         self, module_product, sync_repo, content_view, target_sat
     ):
@@ -437,7 +419,6 @@ class TestContentViewFilter:
         for repo in cvf.repository:
             assert repo.id in (sync_repo.id, docker_repository.id)
 
-    @pytest.mark.tier2
     def test_negative_update_same_name(self, content_view, target_sat):
         """Try to update content view filter's name to already used one
 
@@ -454,7 +435,6 @@ class TestContentViewFilter:
         with pytest.raises(HTTPError):
             cvf.update(['name'])
 
-    @pytest.mark.tier2
     def test_negative_update_cv_by_id(self, content_view, target_sat):
         """Try to update content view filter using incorrect content
         view ID
@@ -469,7 +449,6 @@ class TestContentViewFilter:
         with pytest.raises(HTTPError):
             cvf.update(['content_view'])
 
-    @pytest.mark.tier2
     def test_negative_update_repo_by_id(self, sync_repo, content_view, target_sat):
         """Try to update content view filter using incorrect repository
         ID
@@ -487,7 +466,6 @@ class TestContentViewFilter:
         with pytest.raises(HTTPError):
             cvf.update(['repository'])
 
-    @pytest.mark.tier2
     def test_negative_update_repo(self, module_product, sync_repo, content_view, target_sat):
         """Try to update content view filter with new repository which doesn't
         belong to filter's content view
@@ -509,7 +487,6 @@ class TestContentViewFilter:
         with pytest.raises(HTTPError):
             cvf.update(['repository'])
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'filter_type', ['erratum', 'package_group', 'rpm', 'modulemd', 'docker']
     )
@@ -556,7 +533,6 @@ class TestContentViewFilter:
 class TestContentViewFilterSearch:
     """Tests that search through content view filters."""
 
-    @pytest.mark.tier1
     def test_positive_search_erratum(self, content_view, target_sat):
         """Search for an erratum content view filter's rules.
 
@@ -571,7 +547,6 @@ class TestContentViewFilterSearch:
         cv_filter = target_sat.api.ErratumContentViewFilter(content_view=content_view).create()
         target_sat.api.ContentViewFilterRule(content_view_filter=cv_filter).search()
 
-    @pytest.mark.tier1
     def test_positive_search_package_group(self, content_view, target_sat):
         """Search for an package group content view filter's rules.
 
@@ -584,7 +559,6 @@ class TestContentViewFilterSearch:
         cv_filter = target_sat.api.PackageGroupContentViewFilter(content_view=content_view).create()
         target_sat.api.ContentViewFilterRule(content_view_filter=cv_filter).search()
 
-    @pytest.mark.tier1
     def test_positive_search_rpm(self, content_view, target_sat):
         """Search for an rpm content view filter's rules.
 
@@ -604,7 +578,6 @@ class TestContentViewFilterRule:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    @pytest.mark.tier2
     def test_positive_promote_module_stream_filter(
         self, module_org, content_view_module_stream, target_sat
     ):
@@ -652,7 +625,6 @@ class TestContentViewFilterRule:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    @pytest.mark.tier2
     def test_positive_include_exclude_module_stream_filter(
         self, content_view_module_stream, target_sat
     ):
@@ -711,7 +683,6 @@ class TestContentViewFilterRule:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    @pytest.mark.tier2
     def test_positive_multi_level_filters(self, content_view_module_stream, target_sat):
         """Verify promotion of Content View and Verify count after applying
         multi_filters (errata and module stream)
@@ -753,7 +724,6 @@ class TestContentViewFilterRule:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    @pytest.mark.tier2
     def test_positive_dependency_solving_module_stream_filter(
         self, content_view_module_stream, target_sat
     ):

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -34,7 +34,6 @@ def module_lce_cv(module_org, module_target_sat):
     return lce1, lce2, default_cvv
 
 
-@pytest.mark.tier2
 def test_positive_promote_out_of_sequence_environment(module_org, module_lce_cv, module_target_sat):
     """Promote a content view version to a lifecycle environment
     that is 'out of sequence'.
@@ -60,7 +59,6 @@ def test_positive_promote_out_of_sequence_environment(module_org, module_lce_cv,
     assert len(version.environment) == 2
 
 
-@pytest.mark.tier2
 def test_negative_promote_valid_environment(module_lce_cv):
     """Attempt to promote the default content view version.
 
@@ -75,7 +73,6 @@ def test_negative_promote_valid_environment(module_lce_cv):
         default_cvv.promote(data={'environment_ids': lce1.id, 'force': False})
 
 
-@pytest.mark.tier2
 def test_negative_promote_out_of_sequence_environment(module_lce_cv, module_org, module_target_sat):
     """Attempt to promote a content view version to a Lifecycle environment
     that is 'out of sequence'.
@@ -101,7 +98,6 @@ def test_negative_promote_out_of_sequence_environment(module_lce_cv, module_org,
 # Tests for content view version promotion.
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_delete(module_org, module_product, module_target_sat):
     """Create content view and publish it. After that try to
@@ -145,7 +141,6 @@ def test_positive_delete(module_org, module_product, module_target_sat):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_delete_non_default(module_org, module_target_sat):
     """Create content view and publish and promote it to new
     environment. After that try to disassociate content view from 'Library'
@@ -177,7 +172,6 @@ def test_positive_delete_non_default(module_org, module_target_sat):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_delete_composite_version(module_org, module_target_sat):
     """Create composite content view and publish it. After that try to
@@ -220,7 +214,6 @@ def test_positive_delete_composite_version(module_org, module_target_sat):
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_remove_cv_version_from_env_with_host_registered():
     """Remove promoted content view version from environment that is used
     in association of an Activation key and content-host registration.
@@ -257,7 +250,6 @@ def test_positive_remove_cv_version_from_env_with_host_registered():
 
 @pytest.mark.upgrade
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_delete_cv_multi_env_promoted_with_host_registered():
     """Delete published content view with version promoted to multiple
      environments, with one of the environments used in association of an
@@ -296,7 +288,6 @@ def test_positive_delete_cv_multi_env_promoted_with_host_registered():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_remove_cv_version_from_multi_env_capsule_scenario():
     """Remove promoted content view version from multiple environments,
     with satellite module_lce_cv to use capsule

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -170,7 +170,6 @@ class TestDiscoveredHost:
     @pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
     @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
     @pytest.mark.rhel_ver_list([8, 9])
-    @pytest.mark.tier3
     def test_positive_provision_pxe_host(
         self,
         module_provisioning_rhel_content,
@@ -225,7 +224,6 @@ class TestDiscoveredHost:
     @pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
     @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
     @pytest.mark.rhel_ver_list([8, 9])
-    @pytest.mark.tier3
     def test_positive_provision_pxe_less_host(
         self,
         module_discovery_sat,
@@ -269,7 +267,6 @@ class TestDiscoveredHost:
         assert_discovered_host_provisioned(shell, module_provisioning_rhel_content.ksrepo)
         request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
 
-    @pytest.mark.tier3
     def test_positive_auto_provision_pxe_host(
         self, module_discovery_hostgroup, module_target_sat, discovery_org, discovery_location
     ):
@@ -300,7 +297,6 @@ class TestDiscoveredHost:
         result = module_target_sat.api.DiscoveredHost(id=discovered_host['id']).auto_provision()
         assert f'provisioned with rule {rule.name}' in result['message']
 
-    @pytest.mark.tier3
     def test_positive_auto_provision_all(
         self, module_discovery_hostgroup, module_target_sat, discovery_org, discovery_location
     ):
@@ -335,7 +331,6 @@ class TestDiscoveredHost:
         assert '2 discovered hosts were provisioned' in result['message']
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     def test_positive_refresh_facts_pxe_host(self, module_target_sat):
         """Refresh the facts of pxe based discovered hosts by adding a new NIC
 
@@ -358,7 +353,6 @@ class TestDiscoveredHost:
     @pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
     @pytest.mark.parametrize('pxe_loader', ['uefi'], indirect=True)
     @pytest.mark.rhel_ver_match('9')
-    @pytest.mark.tier3
     def test_positive_reboot_pxe_host(
         self,
         module_provisioning_rhel_content,
@@ -401,7 +395,6 @@ class TestDiscoveredHost:
     @pytest.mark.on_premises_provisioning
     @pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
     @pytest.mark.rhel_ver_match('9')
-    @pytest.mark.tier3
     def test_positive_reboot_all_pxe_hosts(
         self,
         module_provisioning_rhel_content,
@@ -484,7 +477,6 @@ class TestFakeDiscoveryTests:
             }
         )
 
-    @pytest.mark.tier2
     def test_positive_upload_facts(self, target_sat):
         """Upload fake facts to create a discovered host
 
@@ -507,7 +499,6 @@ class TestFakeDiscoveryTests:
         host_name = 'mac{}'.format(discovered_host['mac'].replace(':', ''))
         assert discovered_host['name'] == host_name
 
-    @pytest.mark.tier3
     def test_positive_delete_pxe_host(self, target_sat):
         """Delete a pxe-based discovered hosts
 

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -38,7 +38,6 @@ def module_org(module_org):
     module_org.delete()
 
 
-@pytest.mark.tier1
 @pytest.mark.e2e
 def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup, module_target_sat):
     """Create a new discovery rule with several attributes, update them
@@ -98,7 +97,6 @@ def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup,
         discovery_rule.read()
 
 
-@pytest.mark.tier1
 def test_negative_create_with_invalid_host_limit_and_priority(module_target_sat):
     """Create a discovery rule with invalid host limit and priority
 
@@ -112,7 +110,6 @@ def test_negative_create_with_invalid_host_limit_and_priority(module_target_sat)
         module_target_sat.api.DiscoveryRule(priority=gen_string('alpha')).create()
 
 
-@pytest.mark.tier3
 def test_positive_update_and_provision_with_rule_priority(
     module_target_sat, module_discovery_hostgroup, discovery_location, discovery_org
 ):
@@ -158,7 +155,6 @@ def test_positive_update_and_provision_with_rule_priority(
             _.read()
 
 
-@pytest.mark.tier3
 def test_positive_multi_provision_with_rule_limit(
     request, module_target_sat, module_discovery_hostgroup, discovery_location, discovery_org
 ):

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -116,7 +116,6 @@ class TestDockerRepository:
     :team: Phoenix-content
     """
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_docker_repository_names()))
     def test_positive_create_with_name(self, module_product, name, module_target_sat):
         """Create one Docker-type repository
@@ -135,7 +134,6 @@ class TestDockerRepository:
         assert repo.docker_upstream_name == settings.container.upstream_name
         assert repo.content_type == 'docker'
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('upstream_name', **parametrized(valid_docker_upstream_names()))
     def test_positive_create_with_upstream_name(
         self, module_product, upstream_name, module_target_sat
@@ -156,7 +154,6 @@ class TestDockerRepository:
         assert repo.docker_upstream_name == upstream_name
         assert repo.content_type == 'docker'
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('upstream_name', **parametrized(invalid_docker_upstream_names()))
     def test_negative_create_with_invalid_upstream_name(
         self, module_product, upstream_name, module_target_sat
@@ -176,7 +173,6 @@ class TestDockerRepository:
         with pytest.raises(HTTPError):
             _create_repository(module_target_sat, module_product, upstream_name=upstream_name)
 
-    @pytest.mark.tier2
     def test_positive_create_repos_using_same_product(self, module_product, module_target_sat):
         """Create multiple Docker-type repositories
 
@@ -190,7 +186,6 @@ class TestDockerRepository:
             repo = _create_repository(module_target_sat, module_product)
             assert repo.id in [repo_.id for repo_ in module_product.read().repository]
 
-    @pytest.mark.tier2
     def test_positive_create_repos_using_multiple_products(self, module_org, module_target_sat):
         """Create multiple Docker-type repositories on multiple products
 
@@ -208,7 +203,6 @@ class TestDockerRepository:
                 product = product.read()
                 assert repo.id in [repo_.id for repo_ in product.repository]
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(valid_docker_repository_names()))
     def test_positive_update_name(self, repo, new_name):
         """Create a Docker-type repository and update its name.
@@ -226,7 +220,6 @@ class TestDockerRepository:
         repo = repo.update()
         assert repo.name == new_name
 
-    @pytest.mark.tier1
     def test_positive_update_upstream_name(self, repo):
         """Create a Docker-type repository and update its upstream name.
 
@@ -245,7 +238,6 @@ class TestDockerRepository:
         repo = repo.update()
         assert repo.docker_upstream_name == new_upstream_name
 
-    @pytest.mark.tier2
     def test_positive_update_url(self, repo):
         """Create a Docker-type repository and update its URL.
 
@@ -265,7 +257,6 @@ class TestDockerRepository:
         assert repo.url == new_url
         assert repo.url != settings.container.registry_hub
 
-    @pytest.mark.tier1
     def test_positive_delete(self, repo):
         """Create and delete a Docker-type repository
 
@@ -281,7 +272,6 @@ class TestDockerRepository:
         with pytest.raises(HTTPError):
             repo.read()
 
-    @pytest.mark.tier2
     def test_positive_delete_random_repo(self, module_org, module_target_sat):
         """Create Docker-type repositories on multiple products and
         delete a random repository from a random product.
@@ -322,7 +312,6 @@ class TestDockerContentView:
     :team: Phoenix-content
     """
 
-    @pytest.mark.tier2
     def test_positive_add_synced_docker_repo(self, module_org, module_product, module_target_sat):
         """Create and sync a Docker-type repository
 
@@ -344,7 +333,6 @@ class TestDockerContentView:
         content_view = content_view.update(['repository'])
         assert repo.id in [repo_.id for repo_ in content_view.repository]
 
-    @pytest.mark.tier2
     def test_positive_add_docker_repos_to_ccv(self, module_org, module_target_sat):
         """Add multiple Docker-type repositories to a composite
         content view.
@@ -381,7 +369,6 @@ class TestDockerContentView:
             comp_content_view = comp_content_view.update(['component'])
             assert cv_version.id in [component.id for component in comp_content_view.component]
 
-    @pytest.mark.tier2
     def test_positive_publish_with_docker_repo_composite(self, module_org, module_target_sat):
         """Add Docker-type repository to composite content view and
         publish it once.
@@ -432,7 +419,6 @@ class TestDockerContentView:
         assert comp_content_view.last_published is not None
         assert float(comp_content_view.next_version) > 1.0
 
-    @pytest.mark.tier2
     def test_positive_promote_multiple_with_docker_repo(self, module_org, module_target_sat):
         """Add Docker-type repository to content view and publish it.
         Then promote it to multiple available lifecycle-environments.
@@ -463,7 +449,6 @@ class TestDockerContentView:
             assert len(cvv.read().environment) == i + 1
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     def test_positive_promote_multiple_with_docker_repo_composite(
         self, module_org, module_target_sat
     ):
@@ -514,7 +499,6 @@ class TestDockerActivationKey:
     :team: Phoenix-subscriptions
     """
 
-    @pytest.mark.tier2
     def test_positive_add_docker_repo_cv(
         self, module_lce, module_org, repo, content_view_publish_promote, module_target_sat
     ):
@@ -534,7 +518,6 @@ class TestDockerActivationKey:
         assert ak.content_view.id == content_view.id
         assert ak.content_view.read().repository[0].id == repo.id
 
-    @pytest.mark.tier2
     def test_positive_remove_docker_repo_cv(
         self, module_org, module_lce, content_view_publish_promote, module_target_sat
     ):
@@ -555,7 +538,6 @@ class TestDockerActivationKey:
         ak.content_view = None
         assert ak.update(['content_view']).content_view is None
 
-    @pytest.mark.tier2
     def test_positive_add_docker_repo_ccv(
         self, content_view_version, module_lce, module_org, module_target_sat
     ):
@@ -586,7 +568,6 @@ class TestDockerActivationKey:
         ).create()
         assert ak.content_view.id == comp_content_view.id
 
-    @pytest.mark.tier2
     def test_positive_remove_docker_repo_ccv(
         self, module_lce, module_org, content_view_version, module_target_sat
     ):

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -29,7 +29,6 @@ from robottelo.utils.datafactory import (
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_CRUD_with_attributes(
     session_puppet_enabled_sat, module_puppet_org, module_puppet_loc
@@ -100,7 +99,6 @@ def test_positive_CRUD_with_attributes(
         environment.read()
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_environments_list()))
 def test_positive_create_with_name(name, session_puppet_enabled_sat):
     """Create an environment and provide a valid name.
@@ -115,7 +113,6 @@ def test_positive_create_with_name(name, session_puppet_enabled_sat):
     assert env.name == name
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
 def test_negative_create_with_too_long_name(name, session_puppet_enabled_sat):
     """Create an environment and provide an invalid name.
@@ -130,7 +127,6 @@ def test_negative_create_with_too_long_name(name, session_puppet_enabled_sat):
         session_puppet_enabled_sat.api.Environment(name=name).create()
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_environments_list()))
 def test_negative_create_with_invalid_characters(name, session_puppet_enabled_sat):
     """Create an environment and provide an illegal name.
@@ -145,7 +141,6 @@ def test_negative_create_with_invalid_characters(name, session_puppet_enabled_sa
         session_puppet_enabled_sat.api.Environment(name=name).create()
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(valid_environments_list()))
 def test_positive_update_name(module_puppet_environment, new_name, session_puppet_enabled_sat):
     """Create environment entity providing the initial name, then
@@ -163,7 +158,6 @@ def test_positive_update_name(module_puppet_environment, new_name, session_puppe
     assert env.name == new_name
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
 def test_negative_update_name(module_puppet_environment, new_name, session_puppet_enabled_sat):
     """Create environment entity providing the initial name, then
@@ -191,7 +185,6 @@ Satellite may assign to fields.
 """
 
 
-@pytest.mark.tier2
 def test_positive_update_loc(module_puppet_environment):
     """Update an environment. Inspect the server's response.
 
@@ -207,7 +200,6 @@ def test_positive_update_loc(module_puppet_environment):
     assert len(names & attributes) >= 1, f'None of {names} are in {attributes}'
 
 
-@pytest.mark.tier2
 def test_positive_update_org(module_puppet_environment):
     """Update an environment. Inspect the server's response.
 

--- a/tests/foreman/api/test_eol_banner.py
+++ b/tests/foreman/api/test_eol_banner.py
@@ -22,7 +22,6 @@ from robottelo.constants import LIFECYCLE_METADATA_FILE
 from robottelo.logging import logger
 
 
-@pytest.mark.tier2
 def test_positive_check_eol_date(target_sat):
     """Check if the EOL date for the satellite version
 

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -508,7 +508,6 @@ def _publish_and_wait(sat, org, cv, search_rate=1, max_tries=10):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
 @pytest.mark.e2e
@@ -655,7 +654,6 @@ def test_positive_install_in_hc(
         )
 
 
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
 @pytest.mark.e2e
@@ -939,7 +937,6 @@ def test_positive_install_multiple_in_host(
     )
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_list_sorted_filtered(custom_repo, target_sat):
     """View, sort, and filter all errata specific to repository.
@@ -1065,7 +1062,6 @@ def setup_content_rhel8(
     return _result if return_result else None
 
 
-@pytest.mark.tier2
 def test_positive_get_count_for_host(
     setup_content_rhel8, activation_key, rhel8_contenthost, module_target_sat
 ):
@@ -1133,7 +1129,6 @@ def test_positive_get_count_for_host(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier3
 def test_positive_get_applicable_for_host(
     setup_content_rhel8, activation_key, rhel8_contenthost, target_sat
 ):
@@ -1199,7 +1194,6 @@ def test_positive_get_applicable_for_host(
     assert REAL_RHEL8_1_ERRATA_ID in [errata['errata_id'] for errata in erratum]
 
 
-@pytest.mark.tier3
 def test_positive_get_diff_for_cv_envs(target_sat):
     """Generate a difference in errata between a set of environments
     for a content view
@@ -1253,7 +1247,6 @@ def test_positive_get_diff_for_cv_envs(target_sat):
     assert {cvv_id for cvv_id in cvv_ids} == set(both_cvvs_errata['comparison'])
 
 
-@pytest.mark.tier3
 def test_positive_incremental_update_required(
     module_sca_manifest_org,
     module_lce,
@@ -1370,7 +1363,6 @@ def rh_repo_module_manifest(module_sca_manifest_org, module_target_sat):
     return rh_repo
 
 
-@pytest.mark.tier3
 def test_positive_incremental_update_apply_to_envs_cvs(
     target_sat,
     module_sca_manifest_org,

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -28,7 +28,6 @@ def module_perms(module_target_sat):
     )
 
 
-@pytest.mark.tier1
 def test_positive_create_with_permission(module_perms, module_target_sat):
     """Create a filter and assign it some permissions.
 
@@ -45,7 +44,6 @@ def test_positive_create_with_permission(module_perms, module_target_sat):
     assert filter_perms == perms
 
 
-@pytest.mark.tier1
 def test_positive_delete(module_perms, module_target_sat):
     """Create a filter and delete it afterwards.
 
@@ -61,7 +59,6 @@ def test_positive_delete(module_perms, module_target_sat):
         filter_.read()
 
 
-@pytest.mark.tier1
 def test_positive_delete_role(module_perms, module_target_sat):
     """Create a filter and delete the role it points at.
 

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -16,7 +16,6 @@ import pytest
 from requests.exceptions import HTTPError
 
 
-@pytest.mark.tier1
 def test_negative_fetch_non_existent_task(target_sat):
     """Fetch a non-existent task.
 
@@ -30,7 +29,6 @@ def test_negative_fetch_non_existent_task(target_sat):
         target_sat.api.ForemanTask(id='abc123').read()
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 @pytest.mark.e2e
 def test_positive_get_summary(target_sat):

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -34,7 +34,6 @@ def update_smart_proxy(smart_proxy_location, smart_proxy):
         smart_proxy.update(['location'])
 
 
-@pytest.mark.tier1
 def test_positive_get_search(target_sat):
     """GET ``api/v2/hosts`` and specify the ``search`` parameter.
 
@@ -55,7 +54,6 @@ def test_positive_get_search(target_sat):
     assert response.json()['search'] == query
 
 
-@pytest.mark.tier1
 def test_positive_get_per_page(target_sat):
     """GET ``api/v2/hosts`` and specify the ``per_page`` parameter.
 
@@ -77,7 +75,6 @@ def test_positive_get_per_page(target_sat):
     assert response.json()['per_page'] == per_page
 
 
-@pytest.mark.tier2
 def test_positive_search_by_org_id(target_sat):
     """Search for host by specifying host's organization id
 
@@ -99,7 +96,6 @@ def test_positive_search_by_org_id(target_sat):
     assert results[0].id == host.id
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('owner_type', ['User', 'Usergroup'])
 def test_negative_create_with_owner_type(owner_type, target_sat):
     """Create a host and specify only ``owner_type``.
@@ -117,7 +113,6 @@ def test_negative_create_with_owner_type(owner_type, target_sat):
     assert str(422) in str(error)
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('owner_type', ['User', 'Usergroup'])
 def test_positive_update_owner_type(
     owner_type, module_org, module_location, module_user, module_target_sat
@@ -147,7 +142,6 @@ def test_positive_update_owner_type(
     assert host.owner.read() == owners[owner_type]
 
 
-@pytest.mark.tier1
 def test_positive_create_and_update_with_name(target_sat):
     """Create and update a host with different names and minimal input parameters
 
@@ -166,7 +160,6 @@ def test_positive_create_and_update_with_name(target_sat):
     assert host.name == f'{new_name}.{host.domain.read().name}'
 
 
-@pytest.mark.tier1
 def test_positive_create_and_update_with_ip(target_sat):
     """Create and update host with IP address specified
 
@@ -185,7 +178,6 @@ def test_positive_create_and_update_with_ip(target_sat):
     assert host.ip == new_ip_addr
 
 
-@pytest.mark.tier1
 def test_positive_create_and_update_mac(target_sat):
     """Create host with MAC address and update it
 
@@ -205,7 +197,6 @@ def test_positive_create_and_update_mac(target_sat):
     assert host.mac == new_mac
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_with_hostgroup(
     module_org, module_location, module_lce, module_published_cv, module_target_sat
 ):
@@ -241,7 +232,6 @@ def test_positive_create_and_update_with_hostgroup(
     assert host.hostgroup.read().name == new_hostgroup.name
 
 
-@pytest.mark.tier2
 def test_positive_create_inherit_lce_cv(
     module_default_org_view, module_lce_library, module_org, module_target_sat
 ):
@@ -268,7 +258,6 @@ def test_positive_create_inherit_lce_cv(
     assert host.content_facet_attributes['content_view']['id'] == hostgroup.content_view.id
 
 
-@pytest.mark.tier2
 def test_positive_create_with_inherited_params(module_org, module_location, module_target_sat):
     """Create a new Host in organization and location with parameters
 
@@ -304,7 +293,6 @@ def test_positive_create_with_inherited_params(module_org, module_location, modu
     assert expected_params == {(param['name'], param['value']) for param in host.all_parameters}
 
 
-@pytest.mark.tier1
 def test_positive_create_and_update_with_puppet_proxy(
     session_puppet_enabled_sat, session_puppet_enabled_proxy
 ):
@@ -326,7 +314,6 @@ def test_positive_create_and_update_with_puppet_proxy(
     assert new_host.puppet_proxy.read().name == session_puppet_enabled_proxy.name
 
 
-@pytest.mark.tier1
 def test_positive_create_with_puppet_ca_proxy(
     session_puppet_enabled_sat, session_puppet_enabled_proxy
 ):
@@ -349,7 +336,6 @@ def test_positive_create_with_puppet_ca_proxy(
     assert new_host.puppet_ca_proxy.read().name == session_puppet_enabled_proxy.name
 
 
-@pytest.mark.tier2
 @pytest.mark.e2e
 def test_positive_end_to_end_with_puppet_class(
     module_puppet_org,
@@ -394,7 +380,6 @@ def test_positive_end_to_end_with_puppet_class(
     }
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_with_subnet(
     module_location, module_org, module_default_subnet, module_target_sat
 ):
@@ -416,7 +401,6 @@ def test_positive_create_and_update_with_subnet(
     assert host.subnet.read().name == new_subnet.name
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_with_compresource(
     module_org, module_location, module_cr_libvirt, module_target_sat
 ):
@@ -439,7 +423,6 @@ def test_positive_create_and_update_with_compresource(
     assert host.compute_resource.read().name == new_compresource.name
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_with_model(module_model, module_target_sat):
     """Create and update a host with model specified
 
@@ -455,7 +438,6 @@ def test_positive_create_and_update_with_model(module_model, module_target_sat):
     assert host.model.read().name == new_model.name
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_with_user(
     module_org, module_location, module_user, module_target_sat
 ):
@@ -477,7 +459,6 @@ def test_positive_create_and_update_with_user(
     assert host.owner.read() == new_user
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_with_usergroup(
     module_org, module_location, function_role, module_target_sat
 ):
@@ -504,7 +485,6 @@ def test_positive_create_and_update_with_usergroup(
     assert host.owner.read().name == new_usergroup.name
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('build', [True, False])
 def test_positive_create_and_update_with_build_parameter(build, target_sat):
     """Create and update a host with 'build' parameter specified.
@@ -526,7 +506,6 @@ def test_positive_create_and_update_with_build_parameter(build, target_sat):
     assert host.build == (not build)
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('enabled', [True, False], ids=['enabled', 'disabled'])
 def test_positive_create_and_update_with_enabled_parameter(enabled, target_sat):
     """Create and update a host with 'enabled' parameter specified.
@@ -549,7 +528,6 @@ def test_positive_create_and_update_with_enabled_parameter(enabled, target_sat):
     assert host.enabled == (not enabled)
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('managed', [True, False], ids=['managed', 'unmanaged'])
 def test_positive_create_and_update_with_managed_parameter(managed, target_sat):
     """Create and update a host with managed parameter specified.
@@ -572,7 +550,6 @@ def test_positive_create_and_update_with_managed_parameter(managed, target_sat):
     assert host.managed == (not managed)
 
 
-@pytest.mark.tier1
 def test_positive_create_and_update_with_comment(target_sat):
     """Create and update a host with a comment
 
@@ -591,7 +568,6 @@ def test_positive_create_and_update_with_comment(target_sat):
     assert host.comment == new_comment
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_with_compute_profile(module_compute_profile, module_target_sat):
     """Create and update a host with a compute profile specified
 
@@ -608,7 +584,6 @@ def test_positive_create_and_update_with_compute_profile(module_compute_profile,
     assert host.compute_profile.read().name == new_cprofile.name
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_with_content_view(
     module_org, module_location, module_default_org_view, module_lce_library, module_target_sat
 ):
@@ -638,7 +613,6 @@ def test_positive_create_and_update_with_content_view(
     assert host.content_facet_attributes['lifecycle_environment']['id'] == module_lce_library.id
 
 
-@pytest.mark.tier1
 @pytest.mark.e2e
 def test_positive_end_to_end_with_host_parameters(module_org, module_location, module_target_sat):
     """Create a host with a host parameters specified
@@ -674,7 +648,6 @@ def test_positive_end_to_end_with_host_parameters(module_org, module_location, m
     assert 'id' in host.host_parameters_attributes[0]
 
 
-@pytest.mark.tier2
 @pytest.mark.e2e
 def test_positive_end_to_end_with_image(
     module_org, module_location, module_cr_libvirt, module_libvirt_image, module_target_sat
@@ -704,7 +677,6 @@ def test_positive_end_to_end_with_image(
     assert host.image.id == module_libvirt_image.id
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('method', ['build', 'image'])
 def test_positive_create_with_provision_method(
     method, module_org, module_location, module_cr_libvirt, module_target_sat
@@ -729,7 +701,6 @@ def test_positive_create_with_provision_method(
     assert host.provision_method == method
 
 
-@pytest.mark.tier1
 def test_positive_delete(target_sat):
     """Delete a host
 
@@ -745,7 +716,6 @@ def test_positive_delete(target_sat):
         host.read()
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_domain(
     module_org, module_location, module_domain, module_target_sat
 ):
@@ -768,7 +738,6 @@ def test_positive_create_and_update_domain(
     assert host.domain.read().name == new_domain.name
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_env(
     module_puppet_org, module_puppet_loc, module_puppet_environment, session_puppet_enabled_sat
 ):
@@ -793,7 +762,6 @@ def test_positive_create_and_update_env(
     assert host.environment.read().name == new_env.name
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_arch(module_architecture, module_target_sat):
     """Create and update a host with an architecture
 
@@ -810,7 +778,6 @@ def test_positive_create_and_update_arch(module_architecture, module_target_sat)
     assert host.architecture.read().name == new_arch.name
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_os(module_os, module_target_sat):
     """Create and update a host with an operating system
 
@@ -832,7 +799,6 @@ def test_positive_create_and_update_os(module_os, module_target_sat):
     assert host.operatingsystem.read().name == new_os.name
 
 
-@pytest.mark.tier2
 def test_positive_create_and_update_medium(module_org, module_location, module_target_sat):
     """Create and update a host with a medium
 
@@ -858,7 +824,6 @@ def test_positive_create_and_update_medium(module_org, module_location, module_t
     assert host.medium.read().name == new_medium.name
 
 
-@pytest.mark.tier1
 def test_negative_update_name(module_host):
     """Attempt to update a host with invalid or empty name
 
@@ -876,7 +841,6 @@ def test_negative_update_name(module_host):
     assert host.read().name != f'{new_name}.{host.domain.read().name}'.lower()
 
 
-@pytest.mark.tier1
 def test_negative_update_mac(module_host):
     """Attempt to update a host with invalid or empty MAC address
 
@@ -894,7 +858,6 @@ def test_negative_update_mac(module_host):
     assert host.read().mac != new_mac
 
 
-@pytest.mark.tier2
 def test_negative_update_arch(module_architecture, module_target_sat):
     """Attempt to update a host with an architecture, which does not belong
     to host's operating system
@@ -910,7 +873,6 @@ def test_negative_update_arch(module_architecture, module_target_sat):
     assert host.read().architecture.read().name != module_architecture.name
 
 
-@pytest.mark.tier2
 def test_negative_update_os(target_sat):
     """Attempt to update a host with an operating system, which is not
     associated with host's medium
@@ -929,7 +891,6 @@ def test_negative_update_os(target_sat):
     assert host.read().operatingsystem.read().name != new_os.name
 
 
-@pytest.mark.tier3
 def test_positive_read_content_source_id(
     module_org, module_location, module_lce, module_published_cv, target_sat
 ):
@@ -963,7 +924,6 @@ def test_positive_read_content_source_id(
     assert content_source_id == proxy.id
 
 
-@pytest.mark.tier3
 def test_positive_update_content_source_id(
     module_org, module_location, module_lce, module_published_cv, target_sat
 ):
@@ -1002,7 +962,6 @@ def test_positive_update_content_source_id(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_read_enc_information(
     module_puppet_org,
     module_puppet_loc,
@@ -1068,7 +1027,6 @@ def test_positive_read_enc_information(
         assert host_enc_parameters[param['name']] == param['value']
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_add_future_subscription():
     """Attempt to add a future-dated subscription to a content host.
@@ -1085,7 +1043,6 @@ def test_positive_add_future_subscription():
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_add_future_subscription_with_ak():
     """Register a content host with an activation key that has a
@@ -1103,7 +1060,6 @@ def test_positive_add_future_subscription_with_ak():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_negative_auto_attach_future_subscription():
     """Run auto-attach on a content host, with a current and future-dated
@@ -1122,7 +1078,6 @@ def test_negative_auto_attach_future_subscription():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_create_baremetal_with_bios():
     """Create a new Host from provided MAC address
 
@@ -1141,7 +1096,6 @@ def test_positive_create_baremetal_with_bios():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_create_baremetal_with_uefi():
     """Create a new Host from provided MAC address
 
@@ -1160,7 +1114,6 @@ def test_positive_create_baremetal_with_uefi():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_verify_files_with_pxegrub_uefi():
     """Provision a new Host and verify the tftp and dhcpd file
     structure is correct
@@ -1190,7 +1143,6 @@ def test_positive_verify_files_with_pxegrub_uefi():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_verify_files_with_pxegrub_uefi_secureboot():
     """Provision a new Host and verify the tftp and dhcpd file structure is
     correct
@@ -1224,7 +1176,6 @@ def test_positive_verify_files_with_pxegrub_uefi_secureboot():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_verify_files_with_pxegrub2_uefi():
     """Provision a new UEFI Host and verify the tftp and dhcpd file
     structure is correct
@@ -1258,7 +1209,6 @@ def test_positive_verify_files_with_pxegrub2_uefi():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
     """Provision a new UEFI Host and verify the tftp and dhcpd file
     structure is correct
@@ -1291,7 +1241,6 @@ def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
     """
 
 
-@pytest.mark.tier1
 def test_positive_read_puppet_proxy_name(session_puppet_enabled_sat, session_puppet_enabled_proxy):
     """Read a hostgroup created with puppet proxy and inspect server's
     response
@@ -1313,7 +1262,6 @@ def test_positive_read_puppet_proxy_name(session_puppet_enabled_sat, session_pup
     assert session_puppet_enabled_proxy.name == host['puppet_proxy_name']
 
 
-@pytest.mark.tier1
 def test_positive_read_puppet_ca_proxy_name(
     session_puppet_enabled_sat, session_puppet_enabled_proxy
 ):
@@ -1337,7 +1285,6 @@ def test_positive_read_puppet_ca_proxy_name(
     assert session_puppet_enabled_proxy.name == host['puppet_ca_proxy_name']
 
 
-@pytest.mark.tier2
 def test_positive_list_hosts_thin_all(module_target_sat):
     """List hosts with thin=true and per_page=all
 
@@ -1365,7 +1312,6 @@ def test_positive_list_hosts_thin_all(module_target_sat):
 class TestHostInterface:
     """Tests for Host Interfaces"""
 
-    @pytest.mark.tier1
     @pytest.mark.e2e
     def test_positive_create_end_to_end(self, module_host, target_sat):
         """Create update and delete an interface with different names and minimal input
@@ -1388,7 +1334,6 @@ class TestHostInterface:
         with pytest.raises(HTTPError):
             interface.read()
 
-    @pytest.mark.tier1
     def test_negative_end_to_end(self, module_host, target_sat):
         """Attempt to create and update an interface with different invalid entries as names
         (>255 chars, unsupported string types), at the end attempt to remove primary interface
@@ -1422,7 +1367,6 @@ class TestHostInterface:
             pytest.fail("HTTPError 404 raised unexpectedly!")
 
     @pytest.mark.upgrade
-    @pytest.mark.tier1
     def test_positive_delete_and_check_host(self, target_sat):
         """Delete host's interface (not primary) and make sure the host was not
         accidentally removed altogether with the interface
@@ -1450,7 +1394,6 @@ class TestHostInterface:
 class TestHostBulkAction:
     """Tests for host bulk actions."""
 
-    @pytest.mark.tier2
     def test_positive_bulk_destroy(self, module_org, module_target_sat):
         """Destroy multiple hosts make sure that hosts were removed,
         or were not removed when host is excluded from the list.

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -31,7 +31,6 @@ def fake_hosts(module_org, module_target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_name(module_org, name, module_target_sat):
     """Create host collections with different names.
 
@@ -50,7 +49,6 @@ def test_positive_create_with_name(module_org, name, module_target_sat):
     assert host_collection.name == name
 
 
-@pytest.mark.tier1
 def test_positive_list(module_org, module_target_sat):
     """Create new host collection and then retrieve list of all existing
     host collections
@@ -71,7 +69,6 @@ def test_positive_list(module_org, module_target_sat):
     assert len(hc_list) >= 1
 
 
-@pytest.mark.tier1
 def test_positive_list_for_organization(target_sat):
     """Create host collection for specific organization. Retrieve list of
     host collections for that organization
@@ -91,7 +88,6 @@ def test_positive_list_for_organization(target_sat):
 
 
 @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_description(module_org, desc, module_target_sat):
     """Create host collections with different descriptions.
 
@@ -110,7 +106,6 @@ def test_positive_create_with_description(module_org, desc, module_target_sat):
     assert host_collection.description == desc
 
 
-@pytest.mark.tier1
 def test_positive_create_with_limit(module_org, module_target_sat):
     """Create host collections with different limits.
 
@@ -130,7 +125,6 @@ def test_positive_create_with_limit(module_org, module_target_sat):
 
 
 @pytest.mark.parametrize("unlimited", [False, True])
-@pytest.mark.tier1
 def test_positive_create_with_unlimited_hosts(module_org, unlimited, module_target_sat):
     """Create host collection with different values of 'unlimited hosts'
     parameter.
@@ -152,7 +146,6 @@ def test_positive_create_with_unlimited_hosts(module_org, unlimited, module_targ
     assert host_collection.unlimited_hosts == unlimited
 
 
-@pytest.mark.tier1
 def test_positive_create_with_host(module_org, fake_hosts, module_target_sat):
     """Create a host collection that contains a host.
 
@@ -171,7 +164,6 @@ def test_positive_create_with_host(module_org, fake_hosts, module_target_sat):
     assert len(host_collection.host) == 1
 
 
-@pytest.mark.tier1
 def test_positive_create_with_hosts(module_org, fake_hosts, module_target_sat):
     """Create a host collection that contains hosts.
 
@@ -190,7 +182,6 @@ def test_positive_create_with_hosts(module_org, fake_hosts, module_target_sat):
     assert len(host_collection.host) == len(fake_hosts)
 
 
-@pytest.mark.tier2
 def test_positive_add_host(module_org, fake_hosts, module_target_sat):
     """Add a host to host collection.
 
@@ -207,7 +198,6 @@ def test_positive_add_host(module_org, fake_hosts, module_target_sat):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_add_hosts(module_org, fake_hosts, module_target_sat):
     """Add hosts to host collection.
 
@@ -224,7 +214,6 @@ def test_positive_add_hosts(module_org, fake_hosts, module_target_sat):
     assert len(host_collection.host) == len(fake_hosts)
 
 
-@pytest.mark.tier1
 def test_positive_read_host_ids(module_org, fake_hosts, module_target_sat):
     """Read a host collection and look at the ``host_ids`` field.
 
@@ -246,7 +235,6 @@ def test_positive_read_host_ids(module_org, fake_hosts, module_target_sat):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_update_name(module_org, new_name, module_target_sat):
     """Check if host collection name can be updated
 
@@ -264,7 +252,6 @@ def test_positive_update_name(module_org, new_name, module_target_sat):
 
 
 @pytest.mark.parametrize('new_desc', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_update_description(module_org, new_desc, module_target_sat):
     """Check if host collection description can be updated
 
@@ -281,7 +268,6 @@ def test_positive_update_description(module_org, new_desc, module_target_sat):
     assert host_collection.update().description == new_desc
 
 
-@pytest.mark.tier1
 def test_positive_update_limit(module_org, module_target_sat):
     """Check if host collection limit can be updated
 
@@ -299,7 +285,6 @@ def test_positive_update_limit(module_org, module_target_sat):
         assert host_collection.update().max_hosts == limit
 
 
-@pytest.mark.tier1
 def test_positive_update_unlimited_hosts(module_org, module_target_sat):
     """Check if host collection 'unlimited hosts' parameter can be updated
 
@@ -323,7 +308,6 @@ def test_positive_update_unlimited_hosts(module_org, module_target_sat):
         assert host_collection.unlimited_hosts == unlimited
 
 
-@pytest.mark.tier1
 def test_positive_update_host(module_org, fake_hosts, module_target_sat):
     """Update host collection's host.
 
@@ -342,7 +326,6 @@ def test_positive_update_host(module_org, fake_hosts, module_target_sat):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier1
 def test_positive_update_hosts(module_org, fake_hosts, module_target_sat):
     """Update host collection's hosts.
 
@@ -363,7 +346,6 @@ def test_positive_update_hosts(module_org, fake_hosts, module_target_sat):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier1
 def test_positive_delete(module_org, module_target_sat):
     """Check if host collection can be deleted
 
@@ -380,7 +362,6 @@ def test_positive_delete(module_org, module_target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_create_with_invalid_name(module_org, name, module_target_sat):
     """Try to create host collections with different invalid names
 

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -45,7 +45,6 @@ class TestHostGroup:
     """Tests for host group entity."""
 
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     def test_inherit_puppetclass(self, session_puppet_enabled_sat):
         """Host that created from HostGroup entity with PuppetClass
         assigned to it should inherit such puppet class information under
@@ -154,7 +153,6 @@ class TestHostGroup:
         assert host_attrs['all_puppetclasses'][0]['name'] == puppet_class
 
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     def test_rebuild_config(self, module_org, module_location, hostgroup, module_target_sat):
         """'Rebuild orchestration config' of an existing host group
 
@@ -187,7 +185,6 @@ class TestHostGroup:
             == 'Configuration successfully rebuilt.'
         )
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_hostgroups_list()))
     def test_positive_create_with_name(self, name, module_org, module_location, module_target_sat):
         """Create a hostgroup with different names
@@ -205,7 +202,6 @@ class TestHostGroup:
         ).create()
         assert name == hostgroup.name
 
-    @pytest.mark.tier1
     def test_positive_clone(self, hostgroup, target_sat):
         """Create a hostgroup by cloning an existing one
 
@@ -231,7 +227,6 @@ class TestHostGroup:
 
         assert hostgroup_cloned_reduced.items() <= hostgroup_origin.items()
 
-    @pytest.mark.tier1
     def test_positive_create_with_properties(
         self, module_puppet_org, module_puppet_loc, session_puppet_enabled_sat
     ):
@@ -384,7 +379,6 @@ class TestHostGroup:
             hostgroup.read()
 
     @pytest.mark.stubbed('Remove stub once proper infrastructure will be created')
-    @pytest.mark.tier2
     def test_positive_create_with_realm(self, module_org, module_location, target_sat):
         """Create a hostgroup with realm specified
 
@@ -407,7 +401,6 @@ class TestHostGroup:
         ).create()
         assert hostgroup.realm.read().name == realm.name
 
-    @pytest.mark.tier2
     def test_positive_create_with_locs(self, module_org, module_target_sat):
         """Create a hostgroup with multiple locations specified
 
@@ -428,7 +421,6 @@ class TestHostGroup:
         ).create()
         assert {loc.name for loc in locs} == {loc.read().name for loc in hostgroup.location}
 
-    @pytest.mark.tier2
     def test_positive_create_with_orgs(self, target_sat):
         """Create a hostgroup with multiple organizations specified
 
@@ -444,7 +436,6 @@ class TestHostGroup:
         hostgroup = target_sat.api.HostGroup(organization=orgs).create()
         assert {org.name for org in orgs}, {org.read().name for org in hostgroup.organization}
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_hostgroups_list()))
     def test_positive_update_name(self, name, hostgroup):
         """Update a hostgroup with a new name
@@ -461,7 +452,6 @@ class TestHostGroup:
         hostgroup = hostgroup.update(['name'])
         assert name == hostgroup.name
 
-    @pytest.mark.tier2
     def test_positive_update_puppet_ca_proxy(self, puppet_hostgroup, session_puppet_enabled_sat):
         """Update a hostgroup with a new puppet CA proxy
 
@@ -480,7 +470,6 @@ class TestHostGroup:
         assert puppet_hostgroup.puppet_ca_proxy.read().name == new_proxy.name
 
     @pytest.mark.stubbed('Remove stub once proper infrastructure will be created')
-    @pytest.mark.tier2
     def test_positive_update_realm(self, module_org, module_location, target_sat):
         """Update a hostgroup with a new realm
 
@@ -512,7 +501,6 @@ class TestHostGroup:
         hostgroup = hostgroup.update(['realm'])
         assert hostgroup.realm.read().name == new_realm.name
 
-    @pytest.mark.tier2
     def test_positive_update_puppet_proxy(self, puppet_hostgroup, session_puppet_enabled_sat):
         """Update a hostgroup with a new puppet proxy
 
@@ -530,7 +518,6 @@ class TestHostGroup:
         puppet_hostgroup = puppet_hostgroup.update(['puppet_proxy'])
         assert puppet_hostgroup.puppet_proxy.read().name == new_proxy.name
 
-    @pytest.mark.tier2
     def test_positive_update_content_source(self, hostgroup, target_sat):
         """Update a hostgroup with a new puppet proxy
 
@@ -548,7 +535,6 @@ class TestHostGroup:
         hostgroup = hostgroup.update(['content_source'])
         assert hostgroup.content_source.read().name == new_content_source.name
 
-    @pytest.mark.tier2
     def test_positive_update_locs(self, module_org, hostgroup, module_target_sat):
         """Update a hostgroup with new multiple locations
 
@@ -567,7 +553,6 @@ class TestHostGroup:
         hostgroup = hostgroup.update(['location'])
         assert {loc.name for loc in new_locs}, {loc.read().name for loc in hostgroup.location}
 
-    @pytest.mark.tier2
     def test_positive_update_orgs(self, hostgroup, target_sat):
         """Update a hostgroup with new multiple organizations
 
@@ -583,7 +568,6 @@ class TestHostGroup:
         hostgroup = hostgroup.update(['organization'])
         assert {org.name for org in new_orgs} == {org.read().name for org in hostgroup.organization}
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_name(self, name, module_org, module_location, module_target_sat):
         """Attempt to create a hostgroup with invalid names
@@ -601,7 +585,6 @@ class TestHostGroup:
                 location=[module_location], name=name, organization=[module_org]
             ).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, new_name, hostgroup):
         """Attempt to update a hostgroup with invalid names
@@ -620,7 +603,6 @@ class TestHostGroup:
             hostgroup.update(['name'])
         assert hostgroup.read().name == original_name
 
-    @pytest.mark.tier2
     def test_positive_create_with_group_parameters(self, module_org, module_target_sat):
         """Create a hostgroup with 'group parameters' specified
 
@@ -651,7 +633,6 @@ class TestHostGroupMissingAttr:
     Satellite may assign to fields.
     """
 
-    @pytest.mark.tier2
     def test_positive_get_content_source(self, hostgroup, module_target_sat):
         """Read a host group. Inspect the server's response.
 
@@ -669,7 +650,6 @@ class TestHostGroupMissingAttr:
             f'{names.difference(hostgroup_attrs)} not found in {hostgroup_attrs}'
         )
 
-    @pytest.mark.tier2
     def test_positive_get_cv(self, hostgroup, module_target_sat):
         """Read a host group. Inspect the server's response.
 
@@ -687,7 +667,6 @@ class TestHostGroupMissingAttr:
             f'{names.difference(hostgroup_attrs)} not found in {hostgroup_attrs}'
         )
 
-    @pytest.mark.tier2
     def test_positive_get_lce(self, hostgroup, module_target_sat):
         """Read a host group. Inspect the server's response.
 
@@ -705,7 +684,6 @@ class TestHostGroupMissingAttr:
             f'{names.difference(hostgroup_attrs)} not found in {hostgroup_attrs}'
         )
 
-    @pytest.mark.tier2
     def test_positive_read_puppet_proxy_name(self, session_puppet_enabled_sat):
         """Read a hostgroup created with puppet proxy and inspect server's
         response
@@ -726,7 +704,6 @@ class TestHostGroupMissingAttr:
         assert 'puppet_proxy_name' in hg
         assert proxy.name == hg['puppet_proxy_name']
 
-    @pytest.mark.tier2
     def test_positive_read_puppet_ca_proxy_name(self, session_puppet_enabled_sat):
         """Read a hostgroup created with puppet ca proxy and inspect server's
         response

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -20,7 +20,6 @@ from robottelo.config import settings
 from robottelo.constants.repos import ANSIBLE_GALAXY, CUSTOM_FILE_REPO
 
 
-@pytest.mark.tier2
 @pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
@@ -153,7 +152,6 @@ def test_positive_end_to_end(
     indirect=True,
     ids=['auth_http_proxy', 'unauth_http_proxy'],
 )
-@pytest.mark.tier3
 def test_positive_install_content_with_http_proxy(
     setup_http_proxy, module_target_sat, rhel_contenthost, function_sca_manifest_org
 ):
@@ -225,7 +223,6 @@ def test_positive_install_content_with_http_proxy(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 def test_positive_assign_http_proxy_to_products(target_sat, function_org):
     """Assign http_proxy to Products and check whether http-proxy is
      used during sync.
@@ -288,7 +285,6 @@ def test_positive_assign_http_proxy_to_products(target_sat, function_org):
     assert 'success' in product_a.sync()['result'], 'Product sync failed'
 
 
-@pytest.mark.tier2
 def test_positive_sync_proxy_with_certificate(request, target_sat, module_org, module_product):
     """Assign http_proxy with cacert.crt to repository and test
        that http_proxy and cacert are used during sync.

--- a/tests/foreman/api/test_ldapauthsource.py
+++ b/tests/foreman/api/test_ldapauthsource.py
@@ -19,7 +19,6 @@ from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 from robottelo.utils.datafactory import generate_strings_list
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize('auth_source_type', ['AD', 'IPA'])
 def test_positive_endtoend(

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -41,7 +41,6 @@ def lce(module_org, module_target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_name(name, target_sat):
     """Create lifecycle environment with valid name only
 
@@ -57,7 +56,6 @@ def test_positive_create_with_name(name, target_sat):
 
 
 @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_description(desc, target_sat):
     """Create lifecycle environment with valid description
 
@@ -73,7 +71,6 @@ def test_positive_create_with_description(desc, target_sat):
     assert target_sat.api.LifecycleEnvironment(description=desc).create().description == desc
 
 
-@pytest.mark.tier1
 def test_positive_create_prior(module_org, module_target_sat):
     """Create a lifecycle environment with valid name with Library as
     prior
@@ -90,7 +87,6 @@ def test_positive_create_prior(module_org, module_target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-@pytest.mark.tier3
 def test_negative_create_with_invalid_name(name, target_sat):
     """Create lifecycle environment providing an invalid name
 
@@ -107,7 +103,6 @@ def test_negative_create_with_invalid_name(name, target_sat):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_update_name(module_lce, new_name, module_target_sat):
     """Create lifecycle environment providing the initial name, then
     update its name to another valid name.
@@ -125,7 +120,6 @@ def test_positive_update_name(module_lce, new_name, module_target_sat):
 
 
 @pytest.mark.parametrize('new_desc', **parametrized(valid_data_list()))
-@pytest.mark.tier2
 def test_positive_update_description(module_lce, new_desc, module_target_sat):
     """Create lifecycle environment providing the initial
     description, then update its description to another one.
@@ -145,7 +139,6 @@ def test_positive_update_description(module_lce, new_desc, module_target_sat):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
-@pytest.mark.tier1
 def test_negative_update_name(module_lce, new_name):
     """Update lifecycle environment providing an invalid name
 
@@ -166,7 +159,6 @@ def test_negative_update_name(module_lce, new_name):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_delete(lce, name, target_sat):
     """Create lifecycle environment and then delete it.
@@ -185,7 +177,6 @@ def test_positive_delete(lce, name, target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier2
 def test_positive_search_in_org(name, target_sat):
     """Search for a lifecycle environment and specify an org ID.
 
@@ -209,7 +200,6 @@ def test_positive_search_in_org(name, target_sat):
     assert {lc_env_.name for lc_env_ in lc_envs}, {'Library', lc_env.name}
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed('Implement once BZ1348727 is fixed')
 def test_positive_create_environment_after_host_register():
     """Verify that no error is thrown when creating an environment after

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -81,7 +81,6 @@ class TestLocation:
             new_user=target_sat.api.User().create(),
         )
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_loc_data_list()))
     def test_positive_create_with_name(self, name, target_sat):
         """Create new locations using different inputs as a name
@@ -98,7 +97,6 @@ class TestLocation:
         location = target_sat.api.Location(name=name).create()
         assert location.name == name
 
-    @pytest.mark.tier1
     def test_positive_create_and_delete_with_comma_separated_name(self, target_sat):
         """Create new location using name that has comma inside, delete location
 
@@ -113,7 +111,6 @@ class TestLocation:
         with pytest.raises(HTTPError):
             location.read()
 
-    @pytest.mark.tier2
     def test_positive_create_and_update_with_org(self, make_orgs, target_sat):
         """Create new location with assigned organization to it
 
@@ -132,7 +129,6 @@ class TestLocation:
         location = location.update(['organization'])
         assert {org.id for org in orgs} == {org.id for org in location.organization}
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_name(self, name, target_sat):
         """Attempt to create new location using invalid names only
@@ -148,7 +144,6 @@ class TestLocation:
         with pytest.raises(HTTPError):
             target_sat.api.Location(name=name).create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_same_name(self, target_sat):
         """Attempt to create new location using name of existing entity
 
@@ -164,7 +159,6 @@ class TestLocation:
         with pytest.raises(HTTPError):
             target_sat.api.Location(name=name).create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_domain(self, target_sat):
         """Attempt to create new location using non-existent domain identifier
 
@@ -176,7 +170,6 @@ class TestLocation:
         with pytest.raises(HTTPError):
             target_sat.api.Location(domain=[gen_integer(10000, 99999)]).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(valid_loc_data_list()))
     def test_positive_update_name(self, new_name, target_sat):
         """Update location with new name
@@ -193,7 +186,6 @@ class TestLocation:
         location.name = new_name
         assert location.update(['name']).name == new_name
 
-    @pytest.mark.tier2
     def test_positive_update_entities(self, make_entities, target_sat):
         """Update location with new domain
 
@@ -229,7 +221,6 @@ class TestLocation:
         assert location.update(['user']).user[0].id == make_entities["new_user"].id
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier2
     def test_positive_create_update_and_remove_capsule(self, make_proxies, target_sat):
         """Update location with new capsule
 
@@ -258,7 +249,6 @@ class TestLocation:
         location = location.update(['smart_proxy'])
         assert len(location.smart_proxy) == 0
 
-    @pytest.mark.tier2
     def test_negative_update_domain(self, target_sat):
         """Try to update existing location with incorrect domain. Use
         domain id
@@ -274,7 +264,6 @@ class TestLocation:
         with pytest.raises(HTTPError):
             assert location.update(['domain']).domain[0].id != domain.id
 
-    @pytest.mark.tier1
     def test_default_loc_id_check(self, target_sat):
         """test to check the default_location id
 
@@ -290,7 +279,6 @@ class TestLocation:
         )
         assert default_loc_id == 2
 
-    @pytest.mark.tier1
     def test_positive_get_location_by_name(self, make_entities, target_sat):
         """test to search location by name
 

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -33,7 +33,6 @@ class TestMedia:
     def class_media(self, module_org, class_target_sat):
         return class_target_sat.api.Media(organization=[module_org]).create()
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         ('name', 'new_name'),
@@ -60,7 +59,6 @@ class TestMedia:
         with pytest.raises(HTTPError):
             media.read()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('os_family', **parametrized(OPERATING_SYSTEMS))
     def test_positive_create_update_with_os_family(self, module_org, os_family, module_target_sat):
         """Create and update media with every OS family possible
@@ -78,7 +76,6 @@ class TestMedia:
         media.os_family = new_os_family
         assert media.update(['os_family']).os_family == new_os_family
 
-    @pytest.mark.tier2
     def test_positive_create_with_location(self, module_org, module_location, module_target_sat):
         """Create media entity assigned to non-default location
 
@@ -92,7 +89,6 @@ class TestMedia:
         ).create()
         assert media.location[0].read().name == module_location.name
 
-    @pytest.mark.tier2
     def test_positive_create_with_os(self, module_org, module_target_sat):
         """Create media entity assigned to operation system entity
 
@@ -107,7 +103,6 @@ class TestMedia:
         ).create()
         assert os.read().medium[0].read().name == media.name
 
-    @pytest.mark.tier2
     def test_positive_create_update_url(self, module_org, module_target_sat):
         """Create media entity providing the initial url path, then
         update that url to another valid one.
@@ -125,7 +120,6 @@ class TestMedia:
         media = module_target_sat.api.Media(id=media.id, path_=new_url).update(['path_'])
         assert media.path_ == new_url
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_invalid_name(self, name, target_sat):
         """Try to create media entity providing an invalid name
@@ -141,7 +135,6 @@ class TestMedia:
         with pytest.raises(HTTPError):
             target_sat.api.Media(name=name).create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_invalid_url(self, target_sat):
         """Try to create media entity providing an invalid URL
 
@@ -154,7 +147,6 @@ class TestMedia:
         with pytest.raises(HTTPError):
             target_sat.api.Media(path_='NON_EXISTENT_URL').create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_invalid_os_family(self, target_sat):
         """Try to create media entity providing an invalid OS family
 
@@ -167,7 +159,6 @@ class TestMedia:
         with pytest.raises(HTTPError):
             target_sat.api.Media(os_family='NON_EXISTENT_OS').create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, class_media, new_name, target_sat):
         """Create media entity providing the initial name, then try to
@@ -184,7 +175,6 @@ class TestMedia:
         with pytest.raises(HTTPError):
             target_sat.api.Media(id=class_media.id, name=new_name).update(['name'])
 
-    @pytest.mark.tier1
     def test_negative_update_url(self, class_media, target_sat):
         """Try to update media with invalid url.
 
@@ -197,7 +187,6 @@ class TestMedia:
         with pytest.raises(HTTPError):
             target_sat.api.Media(id=class_media.id, path_='NON_EXISTENT_URL').update(['path_'])
 
-    @pytest.mark.tier1
     def test_negative_update_os_family(self, class_media, target_sat):
         """Try to update media with invalid operation system.
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -111,7 +111,6 @@ def get_entities_for_unauthorized(all_entities, exclude_entities, max_num=10):
 class TestEntity:
     """Issue HTTP requests to various ``entity/`` paths."""
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'entity_cls',
         **parametrized(VALID_ENTITIES - STATUS_CODE_ENTITIES),
@@ -134,7 +133,6 @@ class TestEntity:
         assert response.status_code == http.client.OK
         assert 'application/json' in response.headers['content-type']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'entity_cls',
         **parametrized(get_entities_for_unauthorized(VALID_ENTITIES, {entities.ActivationKey})),
@@ -154,7 +152,6 @@ class TestEntity:
         response = client.get(entity_cls().path(), auth=(), verify=False)
         assert response.status_code == http.client.UNAUTHORIZED
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'entity_cls',
         **parametrized(get_entities_for_unauthorized(VALID_ENTITIES, {entities.TemplateKind})),
@@ -177,7 +174,6 @@ class TestEntity:
         assert response.status_code == http.client.CREATED
         assert 'application/json' in response.headers['content-type']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'entity_cls',
         **parametrized(get_entities_for_unauthorized(VALID_ENTITIES, {entities.TemplateKind})),
@@ -202,7 +198,6 @@ class TestEntity:
 class TestEntityId:
     """Issue HTTP requests to various ``entity/:id`` paths."""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('entity_cls', **parametrized(VALID_ENTITIES - {entities.TemplateKind}))
     def test_positive_get_status_code(self, entity_cls):
         """Create an entity and GET it.
@@ -221,7 +216,6 @@ class TestEntityId:
         assert response.status_code == http.client.OK
         assert 'application/json' in response.headers['content-type']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('entity_cls', **parametrized(VALID_ENTITIES - {entities.TemplateKind}))
     def test_positive_put_status_code(self, entity_cls):
         """Issue a PUT request and check the returned status code.
@@ -252,7 +246,6 @@ class TestEntityId:
         assert response.status_code == http.client.OK
         assert 'application/json' in response.headers['content-type']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('entity_cls', **parametrized(VALID_ENTITIES - {entities.TemplateKind}))
     def test_positive_delete_status_code(self, entity_cls):
         """Issue an HTTP DELETE request and check the returned status
@@ -290,7 +283,6 @@ class TestDoubleCheck:
     action to ensure that the intended action was accomplished.
     """
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('entity_cls', **parametrized(VALID_ENTITIES - {entities.TemplateKind}))
     def test_positive_put_and_get_requests(self, entity_cls):
         """Update an entity, then read it back.
@@ -329,7 +321,6 @@ class TestDoubleCheck:
             assert key in entity_attrs
             assert value == entity_attrs[key]
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('entity_cls', **parametrized(VALID_ENTITIES - {entities.TemplateKind}))
     def test_positive_post_and_get_requests(self, entity_cls):
         """Create an entity, then read it back.
@@ -353,7 +344,6 @@ class TestDoubleCheck:
             assert key in entity_attrs
             assert value == entity_attrs[key]
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('entity_cls', **parametrized(VALID_ENTITIES - {entities.TemplateKind}))
     def test_positive_delete_and_get_requests(self, entity_cls):
         """Issue an HTTP DELETE request and GET the deleted entity.
@@ -378,7 +368,6 @@ class TestEntityRead:
     ``nailgun.entity_mixins.EntityReadMixin`` are working properly.
     """
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'entity_cls',
         **parametrized(
@@ -406,7 +395,6 @@ class TestEntityRead:
         entity_id = entity_cls().create_json()['id']
         assert isinstance(entity_cls(id=entity_id).read(), entity_cls)
 
-    @pytest.mark.tier1
     def test_positive_architecture_read(self, target_sat):
         """Create an arch that points to an OS, and read the arch.
 
@@ -423,7 +411,6 @@ class TestEntityRead:
         assert len(architecture.operatingsystem) == 1
         assert architecture.operatingsystem[0].id == os_id
 
-    @pytest.mark.tier1
     def test_positive_syncplan_read(self, target_sat):
         """Create a SyncPlan and read it back using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
@@ -441,7 +428,6 @@ class TestEntityRead:
             target_sat.api.SyncPlan(organization=org_id, id=syncplan_id).read(), entities.SyncPlan
         )
 
-    @pytest.mark.tier1
     def test_positive_osparameter_read(self, target_sat):
         """Create an OperatingSystemParameter and get it using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
@@ -460,7 +446,6 @@ class TestEntityRead:
             target_sat.api.OperatingSystemParameter,
         )
 
-    @pytest.mark.tier1
     def test_positive_permission_read(self, target_sat):
         """Create an Permission entity and get it using
         ``nailgun.entity_mixins.EntityReadMixin.read``.
@@ -476,7 +461,6 @@ class TestEntityRead:
         assert perm.name
         assert perm.resource_type
 
-    @pytest.mark.tier1
     def test_positive_media_read(self, target_sat):
         """Create a media pointing at an OS and read the media.
 

--- a/tests/foreman/api/test_notifications.py
+++ b/tests/foreman/api/test_notifications.py
@@ -275,7 +275,6 @@ def failed_repo_sync_task(target_sat, fake_yum_repo):
     return task_status
 
 
-@pytest.mark.tier3
 @pytest.mark.usefixtures(
     'admin_user_with_localhost_email',
     'reschedule_long_running_tasks_notification',
@@ -327,7 +326,6 @@ def test_positive_notification_for_long_running_tasks(long_running_task, root_ma
                 assert not findall(r'_\("[\w\s]*"\)', body_text), 'Untranslated strings found.'
 
 
-@pytest.mark.tier3
 @pytest.mark.usefixtures(
     'sysadmin_user_with_subscription_reposync_fail',
     'wait_for_failed_repo_sync_mail',
@@ -366,7 +364,6 @@ def test_positive_notification_failed_repo_sync(failed_repo_sync_task, root_mail
                 assert f'/foreman_tasks/tasks/{task_id}' in body_text
 
 
-@pytest.mark.tier1
 def test_positive_notification_recipients(target_sat):
     """Check that endpoint `/notification_recipients` works and returns correct data structure.
 
@@ -395,7 +392,6 @@ def test_positive_notification_recipients(target_sat):
         assert set(notification_keys) == set(notification.keys())
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'admin_user_with_custom_settings',
     [

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -169,7 +169,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             module_target_sat.api.OperatingSystem(id=os.id).read()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_create_with_name(self, name, target_sat):
         """Create operating system with valid name only
@@ -186,7 +185,6 @@ class TestOperatingSystem:
         os = target_sat.api.OperatingSystem(name=name).create()
         assert os.name == name
 
-    @pytest.mark.tier2
     def test_positive_create_with_archs(self, target_sat):
         """Create an operating system that points at multiple different
         architectures.
@@ -203,7 +201,6 @@ class TestOperatingSystem:
         assert len(operating_sys.architecture) == len(amount)
         assert {arch.id for arch in operating_sys.architecture} == {arch.id for arch in archs}
 
-    @pytest.mark.tier2
     def test_positive_create_with_ptables(self, target_sat):
         """Create an operating system that points at multiple different
         partition tables.
@@ -220,7 +217,6 @@ class TestOperatingSystem:
         assert len(operating_sys.ptable) == len(amount)
         assert {ptable.id for ptable in operating_sys.ptable} == {ptable.id for ptable in ptables}
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_invalid_name(self, name, target_sat):
         """Try to create operating system entity providing an invalid
@@ -237,7 +233,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(name=name).create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_invalid_os_family(self, target_sat):
         """Try to create operating system entity providing an invalid
         operating system family
@@ -251,7 +246,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(family='NON_EXISTENT_OS').create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_too_long_description(self, target_sat):
         """Try to create operating system entity providing too long
         description value
@@ -267,7 +261,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(description=gen_string('alphanumeric', 256)).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('major_version', **parametrized((gen_string('numeric', 6), '', '-6')))
     def test_negative_create_with_invalid_major_version(self, major_version, target_sat):
         """Try to create operating system entity providing incorrect
@@ -287,7 +280,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(major=major_version).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('minor_version', **parametrized((gen_string('numeric', 17), '-5')))
     def test_negative_create_with_invalid_minor_version(self, minor_version, target_sat):
         """Try to create operating system entity providing incorrect
@@ -304,7 +296,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(minor=minor_version).create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_invalid_password_hash(self, target_sat):
         """Try to create operating system entity providing invalid
         password hash value
@@ -318,7 +309,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(password_hash='INVALID_HASH').create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_same_name_and_version(self, target_sat):
         """Create operating system providing valid name and major
         version. Then try to create operating system using the same name and
@@ -334,7 +324,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(name=os.name, major=os.major).create()
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_update_medias(self, module_org, module_target_sat):
         """Create an operating system that points at media entity and
@@ -356,7 +345,6 @@ class TestOperatingSystem:
         assert len(os.medium) == len(amount)
         assert {medium.id for medium in os.medium} == {medium.id for medium in medias}
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, new_name, target_sat):
         """Create operating system entity providing the initial name,
@@ -374,7 +362,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             os = target_sat.api.OperatingSystem(id=os.id, name=new_name).update(['name'])
 
-    @pytest.mark.tier1
     def test_negative_update_major_version(self, target_sat):
         """Create operating entity providing the initial major version,
         then update that version to invalid one.
@@ -391,7 +378,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(id=os.id, major='-20').update(['major'])
 
-    @pytest.mark.tier1
     def test_negative_update_minor_version(self, target_sat):
         """Create operating entity providing the initial minor version,
         then update that version to invalid one.
@@ -406,7 +392,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(id=os.id, minor='INVALID_VERSION').update(['minor'])
 
-    @pytest.mark.tier1
     def test_negative_update_os_family(self, target_sat):
         """Create operating entity providing the initial os family, then
         update that family to invalid one.

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -56,7 +56,6 @@ def valid_org_data_list():
 class TestOrganization:
     """Tests for the ``organizations`` path."""
 
-    @pytest.mark.tier1
     def test_positive_create(self, target_sat):
         """Create an organization using a 'text/plain' content-type.
 
@@ -80,7 +79,6 @@ class TestOrganization:
         else:
             assert response.status_code == http.client.UNSUPPORTED_MEDIA_TYPE
 
-    @pytest.mark.tier1
     @pytest.mark.build_sanity
     @pytest.mark.parametrize('name', **parametrized(valid_org_data_list()))
     def test_positive_create_with_name_and_description(self, name, target_sat):
@@ -104,7 +102,6 @@ class TestOrganization:
         assert isinstance(org.label, str)
         assert len(org.label) > 0
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_invalid_name(self, name, target_sat):
         """Create an org with an incorrect name.
@@ -118,7 +115,6 @@ class TestOrganization:
         with pytest.raises(HTTPError):
             target_sat.api.Organization(name=name).create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_same_name(self, target_sat):
         """Create two organizations with identical names.
 
@@ -132,7 +128,6 @@ class TestOrganization:
         with pytest.raises(HTTPError):
             target_sat.api.Organization(name=name).create()
 
-    @pytest.mark.tier1
     def test_negative_check_org_endpoint(self, module_sca_manifest_org):
         """Check manifest cert is not exposed in api endpoint
 
@@ -150,7 +145,6 @@ class TestOrganization:
         assert 'BEGIN CERTIFICATE' not in orgstring
         assert 'BEGIN RSA PRIVATE KEY' not in orgstring
 
-    @pytest.mark.tier1
     def test_positive_search(self, target_sat):
         """Create an organization, then search for it by name.
 
@@ -166,7 +160,6 @@ class TestOrganization:
         assert orgs[0].id == org.id
         assert orgs[0].name == org.name
 
-    @pytest.mark.tier1
     def test_negative_create_with_wrong_path(self, target_sat):
         """Attempt to create an organization using foreman API path
         (``api/v2/organizations``)
@@ -187,7 +180,6 @@ class TestOrganization:
         assert err.value.response.status_code == 404
         assert 'Route overriden by Katello' in err.value.response.text
 
-    @pytest.mark.tier2
     def test_default_org_id_check(self, target_sat):
         """test to check the default_organization id
 
@@ -213,7 +205,6 @@ class TestOrganizationUpdate:
         """Create an organization."""
         return target_sat.api.Organization().create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_org_data_list()))
     def test_positive_update_name(self, module_org, name):
         """Update an organization's name with valid values.
@@ -230,7 +221,6 @@ class TestOrganizationUpdate:
         module_org = module_org.update(['name'])
         assert module_org.name == name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('desc', **parametrized(valid_org_data_list()))
     def test_positive_update_description(self, module_org, desc):
         """Update an organization's description with valid values.
@@ -247,7 +237,6 @@ class TestOrganizationUpdate:
         module_org = module_org.update(['description'])
         assert module_org.description == desc
 
-    @pytest.mark.tier2
     def test_positive_update_user(self, module_org, target_sat):
         """Update an organization, associate user with it.
 
@@ -262,7 +251,6 @@ class TestOrganizationUpdate:
         assert len(module_org.user) == 1
         assert module_org.user[0].id == user.id
 
-    @pytest.mark.tier2
     def test_positive_update_subnet(self, module_org, target_sat):
         """Update an organization, associate subnet with it.
 
@@ -277,7 +265,6 @@ class TestOrganizationUpdate:
         assert len(module_org.subnet) == 1
         assert module_org.subnet[0].id == subnet.id
 
-    @pytest.mark.tier2
     def test_positive_add_and_remove_hostgroup(self, target_sat):
         """Add a hostgroup to an organization and then remove it
 
@@ -299,7 +286,6 @@ class TestOrganizationUpdate:
         assert len(org.hostgroup) == 0
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     def test_positive_add_and_remove_smart_proxy(self, target_sat):
         """Add a smart proxy to an organization
 
@@ -337,7 +323,6 @@ class TestOrganizationUpdate:
         # Verify smart proxy was actually removed
         assert len(org.smart_proxy) == 0
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('update_field', ['name', 'label'])
     def test_negative_update(self, module_org, update_field, target_sat):
         """Update an organization's attributes with invalid values.

--- a/tests/foreman/api/test_oscap_tailoringfiles.py
+++ b/tests/foreman/api/test_oscap_tailoringfiles.py
@@ -20,7 +20,6 @@ from robottelo.utils.datafactory import gen_string
 class TestTailoringFile:
     """Implements Tailoring Files tests in API."""
 
-    @pytest.mark.tier1
     @pytest.mark.e2e
     def test_positive_crud_tailoringfile(
         self, default_org, default_location, tailoring_file_path, target_sat

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -19,7 +19,6 @@ import pytest
 class TestOscapPolicy:
     """Implements Oscap Policy tests in API."""
 
-    @pytest.mark.tier1
     @pytest.mark.e2e
     def test_positive_crud_scap_policy(
         self, default_org, default_location, scap_content, tailoring_file, target_sat

--- a/tests/foreman/api/test_parameters.py
+++ b/tests/foreman/api/test_parameters.py
@@ -15,7 +15,6 @@ from fauxfactory import gen_string
 import pytest
 
 
-@pytest.mark.tier1
 @pytest.mark.e2e
 @pytest.mark.upgrade
 def test_positive_parameter_precedence_impact(

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -34,7 +34,6 @@ from robottelo.utils.datafactory import (
 class TestPartitionTable:
     """Tests for the ``ptables`` path."""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'name', **parametrized(generate_strings_list(length=1, exclude_types='alphanumeric'))
     )
@@ -54,7 +53,6 @@ class TestPartitionTable:
         ptable = target_sat.api.PartitionTable(name=name).create()
         assert ptable.name == name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         ('name', 'new_name'),
         **parametrized(
@@ -90,7 +88,6 @@ class TestPartitionTable:
         with pytest.raises(HTTPError):
             ptable.read()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         ('layout', 'new_layout'),
         **parametrized(list(zip(valid_data_list(), valid_data_list(), strict=True))),
@@ -113,7 +110,6 @@ class TestPartitionTable:
         ptable.layout = new_layout
         assert ptable.update(['layout']).layout == new_layout
 
-    @pytest.mark.tier1
     def test_positive_create_with_layout_length(self, target_sat):
         """Create a Partition Table with layout length more than 4096 chars
 
@@ -128,7 +124,6 @@ class TestPartitionTable:
         ptable = target_sat.api.PartitionTable(layout=layout).create()
         assert ptable.layout == layout
 
-    @pytest.mark.tier1
     def test_positive_create_update_with_os(self, target_sat):
         """Create new partition table with random operating system and update it with
             random operating system
@@ -165,7 +160,6 @@ class TestPartitionTable:
         assert len(result) == 1
         assert result[0].read().organization[0].id == module_org.id
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_invalid_name(self, target_sat, name):
         """Try to create partition table using invalid names only
@@ -181,7 +175,6 @@ class TestPartitionTable:
         with pytest.raises(HTTPError):
             target_sat.api.PartitionTable(name=name).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('layout', **parametrized(('', ' ', None)))
     def test_negative_create_with_empty_layout(self, target_sat, layout):
         """Try to create partition table with empty layout
@@ -195,7 +188,6 @@ class TestPartitionTable:
         with pytest.raises(HTTPError):
             target_sat.api.PartitionTable(layout=layout).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, target_sat, new_name):
         """Try to update partition table using invalid names only
@@ -213,7 +205,6 @@ class TestPartitionTable:
         with pytest.raises(HTTPError):
             assert ptable.update(['name']).name != new_name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_layout', **parametrized(('', ' ', None)))
     def test_negative_update_layout(self, target_sat, new_layout):
         """Try to update partition table with empty layout

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -44,7 +44,6 @@ class TestPermission:
         #: e.g. ['view_architectures', 'create_architectures', …]
         cls.permission_names = list(chain.from_iterable(expected_permissions.values()))
 
-    @pytest.mark.tier1
     def test_positive_search_by_name(self, target_sat):
         """Search for a permission by name.
 
@@ -69,7 +68,6 @@ class TestPermission:
         if failures:
             pytest.fail(json.dumps(failures, indent=True, sort_keys=True))
 
-    @pytest.mark.tier1
     def test_positive_search_by_resource_type(self, target_sat):
         """Search for permissions by resource type.
 
@@ -102,7 +100,6 @@ class TestPermission:
         if failures:
             pytest.fail(json.dumps(failures, indent=True, sort_keys=True))
 
-    @pytest.mark.tier1
     def test_positive_search(self, target_sat):
         """search with no parameters return all permissions
 
@@ -240,7 +237,6 @@ class TestUserRole:
                 entity.location = location
         return entity
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'entity_cls',
         **parametrized([entities.Architecture, entities.Domain, entities.ActivationKey]),
@@ -273,7 +269,6 @@ class TestUserRole:
         new_entity = new_entity.create_json()
         entity_cls(id=new_entity['id']).read()  # As admin user.
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'entity_cls',
         **parametrized([entities.Architecture, entities.Domain, entities.ActivationKey]),
@@ -300,7 +295,6 @@ class TestUserRole:
         entity_cls(self.cfg, id=new_entity.id).read()
 
     @pytest.mark.upgrade
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'entity_cls',
         **parametrized(
@@ -330,7 +324,6 @@ class TestUserRole:
         with pytest.raises(HTTPError):
             new_entity.read()  # As admin user
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'entity_cls',
         **parametrized([entities.Architecture, entities.Domain, entities.ActivationKey]),

--- a/tests/foreman/api/test_ping.py
+++ b/tests/foreman/api/test_ping.py
@@ -14,11 +14,10 @@
 
 import pytest
 
-pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]
-
 
 @pytest.mark.e2e
 @pytest.mark.build_sanity
+@pytest.mark.upgrade
 def test_positive_ping(target_sat):
     """Check if all services are running
 

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -31,7 +31,6 @@ from robottelo.utils.datafactory import (
 )
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
 def test_negative_create_with_name(name, module_org, module_target_sat):
     """Create a product providing invalid names only
@@ -48,7 +47,6 @@ def test_negative_create_with_name(name, module_org, module_target_sat):
         module_target_sat.api.Product(name=name, organization=module_org).create()
 
 
-@pytest.mark.tier1
 def test_negative_create_with_same_name(module_org, module_target_sat):
     """Create a product providing a name of already existent entity
 
@@ -64,7 +62,6 @@ def test_negative_create_with_same_name(module_org, module_target_sat):
         module_target_sat.api.Product(name=name, organization=module_org).create()
 
 
-@pytest.mark.tier1
 def test_negative_create_with_label(module_org, module_target_sat):
     """Create a product providing invalid label
 
@@ -79,7 +76,6 @@ def test_negative_create_with_label(module_org, module_target_sat):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_create_product_and_update_gpg(module_org, module_target_sat):
     """Create a product with GPG key and update it with new GPGKey
 
@@ -105,7 +101,6 @@ def test_positive_create_product_and_update_gpg(module_org, module_target_sat):
     assert product.gpg_key.id == gpg_key_2.id
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
 def test_negative_update_name(name, module_org, module_target_sat):
     """Attempt to update product name to invalid one
@@ -123,7 +118,6 @@ def test_negative_update_name(name, module_org, module_target_sat):
         module_target_sat.api.Product(id=product.id, name=name).update(['name'])
 
 
-@pytest.mark.tier1
 def test_negative_update_label(module_org, module_target_sat):
     """Attempt to update product label to another one.
 
@@ -139,7 +133,6 @@ def test_negative_update_label(module_org, module_target_sat):
         product.update(['label'])
 
 
-@pytest.mark.tier1
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_sync(module_org, module_target_sat):
     """Sync product (repository within a product)
@@ -159,7 +152,6 @@ def test_positive_sync(module_org, module_target_sat):
     assert repo.read().content_counts['rpm'] >= 1
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_sync_several_repos(module_org, module_target_sat):
@@ -190,7 +182,6 @@ def test_positive_sync_several_repos(module_org, module_target_sat):
     assert docker_repo.read().content_counts['docker_tag'] >= 1
 
 
-@pytest.mark.tier2
 def test_positive_filter_product_list(module_sca_manifest_org, module_target_sat):
     """Filter products based on param 'custom/redhat_only'
 
@@ -216,7 +207,6 @@ def test_positive_filter_product_list(module_sca_manifest_org, module_target_sat
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 def test_positive_product_end_to_end(module_target_sat, module_org):
     """Product scenario with all possible crud operations
 

--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -127,7 +127,6 @@ def tftpboot(module_org, module_target_sat):
 class TestProvisioningTemplate:
     """Tests for provisioning templates"""
 
-    @pytest.mark.tier1
     @pytest.mark.e2e
     @pytest.mark.upgrade
     def test_positive_end_to_end_crud(
@@ -208,7 +207,6 @@ class TestProvisioningTemplate:
         assert e3.value.response.status_code == 404
 
     @pytest.mark.e2e
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_build_pxe_default(self, tftpboot, module_target_sat):
         """Call the "build_pxe_default" path.

--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -24,8 +24,6 @@ from robottelo.config import (
     user_nailgun_config,
 )
 
-pytestmark = pytest.mark.tier1
-
 
 @pytest.mark.e2e
 @pytest.mark.pit_client
@@ -87,7 +85,6 @@ def test_host_registration_end_to_end(
     assert rhel_contenthost.subscription_config['server']['port'] == constants.CLIENT_PORT
 
 
-@pytest.mark.tier3
 @pytest.mark.pit_client
 @pytest.mark.rhel_ver_match('[^6]')
 def test_positive_allow_reregistration_when_dmi_uuid_changed(
@@ -214,7 +211,6 @@ def test_positive_rex_interface_for_global_registration(
             assert interface['mac'] == mac_address
 
 
-@pytest.mark.tier1
 def test_negative_global_registration_without_ak(module_target_sat):
     """Attempt to register a host without ActivationKey
 

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -21,7 +21,6 @@ from robottelo.utils import ohsnap
 CAPSULE_TARGET_VERSION = f'6.{get_sat_version().minor}.z'
 
 
-@pytest.mark.tier4
 def test_positive_find_capsule_upgrade_playbook(target_sat):
     """Check that Capsule Upgrade playbook is present on Satellite
 
@@ -38,7 +37,6 @@ def test_positive_find_capsule_upgrade_playbook(target_sat):
     assert len(templates) > 0
 
 
-@pytest.mark.tier3
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.parametrize(
@@ -171,7 +169,6 @@ def test_negative_time_to_pickup(
     assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
 
 
-@pytest.mark.tier3
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.parametrize(

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -86,7 +86,6 @@ def setup_content(module_sca_manifest_org, module_target_sat):
 # Tests for ``katello/api/v2/report_templates``.
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 def test_positive_CRUDL(name, target_sat):
     """Create, Read, Update, Delete, List
@@ -130,7 +129,6 @@ def test_positive_CRUDL(name, target_sat):
         rt = target_sat.api.ReportTemplate(id=rt.id).read()
 
 
-@pytest.mark.tier1
 def test_positive_generate_report_nofilter(target_sat):
     """Generate Host - Statuses report
 
@@ -157,7 +155,6 @@ def test_positive_generate_report_nofilter(target_sat):
     assert host_name in res
 
 
-@pytest.mark.tier2
 def test_positive_generate_report_filter(target_sat):
     """Generate Host - Statuses report
 
@@ -187,7 +184,6 @@ def test_positive_generate_report_filter(target_sat):
     assert host2_name in res
 
 
-@pytest.mark.tier2
 def test_positive_report_add_userinput(target_sat):
     """Add user input to template, use it in template, generate template
 
@@ -221,7 +217,6 @@ def test_positive_report_add_userinput(target_sat):
     assert f'value="{input_value}"' in res
 
 
-@pytest.mark.tier2
 def test_positive_lock_clone_nodelete_unlock_report(target_sat):
     """Lock report template. Check it can be cloned and can't be deleted or edited.
        Unlock. Check it can be deleted and edited.
@@ -295,7 +290,6 @@ def test_positive_lock_clone_nodelete_unlock_report(target_sat):
     )
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_export_report():
     """Export report template
@@ -314,7 +308,6 @@ def test_positive_export_report():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_generate_report_sanitized():
     """Generate report template where there are values in comma outputted which might
@@ -335,7 +328,6 @@ def test_positive_generate_report_sanitized():
     """
 
 
-@pytest.mark.tier2
 def test_negative_create_report_without_name(module_target_sat):
     """Try to create a report template with empty name
 
@@ -356,7 +348,6 @@ def test_negative_create_report_without_name(module_target_sat):
     assert "Name can't be blank" in report_response.value.response.text
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
 def test_positive_applied_errata(
@@ -432,7 +423,6 @@ def test_positive_applied_errata(
     assert res[0]['issued']
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
 def test_positive_applied_errata_report_with_invalid_errata(
@@ -508,7 +498,6 @@ def test_positive_applied_errata_report_with_invalid_errata(
     )
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
 def test_positive_applied_errata_by_search(
@@ -589,7 +578,6 @@ def test_positive_applied_errata_by_search(
     assert res[0]['issued']
 
 
-@pytest.mark.tier2
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('N-2')
 def test_positive_applied_errata_for_specific_hosts(
@@ -740,7 +728,6 @@ def test_positive_applied_errata_for_specific_hosts(
     assert RHSA['host'].hostname not in rhba_report_hosts
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_generate_nonblocking():
     """Generate an Applied Errata report
@@ -760,7 +747,6 @@ def test_positive_generate_nonblocking():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_generate_email_compressed():
     """Generate an Applied Errata report, get it by e-mail, compressed
@@ -780,7 +766,6 @@ def test_positive_generate_email_compressed():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_generate_email_uncompressed():
     """Generate an Applied Errata report, get it by e-mail, uncompressed
@@ -801,7 +786,6 @@ def test_positive_generate_email_uncompressed():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_negative_bad_email():
     """Report can't be generated when incorrectly formed mail specified
@@ -820,7 +804,6 @@ def test_negative_bad_email():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_cleanup_task_running():
     """Report can't be generated when incorrectly formed mail specified
@@ -839,7 +822,6 @@ def test_positive_cleanup_task_running():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_negative_nonauthor_of_report_cant_download_it():
     """The resulting report should only be downloadable by
@@ -861,7 +843,6 @@ def test_negative_nonauthor_of_report_cant_download_it():
 
 
 @pytest.mark.no_containers
-@pytest.mark.tier3
 def test_positive_generate_job_report(setup_content, module_target_sat, content_hosts):
     """Generate a report using the Job - Invocation Report template.
 
@@ -922,7 +903,6 @@ def test_positive_generate_job_report(setup_content, module_target_sat, content_
     assert '/root' in res[1]['stdout']
 
 
-@pytest.mark.tier2
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('[^6]')
 def test_positive_installable_errata(
@@ -1037,7 +1017,6 @@ def test_positive_installable_errata(
     assert installable_errata['Erratum'] == ERRATUM_ID
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('[^6]')
 def test_positive_installed_products(
     target_sat,

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -30,7 +30,6 @@ from robottelo.exceptions import CLIReturnCodeError
 from robottelo.utils.datafactory import parametrized
 
 
-@pytest.mark.tier1
 def test_negative_disable_repository_with_cv(module_sca_manifest_org, target_sat):
     """Attempt to disable a Repository that is published in a Content View
 
@@ -71,7 +70,6 @@ def test_negative_disable_repository_with_cv(module_sca_manifest_org, target_sat
     )
 
 
-@pytest.mark.tier1
 def test_positive_update_repository_metadata(module_org, target_sat):
     """Update a Repositories url and check that the rpm content counts are different.
         This process will modify the publication of a repo(metadata).
@@ -143,7 +141,6 @@ def test_positive_epel_repositories_with_mirroring_policy(
     assert module_repo_options['mirroring_policy'] == repodata.mirroring_policy
 
 
-@pytest.mark.tier4
 @pytest.mark.parametrize('distro', ['rhel7', 'rhel8_bos', 'rhel9_bos'])
 def test_positive_sync_kickstart_repo(distro, module_sca_manifest_org, target_sat):
     """No encoding gzip errors on kickstart repositories sync, kickstart content present.
@@ -223,7 +220,6 @@ def test_positive_sync_upstream_repo_with_zst_compression(
     assert result.status == 1
 
 
-@pytest.mark.tier1
 @pytest.mark.manifester
 def test_negative_upload_expired_manifest(request, default_org, target_sat):
     """Upload an expired manifest and attempt to refresh it
@@ -252,7 +248,6 @@ def test_negative_upload_expired_manifest(request, default_org, target_sat):
     )
 
 
-@pytest.mark.tier1
 def test_positive_multiple_orgs_with_same_repo(target_sat):
     """Test that multiple organizations with the same repository synced have matching metadata
 

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -75,7 +75,6 @@ def repo(repo_options, target_sat):
 class TestRepository:
     """Tests for ``katello/api/v2/repositories``."""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -96,7 +95,6 @@ class TestRepository:
         """
         assert repo_options['name'] == repo.name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized([{'label': label} for label in datafactory.valid_labels_list()]),
@@ -116,7 +114,6 @@ class TestRepository:
         assert repo.label == repo_options['label']
         assert repo.name != repo_options['label']
 
-    @pytest.mark.tier1
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -139,7 +136,6 @@ class TestRepository:
         for k in 'content_type', 'url':
             assert getattr(repo, k) == repo_options[k]
 
-    @pytest.mark.tier1
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -173,7 +169,6 @@ class TestRepository:
         for k in 'content_type', 'url':
             assert getattr(repo, k) == repo_options[k]
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -198,7 +193,6 @@ class TestRepository:
         """
         assert repo.download_policy == repo_options['download_policy']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options', **datafactory.parametrized([{'content_type': 'yum'}]), indirect=True
     )
@@ -221,7 +215,6 @@ class TestRepository:
         assert default_dl_policy
         assert repo.download_policy == default_dl_policy[0].value
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options', **datafactory.parametrized([{'content_type': 'yum'}]), indirect=True
     )
@@ -246,7 +239,6 @@ class TestRepository:
         repo = repo.update(['download_policy'])
         assert repo.download_policy == 'on_demand'
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized([{'content_type': 'yum', 'download_policy': 'on_demand'}]),
@@ -268,7 +260,6 @@ class TestRepository:
         repo = repo.update(['download_policy'])
         assert repo.download_policy == 'immediate'
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -293,7 +284,6 @@ class TestRepository:
         """
         assert repo.checksum_type == repo_options['checksum_type']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized([{'unprotected': unprotected} for unprotected in (True, False)]),
@@ -313,7 +303,6 @@ class TestRepository:
         """
         assert repo.unprotected == repo_options['unprotected']
 
-    @pytest.mark.tier2
     def test_positive_create_with_gpg(self, module_org, module_product, module_target_sat):
         """Create a repository and provide a GPG key ID.
 
@@ -330,7 +319,6 @@ class TestRepository:
         # Verify that the given GPG key ID is used.
         assert repo.gpg_key.id == gpg_key.id
 
-    @pytest.mark.tier2
     def test_positive_create_same_name_different_orgs(self, repo, target_sat):
         """Create two repos with the same name in two different organizations.
 
@@ -345,7 +333,6 @@ class TestRepository:
         repo_2 = target_sat.api.Repository(product=product_2, name=repo.name).create()
         assert repo_2.name == repo.name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized([{'name': name} for name in datafactory.invalid_values_list()]),
@@ -365,7 +352,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             target_sat.api.Repository(**repo_options).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -388,7 +374,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             target_sat.api.Repository(**repo_options).create()
 
-    @pytest.mark.tier1
     def test_negative_create_label(self, module_product, module_target_sat):
         """Attempt to create repository with invalid label.
 
@@ -403,7 +388,6 @@ class TestRepository:
                 product=module_product, label=gen_string('utf8')
             ).create()
 
-    @pytest.mark.tier1
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -428,7 +412,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             target_sat.api.Repository(**repo_options).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -452,7 +435,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             target_sat.api.Repository(**repo_options).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options', **datafactory.parametrized([{'content_type': 'yum'}]), indirect=True
     )
@@ -473,7 +455,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             repo.update(['download_policy'])
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         [
@@ -500,7 +481,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             target_sat.api.Repository(**repo_options).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -522,7 +502,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             target_sat.api.Repository(**repo_options).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         [
@@ -546,7 +525,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             target_sat.api.Repository(**repo_options).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -573,7 +551,6 @@ class TestRepository:
         assert repo.download_policy == 'on_demand', 'Download policy was not updated'
         assert not repo.checksum_type, 'Checksum type was not reset to Default'
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **datafactory.parametrized(datafactory.valid_data_list()))
     def test_positive_update_name(self, repo, name):
         """Update repository name to another valid name.
@@ -590,7 +567,6 @@ class TestRepository:
         repo = repo.update(['name'])
         assert repo.name == name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -619,7 +595,6 @@ class TestRepository:
         repo = repo.update(['checksum_type'])
         assert repo.checksum_type == updated_checksum
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options', [{'unprotected': False}], ids=['protected'], indirect=True
     )
@@ -648,7 +623,6 @@ class TestRepository:
         repo = repo.update(['unprotected'])
         assert repo.unprotected is True
 
-    @pytest.mark.tier2
     def test_positive_update_gpg(self, module_org, module_product, module_target_sat):
         """Create a repository and update its GPGKey
 
@@ -674,7 +648,6 @@ class TestRepository:
         repo = repo.update(['gpg_key'])
         assert repo.gpg_key.id == gpg_key_2.id
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_upload_delete_srpm(self, repo, target_sat):
         """Create a repository and upload, delete SRPM contents.
@@ -702,7 +675,6 @@ class TestRepository:
         repo.remove_content(data={'ids': [srpm_detail[0].id], 'content_type': 'srpm'})
         assert repo.read().content_counts['srpm'] == 0
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.skip('Uses deprecated SRPM repository')
     @pytest.mark.skipif(
@@ -732,7 +704,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             repo.read()
 
-    @pytest.mark.tier1
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -763,7 +734,6 @@ class TestRepository:
         repo.remove_content(data={'ids': [package.id for package in packages]})
         assert repo.read().content_counts['rpm'] == 0
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **datafactory.parametrized(datafactory.invalid_values_list()))
     def test_negative_update_name(self, repo, name):
         """Attempt to update repository name to invalid one
@@ -780,7 +750,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             repo.update(['name'])
 
-    @pytest.mark.tier1
     def test_negative_update_label(self, repo):
         """Attempt to update repository label to another one.
 
@@ -796,7 +765,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             repo.update(['label'])
 
-    @pytest.mark.tier1
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -820,7 +788,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             repo.update(['url'])
 
-    @pytest.mark.tier2
     def test_positive_synchronize(self, repo):
         """Create a repo and sync it.
 
@@ -832,7 +799,6 @@ class TestRepository:
         repo.sync()
         assert repo.read().content_counts['rpm'] >= 1
 
-    @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -869,7 +835,6 @@ class TestRepository:
         # Verify it has finished
         assert repo.read().content_counts['rpm'] >= 1
 
-    @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -902,7 +867,6 @@ class TestRepository:
         with pytest.raises(TaskFailedError):
             repo.sync()
 
-    @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -936,7 +900,6 @@ class TestRepository:
         repo.sync()
         assert repo.read().content_counts['rpm'] >= 1
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -959,7 +922,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             repo.read()
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -987,7 +949,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             repo.read()
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -1032,7 +993,6 @@ class TestRepository:
         response = client.get(repo_data_file_url, cert=cert_file_path, verify=False)
         assert response.status_code == 200
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -1069,7 +1029,6 @@ class TestRepository:
         response = client.get(new_repo_data_file_url, verify=False)
         assert response.status_code == 200
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -1143,7 +1102,6 @@ class TestRepository:
         assert 'Recreating' in command_output.stdout
         assert 'TaskError' not in command_output.stdout
 
-    @pytest.mark.tier2
     def test_positive_mirroring_policy(self, target_sat):
         """Assert that the content of a repository with 'Mirror Policy' enabled
         is restored properly after resync.
@@ -1197,7 +1155,6 @@ class TestRepository:
         assert len(files) == packages_count
         assert constants.RPM_TO_UPLOAD not in files
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize('policy', ['additive', 'mirror_content_only'])
     def test_positive_sync_with_treeinfo_ignore(
         self, target_sat, function_sca_manifest_org, policy
@@ -1253,7 +1210,6 @@ class TestRepository:
 class TestRepositorySync:
     """Tests for ``/katello/api/repositories/:id/sync``."""
 
-    @pytest.mark.tier2
     def test_positive_sync_repos_with_lots_files(self, target_sat):
         """Attempt to synchronize repository containing a lot of files inside
         rpms.
@@ -1272,7 +1228,6 @@ class TestRepositorySync:
         response = repo.sync()
         assert response, f"Repository {repo} failed to sync."
 
-    @pytest.mark.tier2
     @pytest.mark.build_sanity
     def test_positive_sync_rh(self, module_sca_manifest_org, target_sat):
         """Sync RedHat Repository.
@@ -1292,7 +1247,6 @@ class TestRepositorySync:
         )
         target_sat.api.Repository(id=repo_id).sync()
 
-    @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -1323,7 +1277,6 @@ class TestRepositorySync:
             assert repo.content_counts[key] == count
 
     @pytest.mark.stubbed
-    @pytest.mark.tier2
     def test_positive_sync_rh_app_stream(self):
         """Sync RedHat Appstream Repository.
 
@@ -1335,7 +1288,6 @@ class TestRepositorySync:
         """
         pass
 
-    @pytest.mark.tier3
     def test_positive_bulk_cancel_sync(self, target_sat, module_sca_manifest_org):
         """Bulk cancel 10+ repository syncs
 
@@ -1391,7 +1343,6 @@ class TestRepositorySync:
             )
             assert result.status == 0
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content_type': 'yum', 'url': repo_constants.CUSTOM_RPM_SHA}]),
@@ -1417,7 +1368,6 @@ class TestRepositorySync:
         )
         assert result.status == 1
 
-    @pytest.mark.tier2
     def test_positive_sync_repo_null_contents_changed(self, module_sca_manifest_org, target_sat):
         """test for null contents_changed parameter on actions::katello::repository::sync.
 
@@ -1492,7 +1442,6 @@ class TestRepositorySync:
         )
         assert len(os)
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -1542,7 +1491,6 @@ class TestRepositorySync:
 class TestDockerRepository:
     """Tests specific to using ``Docker`` repositories."""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -1572,7 +1520,6 @@ class TestDockerRepository:
         for k in 'name', 'docker_upstream_name', 'content_type':
             assert getattr(repo, k) == repo_options[k]
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -1617,7 +1564,6 @@ class TestDockerRepository:
         assert 'Task canceled' in sync_task['humanized']['errors']
         assert 'No content added' in sync_task['humanized']['output']
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options_custom_product',
         **datafactory.parametrized(
@@ -1654,7 +1600,6 @@ class TestDockerRepository:
         assert repo.read().content_counts['docker_manifest'] >= 1
         assert repo.product.delete()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized({'docker': {'content_type': 'docker'}}),
@@ -1680,7 +1625,6 @@ class TestDockerRepository:
         repo = repo.update(['name'])
         assert repo.name == new_name
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -1715,7 +1659,6 @@ class TestDockerRepository:
         repo.sync()
         assert repo.read().content_counts['docker_manifest'] >= 1
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -1753,7 +1696,6 @@ class TestDockerRepository:
         with pytest.raises(TaskFailedError, match=msg):
             repo.sync()
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -1795,7 +1737,6 @@ class TestDockerRepository:
         ):
             target_sat.api.Repository(**repo_options).create()
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -1826,7 +1767,6 @@ class TestDockerRepository:
         assert repo.include_tags == repo_options['include_tags']
         assert repo.content_counts['docker_tag'] == 1
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -1893,7 +1833,6 @@ class TestDockerRepository:
     @pytest.mark.skip(
         reason="Tests behavior that is no longer present in the same way, needs refactor"
     )
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -1934,7 +1873,6 @@ class TestDockerRepository:
         assert repo.docker_tags_whitelist == tags
         assert repo.content_counts['docker_tag'] >= 2
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -1965,7 +1903,6 @@ class TestDockerRepository:
         assert repo.include_tags == repo_options['include_tags']
         assert repo.content_counts['docker_tag'] == 1
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -2001,7 +1938,6 @@ class TestDockerRepository:
 # class TestOstreeRepository:
 #     """Tests specific to using ``OSTree`` repositories."""
 #
-#     @pytest.mark.tier1
 #     @pytest.mark.skipif(
 #         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
 #     )
@@ -2025,7 +1961,6 @@ class TestDockerRepository:
 #         """
 #         assert repo.content_type == repo_options['content_type']
 #
-#     @pytest.mark.tier1
 #     @pytest.mark.skipif(
 #         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
 #     )
@@ -2052,7 +1987,6 @@ class TestDockerRepository:
 #         repo = repo.update(['name'])
 #         assert repo.name == new_name
 #
-#     @pytest.mark.tier1
 #     @pytest.mark.skipif(
 #         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
 #     )
@@ -2079,7 +2013,6 @@ class TestDockerRepository:
 #         repo = repo.update(['url'])
 #         assert repo.url == new_url
 #
-#     @pytest.mark.tier1
 #     @pytest.mark.upgrade
 #     @pytest.mark.skipif(
 #         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -2106,7 +2039,6 @@ class TestDockerRepository:
 #         with pytest.raises(HTTPError):
 #             repo.read()
 #
-#     @pytest.mark.tier2
 #     @pytest.mark.skip_if_open("BZ:1625783")
 #     @pytest.mark.run_in_one_thread
 #     @pytest.mark.upgrade
@@ -2138,7 +2070,6 @@ class TestSRPMRepository:
     """Tests specific to using repositories containing source RPMs."""
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     def test_positive_srpm_upload_publish_promote_cv(
         self, module_org, module_lce, repo, module_target_sat
     ):
@@ -2173,7 +2104,6 @@ class TestSRPMRepository:
         )
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -2225,7 +2155,6 @@ class TestSRPMRepositoryIgnoreContent:
     :BZ: 1673215
     """
 
-    @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -2254,7 +2183,6 @@ class TestSRPMRepositoryIgnoreContent:
         repo = repo.read()
         assert repo.content_counts['srpm'] == 0
 
-    @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -2279,7 +2207,6 @@ class TestSRPMRepositoryIgnoreContent:
         repo = repo.read()
         assert repo.content_counts['srpm'] == 2
 
-    @pytest.mark.tier2
     @pytest.mark.skip('Uses deprecated SRPM repository')
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -2314,7 +2241,6 @@ class TestSRPMRepositoryIgnoreContent:
 class TestFileRepository:
     """Specific tests for File Repositories"""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content_type': 'file', 'url': repo_constants.CUSTOM_FILE_REPO}]),
@@ -2344,7 +2270,6 @@ class TestFileRepository:
         )
         assert filesearch[0].name == constants.FAKE_FILE_NEW_NAME
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -2389,7 +2314,6 @@ class TestTokenAuthContainerRepository:
     :team: Phoenix-content
     """
 
-    @pytest.mark.tier2
     def test_positive_create_with_long_token(
         self, module_org, module_product, request, module_target_sat
     ):
@@ -2454,7 +2378,6 @@ class TestTokenAuthContainerRepository:
     except AttributeError:
         container_repo_keys = []
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('repo_key', container_repo_keys)
     def test_positive_tag_whitelist(
         self, request, repo_key, module_org, module_product, module_target_sat
@@ -2506,7 +2429,6 @@ class TestTokenAuthContainerRepository:
 class TestPythonRepository:
     """Specific tests for Python Repositories"""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -19,8 +19,6 @@ import pytest
 
 from robottelo.constants import PRDS, REPOSET
 
-pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.tier1]
-
 PRODUCT_NAME = PRDS['rhel']
 REPOSET_NAME = REPOSET['rhva6']
 ARCH = 'x86_64'
@@ -58,6 +56,7 @@ def match_repos(repos, match_params):
 
 
 @pytest.mark.upgrade
+@pytest.mark.run_in_one_thread
 def test_positive_reposet_enable_and_disable(reposet, params):
     """Enable & disble repo from reposet
 

--- a/tests/foreman/api/test_rhc.py
+++ b/tests/foreman/api/test_rhc.py
@@ -30,7 +30,6 @@ def fixture_enable_rhc_repos(target_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier3
 @pytest.mark.destructive
 def test_positive_configure_cloud_connector(target_sat, default_org, fixture_enable_rhc_repos):
     """

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -35,7 +35,6 @@ def common_assertion(report_path):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 @pytest.mark.e2e
 def test_rhcloud_inventory_api_e2e(
     inventory_settings,
@@ -119,7 +118,6 @@ def test_rhcloud_inventory_api_e2e(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier3
 def test_rhcloud_inventory_api_hosts_synchronization(
     rhcloud_manifest_org,
     rhcloud_registered_hosts,
@@ -216,7 +214,6 @@ def test_inventory_upload_with_http_proxy():
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.e2e
 def test_include_parameter_tags_setting(
     inventory_settings,
@@ -292,7 +289,6 @@ def test_include_parameter_tags_setting(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier3
 def test_rhcloud_scheduled_insights_sync(
     rhcloud_manifest_org,
     rhcloud_registered_hosts,

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -24,7 +24,6 @@ import pytest
 from robottelo.config import get_credentials, get_url
 
 
-@pytest.mark.tier1
 @pytest.mark.pit_server
 def test_positive_path():
     """Check whether the path exists.

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -29,7 +29,6 @@ from robottelo.utils.issue_handlers import is_open
 class TestRole:
     """Tests for ``api/v2/roles``."""
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         ('name', 'new_name'),
@@ -207,7 +206,6 @@ class TestCannedRole:
             user.delete()
         target_sat.cli.LDAPAuthSource.delete({'name': authsource_name})
 
-    @pytest.mark.tier1
     def test_positive_create_role_with_taxonomies(self, role_taxonomies, target_sat):
         """create role with taxonomies
 
@@ -229,7 +227,6 @@ class TestCannedRole:
         assert role_taxonomies['org'].id == role.organization[0].id
         assert role_taxonomies['loc'].id == role.location[0].id
 
-    @pytest.mark.tier1
     def test_positive_create_role_without_taxonomies(self, target_sat):
         """Create role without taxonomies
 
@@ -247,7 +244,6 @@ class TestCannedRole:
         assert not role.organization
         assert not role.location
 
-    @pytest.mark.tier1
     def test_positive_create_filter_without_override(self, role_taxonomies, target_sat):
         """Create filter in role w/o overriding it
 
@@ -280,7 +276,6 @@ class TestCannedRole:
         assert role_taxonomies['loc'].id == filtr.location[0].id
         assert not filtr.override
 
-    @pytest.mark.tier1
     def test_positive_create_non_overridable_filter(self, target_sat):
         """Create non overridable filter in role
 
@@ -306,7 +301,6 @@ class TestCannedRole:
         assert role.id == filtr.role.id
         assert not filtr.override
 
-    @pytest.mark.tier1
     def test_negative_override_non_overridable_filter(self, filter_taxonomies, target_sat):
         """Override non overridable filter
 
@@ -335,7 +329,6 @@ class TestCannedRole:
                 location=[filter_taxonomies['loc']],
             ).create()
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_create_overridable_filter(
         self, role_taxonomies, filter_taxonomies, target_sat
@@ -380,7 +373,6 @@ class TestCannedRole:
         assert role_taxonomies['org'].id != filtr.organization[0].id
         assert role_taxonomies['loc'].id != filtr.location[0].id
 
-    @pytest.mark.tier1
     def test_positive_update_role_taxonomies(self, role_taxonomies, filter_taxonomies, target_sat):
         """Update role taxonomies which applies to its non-overrided filters
 
@@ -415,7 +407,6 @@ class TestCannedRole:
         assert filter_taxonomies['org'].id == filtr.organization[0].id
         assert filter_taxonomies['loc'].id == filtr.location[0].id
 
-    @pytest.mark.tier1
     def test_negative_update_role_taxonomies(self, role_taxonomies, filter_taxonomies, target_sat):
         """Update role taxonomies which doesnt applies to its overrided filters
 
@@ -461,7 +452,6 @@ class TestCannedRole:
         assert org_new.id != filtr.organization[0].id
         assert loc_new.id != filtr.location[0].id
 
-    @pytest.mark.tier1
     def test_positive_disable_filter_override(self, role_taxonomies, filter_taxonomies, target_sat):
         """Unsetting override flag resets filter taxonomies
 
@@ -503,7 +493,6 @@ class TestCannedRole:
         assert filter_taxonomies['org'].id != filtr.organization[0].id
         assert filter_taxonomies['loc'].id != filtr.location[0].id
 
-    @pytest.mark.tier1
     def test_positive_create_org_admin_from_clone(self, target_sat):
         """Create Org Admin role which has access to most of the resources
         within organization
@@ -527,7 +516,6 @@ class TestCannedRole:
         orgadmin_filters = target_sat.api.Role(id=org_admin.id).read().filters
         assert len(default_filters) == len(orgadmin_filters)
 
-    @pytest.mark.tier1
     def test_positive_create_cloned_role_with_taxonomies(self, role_taxonomies, target_sat):
         """Taxonomies can be assigned to cloned role
 
@@ -552,7 +540,6 @@ class TestCannedRole:
         assert role_taxonomies['org'].id == org_admin.organization[0].id
         assert role_taxonomies['loc'].id == org_admin.location[0].id
 
-    @pytest.mark.tier3
     def test_negative_access_entities_from_org_admin(
         self, role_taxonomies, filter_taxonomies, target_sat
     ):
@@ -584,7 +571,6 @@ class TestCannedRole:
         with pytest.raises(HTTPError):
             target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
-    @pytest.mark.tier3
     def test_negative_access_entities_from_user(
         self, role_taxonomies, filter_taxonomies, target_sat
     ):
@@ -616,7 +602,6 @@ class TestCannedRole:
         with pytest.raises(HTTPError):
             target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
-    @pytest.mark.tier2
     def test_positive_override_cloned_role_filter(self, role_taxonomies, target_sat):
         """Cloned role filter overrides
 
@@ -650,7 +635,6 @@ class TestCannedRole:
         assert role_taxonomies['org'].id == filter_cloned.organization[0].id
         assert role_taxonomies['loc'].id == filter_cloned.location[0].id
 
-    @pytest.mark.tier2
     def test_positive_emptiness_of_filter_taxonomies_on_role_clone(
         self, role_taxonomies, filter_taxonomies, target_sat
     ):
@@ -693,7 +677,6 @@ class TestCannedRole:
         assert not filter_cloned.location
         assert filter_cloned.override
 
-    @pytest.mark.tier2
     def test_positive_clone_role_having_overridden_filter_with_taxonomies(
         self, role_taxonomies, filter_taxonomies, target_sat
     ):
@@ -740,7 +723,6 @@ class TestCannedRole:
         assert cloned_filter.unlimited
         assert cloned_filter.override
 
-    @pytest.mark.tier2
     def test_positive_clone_role_having_non_overridden_filter_with_taxonomies(
         self, role_taxonomies, target_sat
     ):
@@ -781,7 +763,6 @@ class TestCannedRole:
         assert not cloned_filter.unlimited
         assert not cloned_filter.override
 
-    @pytest.mark.tier2
     def test_positive_clone_role_having_unlimited_filter_with_taxonomies(
         self, role_taxonomies, target_sat
     ):
@@ -821,7 +802,6 @@ class TestCannedRole:
         assert not cloned_filter.unlimited
         assert not cloned_filter.override
 
-    @pytest.mark.tier2
     def test_positive_clone_role_having_overridden_filter_without_taxonomies(
         self, role_taxonomies, filter_taxonomies, target_sat
     ):  # noqa
@@ -861,7 +841,6 @@ class TestCannedRole:
         assert cloned_filter.unlimited
         assert cloned_filter.override
 
-    @pytest.mark.tier2
     def test_positive_clone_role_without_taxonomies_non_overided_filter(
         self, role_taxonomies, target_sat
     ):
@@ -900,7 +879,6 @@ class TestCannedRole:
         assert cloned_filter.unlimited
         assert not cloned_filter.override
 
-    @pytest.mark.tier2
     def test_positive_clone_role_without_taxonomies_unlimited_filter(
         self, role_taxonomies, target_sat
     ):
@@ -938,7 +916,6 @@ class TestCannedRole:
         assert cloned_filter.unlimited
         assert not cloned_filter.override
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_user_group_users_access_as_org_admin(self, role_taxonomies, target_sat):
         """Users in usergroup can have access to the resources in taxonomies if
@@ -1018,7 +995,6 @@ class TestCannedRole:
             assert domain.id in [dom.id for dom in target_sat.api.Domain(server_config=sc).search()]
             assert subnet.id in [sub.id for sub in target_sat.api.Subnet(server_config=sc).search()]
 
-    @pytest.mark.tier3
     def test_positive_user_group_users_access_contradict_as_org_admins(self):
         """Users in usergroup can/cannot have access to the resources in
         taxonomies depends on the taxonomies of Org Admin role is same/not_same
@@ -1044,7 +1020,6 @@ class TestCannedRole:
 
         """
 
-    @pytest.mark.tier2
     def test_negative_assign_org_admin_to_user_group(
         self, role_taxonomies, filter_taxonomies, target_sat
     ):
@@ -1083,7 +1058,6 @@ class TestCannedRole:
             with pytest.raises(HTTPError):
                 target_sat.api.Domain(server_config=sc, id=dom.id).read()
 
-    @pytest.mark.tier2
     def test_negative_assign_taxonomies_by_org_admin(
         self, role_taxonomies, filter_taxonomies, target_sat
     ):
@@ -1136,7 +1110,6 @@ class TestCannedRole:
         with pytest.raises(HTTPError):
             dom.update(['organization'])
 
-    @pytest.mark.tier1
     def test_positive_remove_org_admin_role(self, role_taxonomies, target_sat):
         """Super Admin user can remove Org Admin role
 
@@ -1170,7 +1143,6 @@ class TestCannedRole:
         user = target_sat.api.User(id=user.id).read()
         assert org_admin.id not in [role.id for role in user.role]
 
-    @pytest.mark.tier2
     def test_positive_taxonomies_control_to_superadmin_with_org_admin(
         self, role_taxonomies, target_sat
     ):
@@ -1212,7 +1184,6 @@ class TestCannedRole:
         except HTTPError as err:
             pytest.fail(str(err))
 
-    @pytest.mark.tier2
     def test_positive_taxonomies_control_to_superadmin_without_org_admin(
         self, role_taxonomies, target_sat
     ):
@@ -1263,7 +1234,6 @@ class TestCannedRole:
         except HTTPError as err:
             pytest.fail(str(err))
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_negative_create_roles_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin doesn't have permissions to create new roles
@@ -1305,7 +1275,6 @@ class TestCannedRole:
                 location=[role_taxonomies['loc']],
             ).create()
 
-    @pytest.mark.tier1
     def test_negative_modify_roles_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin has no permissions to modify existing roles
 
@@ -1332,7 +1301,6 @@ class TestCannedRole:
         with pytest.raises(HTTPError):
             test_role.update(['organization', 'location'])
 
-    @pytest.mark.tier2
     def test_negative_admin_permissions_to_org_admin(self, role_taxonomies, target_sat):
         """Org Admin has no access to Super Admin user
 
@@ -1367,7 +1335,6 @@ class TestCannedRole:
         with pytest.raises(HTTPError):
             target_sat.api.User(server_config=sc, id=1).read()
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_create_user_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin can create new users
@@ -1421,7 +1388,6 @@ class TestCannedRole:
         assert user_login == user.login
         assert org_admin.id == user.role[0].id
 
-    @pytest.mark.tier2
     def test_positive_access_users_inside_org_admin_taxonomies(self, role_taxonomies, target_sat):
         """Org Admin can access users inside its taxonomies
 
@@ -1451,7 +1417,6 @@ class TestCannedRole:
         except HTTPError as err:
             pytest.fail(str(err))
 
-    @pytest.mark.tier2
     def test_negative_access_users_outside_org_admin_taxonomies(
         self, role_taxonomies, filter_taxonomies, target_sat
     ):
@@ -1481,7 +1446,6 @@ class TestCannedRole:
         with pytest.raises(HTTPError):
             target_sat.api.User(server_config=sc, id=test_user.id).read()
 
-    @pytest.mark.tier1
     def test_negative_create_taxonomies_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin cannot define/create organizations but can create
             locations
@@ -1525,7 +1489,6 @@ class TestCannedRole:
             assert loc_name == loc.name
 
     @pytest.mark.upgrade
-    @pytest.mark.tier1
     def test_positive_access_all_global_entities_by_org_admin(
         self, role_taxonomies, filter_taxonomies, target_sat
     ):
@@ -1576,7 +1539,6 @@ class TestCannedRole:
         except HTTPError as err:
             pytest.fail(str(err))
 
-    @pytest.mark.tier3
     def test_negative_access_entities_from_ldap_org_admin(
         self, role_taxonomies, create_ldap, target_sat
     ):
@@ -1621,7 +1583,6 @@ class TestCannedRole:
         with pytest.raises(HTTPError):
             target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
-    @pytest.mark.tier3
     def test_negative_access_entities_from_ldap_user(
         self, role_taxonomies, create_ldap, module_location, module_org, target_sat
     ):
@@ -1664,7 +1625,6 @@ class TestCannedRole:
         with pytest.raises(HTTPError):
             target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
-    @pytest.mark.tier3
     def test_positive_assign_org_admin_to_ldap_user_group(
         self, role_taxonomies, create_ldap, target_sat
     ):
@@ -1726,7 +1686,6 @@ class TestCannedRole:
             # Accessing the Domain resource
             target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
-    @pytest.mark.tier3
     def test_negative_assign_org_admin_to_ldap_user_group(
         self, create_ldap, role_taxonomies, target_sat
     ):
@@ -1792,7 +1751,6 @@ class TestRoleSearchFilter:
     """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     def test_positive_role_lce_search(self):
         """Test role with search filter using lifecycle enviroment.
 
@@ -1816,7 +1774,6 @@ class TestRoleSearchFilter:
         """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     def test_negative_role_lce_search(self):
         """Test role with search filter using lifecycle environment.
 

--- a/tests/foreman/api/test_settings.py
+++ b/tests/foreman/api/test_settings.py
@@ -33,7 +33,6 @@ def valid_timeout_values():
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier1
 @pytest.mark.upgrade
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text(setting_update):
@@ -54,7 +53,6 @@ def test_positive_update_login_page_footer_text(setting_update):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text_without_value(setting_update):
     """Updates parameter "login_text" without any string (empty value)
@@ -71,7 +69,6 @@ def test_positive_update_login_page_footer_text_without_value(setting_update):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text_with_long_string(setting_update):
     """Attempt to update parameter "Login_page_footer_text"
@@ -89,7 +86,6 @@ def test_positive_update_login_page_footer_text_with_long_string(setting_update)
     assert setting_update.value == login_text_value
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_hostname'], indirect=True)
 def test_negative_update_hostname_with_empty_fact(setting_update):
     """Update the Hostname_facts settings without any string(empty values)
@@ -106,7 +102,6 @@ def test_negative_update_hostname_with_empty_fact(setting_update):
         setting_update.update({'value'})
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
 def test_positive_update_hostname_prefix_without_value(setting_update):
     """Update the Hostname_prefix settings without any string(empty values)
@@ -124,7 +119,6 @@ def test_positive_update_hostname_prefix_without_value(setting_update):
         setting_update.update({'value'})
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
 def test_positive_update_hostname_default_prefix(setting_update):
     """Update the default set prefix of hostname_prefix setting
@@ -146,7 +140,6 @@ def test_positive_update_hostname_default_prefix(setting_update):
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_update_hostname_default_facts():
     """Update the default set fact of hostname_facts setting with list of
     facts like: bios_vendor,uuid
@@ -160,7 +153,6 @@ def test_positive_update_hostname_default_facts():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_negative_discover_host_with_invalid_prefix():
     """Update the hostname_prefix with invalid string like
     -mac, 1mac or ^%$
@@ -175,7 +167,6 @@ def test_negative_discover_host_with_invalid_prefix():
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.parametrize('download_policy', ["immediate", "on_demand"])
 @pytest.mark.parametrize('setting_update', ['default_download_policy'], indirect=True)
 def test_positive_custom_repo_download_policy(setting_update, download_policy, target_sat):
@@ -207,7 +198,6 @@ def test_positive_custom_repo_download_policy(setting_update, download_policy, t
     prod.delete()
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('valid_value', **parametrized(valid_timeout_values()))
 @pytest.mark.parametrize('setting_update', ['sync_connect_timeout_v2'], indirect=True)
 def test_positive_update_sync_timeout(setting_update, valid_value):
@@ -228,7 +218,6 @@ def test_positive_update_sync_timeout(setting_update, valid_value):
     assert str(setting_update.value) == valid_value
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('invalid_value', ["-1", "3.1415", "2.71828e+11", "123456789", "0x3f77"])
 @pytest.mark.parametrize('setting_update', ['sync_connect_timeout_v2'], indirect=True)
 def test_negative_update_sync_timeout(setting_update, invalid_value):

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -30,7 +30,6 @@ from robottelo.utils.datafactory import (
 )
 
 
-@pytest.mark.tier1
 def test_positive_create_with_parameter(target_sat):
     """Subnet can be created along with parameters
 
@@ -47,7 +46,6 @@ def test_positive_create_with_parameter(target_sat):
     assert subnet.subnet_parameters_attributes[0]['value'] == parameter[0]['value']
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(generate_strings_list()))
 def test_positive_add_parameter(name, target_sat):
     """Parameters can be created in subnet
@@ -72,7 +70,6 @@ def test_positive_add_parameter(name, target_sat):
     assert subnet_param.value == value
 
 
-@pytest.mark.tier1
 def test_positive_add_parameter_with_values_and_separator(target_sat):
     """Subnet parameters can be created with values separated by comma
 
@@ -97,7 +94,6 @@ def test_positive_add_parameter_with_values_and_separator(target_sat):
     assert subnet_param.value == values
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize(
     'separator', **parametrized({'comma': ',', 'slash': '/', 'dash': '-', 'pipe': '|'})
 )
@@ -126,7 +122,6 @@ def test_positive_create_with_parameter_and_valid_separator(separator, target_sa
     assert subnet_param.value == value
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list() + ['name with space']))
 def test_negative_create_with_parameter_and_invalid_separator(name, target_sat):
     """Subnet parameters can not be created with name with invalid
@@ -155,7 +150,6 @@ def test_negative_create_with_parameter_and_invalid_separator(name, target_sat):
         target_sat.api.Parameter(name=name, subnet=subnet.id).create()
 
 
-@pytest.mark.tier1
 def test_negative_create_with_duplicated_parameters(target_sat):
     """Attempt to create multiple parameters with same key name for the
     same subnet
@@ -183,7 +177,6 @@ def test_negative_create_with_duplicated_parameters(target_sat):
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_inherit_subnet_parmeters_in_host():
     """Host inherits parameters from subnet
 
@@ -209,7 +202,6 @@ def test_positive_inherit_subnet_parmeters_in_host():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_subnet_parameters_override_from_host():
     """Subnet parameters values can be overridden from host
 
@@ -234,7 +226,6 @@ def test_positive_subnet_parameters_override_from_host():
     """
 
 
-@pytest.mark.tier3
 def test_positive_subnet_parameters_override_impact_on_subnet(target_sat):
     """Override subnet parameter from host impact on subnet parameter
 
@@ -281,7 +272,6 @@ def test_positive_subnet_parameters_override_impact_on_subnet(target_sat):
     assert org_subnet.read().subnet_parameters_attributes[0]['value'] == parameter[0]['value']
 
 
-@pytest.mark.tier1
 def test_positive_update_parameter(target_sat):
     """Subnet parameter can be updated
 
@@ -306,7 +296,6 @@ def test_positive_update_parameter(target_sat):
     assert up_subnet.subnet_parameters_attributes[0]['value'] == update_parameter[0]['value']
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list() + ['name with space']))
 def test_negative_update_parameter(new_name, target_sat):
     """Subnet parameter can not be updated with invalid names
@@ -337,7 +326,6 @@ def test_negative_update_parameter(new_name, target_sat):
         sub_param.update(['name'])
 
 
-@pytest.mark.tier2
 def test_positive_update_subnet_parameter_host_impact(target_sat):
     """Update in parameter name and value from subnet component updates
     the parameter in host inheriting that subnet
@@ -378,7 +366,6 @@ def test_positive_update_subnet_parameter_host_impact(target_sat):
     )
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_delete_subnet_parameter(target_sat):
     """Subnet parameter can be deleted
@@ -400,7 +387,6 @@ def test_positive_delete_subnet_parameter(target_sat):
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_delete_subnet_parameter_host_impact():
     """Deleting parameter from subnet component deletes the parameter in
     host inheriting that subnet
@@ -424,7 +410,6 @@ def test_positive_delete_subnet_parameter_host_impact():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_delete_subnet_overridden_parameter_host_impact():
     """Deleting parameter from subnet component doesnt deletes its
@@ -450,7 +435,6 @@ def test_positive_delete_subnet_overridden_parameter_host_impact():
     """
 
 
-@pytest.mark.tier1
 def test_positive_list_parameters(target_sat):
     """Satellite lists all the subnet parameters
 
@@ -490,7 +474,6 @@ def test_positive_list_parameters(target_sat):
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_subnet_parameter_priority():
     """Higher priority hosts component parameter overrides subnet parameter
      with same name
@@ -519,7 +502,6 @@ def test_positive_subnet_parameter_priority():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_negative_component_overrides_subnet_parameter():
     """Lower priority hosts component parameter doesnt overrides subnet
     parameter with same name

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -69,7 +69,6 @@ def module_ak(module_sca_manifest_org, rh_repo, custom_repo, module_target_sat):
     ).create()
 
 
-@pytest.mark.tier1
 def test_positive_refresh(function_sca_manifest_org, request, target_sat):
     """Upload a manifest and refresh it afterwards.
 
@@ -86,7 +85,6 @@ def test_positive_refresh(function_sca_manifest_org, request, target_sat):
     assert sub.search()
 
 
-@pytest.mark.tier1
 def test_positive_create_after_refresh(
     function_sca_manifest_org, second_function_sca_manifest, target_sat
 ):
@@ -115,7 +113,6 @@ def test_positive_create_after_refresh(
         org_sub.delete_manifest(data={'organization_id': function_sca_manifest_org.id})
 
 
-@pytest.mark.tier1
 def test_positive_delete(function_sca_manifest_org, target_sat):
     """Delete an Uploaded manifest.
 
@@ -131,7 +128,6 @@ def test_positive_delete(function_sca_manifest_org, target_sat):
     assert len(sub.search()) == 0
 
 
-@pytest.mark.tier2
 def test_negative_upload(function_sca_manifest, target_sat):
     """Upload the same manifest to two organizations.
 
@@ -148,7 +144,6 @@ def test_negative_upload(function_sca_manifest, target_sat):
     assert len(target_sat.api.Subscription(organization=orgs[1]).search()) == 0
 
 
-@pytest.mark.tier2
 def test_positive_delete_manifest_as_another_user(function_org, function_sca_manifest, target_sat):
     """Verify that uploaded manifest if visible and deletable
         by a different user than the one who uploaded it
@@ -199,7 +194,6 @@ def test_positive_delete_manifest_as_another_user(function_org, function_sca_man
     assert len(target_sat.cli.Subscription.list({'organization-id': function_org.id})) == 0
 
 
-@pytest.mark.tier2
 @pytest.mark.e2e
 @pytest.mark.pit_client
 @pytest.mark.pit_server
@@ -267,7 +261,6 @@ def test_sca_end_to_end(
 
 
 @pytest.mark.rhel_ver_match('7')
-@pytest.mark.tier2
 def test_positive_candlepin_events_processed_by_stomp(
     function_org, target_sat, function_sca_manifest
 ):
@@ -385,7 +378,6 @@ def test_positive_expired_SCA_cert_handling(module_sca_manifest_org, rhel_conten
     assert rhel_contenthost.subscribed
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('N-2')
 def test_positive_os_restriction_on_repos(
     target_sat,

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -96,7 +96,6 @@ def validate_repo_content(repo, content_types, after_sync=True):
             )
 
 
-@pytest.mark.tier1
 def test_positive_get_routes(target_sat):
     """Issue an HTTP GET response to both available routes.
 
@@ -127,7 +126,6 @@ def test_positive_get_routes(target_sat):
 
 
 @pytest.mark.parametrize("enabled", [False, True])
-@pytest.mark.tier1
 def test_positive_create_enabled_disabled(module_org, enabled, request, target_sat):
     """Create sync plan with different 'enabled' field values.
 
@@ -147,7 +145,6 @@ def test_positive_create_enabled_disabled(module_org, enabled, request, target_s
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_name(module_org, name, module_target_sat):
     """Create a sync plan with a random name.
 
@@ -167,7 +164,6 @@ def test_positive_create_with_name(module_org, name, module_target_sat):
 
 
 @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_description(module_org, description, module_target_sat):
     """Create a sync plan with a random description.
 
@@ -188,7 +184,6 @@ def test_positive_create_with_description(module_org, description, module_target
 
 
 @pytest.mark.parametrize('interval', **parametrized(valid_sync_interval()))
-@pytest.mark.tier1
 def test_positive_create_with_interval(module_org, interval, module_target_sat):
     """Create a sync plan with a random interval.
 
@@ -211,7 +206,6 @@ def test_positive_create_with_interval(module_org, interval, module_target_sat):
 
 
 @pytest.mark.parametrize('sync_delta', **parametrized(sync_date_deltas))
-@pytest.mark.tier1
 def test_positive_create_with_sync_date(module_org, sync_delta, target_sat):
     """Create a sync plan and update its sync date.
 
@@ -232,7 +226,6 @@ def test_positive_create_with_sync_date(module_org, sync_delta, target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_create_with_invalid_name(module_org, name, module_target_sat):
     """Create a sync plan with an invalid name.
 
@@ -250,7 +243,6 @@ def test_negative_create_with_invalid_name(module_org, name, module_target_sat):
 
 
 @pytest.mark.parametrize('interval', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_create_with_invalid_interval(module_org, interval, module_target_sat):
     """Create a sync plan with invalid interval specified.
 
@@ -267,7 +259,6 @@ def test_negative_create_with_invalid_interval(module_org, interval, module_targ
         module_target_sat.api.SyncPlan(interval=interval, organization=module_org).create()
 
 
-@pytest.mark.tier1
 def test_negative_create_with_empty_interval(module_org, module_target_sat):
     """Create a sync plan with no interval specified.
 
@@ -286,7 +277,6 @@ def test_negative_create_with_empty_interval(module_org, module_target_sat):
 
 
 @pytest.mark.parametrize("enabled", [False, True])
-@pytest.mark.tier1
 def test_positive_update_enabled(module_org, enabled, request, target_sat):
     """Create sync plan and update it with opposite 'enabled' value.
 
@@ -307,7 +297,6 @@ def test_positive_update_enabled(module_org, enabled, request, target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_update_name(module_org, name, module_target_sat):
     """Create a sync plan and update its name.
 
@@ -328,7 +317,6 @@ def test_positive_update_name(module_org, name, module_target_sat):
 
 
 @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
-@pytest.mark.tier2
 def test_positive_update_description(module_org, description, module_target_sat):
     """Create a sync plan and update its description.
 
@@ -349,7 +337,6 @@ def test_positive_update_description(module_org, description, module_target_sat)
 
 
 @pytest.mark.parametrize('interval', **parametrized(valid_sync_interval()))
-@pytest.mark.tier1
 def test_positive_update_interval(module_org, interval, module_target_sat):
     """Create a sync plan and update its interval.
 
@@ -381,7 +368,6 @@ def test_positive_update_interval(module_org, interval, module_target_sat):
 
 
 @pytest.mark.parametrize('interval', **parametrized(valid_sync_interval()))
-@pytest.mark.tier1
 def test_positive_update_interval_custom_cron(module_org, interval, module_target_sat):
     """Create a sync plan and update its interval to custom cron.
 
@@ -410,7 +396,6 @@ def test_positive_update_interval_custom_cron(module_org, interval, module_targe
 
 
 @pytest.mark.parametrize('sync_delta', **parametrized(sync_date_deltas))
-@pytest.mark.tier1
 def test_positive_update_sync_date(module_org, sync_delta, target_sat):
     """Updated sync plan's sync date.
 
@@ -433,7 +418,6 @@ def test_positive_update_sync_date(module_org, sync_delta, target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_update_name(module_org, name, module_target_sat):
     """Try to update a sync plan with an invalid name.
 
@@ -453,7 +437,6 @@ def test_negative_update_name(module_org, name, module_target_sat):
 
 
 @pytest.mark.parametrize('interval', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_update_interval(module_org, interval, module_target_sat):
     """Try to update a sync plan with invalid interval.
 
@@ -472,7 +455,6 @@ def test_negative_update_interval(module_org, interval, module_target_sat):
         sync_plan.update(['interval'])
 
 
-@pytest.mark.tier2
 def test_positive_add_product(module_org, target_sat):
     """Create a sync plan and add one product to it.
 
@@ -492,7 +474,6 @@ def test_positive_add_product(module_org, target_sat):
     assert sync_plan.product[0].id == product.id
 
 
-@pytest.mark.tier2
 def test_positive_add_products(module_org, target_sat):
     """Create a sync plan and add two products to it.
 
@@ -510,7 +491,6 @@ def test_positive_add_products(module_org, target_sat):
     assert {product.id for product in products} == {product.id for product in sync_plan.product}
 
 
-@pytest.mark.tier2
 def test_positive_remove_product(module_org, target_sat):
     """Create a sync plan with two products and then remove one
     product from it.
@@ -533,7 +513,6 @@ def test_positive_remove_product(module_org, target_sat):
     assert sync_plan.product[0].id == products[1].id
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_remove_products(module_org, target_sat):
     """Create a sync plan with two products and then remove both
@@ -553,7 +532,6 @@ def test_positive_remove_products(module_org, target_sat):
     assert len(sync_plan.read().product) == 0
 
 
-@pytest.mark.tier2
 def test_positive_repeatedly_add_remove(module_org, request, target_sat):
     """Repeatedly add and remove a product from a sync plan.
 
@@ -575,7 +553,6 @@ def test_positive_repeatedly_add_remove(module_org, request, target_sat):
         assert len(sync_plan.read().product) == 0
 
 
-@pytest.mark.tier2
 def test_positive_add_remove_products_custom_cron(module_org, request, target_sat):
     """Create a sync plan with two products having custom cron interval
     and then remove both products from it.
@@ -599,7 +576,6 @@ def test_positive_add_remove_products_custom_cron(module_org, request, target_sa
     assert len(sync_plan.read().product) == 0
 
 
-@pytest.mark.tier4
 def test_negative_synchronize_custom_product_past_sync_date(module_org, request, target_sat):
     """Verify product won't get synced immediately after adding association
     with a sync plan which has already been started
@@ -628,7 +604,6 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org, request,
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
 
 
-@pytest.mark.tier4
 def test_positive_synchronize_custom_product_past_sync_date(module_org, request, target_sat):
     """Create a sync plan with past datetime as a sync date, add a
     custom product and verify the product gets synchronized on the next
@@ -674,7 +649,6 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request,
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 
-@pytest.mark.tier4
 def test_positive_synchronize_custom_product_future_sync_date(module_org, request, target_sat):
     """Create a sync plan with sync date in a future and sync one custom
     product with it automatically.
@@ -722,7 +696,6 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 
-@pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_custom_products_future_sync_date(module_org, request, target_sat):
     """Create a sync plan with sync date in a future and sync multiple
@@ -782,7 +755,6 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier4
 def test_positive_synchronize_rh_product_past_sync_date(
     request, function_sca_manifest_org, target_sat
 ):
@@ -849,7 +821,6 @@ def test_positive_synchronize_rh_product_past_sync_date(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_rh_product_future_sync_date(
     request, function_sca_manifest_org, target_sat
@@ -907,7 +878,6 @@ def test_positive_synchronize_rh_product_future_sync_date(
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 
-@pytest.mark.tier3
 def test_positive_synchronize_custom_product_daily_recurrence(module_org, request, target_sat):
     """Create a daily sync plan with current datetime as a sync date,
     add a custom product and verify the product gets synchronized on
@@ -948,7 +918,6 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 
-@pytest.mark.tier3
 def test_positive_synchronize_custom_product_weekly_recurrence(module_org, request, target_sat):
     """Create a weekly sync plan with a past datetime as a sync date,
     add a custom product and verify the product gets synchronized on
@@ -991,7 +960,6 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org, reque
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 
-@pytest.mark.tier2
 def test_positive_delete_one_product(module_org, target_sat):
     """Create a sync plan with one product and delete it.
 
@@ -1009,7 +977,6 @@ def test_positive_delete_one_product(module_org, target_sat):
         sync_plan.read()
 
 
-@pytest.mark.tier2
 def test_positive_delete_products(module_org, target_sat):
     """Create a sync plan with two products and delete them.
 
@@ -1027,7 +994,6 @@ def test_positive_delete_products(module_org, target_sat):
         sync_plan.read()
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_delete_synced_product_custom_cron(module_org, module_target_sat):
     """Create a sync plan with custom cron with one synced

--- a/tests/foreman/api/test_template_combination.py
+++ b/tests/foreman/api/test_template_combination.py
@@ -14,7 +14,6 @@ import pytest
 from requests.exceptions import HTTPError
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_end_to_end_template_combination(request, module_target_sat, module_hostgroup):
     """Assert API template combination get/delete method works.

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -60,7 +60,6 @@ class TestTemplateSyncTestCase:
             f'[ -f example_template.erb ] || wget {FOREMAN_TEMPLATE_TEST_TEMPLATE}'
         )
 
-    @pytest.mark.tier2
     def test_positive_import_filtered_templates_from_git(
         self, module_org, module_location, module_target_sat
     ):
@@ -138,7 +137,6 @@ class TestTemplateSyncTestCase:
         )
         assert len(rtemplates) == 1
 
-    @pytest.mark.tier2
     def test_import_filtered_templates_from_git_with_negate(self, module_org, module_target_sat):
         """Assure templates with a given filter regex are NOT pulled from
         git repo.
@@ -190,7 +188,6 @@ class TestTemplateSyncTestCase:
         )
         assert len(rtemplates) == 1
 
-    @pytest.mark.tier2
     def test_import_template_with_puppet(self, parametrized_puppet_sat):
         """Importing puppet templates with enabled/disabled puppet module
 
@@ -228,7 +225,6 @@ class TestTemplateSyncTestCase:
         else:
             assert not_imported_count == 2
 
-    @pytest.mark.tier2
     def test_positive_import_and_associate(
         self,
         create_import_export_local_dir,
@@ -367,7 +363,6 @@ class TestTemplateSyncTestCase:
         assert ptemplate
         assert len(ptemplate[0].read().organization) == 1
 
-    @pytest.mark.tier2
     def test_positive_import_from_subdirectory(self, module_org, module_target_sat):
         """Assure templates are imported from specific repositories subdirectory
 
@@ -402,7 +397,6 @@ class TestTemplateSyncTestCase:
 
     # Export tests
 
-    @pytest.mark.tier2
     def test_positive_export_filtered_templates_to_localdir(
         self, module_org, create_import_export_local_dir, target_sat
     ):
@@ -439,7 +433,6 @@ class TestTemplateSyncTestCase:
             target_sat.execute(f'find {dir_path} -type f -name *ansible* | wc -l').stdout.strip()
         )
 
-    @pytest.mark.tier2
     def test_positive_export_filtered_templates_negate(
         self, module_org, create_import_export_local_dir, target_sat
     ):
@@ -474,7 +467,6 @@ class TestTemplateSyncTestCase:
         )
         assert target_sat.execute(f'find {dir_path} -type f | wc -l').stdout.strip() != '0'
 
-    @pytest.mark.tier2
     def test_positive_export_and_import_with_metadata(
         self, create_import_export_local_dir, module_org, module_location, target_sat
     ):
@@ -552,7 +544,6 @@ class TestTemplateSyncTestCase:
         assert result.status == 1
 
     # Take Templates out of Tech Preview Feature Tests
-    @pytest.mark.tier3
     @pytest.mark.parametrize('verbose', [True, False])
     def test_positive_import_json_output_verbose(self, module_org, verbose, module_target_sat):
         """Assert all the required fields displayed in import output when
@@ -603,7 +594,6 @@ class TestTemplateSyncTestCase:
         actual_fields = templates['message']['templates'][0].keys()
         assert sorted(actual_fields) == sorted(expected_fields)
 
-    @pytest.mark.tier2
     def test_positive_import_json_output_changed_key_true(
         self, create_import_export_local_dir, module_org, target_sat
     ):
@@ -639,7 +629,6 @@ class TestTemplateSyncTestCase:
         )
         assert bool(post_template['message']['templates'][0]['changed'])
 
-    @pytest.mark.tier2
     def test_positive_import_json_output_changed_key_false(
         self, create_import_export_local_dir, module_org, module_target_sat
     ):
@@ -673,7 +662,6 @@ class TestTemplateSyncTestCase:
         )
         assert not bool(post_template['message']['templates'][0]['changed'])
 
-    @pytest.mark.tier2
     def test_positive_import_json_output_name_key(
         self, create_import_export_local_dir, module_org, target_sat
     ):
@@ -704,7 +692,6 @@ class TestTemplateSyncTestCase:
         assert 'name' in template['message']['templates'][0]
         assert template_name == template['message']['templates'][0]['name']
 
-    @pytest.mark.tier2
     def test_positive_import_json_output_imported_key(
         self, create_import_export_local_dir, module_org, module_target_sat
     ):
@@ -731,7 +718,6 @@ class TestTemplateSyncTestCase:
         )
         assert bool(template['message']['templates'][0]['imported'])
 
-    @pytest.mark.tier2
     def test_positive_import_json_output_file_key(
         self, create_import_export_local_dir, module_org, module_target_sat
     ):
@@ -758,7 +744,6 @@ class TestTemplateSyncTestCase:
         )
         assert template['message']['templates'][0]['file'] == 'example_template.erb'
 
-    @pytest.mark.tier2
     def test_positive_import_json_output_corrupted_metadata(
         self, create_import_export_local_dir, module_org, target_sat
     ):
@@ -791,7 +776,6 @@ class TestTemplateSyncTestCase:
             template['message']['templates'][0]['additional_errors'] == 'Failed to parse metadata'
         )
 
-    @pytest.mark.tier2
     def test_positive_import_json_output_filtered_skip_message(
         self, create_import_export_local_dir, module_org, module_target_sat
     ):
@@ -827,7 +811,6 @@ class TestTemplateSyncTestCase:
             == "Skipping, 'name' filtered out based on 'filter' and 'negate' settings"
         )
 
-    @pytest.mark.tier2
     def test_positive_import_json_output_no_name_error(
         self, create_import_export_local_dir, module_org, target_sat
     ):
@@ -861,7 +844,6 @@ class TestTemplateSyncTestCase:
             == "No 'name' found in metadata"
         )
 
-    @pytest.mark.tier2
     def test_positive_import_json_output_no_model_error(
         self, create_import_export_local_dir, module_org, target_sat
     ):
@@ -895,7 +877,6 @@ class TestTemplateSyncTestCase:
             == "No 'model' found in metadata"
         )
 
-    @pytest.mark.tier2
     def test_positive_import_json_output_blank_model_error(
         self, create_import_export_local_dir, module_org, target_sat
     ):
@@ -929,7 +910,6 @@ class TestTemplateSyncTestCase:
             == "Template type  was not found, are you missing a plugin?"
         )
 
-    @pytest.mark.tier2
     def test_positive_export_json_output(
         self, create_import_export_local_dir, module_org, target_sat
     ):
@@ -988,7 +968,6 @@ class TestTemplateSyncTestCase:
             == 0
         )
 
-    @pytest.mark.tier3
     def test_positive_import_log_to_production(self, module_org, target_sat):
         """Assert template import logs are logged to production logs
 
@@ -1022,7 +1001,6 @@ class TestTemplateSyncTestCase:
             == 0
         )
 
-    @pytest.mark.tier3
     def test_positive_export_log_to_production(
         self, create_import_export_local_dir, module_org, target_sat
     ):
@@ -1062,7 +1040,6 @@ class TestTemplateSyncTestCase:
             == 0
         )
 
-    @pytest.mark.tier2
     @pytest.mark.skip_if_not_set('git')
     @pytest.mark.parametrize(
         'url',
@@ -1120,7 +1097,6 @@ class TestTemplateSyncTestCase:
         git_count = [row['path'].endswith('.erb') for row in tree].count(True)
         assert len(output['message']['templates']) == git_count
 
-    @pytest.mark.tier2
     def test_positive_import_all_templates_from_repo(self, module_org, module_target_sat):
         """Assure all templates are imported if no filter is specified.
 
@@ -1152,7 +1128,6 @@ class TestTemplateSyncTestCase:
         git_count = [row['path'].endswith('.erb') for row in tree].count(True)
         assert len(output['message']['templates']) == git_count
 
-    @pytest.mark.tier2
     def test_negative_import_locked_template(self, module_org, module_target_sat):
         """Assure locked templates are not pulled from repository.
 
@@ -1201,7 +1176,6 @@ class TestTemplateSyncTestCase:
         ).read()
         assert git_content.decode('utf-8') == sat_content.template
 
-    @pytest.mark.tier2
     def test_positive_import_locked_template(self, module_org, module_target_sat):
         """Assure locked templates are pulled from repository while using force parameter.
 

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -48,7 +48,6 @@ def create_user(module_target_sat):
 class TestUser:
     """Tests for the ``users`` path."""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('username', **parametrized(valid_usernames_list()))
     def test_positive_create_with_username(self, username, target_sat):
         """Create User for all variations of Username
@@ -64,7 +63,6 @@ class TestUser:
         user = target_sat.api.User(login=username).create()
         assert user.login == username
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'firstname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
     )
@@ -84,7 +82,6 @@ class TestUser:
         user = target_sat.api.User(firstname=firstname).create()
         assert user.firstname == firstname
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'lastname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
     )
@@ -104,7 +101,6 @@ class TestUser:
         user = target_sat.api.User(lastname=lastname).create()
         assert user.lastname == lastname
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('mail', **parametrized(valid_emails_list()))
     def test_positive_create_with_email(self, mail, target_sat):
         """Create User for all variations of Email
@@ -120,7 +116,6 @@ class TestUser:
         user = target_sat.api.User(mail=mail).create()
         assert user.mail == mail
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
     def test_positive_create_with_description(self, description, target_sat):
         """Create User for all variations of Description
@@ -136,7 +131,6 @@ class TestUser:
         user = target_sat.api.User(description=description).create()
         assert user.description == description
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'password', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
     )
@@ -154,7 +148,6 @@ class TestUser:
         user = target_sat.api.User(password=password).create()
         assert user is not None
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize('mail', **parametrized(valid_emails_list()))
     def test_positive_delete(self, mail, target_sat):
@@ -173,7 +166,6 @@ class TestUser:
         with pytest.raises(HTTPError):
             user.read()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('login', **parametrized(valid_usernames_list()))
     def test_positive_update_username(self, create_user, login):
         """Update a user and provide new username.
@@ -190,7 +182,6 @@ class TestUser:
         user = create_user.update(['login'])
         assert user.login == login
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('login', **parametrized(invalid_usernames_list()))
     def test_negative_update_username(self, create_user, login):
         """Update a user and provide new login.
@@ -207,7 +198,6 @@ class TestUser:
         with pytest.raises(HTTPError):
             create_user.update(['login'])
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'firstname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
     )
@@ -228,7 +218,6 @@ class TestUser:
         user = create_user.update(['firstname'])
         assert user.firstname == firstname
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'lastname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
     )
@@ -249,7 +238,6 @@ class TestUser:
         user = create_user.update(['lastname'])
         assert user.lastname == lastname
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('mail', **parametrized(valid_emails_list()))
     def test_positive_update_email(self, create_user, mail):
         """Update a user and provide new email.
@@ -266,7 +254,6 @@ class TestUser:
         user = create_user.update(['mail'])
         assert user.mail == mail
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('mail', **parametrized(invalid_emails_list()))
     def test_negative_update_email(self, create_user, mail):
         """Update a user and provide new email.
@@ -283,7 +270,6 @@ class TestUser:
         with pytest.raises(HTTPError):
             create_user.update(['mail'])
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
     def test_positive_update_description(self, create_user, description):
         """Update a user and provide new email.
@@ -300,7 +286,6 @@ class TestUser:
         user = create_user.update(['description'])
         assert user.description == description
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('admin_enable', [True, False])
     def test_positive_update_admin(self, admin_enable, target_sat):
         """Update a user and provide the ``admin`` attribute.
@@ -317,7 +302,6 @@ class TestUser:
         user.admin = not admin_enable
         assert user.update().admin == (not admin_enable)
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('mail', **parametrized(invalid_emails_list()))
     def test_negative_create_with_invalid_email(self, mail, target_sat):
         """Create User with invalid Email Address
@@ -333,7 +317,6 @@ class TestUser:
         with pytest.raises(HTTPError):
             target_sat.api.User(mail=mail).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('invalid_name', **parametrized(invalid_usernames_list()))
     def test_negative_create_with_invalid_username(self, invalid_name, target_sat):
         """Create User with invalid Username
@@ -349,7 +332,6 @@ class TestUser:
         with pytest.raises(HTTPError):
             target_sat.api.User(login=invalid_name).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('invalid_name', **parametrized(invalid_names_list()))
     def test_negative_create_with_invalid_firstname(self, invalid_name, target_sat):
         """Create User with invalid Firstname
@@ -365,7 +347,6 @@ class TestUser:
         with pytest.raises(HTTPError):
             target_sat.api.User(firstname=invalid_name).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('invalid_name', **parametrized(invalid_names_list()))
     def test_negative_create_with_invalid_lastname(self, invalid_name, target_sat):
         """Create User with invalid Lastname
@@ -381,7 +362,6 @@ class TestUser:
         with pytest.raises(HTTPError):
             target_sat.api.User(lastname=invalid_name).create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_blank_authorized_by(self, target_sat):
         """Create User with blank authorized by
 
@@ -394,7 +374,6 @@ class TestUser:
         with pytest.raises(HTTPError):
             target_sat.api.User(auth_source='').create()
 
-    @pytest.mark.tier1
     def test_positive_table_preferences(self, module_target_sat):
         """Create a user, create their Table Preferences, read it
 
@@ -440,7 +419,6 @@ class TestUserRole:
         """Create two roles."""
         return [class_target_sat.api.Role().create() for _ in range(2)]
 
-    @pytest.mark.tier1
     @pytest.mark.build_sanity
     @pytest.mark.parametrize('number_of_roles', range(1, 3))
     def test_positive_create_with_role(self, make_roles, number_of_roles, class_target_sat):
@@ -461,7 +439,6 @@ class TestUserRole:
         assert len(user.role) == number_of_roles
         assert {role.id for role in user.role} == {role.id for role in chosen_roles}
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize('number_of_roles', range(1, 3))
     def test_positive_update(self, create_user, make_roles, number_of_roles):
@@ -493,7 +470,6 @@ class TestSshKeyInUser:
         data_keys = json.loads(DataFile.SSH_KEYS_JSON.read_bytes())
         return dict(user=user, data_keys=data_keys)
 
-    @pytest.mark.tier1
     def test_positive_CRD_ssh_key(self, class_target_sat):
         """SSH Key can be added to User
 
@@ -520,7 +496,6 @@ class TestSshKeyInUser:
         result = class_target_sat.api.SSHKey(user=user).search()
         assert len(result) == 0
 
-    @pytest.mark.tier1
     def test_negative_create_ssh_key(self, create_user, target_sat):
         """Invalid ssh key can not be added in User Template
 
@@ -549,7 +524,6 @@ class TestSshKeyInUser:
         assert re.search('Fingerprint could not be generated', context.value.response.text)
         assert re.search('Length could not be calculated', context.value.response.text)
 
-    @pytest.mark.tier1
     def test_negative_create_invalid_length_ssh_key(self, create_user, target_sat):
         """Attempt to add SSH key that has invalid length
 
@@ -573,7 +547,6 @@ class TestSshKeyInUser:
         assert re.search('Length could not be calculated', context.value.response.text)
         assert not re.search('Fingerprint could not be generated', context.value.response.text)
 
-    @pytest.mark.tier1
     def test_negative_create_ssh_key_with_invalid_name(self, create_user, target_sat):
         """Attempt to add SSH key that has invalid name length
 
@@ -595,7 +568,6 @@ class TestSshKeyInUser:
             ).create()
         assert re.search("Name is too long", context.value.response.text)
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_create_multiple_ssh_key_types(self, create_user, class_target_sat):
         """Multiple types of ssh keys can be added to user
@@ -620,7 +592,6 @@ class TestSshKeyInUser:
         user_sshkeys = class_target_sat.api.SSHKey(user=user).search()
         assert len(user_sshkeys) == 4
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_ssh_key_in_host_enc(self, class_target_sat):
         """SSH key appears in host ENC output
@@ -692,7 +663,6 @@ class TestActiveDirectoryUser:
         org.delete()
         loc.delete()
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize('username', **parametrized(valid_usernames_list()))
     def test_positive_create_in_ldap_mode(self, username, create_ldap, target_sat):
@@ -710,7 +680,6 @@ class TestActiveDirectoryUser:
         ).create()
         assert user.login == username
 
-    @pytest.mark.tier3
     def test_positive_ad_basic_no_roles(self, create_ldap, target_sat):
         """Login with LDAP Auth AD for user with no roles/rights
 
@@ -731,7 +700,6 @@ class TestActiveDirectoryUser:
         with pytest.raises(HTTPError):
             target_sat.api.Architecture(server_config=sc).search()
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_access_entities_from_ldap_org_admin(self, create_ldap, module_target_sat):
         """LDAP User can access resources within its taxonomies if assigned
@@ -841,7 +809,6 @@ class TestFreeIPAUser:
         for user in class_target_sat.api.User().search(query={'search': f'login={username}'}):
             user.delete()
 
-    @pytest.mark.tier3
     def test_positive_ipa_basic_no_roles(self, create_ldap, target_sat):
         """Login with LDAP Auth- FreeIPA for user with no roles/rights
 
@@ -862,7 +829,6 @@ class TestFreeIPAUser:
         with pytest.raises(HTTPError):
             target_sat.api.Architecture(server_config=sc).search()
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_access_entities_from_ipa_org_admin(self, create_ldap, target_sat):
         """LDAP FreeIPA User can access resources within its taxonomies if assigned
@@ -923,7 +889,6 @@ class TestFreeIPAUser:
 class TestPersonalAccessToken:
     """Implement personal access token for the users"""
 
-    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_personal_access_token_admin(self):
         """Personal access token for admin
@@ -942,7 +907,6 @@ class TestPersonalAccessToken:
         :CaseImportance: High
         """
 
-    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_positive_personal_access_token_user_with_role(self):
         """Personal access token for user with a role
@@ -964,7 +928,6 @@ class TestPersonalAccessToken:
         :CaseImportance: High
         """
 
-    @pytest.mark.tier2
     @pytest.mark.stubbed
     def test_expired_personal_access_token(self):
         """Personal access token expired for the user.

--- a/tests/foreman/api/test_usergroup.py
+++ b/tests/foreman/api/test_usergroup.py
@@ -36,7 +36,6 @@ class TestUserGroup:
     def user_group(self, target_sat):
         return target_sat.api.UserGroup().create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_create_with_name(self, target_sat, name):
         """Create new user group using different valid names
@@ -52,7 +51,6 @@ class TestUserGroup:
         user_group = target_sat.api.UserGroup(name=name).create()
         assert user_group.name == name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('login', **parametrized(valid_usernames_list()))
     def test_positive_create_with_user(self, target_sat, login):
         """Create new user group using valid user attached to that group.
@@ -70,7 +68,6 @@ class TestUserGroup:
         assert len(user_group.user) == 1
         assert user_group.user[0].read().login == login
 
-    @pytest.mark.tier1
     def test_positive_create_with_users(self, target_sat):
         """Create new user group using multiple users attached to that group.
 
@@ -87,7 +84,6 @@ class TestUserGroup:
             user.read().login for user in user_group.user
         )
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('role_name', **parametrized(valid_data_list()))
     def test_positive_create_with_role(self, target_sat, role_name):
         """Create new user group using valid role attached to that group.
@@ -105,7 +101,6 @@ class TestUserGroup:
         assert len(user_group.role) == 1
         assert user_group.role[0].read().name == role_name
 
-    @pytest.mark.tier1
     def test_positive_create_with_roles(self, target_sat):
         """Create new user group using multiple roles attached to that group.
 
@@ -122,7 +117,6 @@ class TestUserGroup:
             role.read().name for role in user_group.role
         )
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_create_with_usergroup(self, target_sat, name):
         """Create new user group using another user group attached to the
@@ -141,7 +135,6 @@ class TestUserGroup:
         assert len(user_group.usergroup) == 1
         assert user_group.usergroup[0].read().name == name
 
-    @pytest.mark.tier2
     def test_positive_create_with_usergroups(self, target_sat):
         """Create new user group using multiple user groups attached to that
         initial group.
@@ -158,7 +151,6 @@ class TestUserGroup:
             usergroup.read().name for usergroup in user_group.usergroup
         )
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_name(self, target_sat, name):
         """Attempt to create user group with invalid name.
@@ -174,7 +166,6 @@ class TestUserGroup:
         with pytest.raises(HTTPError):
             target_sat.api.UserGroup(name=name).create()
 
-    @pytest.mark.tier1
     def test_negative_create_with_same_name(self, target_sat):
         """Attempt to create user group with a name of already existent entity.
 
@@ -188,7 +179,6 @@ class TestUserGroup:
         with pytest.raises(HTTPError):
             target_sat.api.UserGroup(name=user_group.name).create()
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
     def test_positive_update(self, user_group, new_name):
         """Update existing user group with different valid names.
@@ -205,7 +195,6 @@ class TestUserGroup:
         user_group = user_group.update(['name'])
         assert new_name == user_group.name
 
-    @pytest.mark.tier1
     def test_positive_update_with_new_user(self, target_sat):
         """Add new user to user group
 
@@ -221,7 +210,6 @@ class TestUserGroup:
         user_group = user_group.update(['user'])
         assert user.login == user_group.user[0].read().login
 
-    @pytest.mark.tier2
     def test_positive_update_with_existing_user(self, target_sat):
         """Update user that assigned to user group with another one
 
@@ -236,7 +224,6 @@ class TestUserGroup:
         user_group = user_group.update(['user'])
         assert users[1].login == user_group.user[0].read().login
 
-    @pytest.mark.tier1
     def test_positive_update_with_new_role(self, target_sat):
         """Add new role to user group
 
@@ -252,7 +239,6 @@ class TestUserGroup:
         user_group = user_group.update(['role'])
         assert new_role.name == user_group.role[0].read().name
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_update_with_new_usergroup(self, target_sat):
         """Add new user group to existing one
@@ -269,7 +255,6 @@ class TestUserGroup:
         user_group = user_group.update(['usergroup'])
         assert new_usergroup.name == user_group.usergroup[0].read().name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update(self, user_group, new_name):
         """Attempt to update existing user group using different invalid names.
@@ -287,7 +272,6 @@ class TestUserGroup:
             user_group.update(['name'])
         assert user_group.read().name != new_name
 
-    @pytest.mark.tier1
     def test_negative_update_with_same_name(self, target_sat):
         """Attempt to update user group with a name of already existent entity.
 
@@ -305,7 +289,6 @@ class TestUserGroup:
             new_user_group.update(['name'])
         assert new_user_group.read().name != name
 
-    @pytest.mark.tier1
     def test_positive_delete(self, target_sat):
         """Create user group with valid name and then delete it
 

--- a/tests/foreman/api/test_webhook.py
+++ b/tests/foreman/api/test_webhook.py
@@ -62,7 +62,6 @@ def assert_event_triggered(channel, event):
 
 
 class TestWebhook:
-    @pytest.mark.tier2
     def test_negative_invalid_event(self, target_sat):
         """Test negative webhook creation with an invalid event
 
@@ -75,7 +74,6 @@ class TestWebhook:
         with pytest.raises(HTTPError):
             target_sat.api.Webhooks(event='invalid_event').create()
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('event', WEBHOOK_EVENTS)
     def test_positive_valid_event(self, event, target_sat):
         """Test positive webhook creation with a valid event
@@ -89,7 +87,6 @@ class TestWebhook:
         hook = target_sat.api.Webhooks(event=event).create()
         assert event in hook.event
 
-    @pytest.mark.tier2
     def test_negative_invalid_method(self, target_sat):
         """Test negative webhook creation with an invalid HTTP method
 
@@ -102,7 +99,6 @@ class TestWebhook:
         with pytest.raises(HTTPError):
             target_sat.api.Webhooks(http_method='NONE').create()
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('method', **parametrized(WEBHOOK_METHODS))
     def test_positive_valid_method(self, method, target_sat):
         """Test positive webhook creation with a valid HTTP method
@@ -116,7 +112,6 @@ class TestWebhook:
         hook = target_sat.api.Webhooks(http_method=method).create()
         assert hook.http_method == method
 
-    @pytest.mark.tier1
     @pytest.mark.e2e
     def test_positive_end_to_end(self, target_sat):
         """Create a new webhook.
@@ -143,7 +138,6 @@ class TestWebhook:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    @pytest.mark.tier2
     @pytest.mark.e2e
     @pytest.mark.parametrize('setting_update', ['safemode_render=False'], indirect=True)
     def test_positive_event_triggered(self, module_org, target_sat, setting_update):

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -18,7 +18,6 @@ pytestmark = [pytest.mark.stubbed]
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier1
 def test_positive_create_report(self):
     """a crashed program and abrt reports are send
 
@@ -38,7 +37,6 @@ def test_positive_create_report(self):
     """
 
 
-@pytest.mark.tier2
 def test_positive_create_reports(self):
     """Counts are correct when abrt sends multiple reports
 
@@ -57,7 +55,6 @@ def test_positive_create_reports(self):
     """
 
 
-@pytest.mark.tier2
 def test_positive_update_timer(self):
     """Edit the smart-proxy-abrt timer
 
@@ -73,7 +70,6 @@ def test_positive_update_timer(self):
     """
 
 
-@pytest.mark.tier2
 def test_positive_identify_hostname(self):
     """Identifying the hostnames
 
@@ -89,7 +85,6 @@ def test_positive_identify_hostname(self):
     """
 
 
-@pytest.mark.tier2
 def test_positive_search_report(self):
     """Able to retrieve reports in CLI
 

--- a/tests/foreman/cli/test_acs.py
+++ b/tests/foreman/cli/test_acs.py
@@ -29,7 +29,6 @@ VAL_CANNOT_BE = 'cannot be'
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.pit_server
 @pytest.mark.parametrize('cnt_type', ['yum', 'file'])
 @pytest.mark.parametrize('acs_type', ['custom', 'simplified', 'rhui'])
@@ -119,7 +118,6 @@ def test_positive_CRUD_all_types(
     assert f'{ACS_NOT_FOUND} {new_acs["id"]}.' in context.value.message, 'ACS was not deleted'
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('acs_type', ['custom', 'simplified', 'rhui'])
 def test_negative_check_name_validation(module_target_sat, acs_type):
     """Check validation when name is not provided.
@@ -144,7 +142,6 @@ def test_negative_check_name_validation(module_target_sat, acs_type):
     assert f'Name {VAL_CANT_BLANK}' in context.value.message
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('acs_type', ['custom', 'rhui'])
 def test_negative_check_custom_rhui_validations(module_target_sat, acs_type, module_yum_repo):
     """Check validations for required and forbidden params specific to Custom and Rhui ACS.
@@ -193,7 +190,6 @@ def test_negative_check_custom_rhui_validations(module_target_sat, acs_type, mod
     )
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('cnt_type', ['yum', 'file'])
 def test_negative_check_simplified_validations(
     module_target_sat, cnt_type, module_yum_repo, module_file_repo

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -34,7 +34,6 @@ def get_default_env(module_org, module_target_sat):
     )
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 def test_positive_create_with_name(module_target_sat, module_sca_manifest_org, name):
     """Create Activation key for all variations of Activation key
@@ -54,7 +53,6 @@ def test_positive_create_with_name(module_target_sat, module_sca_manifest_org, n
     assert new_ak['name'] == name
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
 def test_positive_create_with_description(desc, module_org, module_target_sat):
     """Create Activation key for all variations of Description
@@ -73,7 +71,6 @@ def test_positive_create_with_description(desc, module_org, module_target_sat):
     assert new_ak['description'] == desc
 
 
-@pytest.mark.tier1
 def test_positive_create_with_default_lce_by_id(module_org, get_default_env, target_sat):
     """Create Activation key with associated default environment
 
@@ -90,7 +87,6 @@ def test_positive_create_with_default_lce_by_id(module_org, get_default_env, tar
     assert new_ak_env['lifecycle-environment'] == lce['name']
 
 
-@pytest.mark.tier1
 def test_positive_create_with_non_default_lce(module_org, module_target_sat):
     """Create Activation key with associated custom environment
 
@@ -110,7 +106,6 @@ def test_positive_create_with_non_default_lce(module_org, module_target_sat):
     assert new_ak_env['lifecycle-environment'] == env['name']
 
 
-@pytest.mark.tier1
 def test_positive_create_with_default_lce_by_name(module_org, get_default_env, module_target_sat):
     """Create Activation key with associated environment by name
 
@@ -127,7 +122,6 @@ def test_positive_create_with_default_lce_by_name(module_org, get_default_env, m
     assert new_ak_env['lifecycle-environment'] == lce['name']
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 def test_positive_create_with_cv(name, module_org, get_default_env, module_target_sat):
     """Create Activation key for all variations of Content Views
@@ -153,7 +147,6 @@ def test_positive_create_with_cv(name, module_org, get_default_env, module_targe
     assert new_ak_cv['content-view'] == name
 
 
-@pytest.mark.tier1
 def test_positive_create_with_usage_limit_default(module_org, module_target_sat):
     """Create Activation key with default Usage limit (Unlimited)
 
@@ -167,7 +160,6 @@ def test_positive_create_with_usage_limit_default(module_org, module_target_sat)
     assert new_ak['host-limit'] == '0 of Unlimited'
 
 
-@pytest.mark.tier1
 def test_positive_create_with_usage_limit_finite(module_org, module_target_sat):
     """Create Activation key with finite Usage limit
 
@@ -183,7 +175,6 @@ def test_positive_create_with_usage_limit_finite(module_org, module_target_sat):
     assert new_ak['host-limit'] == '0 of 10'
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_create_content_and_check_enabled(module_org, module_target_sat):
     """Create activation key and add content to it. Check enabled state.
@@ -204,7 +195,6 @@ def test_positive_create_content_and_check_enabled(module_org, module_target_sat
     assert content[0]['default-enabled?'] == 'false'
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
 def test_negative_create_with_invalid_name(name, module_org, module_target_sat):
     """Create Activation key with invalid Name
@@ -228,7 +218,6 @@ def test_negative_create_with_invalid_name(name, module_org, module_target_sat):
         assert 'Name is too long (maximum is 255 characters)' in str(raise_ctx)
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'limit',
     **parametrized([value for value in invalid_values_list() if not value.isdigit()] + [0.5]),
@@ -258,7 +247,6 @@ def test_negative_create_with_usage_limit_with_not_integers(module_org, limit, m
         assert 'Numeric value is required.' in str(raise_ctx)
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize('invalid_values', ['-1', '-500', 0])
 def test_negative_create_with_usage_limit_with_invalid_integers(
     module_org, invalid_values, module_target_sat
@@ -281,7 +269,6 @@ def test_negative_create_with_usage_limit_with_invalid_integers(
     assert 'Failed to create ActivationKey with data:' in str(raise_ctx)
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 def test_positive_delete_by_name(name, module_org, module_target_sat):
     """Create Activation key and delete it for all variations of
@@ -305,7 +292,6 @@ def test_positive_delete_by_name(name, module_org, module_target_sat):
         module_target_sat.cli.ActivationKey.info({'id': new_ak['id']})
 
 
-@pytest.mark.tier1
 def test_positive_delete_by_org_name(module_org, module_target_sat):
     """Create Activation key and delete it using organization name
     for which that key was created
@@ -324,7 +310,6 @@ def test_positive_delete_by_org_name(module_org, module_target_sat):
         module_target_sat.cli.ActivationKey.info({'id': new_ak['id']})
 
 
-@pytest.mark.tier1
 def test_positive_delete_by_org_label(module_org, module_target_sat):
     """Create Activation key and delete it using organization label
     for which that key was created
@@ -343,7 +328,6 @@ def test_positive_delete_by_org_label(module_org, module_target_sat):
         module_target_sat.cli.ActivationKey.info({'id': new_ak['id']})
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_delete_with_cv(module_org, module_target_sat):
     """Create activation key with content view assigned to it and
@@ -362,7 +346,6 @@ def test_positive_delete_with_cv(module_org, module_target_sat):
         module_target_sat.cli.ActivationKey.info({'id': new_ak['id']})
 
 
-@pytest.mark.tier2
 def test_positive_delete_with_lce(module_org, get_default_env, module_target_sat):
     """Create activation key with lifecycle environment assigned to
     it and delete it using activation key id
@@ -379,7 +362,6 @@ def test_positive_delete_with_lce(module_org, get_default_env, module_target_sat
         module_target_sat.cli.ActivationKey.info({'id': new_ak['id']})
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 def test_positive_update_name_by_id(module_org, name, module_target_sat):
     """Update Activation Key Name in Activation key searching by ID
@@ -402,7 +384,6 @@ def test_positive_update_name_by_id(module_org, name, module_target_sat):
     assert updated_ak['name'] == name
 
 
-@pytest.mark.tier1
 def test_positive_update_name_by_name(module_org, module_target_sat):
     """Update Activation Key Name in an Activation key searching by
     name
@@ -424,7 +405,6 @@ def test_positive_update_name_by_name(module_org, module_target_sat):
     assert updated_ak['name'] == new_name
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
 def test_positive_update_description(description, module_org, module_target_sat):
     """Update Description in an Activation key
@@ -451,7 +431,6 @@ def test_positive_update_description(description, module_org, module_target_sat)
     assert updated_ak['description'] == description
 
 
-@pytest.mark.tier2
 def test_positive_update_lce(module_org, get_default_env, module_target_sat):
     """Update Environment in an Activation key
 
@@ -483,7 +462,6 @@ def test_positive_update_lce(module_org, get_default_env, module_target_sat):
     assert updated_ak['lifecycle-environment'] == env['name']
 
 
-@pytest.mark.tier2
 def test_positive_update_cv(module_org, module_target_sat):
     """Update Content View in an Activation key
 
@@ -503,7 +481,6 @@ def test_positive_update_cv(module_org, module_target_sat):
     assert updated_ak['content-view'] == new_cv['name']
 
 
-@pytest.mark.tier1
 def test_positive_update_usage_limit_to_finite_number(module_org, module_target_sat):
     """Update Usage limit from Unlimited to a finite number
 
@@ -522,7 +499,6 @@ def test_positive_update_usage_limit_to_finite_number(module_org, module_target_
     assert updated_ak['host-limit'] == '0 of 2147483647'
 
 
-@pytest.mark.tier1
 def test_positive_update_usage_limit_to_unlimited(module_org, module_target_sat):
     """Update Usage limit from definite number to Unlimited
 
@@ -543,7 +519,6 @@ def test_positive_update_usage_limit_to_unlimited(module_org, module_target_sat)
     assert updated_ak['host-limit'] == '0 of Unlimited'
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
 def test_negative_update_name(module_org, name, module_target_sat):
     """Try to update Activation Key using invalid value for its name
@@ -565,7 +540,6 @@ def test_negative_update_name(module_org, name, module_target_sat):
     assert 'Could not update the activation key:' in raise_ctx.value.message
 
 
-@pytest.mark.tier2
 def test_negative_update_usage_limit(module_org, module_target_sat):
     """Try to update Activation Key using invalid value for its
     usage limit attribute
@@ -585,7 +559,6 @@ def test_negative_update_usage_limit(module_org, module_target_sat):
     assert 'Validation failed: Max hosts must be less than 2147483648' in raise_ctx.value.message
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_positive_usage_limit(module_org, module_location, target_sat, content_hosts):
@@ -631,7 +604,6 @@ def test_positive_usage_limit(module_org, module_location, target_sat, content_h
     assert f"Max Hosts ({max_hosts}) reached for activation key '{new_ak.name}'" in result.stderr
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('host_col_name', **parametrized(valid_data_list()))
 def test_positive_update_host_collection(module_org, host_col_name, module_target_sat):
     """Test that host collections can be associated to Activation
@@ -666,7 +638,6 @@ def test_positive_update_host_collection(module_org, host_col_name, module_targe
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_update_host_collection_with_default_org(module_org, module_target_sat):
     """Test that host collection can be associated to Activation
     Keys with specified default organization setting in config
@@ -694,7 +665,6 @@ def test_positive_update_host_collection_with_default_org(module_org, module_tar
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 def test_positive_add_redhat_product(function_sca_manifest_org, target_sat):
     """Test that RH product can be associated to Activation Keys
 
@@ -722,7 +692,6 @@ def test_positive_add_redhat_product(function_sca_manifest_org, target_sat):
     assert content[0]['name'] == REPOSET['rhst7']
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_custom_product(function_org, target_sat):
     """Test that custom product can be associated to Activation Keys
@@ -745,7 +714,6 @@ def test_positive_add_custom_product(function_org, target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_redhat_and_custom_products(module_target_sat, function_sca_manifest_org):
@@ -793,7 +761,6 @@ def test_positive_add_redhat_and_custom_products(module_target_sat, function_sca
     assert {REPOSET['rhst7'], repo['name']} == {pc['name'] for pc in content}
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.rhel_ver_match('[^6]')
 def test_positive_update_aks_to_chost(
@@ -837,7 +804,6 @@ def test_positive_update_aks_to_chost(
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_update_aks_to_chost_in_one_command(module_org):
     """Check if multiple Activation keys can be attached to a
     Content host in one command. Here is a command details
@@ -861,7 +827,6 @@ def test_positive_update_aks_to_chost_in_one_command(module_org):
     """
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 def test_positive_list_by_name(module_org, name, module_target_sat):
     """List Activation key for all variations of Activation key name
@@ -884,7 +849,6 @@ def test_positive_list_by_name(module_org, name, module_target_sat):
     assert result[0]['name'] == name
 
 
-@pytest.mark.tier1
 def test_positive_list_by_cv_id(module_org, module_target_sat):
     """List Activation key for provided Content View ID
 
@@ -905,7 +869,6 @@ def test_positive_list_by_cv_id(module_org, module_target_sat):
     assert result[0]['content-view'] == cv['name']
 
 
-@pytest.mark.tier1
 def test_positive_create_using_old_name(module_org, module_target_sat):
     """Create activation key, rename it and create another with the
     initial name
@@ -932,7 +895,6 @@ def test_positive_create_using_old_name(module_org, module_target_sat):
     assert new_activation_key['name'] == name
 
 
-@pytest.mark.tier2
 def test_positive_remove_host_collection_by_id(module_org, module_target_sat):
     """Test that hosts associated to Activation Keys can be removed
     using id of that host collection
@@ -980,7 +942,6 @@ def test_positive_remove_host_collection_by_id(module_org, module_target_sat):
     assert len(activation_key['host-collections']) == 0
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('host_col', **parametrized(valid_data_list()))
 def test_positive_remove_host_collection_by_name(module_org, host_col, module_target_sat):
     """Test that hosts associated to Activation Keys can be removed
@@ -1032,7 +993,6 @@ def test_positive_remove_host_collection_by_name(module_org, host_col, module_ta
     assert len(activation_key['host-collections']) == 0
 
 
-@pytest.mark.tier2
 def test_create_ak_with_syspurpose_set(module_sca_manifest_org, module_target_sat):
     """Test that an activation key can be created with system purpose values set.
 
@@ -1081,7 +1041,6 @@ def test_create_ak_with_syspurpose_set(module_sca_manifest_org, module_target_sa
     assert updated_ak['system-purpose']['purpose-usage'] == ''
 
 
-@pytest.mark.tier2
 def test_update_ak_with_syspurpose_values(module_sca_manifest_org, module_target_sat):
     """Test that system purpose values can be added to an existing activation key
     and can then be changed.
@@ -1148,7 +1107,6 @@ def test_update_ak_with_syspurpose_values(module_sca_manifest_org, module_target
     assert updated_ak['system-purpose']['service-level'] == "Premium"
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
 def test_positive_copy_by_parent_id(module_org, new_name, module_target_sat):
     """Copy Activation key for all valid Activation Key name
@@ -1171,7 +1129,6 @@ def test_positive_copy_by_parent_id(module_org, new_name, module_target_sat):
     assert 'Activation key copied.' in result
 
 
-@pytest.mark.tier1
 def test_positive_copy_by_parent_name(module_org, module_target_sat):
     """Copy Activation key by passing name of parent
 
@@ -1194,7 +1151,6 @@ def test_positive_copy_by_parent_name(module_org, module_target_sat):
     assert 'Activation key copied.' in result
 
 
-@pytest.mark.tier1
 def test_negative_copy_with_same_name(module_org, module_target_sat):
     """Copy activation key with duplicate name
 
@@ -1218,7 +1174,6 @@ def test_negative_copy_with_same_name(module_org, module_target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_copy_activationkey_and_check_content(
     function_sca_manifest_org, module_target_sat
@@ -1262,7 +1217,6 @@ def test_positive_copy_activationkey_and_check_content(
     assert new_content[0]['name'] == REPOSET['rhst7']
 
 
-@pytest.mark.tier1
 def test_positive_update_autoattach_toggle(module_org, module_target_sat):
     """Update Activation key with inverse auto-attach value
 
@@ -1289,7 +1243,6 @@ def test_positive_update_autoattach_toggle(module_org, module_target_sat):
     assert updated_ak['auto-attach'] == new_value
 
 
-@pytest.mark.tier1
 def test_positive_update_autoattach(module_org, module_target_sat):
     """Update Activation key with valid auto-attach values
 
@@ -1307,7 +1260,6 @@ def test_positive_update_autoattach(module_org, module_target_sat):
         assert result[0]['message'] == 'Activation key updated.'
 
 
-@pytest.mark.tier2
 def test_negative_update_autoattach(module_org, module_target_sat):
     """Attempt to update Activation key with bad auto-attach value
 
@@ -1335,7 +1287,6 @@ def test_negative_update_autoattach(module_org, module_target_sat):
     assert "'--auto-attach': value must be one of" in exe.value.stderr.lower()
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_content_override(module_org, module_target_sat):
     """Positive content override
@@ -1373,7 +1324,6 @@ def test_positive_content_override(module_org, module_target_sat):
         assert content[0]['override'] == f'enabled:{int(override_value)}'
 
 
-@pytest.mark.tier2
 def test_positive_remove_user(module_org, module_target_sat):
     """Delete any user who has previously created an activation key
     and check that activation key still exists
@@ -1397,7 +1347,6 @@ def test_positive_remove_user(module_org, module_target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 def test_positive_view_content_by_non_admin_user(function_sca_manifest_org, module_target_sat):
     """Attempt to read activation key content by non admin user
 
@@ -1495,7 +1444,6 @@ def test_positive_view_content_by_non_admin_user(function_sca_manifest_org, modu
     assert reposet[0]['id'] == content[0]['id']
 
 
-@pytest.mark.tier3
 def test_positive_invalid_release_version(module_sca_manifest_org, module_target_sat):
     """Check invalid release versions when updating or creating an activation key
 

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -149,7 +149,6 @@ class TestAnsibleCfgMgmt:
         )
 
     @pytest.mark.e2e
-    @pytest.mark.tier2
     def test_add_and_remove_ansible_role_hostgroup(self, target_sat):
         """
         Test add and remove functionality for ansible roles in hostgroup via CLI
@@ -193,7 +192,6 @@ class TestAnsibleCfgMgmt:
         )
         assert 'Ansible role has been disassociated.' in result[0]['message']
 
-    @pytest.mark.tier3
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_ansible_variables_installed_with_collection(
         self, request, target_sat, module_org, module_ak_with_cv, rhel_contenthost
@@ -259,7 +257,6 @@ class TestAnsibleCfgMgmt:
             target_sat.execute(f'rm -rf {path}/ansible_collections/')
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 class TestAnsibleREX:
     """Test class for remote execution via Ansible
@@ -628,7 +625,6 @@ class TestAnsibleREX:
         collection_path = client.execute('ls ~/ansible_collections').stdout
         assert 'oasis_roles' in collection_path
 
-    @pytest.mark.tier3
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     @pytest.mark.parametrize('auth_type', ['admin', 'non-admin'])

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -32,7 +32,6 @@ class TestArchitecture:
         """Shared architecture for tests"""
         return class_target_sat.cli_factory.make_architecture()
 
-    @pytest.mark.tier1
     def test_positive_CRUD(self, module_target_sat):
         """Create a new Architecture, update the name and delete the Architecture itself.
 
@@ -55,7 +54,6 @@ class TestArchitecture:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Architecture.info({'id': architecture['id']})
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_name(self, name, module_target_sat):
         """Don't create an Architecture with invalid data.
@@ -74,7 +72,6 @@ class TestArchitecture:
 
         assert 'Could not create the architecture:' in error.value.message
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, class_architecture, new_name, module_target_sat):
         """Create Architecture then fail to update its name
@@ -98,7 +95,6 @@ class TestArchitecture:
         result = module_target_sat.cli.Architecture.info({'id': class_architecture['id']})
         assert class_architecture['name'] == result['name']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
     def test_negative_delete_by_id(self, entity_id, module_target_sat):
         """Delete architecture by invalid ID

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -58,7 +58,6 @@ def non_admin_user(module_target_sat):
     return user
 
 
-@pytest.mark.tier1
 def test_positive_create_session(admin_user, target_sat):
     """Check if user stays authenticated with session enabled
 
@@ -96,7 +95,6 @@ def test_positive_create_session(admin_user, target_sat):
         target_sat.cli.Settings.set({'name': 'idle_timeout', 'value': f'{idle_timeout}'})
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_disable_session(admin_user, target_sat):
     """Check if user logs out when session is disabled
@@ -128,7 +126,6 @@ def test_positive_disable_session(admin_user, target_sat):
         target_sat.cli.Org.with_user().list()
 
 
-@pytest.mark.tier1
 def test_positive_log_out_from_session(admin_user, target_sat):
     """Check if session is terminated when user logs out
 
@@ -157,7 +154,6 @@ def test_positive_log_out_from_session(admin_user, target_sat):
         target_sat.cli.Org.with_user().list()
 
 
-@pytest.mark.tier1
 def test_positive_change_session(admin_user, non_admin_user, target_sat):
     """Change from existing session to a different session
 
@@ -187,7 +183,6 @@ def test_positive_change_session(admin_user, non_admin_user, target_sat):
     assert target_sat.cli.User.with_user().list()
 
 
-@pytest.mark.tier1
 def test_positive_session_survives_unauthenticated_call(admin_user, target_sat):
     """Check if session stays up after unauthenticated call
 
@@ -219,7 +214,6 @@ def test_positive_session_survives_unauthenticated_call(admin_user, target_sat):
     target_sat.cli.Org.with_user().list()
 
 
-@pytest.mark.tier1
 def test_positive_session_survives_failed_login(admin_user, non_admin_user, target_sat):
     """Check if session stays up after failed login attempt
 
@@ -257,7 +251,6 @@ def test_positive_session_survives_failed_login(admin_user, non_admin_user, targ
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 def test_positive_session_preceeds_saved_credentials(admin_user, target_sat):
     """Check if enabled session is mutually exclusive with
     saved credentials in hammer config
@@ -296,7 +289,6 @@ def test_positive_session_preceeds_saved_credentials(admin_user, target_sat):
         target_sat.cli.Settings.set({'name': 'idle_timeout', 'value': f'{idle_timeout}'})
 
 
-@pytest.mark.tier1
 def test_negative_no_credentials(target_sat):
     """Attempt to execute command without authentication
 
@@ -314,7 +306,6 @@ def test_negative_no_credentials(target_sat):
         target_sat.cli.Org.with_user().list()
 
 
-@pytest.mark.tier1
 def test_negative_no_permissions(admin_user, non_admin_user, target_sat):
     """Attempt to execute command out of user's permissions
 

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -21,7 +21,6 @@ from robottelo.config import settings
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
-@pytest.mark.tier1
 def test_positive_register(
     module_org,
     module_location,

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -18,7 +18,6 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.mark.skip_if_not_set('fake_capsules')
-@pytest.mark.tier1
 def test_positive_import_puppet_classes(session_puppet_enabled_sat, puppet_proxy_port_range):
     """Import puppet classes from proxy
 

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -307,7 +307,6 @@ def test_positive_update_counts(target_sat, module_capsule_configured):
     )
 
 
-@pytest.mark.tier4
 @pytest.mark.skip_if_not_set('capsule')
 def test_positive_exported_imported_content_sync(
     target_sat,

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -55,7 +55,6 @@ def module_sc_params(session_puppet_enabled_sat, module_puppet):
     return {'list': sc_params_list, 'ids': sc_params_ids_list}
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.skipif(

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -53,7 +53,6 @@ class TestAzureRMComputeResourceTestCase:
     """AzureRm compute resource Tests"""
 
     @pytest.mark.upgrade
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
     )
@@ -112,7 +111,6 @@ class TestAzureRMComputeResourceTestCase:
         assert not sat_azure.cli.ComputeResource.exists(search=('name', result['name']))
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
     )
@@ -212,7 +210,6 @@ class TestAzureRMComputeResourceTestCase:
         assert result['message'] == 'Image deleted.'
         assert result['name'] == new_img_name
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
     )
@@ -229,7 +226,6 @@ class TestAzureRMComputeResourceTestCase:
         result = sat_azure.cli.ComputeResource.networks({'id': module_azurerm_cr.id})
         assert len(result) > 0
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
     )
@@ -378,7 +374,6 @@ class TestAzureRMFinishTemplateProvisioning:
 
     @pytest.mark.e2e
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     @pytest.mark.parametrize('sat_azure', ['sat'], indirect=True)
     def test_positive_azurerm_host_provisioned(
         self,
@@ -507,7 +502,6 @@ class TestAzureRMUserDataProvisioning:
         return azurermclient.get_vm(name=class_host_ud['name'].split('.')[0])
 
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
     )

--- a/tests/foreman/cli/test_computeresource_ec2.py
+++ b/tests/foreman/cli/test_computeresource_ec2.py
@@ -33,7 +33,6 @@ def aws(module_target_sat):
     return aws
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_create_ec2_with_custom_region(aws, module_target_sat):
     """Create a new ec2 compute resource with custom region

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -169,7 +169,6 @@ def test_positive_crud_libvirt_cr(module_target_sat, module_org, module_location
     assert not module_target_sat.cli.ComputeResource.exists(search=('name', cr_list[0]['name']))
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 @pytest.mark.parametrize('options', **parametrized(valid_name_desc_data()))
 def test_positive_create_with_libvirt(libvirt_url, options, target_sat):
@@ -193,7 +192,6 @@ def test_positive_create_with_libvirt(libvirt_url, options, target_sat):
     )
 
 
-@pytest.mark.tier2
 def test_positive_create_with_locs(libvirt_url, module_target_sat):
     """Create Compute Resource with multiple locations
 
@@ -221,7 +219,6 @@ def test_positive_create_with_locs(libvirt_url, module_target_sat):
 # Negative create
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_create_data()))
 def test_negative_create_with_name_url(libvirt_url, options, target_sat):
     """Compute Resource negative create with invalid values
@@ -244,7 +241,6 @@ def test_negative_create_with_name_url(libvirt_url, options, target_sat):
         )
 
 
-@pytest.mark.tier2
 def test_negative_create_with_same_name(libvirt_url, module_target_sat):
     """Compute Resource negative create with the same name
 
@@ -270,7 +266,6 @@ def test_negative_create_with_same_name(libvirt_url, module_target_sat):
 # Update Positive
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('options', **parametrized(valid_update_data()))
 def test_positive_update_name(libvirt_url, options, module_target_sat):
     """Compute Resource positive update
@@ -300,7 +295,6 @@ def test_positive_update_name(libvirt_url, options, module_target_sat):
 # Update Negative
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_update_data()))
 def test_negative_update(libvirt_url, options, module_target_sat):
     """Compute Resource negative update
@@ -326,7 +320,6 @@ def test_negative_update(libvirt_url, options, module_target_sat):
         assert comp_res[key] == result[key]
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('set_console_password', ['true', 'false'])
 def test_positive_create_with_console_password_and_name(
     libvirt_url, set_console_password, module_target_sat
@@ -353,7 +346,6 @@ def test_positive_create_with_console_password_and_name(
     )
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('set_console_password', ['true', 'false'])
 def test_positive_update_console_password(libvirt_url, set_console_password, module_target_sat):
     """Update a compute resource with ``--set-console-password``.
@@ -379,7 +371,6 @@ def test_positive_update_console_password(libvirt_url, set_console_password, mod
 
 @pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_end_to_end(

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -45,7 +45,6 @@ class TestOSPComputeResourceTestCase:
         return versions[getattr(request, 'param', 'osp16')]
 
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     @pytest.mark.parametrize('osp_version', ['osp16', 'osp17'], indirect=True)
     @pytest.mark.parametrize(
         'id_type',
@@ -105,7 +104,6 @@ class TestOSPComputeResourceTestCase:
             compute_resource = target_sat.cli.ComputeResource.info({'id': compute_resource['id']})
         assert new_name == compute_resource['name']
 
-    @pytest.mark.tier3
     def test_negative_create_osp_with_url(self, target_sat):
         """Attempt to create Openstack compute resource with invalid URL
 
@@ -131,7 +129,6 @@ class TestOSPComputeResourceTestCase:
                 }
             )
 
-    @pytest.mark.tier3
     @pytest.mark.stubbed
     def test_positive_provision_osp_with_host_group(self):
         """Provision a host on Openstack compute resource with
@@ -155,7 +152,6 @@ class TestOSPComputeResourceTestCase:
         """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_provision_osp_without_host_group(self):
         """Provision a host on Openstack compute resource without

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -36,7 +36,6 @@ def rhev():
     return rhev
 
 
-@pytest.mark.tier1
 def test_positive_create_rhev_with_valid_name(rhev, module_target_sat):
     """Create Compute Resource of type Rhev with valid name
 
@@ -60,7 +59,6 @@ def test_positive_create_rhev_with_valid_name(rhev, module_target_sat):
     )
 
 
-@pytest.mark.tier1
 def test_positive_rhev_info(rhev, module_target_sat):
     """List the info of RHEV compute resource
 
@@ -86,7 +84,6 @@ def test_positive_rhev_info(rhev, module_target_sat):
     assert compute_resource['name'] == name
 
 
-@pytest.mark.tier1
 def test_positive_delete_by_name(rhev, module_target_sat):
     """Delete the RHEV compute resource by name
 
@@ -113,7 +110,6 @@ def test_positive_delete_by_name(rhev, module_target_sat):
     assert not result
 
 
-@pytest.mark.tier1
 def test_positive_delete_by_id(rhev, module_target_sat):
     """Delete the RHEV compute resource by id
 
@@ -140,7 +136,6 @@ def test_positive_delete_by_id(rhev, module_target_sat):
     assert not result
 
 
-@pytest.mark.tier2
 def test_negative_create_rhev_with_url(rhev, module_target_sat):
     """RHEV compute resource negative create with invalid values
 
@@ -162,7 +157,6 @@ def test_negative_create_rhev_with_url(rhev, module_target_sat):
         )
 
 
-@pytest.mark.tier2
 def test_negative_create_with_same_name(rhev, module_target_sat):
     """RHEV compute resource negative create with the same name
 
@@ -202,7 +196,6 @@ def test_negative_create_with_same_name(rhev, module_target_sat):
         )
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_update_name(rhev, module_target_sat):
     """RHEV compute resource positive update
@@ -235,7 +228,6 @@ def test_positive_update_name(rhev, module_target_sat):
     assert new_name == module_target_sat.cli.ComputeResource.info({'id': comp_res['id']})['name']
 
 
-@pytest.mark.tier2
 def test_positive_add_image_rhev_with_name(rhev, module_os, module_target_sat):
     """Add images to the RHEV compute resource
 
@@ -281,7 +273,6 @@ def test_positive_add_image_rhev_with_name(rhev, module_os, module_target_sat):
     assert result[0]['uuid'] == rhev.image_uuid
 
 
-@pytest.mark.tier2
 def test_negative_add_image_rhev_with_invalid_uuid(rhev, module_os, module_target_sat):
     """Attempt to add invalid image to the RHEV compute resource
 
@@ -323,7 +314,6 @@ def test_negative_add_image_rhev_with_invalid_uuid(rhev, module_os, module_targe
         )
 
 
-@pytest.mark.tier2
 def test_negative_add_image_rhev_with_invalid_name(rhev, module_os, module_target_sat):
     """Attempt to add invalid image name to the RHEV compute resource
 
@@ -370,7 +360,6 @@ def test_negative_add_image_rhev_with_invalid_name(rhev, module_os, module_targe
 
 @pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_rhev_with_host_group(
@@ -511,7 +500,6 @@ def test_positive_provision_rhev_with_host_group(
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_provision_rhev_without_host_group(rhev):
     """Provision a host on RHEV compute resource without
@@ -536,7 +524,6 @@ def test_positive_provision_rhev_without_host_group(rhev):
 
 
 @pytest.mark.on_premises_provisioning
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_rhev_image_based_and_disassociate(

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -19,7 +19,6 @@ from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 
 
-@pytest.mark.tier1
 @pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
@@ -81,7 +80,6 @@ def test_positive_vmware_cr_end_to_end(target_sat, module_org, module_location, 
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
 @pytest.mark.parametrize('provision_method', ['build', 'bootdisk'])
 @pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.tier3
 def test_positive_provision_end_to_end(
     request,
     setting_update,
@@ -157,7 +155,6 @@ def test_positive_provision_end_to_end(
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
 @pytest.mark.parametrize('pxe_loader', ['bios'], indirect=True)
 @pytest.mark.rhel_ver_match('[8]')
-@pytest.mark.tier3
 def test_positive_image_provision_end_to_end(
     request,
     setting_update,

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -51,7 +51,6 @@ class TestDockerClient:
     :CaseImportance: Medium
     """
 
-    @pytest.mark.tier3
     def test_positive_pull_image(
         self, request, module_org, module_container_contenthost, target_sat
     ):
@@ -108,7 +107,6 @@ class TestDockerClient:
             module_container_contenthost.execute(f'docker rmi {repo["published-at"]}')
 
     @pytest.mark.skip_if_not_set('docker')
-    @pytest.mark.tier3
     @pytest.mark.e2e
     def test_positive_container_admin_end_to_end_search(
         self, request, module_org, module_container_contenthost, target_sat
@@ -220,7 +218,6 @@ class TestDockerClient:
         assert docker_repo_uri in result.stdout
 
     @pytest.mark.skip_if_not_set('docker')
-    @pytest.mark.tier3
     @pytest.mark.e2e
     def test_positive_container_admin_end_to_end_pull(
         self, request, module_org, module_container_contenthost, target_sat

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -94,7 +94,6 @@ def vm(
     return module_rhel_contenthost
 
 
-@pytest.mark.tier2
 @pytest.mark.pit_client
 @pytest.mark.pit_server
 @pytest.mark.rhel_ver_match('9')
@@ -136,7 +135,6 @@ def test_positive_list_installable_updates(vm, module_target_sat):
     assert REAL_RHEL9_PACKAGE in applicable_packages[0]['filename']
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.pit_client
 @pytest.mark.pit_server
@@ -173,7 +171,6 @@ def test_positive_erratum_installable(vm, module_target_sat):
     assert erratum[0]['installable'] == 'true'
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_rct_shows_sca_enabled(module_sca_manifest, module_target_sat):
     """Assert unrestricted (SCA) manifest shows SCA enabled.
@@ -196,7 +193,6 @@ def test_positive_rct_shows_sca_enabled(module_sca_manifest, module_target_sat):
 
 
 @pytest.mark.rhel_ver_match('9')
-@pytest.mark.tier3
 def test_negative_unregister_and_pull_content(vm):
     """Attempt to retrieve content after host has been unregistered from Satellite
 

--- a/tests/foreman/cli/test_contentcredentials.py
+++ b/tests/foreman/cli/test_contentcredentials.py
@@ -69,7 +69,6 @@ def wait_for_repo_metadata_tasks(sat, org_name, repo_name='', product_name=''):
 search_key = 'name'
 
 
-@pytest.mark.tier1
 def test_verify_gpg_key_content_displayed(target_sat, module_org):
     """content-credential info should display key content
 
@@ -89,7 +88,6 @@ def test_verify_gpg_key_content_displayed(target_sat, module_org):
     assert gpg_key['content'] == content
 
 
-@pytest.mark.tier1
 def test_positive_get_info_by_name(target_sat, module_org):
     """Create single gpg key and get its info by name
 
@@ -110,7 +108,6 @@ def test_positive_get_info_by_name(target_sat, module_org):
     assert gpg_key['name'] == name
 
 
-@pytest.mark.tier1
 def test_positive_block_delete_key_in_use(target_sat, module_org):
     """Create a product and single associated repository. Create a new gpg key and associate
         it with the product and repository. Attempt to delete the gpg key in use
@@ -159,7 +156,6 @@ def test_positive_block_delete_key_in_use(target_sat, module_org):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_default_org(target_sat, name, default_org):
     """Create gpg key with valid name and valid gpg key via file
     import using the default created organization
@@ -185,7 +181,6 @@ def test_positive_create_with_default_org(target_sat, name, default_org):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_custom_org(target_sat, name, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import using a new organization
@@ -213,7 +208,6 @@ def test_positive_create_with_custom_org(target_sat, name, module_org):
     assert gpg_key[search_key] == result[search_key]
 
 
-@pytest.mark.tier1
 def test_negative_create_with_same_name(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then try to create new one with same name
@@ -240,7 +234,6 @@ def test_negative_create_with_same_name(target_sat, module_org):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_negative_create_with_no_gpg_key(name, target_sat, module_org):
     """Create gpg key with valid name and no gpg key
 
@@ -257,7 +250,6 @@ def test_negative_create_with_no_gpg_key(name, target_sat, module_org):
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_create_with_invalid_name(target_sat, name, module_org):
     """Create gpg key with invalid name and valid gpg key via
     file import
@@ -278,7 +270,6 @@ def test_negative_create_with_invalid_name(target_sat, name, module_org):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_delete(target_sat, name, module_org):
     """Create gpg key with valid name and valid gpg key via file
@@ -309,7 +300,6 @@ def test_positive_delete(target_sat, name, module_org):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_update_name(target_sat, new_name, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then update its name
@@ -336,7 +326,6 @@ def test_positive_update_name(target_sat, new_name, module_org):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_update_key(name, module_org, target_sat):
     """Create gpg key with valid name and valid gpg key via file
     import then update its gpg key file
@@ -366,7 +355,6 @@ def test_positive_update_key(name, module_org, target_sat):
 
 
 @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_update_name(target_sat, new_name, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then fail to update its name
@@ -390,7 +378,6 @@ def test_negative_update_name(target_sat, new_name, module_org):
         )
 
 
-@pytest.mark.tier2
 def test_positive_add_empty_product(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then associate it with empty (no repos) custom product
@@ -406,7 +393,6 @@ def test_positive_add_empty_product(target_sat, module_org):
     assert product['gpg']['gpg-key'] == gpg_key['name']
 
 
-@pytest.mark.tier2
 def test_positive_add_product_with_repo(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then associate it with custom product that has one repository
@@ -437,7 +423,6 @@ def test_positive_add_product_with_repo(target_sat, module_org):
     assert repo['gpg-key']['id'] == gpg_key['id']
 
 
-@pytest.mark.tier2
 def test_positive_add_product_with_repos(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then associate it with custom product that has more than one
@@ -469,7 +454,6 @@ def test_positive_add_product_with_repos(target_sat, module_org):
         assert repo['gpg-key']['id'] == gpg_key['id']
 
 
-@pytest.mark.tier2
 def test_positive_add_repo_from_product_with_repo(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then associate it to repository from custom product that has
@@ -500,7 +484,6 @@ def test_positive_add_repo_from_product_with_repo(target_sat, module_org):
     assert product['gpg'].get('gpg-key-id') != gpg_key['id']
 
 
-@pytest.mark.tier2
 def test_positive_add_repo_from_product_with_repos(target_sat, module_org):
     """Create gpg key via file import and associate with custom repo
 
@@ -537,7 +520,6 @@ def test_positive_add_repo_from_product_with_repos(target_sat, module_org):
         assert repo['gpg-key'].get('id') != gpg_key['id']
 
 
-@pytest.mark.tier2
 def test_positive_update_key_for_empty_product(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then associate it with empty (no repos) custom product then
@@ -573,7 +555,6 @@ def test_positive_update_key_for_empty_product(target_sat, module_org):
     assert product['gpg']['gpg-key'] == new_name
 
 
-@pytest.mark.tier2
 def test_positive_update_key_for_product_with_repo(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then associate it with custom product that has one repository
@@ -625,7 +606,6 @@ def test_positive_update_key_for_product_with_repo(target_sat, module_org):
     assert repo['gpg-key'].get('name') == new_name
 
 
-@pytest.mark.tier2
 def test_positive_update_key_for_product_with_repos(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then associate it with custom product that has more than one
@@ -684,7 +664,6 @@ def test_positive_update_key_for_product_with_repos(target_sat, module_org):
         assert repo['gpg-key'].get('name') == new_name
 
 
-@pytest.mark.tier2
 def test_positive_update_key_for_repo_from_product_with_repo(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then associate it to repository from custom product that has
@@ -728,7 +707,6 @@ def test_positive_update_key_for_repo_from_product_with_repo(target_sat, module_
     assert product['gpg']['gpg-key'] != new_name
 
 
-@pytest.mark.tier2
 def test_positive_update_key_for_repo_from_product_with_repos(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then associate it to repository from custom product that has
@@ -783,7 +761,6 @@ def test_positive_update_key_for_repo_from_product_with_repos(target_sat, module
         assert repo['gpg-key'].get('name') != new_name
 
 
-@pytest.mark.tier1
 def test_positive_list(module_target_sat, module_org):
     """Create gpg key and list it
 
@@ -806,7 +783,6 @@ def test_positive_list(module_target_sat, module_org):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_search(target_sat, name, module_org):
     """Create gpg key and search for it
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -78,7 +78,6 @@ class TestContentView:
     """Content View CLI Tests"""
 
     @pytest.mark.parametrize('name', **parametrized(valid_names_list()))
-    @pytest.mark.tier1
     def test_positive_create_with_name(self, module_org, module_target_sat, name):
         """create content views with different names
 
@@ -96,7 +95,6 @@ class TestContentView:
         assert content_view['name'] == name.strip()
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self, module_org, module_target_sat, name):
         """create content views with invalid names
 
@@ -114,7 +112,6 @@ class TestContentView:
                 {'name': name, 'organization-id': module_org.id}
             )
 
-    @pytest.mark.tier1
     def test_negative_create_with_org_name(self, module_target_sat):
         """Create content view with invalid org name
 
@@ -128,7 +125,6 @@ class TestContentView:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.ContentView.create({'organization-id': gen_string('alpha')})
 
-    @pytest.mark.tier2
     def test_positive_create_with_repo_id(self, module_org, module_product, module_target_sat):
         """Create content view providing repository id
 
@@ -149,7 +145,6 @@ class TestContentView:
         assert cv['yum-repositories'][0]['id'] == repo['id']
 
     @pytest.mark.parametrize('new_name', **parametrized(valid_names_list()))
-    @pytest.mark.tier1
     def test_positive_update_name_by_id(self, module_org, module_target_sat, new_name):
         """Find content view by its id and update its name afterwards
 
@@ -171,7 +166,6 @@ class TestContentView:
         assert cv['name'] == new_name.strip()
 
     @pytest.mark.parametrize('new_name', **parametrized(valid_names_list()))
-    @pytest.mark.tier1
     def test_positive_update_name_by_name(self, module_org, module_target_sat, new_name):
         """Find content view by its name and update it
 
@@ -193,7 +187,6 @@ class TestContentView:
         assert cv['name'] == new_name.strip()
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier2
     def test_positive_update_filter(self, repo_setup, module_target_sat):
         """Edit content views for a rh content, add a filter and update filter
 
@@ -237,7 +230,6 @@ class TestContentView:
         cvf = module_target_sat.cli.ContentView.filter.info({'id': cvf['filter-id']})
         assert cvf['rules'][0]['types'] == 'security'
 
-    @pytest.mark.tier1
     def test_positive_delete_by_id(self, module_org, module_target_sat):
         """delete content view by its id
 
@@ -252,7 +244,6 @@ class TestContentView:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.ContentView.info({'id': cv['id']})
 
-    @pytest.mark.tier1
     def test_positive_delete_by_name(self, module_org, module_target_sat):
         """delete content view by its name
 
@@ -271,7 +262,6 @@ class TestContentView:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.ContentView.info({'id': cv['id']})
 
-    @pytest.mark.tier2
     def test_positive_delete_version_by_name(self, module_org, module_target_sat):
         """Create content view and publish it. After that try to
         disassociate content view from 'Library' environment through
@@ -306,7 +296,6 @@ class TestContentView:
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
         assert len(content_view['versions']) == 0
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_delete_version_by_id(self, module_org, module_product, module_target_sat):
         """Create content view and publish it. After that try to
@@ -354,7 +343,6 @@ class TestContentView:
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         assert len(new_cv['versions']) == 0
 
-    @pytest.mark.tier2
     def test_negative_publish_during_repo_sync(
         self,
         module_cv,
@@ -427,7 +415,6 @@ class TestContentView:
         assert 'Pending tasks detected' in humanized
         assert repo_task_id in humanized
 
-    @pytest.mark.tier2
     def test_negative_delete_version_by_id(self, module_org, module_target_sat):
         """Create content view and publish it. Try to delete content
         view version while content view is still associated with lifecycle
@@ -454,7 +441,6 @@ class TestContentView:
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
         assert len(content_view['versions']) == 1
 
-    @pytest.mark.tier3
     def test_positive_remove_lce_by_id_and_reassign_ak(self, module_org, module_target_sat):
         """Remove content view environment and re-assign activation key to
         another environment and content view
@@ -519,7 +505,6 @@ class TestContentView:
         destination_cv = module_target_sat.cli.ContentView.info({'id': destination_cv['id']})
         assert destination_cv['activation-keys'][0] == ac_key['name']
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_remove_lce_by_id_and_reassign_chost(self, module_org, module_target_sat):
         """Remove content view environment and re-assign content host to
@@ -589,7 +574,6 @@ class TestContentView:
         destination_cv = module_target_sat.cli.ContentView.info({'id': destination_cv['id']})
         assert destination_cv['content-host-count'] == '1'
 
-    @pytest.mark.tier1
     def test_positive_remove_version_by_id(self, module_org, module_target_sat):
         """Delete content view version using 'remove' command by id
 
@@ -615,7 +599,6 @@ class TestContentView:
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         assert len(new_cv['versions']) == 0
 
-    @pytest.mark.tier1
     def test_positive_remove_version_by_name(self, module_org, module_target_sat):
         """Delete content view version using 'remove' command by name
 
@@ -642,7 +625,6 @@ class TestContentView:
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         assert len(new_cv['versions']) == 0
 
-    @pytest.mark.tier1
     def test_positive_remove_repository_by_id(self, module_org, module_product, module_target_sat):
         """Remove associated repository from content view by id
 
@@ -672,7 +654,6 @@ class TestContentView:
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         assert 'yum-repositories' not in new_cv
 
-    @pytest.mark.tier1
     def test_positive_remove_repository_by_name(
         self, module_org, module_product, module_target_sat
     ):
@@ -704,7 +685,6 @@ class TestContentView:
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         assert 'yum-repositories' not in new_cv
 
-    @pytest.mark.tier2
     def test_positive_remove_version_by_id_from_composite(
         self, module_org, module_product, module_target_sat
     ):
@@ -757,7 +737,6 @@ class TestContentView:
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         assert len(new_cv['versions']) == 0
 
-    @pytest.mark.tier2
     def test_positive_remove_component_by_name(self, module_org, module_product, module_target_sat):
         """Create a composite content view and remove component from it by name
 
@@ -809,7 +788,6 @@ class TestContentView:
         comp_cv = module_target_sat.cli.ContentView.info({'id': comp_cv['id']})
         assert 'components' not in comp_cv
 
-    @pytest.mark.tier3
     def test_positive_create_composite_with_component_ids(self, module_org, module_target_sat):
         """Create a composite content view with a component_ids option which
         ids are from different content views
@@ -844,7 +822,6 @@ class TestContentView:
 
         assert {comp['id'] for comp in comp_cv['components']} == set(component_ids)
 
-    @pytest.mark.tier3
     def test_negative_create_composite_with_component_ids(self, module_org, module_target_sat):
         """Attempt to create a composite content view with a component_ids
         option which ids are from the same content view
@@ -876,7 +853,6 @@ class TestContentView:
             )
         assert 'Failed to create ContentView with data:' in str(context)
 
-    @pytest.mark.tier3
     def test_positive_update_composite_with_component_ids(self, module_org, module_target_sat):
         """Update a composite content view with a component_ids option
 
@@ -908,7 +884,6 @@ class TestContentView:
         assert comp_cv['components'][0]['id'] == component_ids
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_add_rh_repo_by_id_and_create_filter(
         self, module_sca_manifest_org, module_rhel_content, module_target_sat
@@ -951,7 +926,6 @@ class TestContentView:
         )
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -1006,7 +980,6 @@ class TestContentView:
         )
         assert filter_info['rules'][0]['id'] == content_view_filter_rule['rule-id']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('add_by_name', [True, False], ids=['name', 'id'])
     def test_positive_add_custom_repo_by(
         self, module_org, module_product, module_target_sat, add_by_name
@@ -1042,7 +1015,6 @@ class TestContentView:
         assert new_cv['yum-repositories'][0]['name'] == new_repo['name']
         assert new_cv['yum-repositories'][0]['id'] == new_repo['id']
 
-    @pytest.mark.tier2
     def test_negative_add_same_yum_repo_twice(self, module_org, module_product, module_target_sat):
         """attempt to associate the same repo multiple times within a
         content view
@@ -1076,7 +1048,6 @@ class TestContentView:
         assert len(new_cv['yum-repositories']) == repos_length
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier2
     def test_positive_promote_rh_content(
         self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
@@ -1114,7 +1085,6 @@ class TestContentView:
         assert environment in new_cv['lifecycle-environments']
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier3
     def test_positive_promote_rh_and_custom_content(
         self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
@@ -1177,7 +1147,6 @@ class TestContentView:
         assert environment in new_cv['lifecycle-environments']
 
     @pytest.mark.build_sanity
-    @pytest.mark.tier2
     def test_positive_promote_custom_content(self, module_org, module_product, module_target_sat):
         """attempt to promote a content view containing custom content
 
@@ -1221,7 +1190,6 @@ class TestContentView:
             'lifecycle-environments'
         ]
 
-    @pytest.mark.tier2
     def test_positive_promote_ccv(self, module_org, module_product, module_target_sat):
         """attempt to promote a content view containing custom content
 
@@ -1281,7 +1249,6 @@ class TestContentView:
             'lifecycle-environments'
         ]
 
-    @pytest.mark.tier2
     def test_negative_promote_default_cv(self, module_org, module_target_sat):
         """attempt to promote a default content view
 
@@ -1308,7 +1275,6 @@ class TestContentView:
                 {'id': cvv['id'], 'to-lifecycle-environment-id': environment['id']}
             )
 
-    @pytest.mark.tier2
     def test_negative_promote_with_invalid_lce(self, module_org, module_product, module_target_sat):
         """attempt to promote a content view using an invalid
         environment
@@ -1350,7 +1316,6 @@ class TestContentView:
 
     @pytest.mark.run_in_one_thread
     @pytest.mark.pit_server
-    @pytest.mark.tier3
     def test_positive_publish_rh_and_custom_content(
         self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
@@ -1406,7 +1371,6 @@ class TestContentView:
         )
         assert new_cv['versions'][0]['version'] == '1.0'
 
-    @pytest.mark.tier2
     def test_positive_publish_custom_major_minor_cv_version(self, module_target_sat):
         """CV can published with custom major and minor versions
 
@@ -1439,7 +1403,6 @@ class TestContentView:
         assert cvv.split('.')[1] == str(minor)
 
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -1506,7 +1469,6 @@ class TestContentView:
         )
         assert len(module_streams) > 13
 
-    @pytest.mark.tier2
     def test_positive_republish_after_content_removed(
         self, module_org, module_product, module_target_sat
     ):
@@ -1577,7 +1539,6 @@ class TestContentView:
         assert len(new_cv['versions']) == 2
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier2
     def test_positive_republish_after_rh_content_removed(
         self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
@@ -1625,7 +1586,6 @@ class TestContentView:
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         assert len(new_cv['versions']) == 2
 
-    @pytest.mark.tier2
     def test_positive_publish_ccv(self, module_org, module_product, module_target_sat):
         """attempt to publish a composite content view containing custom
         content
@@ -1675,7 +1635,6 @@ class TestContentView:
         assert composite_cv['lifecycle-environments'][0]['name'] == constants.ENVIRONMENT
         assert composite_cv['versions'][0]['version'] == '1.0'
 
-    @pytest.mark.tier2
     def test_positive_auto_update_composite_to_latest_cv_version(
         self, module_org, module_target_sat
     ):
@@ -1746,7 +1705,6 @@ class TestContentView:
         assert components[0]['current-version'] == '2.0'
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier3
     def test_positive_subscribe_chost_by_id_using_rh_content(
         self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
@@ -1795,7 +1753,6 @@ class TestContentView:
         assert content_view['content-host-count'] == '1'
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_subscribe_chost_by_id_using_rh_content_and_filters(
         self, module_sca_manifest_org, module_rhel_content, module_target_sat
@@ -1867,7 +1824,6 @@ class TestContentView:
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
         assert content_view['content-host-count'] == '1'
 
-    @pytest.mark.tier3
     def test_positive_subscribe_chost_by_id_using_ccv(self, module_org, module_target_sat):
         """Attempt to subscribe content host to composite content view
 
@@ -1906,7 +1862,6 @@ class TestContentView:
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
         assert content_view['content-host-count'] == '1'
 
-    @pytest.mark.tier3
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -2072,7 +2027,6 @@ class TestContentView:
         assert len(org_hosts) == 1
         assert org_hosts[0]['name'] == rhel_contenthost.hostname
 
-    @pytest.mark.tier3
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_sub_host_with_restricted_user_perm_at_default_loc(
         self, module_org, rhel_contenthost, target_sat
@@ -2224,7 +2178,6 @@ class TestContentView:
         assert len(org_hosts) == 1
         assert org_hosts[0]['name'] == rhel_contenthost.hostname
 
-    @pytest.mark.tier1
     def test_positive_clone_by_name(self, module_org, module_target_sat):
         """Clone existing content view by name
 
@@ -2250,7 +2203,6 @@ class TestContentView:
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         assert new_cv['name'] == cloned_cv_name
 
-    @pytest.mark.tier2
     def test_positive_clone_within_same_env(self, module_org, module_target_sat):
         """Attempt to create, publish and promote new content view based on
         existing view within the same environment as the original content view
@@ -2287,7 +2239,6 @@ class TestContentView:
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         assert {'id': lc_env['id'], 'name': lc_env['name']} in new_cv['lifecycle-environments']
 
-    @pytest.mark.tier2
     def test_positive_clone_with_diff_env(self, module_org, module_target_sat):
         """Attempt to create, publish and promote new content view based on
         existing view but promoted to a different environment
@@ -2330,7 +2281,6 @@ class TestContentView:
             'lifecycle-environments'
         ]
 
-    @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -2404,7 +2354,6 @@ class TestContentView:
             content_view['id'], content_view_version['id'], sat=module_target_sat
         )
 
-    @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -2497,7 +2446,6 @@ class TestContentView:
         }
         assert {lce_dev['name']} == content_view_version_lce_names
 
-    @pytest.mark.tier3
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -2618,7 +2566,6 @@ class TestContentView:
         )
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_remove_cv_version_from_env_with_host_registered(self):
         """Remove promoted content view version from environment that is used
@@ -2656,7 +2603,6 @@ class TestContentView:
         """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     def test_positive_delete_cv_multi_env_promoted_with_host_registered(self):
         """Delete published content view with version promoted to multiple
          environments, with one of the environments used in association of an
@@ -2695,7 +2641,6 @@ class TestContentView:
         """
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -2884,7 +2829,6 @@ class TestContentView:
             else:
                 assert content_view['name'] not in capsule_content_info_lce_cvs_names
 
-    @pytest.mark.tier2
     def test_negative_user_with_no_create_view_cv_permissions(self, module_org, module_target_sat):
         """Unauthorized users are not able to create/view content views
 
@@ -2916,7 +2860,6 @@ class TestContentView:
                     no_rights_user['login'], no_rights_user['password']
                 ).info({'id': con_view['id']})
 
-    @pytest.mark.tier2
     def test_negative_user_with_read_only_cv_permission(self, module_org, module_target_sat):
         """Read-only user is able to view content view
 
@@ -2991,7 +2934,6 @@ class TestContentView:
                 {'organization-id': module_org.id}
             )
 
-    @pytest.mark.tier2
     def test_positive_user_with_all_cv_permissions(self, module_org, module_target_sat):
         """A user with all content view permissions is able to create,
         read, modify, promote, publish content views
@@ -3059,7 +3001,6 @@ class TestContentView:
         cv = module_target_sat.cli.ContentView.info({'id': cv['id']})
         assert environment['id'] in [env['id'] for env in cv['lifecycle-environments']]
 
-    @pytest.mark.tier3
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -3122,7 +3063,6 @@ class TestContentView:
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
         assert '1.1' in [cvv_['version'] for cvv_ in content_view['versions']]
 
-    @pytest.mark.tier2
     def test_ccv_inc_update_autopublish(self, module_org, module_product, module_target_sat):
         """A CCV containing a CV that has an incremental update applied should auto-publish
 
@@ -3209,7 +3149,6 @@ class TestContentView:
         )
         assert 'Auto Publish' in cvv[0]['description']
 
-    @pytest.mark.tier2
     def test_version_info_by_lce(self, module_org, module_target_sat):
         """Hammer version info can be passed the lce id/name argument without error
 
@@ -3254,7 +3193,6 @@ class TestContentView:
         )
         assert cvv_info['version'] == '1.0'
 
-    @pytest.mark.tier2
     def test_show_all_repo_ids(self, module_org, module_product, module_target_sat):
         """Hammer content-view list shows all repo ids
 
@@ -3294,7 +3232,6 @@ class TestContentView:
         list_info = module_target_sat.cli.ContentView.list({'name': cv.name})
         assert set(list_info[0]['repository-ids'].split(', ')) == set(id_list)
 
-    @pytest.mark.tier2
     def test_cv_version_purge(self, module_org, module_target_sat):
         """Hammer content-view purge correctly purges CV Versions, instead
         of just up to the per page value
@@ -3434,7 +3371,6 @@ class TestContentViewFileRepo:
         assert int(new_repo['content-counts']['files']) > 0
         return new_repo
 
-    @pytest.mark.tier3
     def test_positive_arbitrary_file_repo_addition(
         self, module_org, module_product, module_target_sat
     ):
@@ -3475,7 +3411,6 @@ class TestContentViewFileRepo:
         cv = module_target_sat.cli.ContentView.info({'id': cv['id']})
         assert cv['file-repositories'][0]['name'] == repo['name']
 
-    @pytest.mark.tier3
     def test_positive_arbitrary_file_repo_removal(
         self, module_org, module_product, module_target_sat
     ):
@@ -3514,7 +3449,6 @@ class TestContentViewFileRepo:
         cv_info = module_target_sat.cli.ContentView.info({'id': cv['id']})
         assert 'file-repositories' not in cv_info, 'No file repo should be listed'
 
-    @pytest.mark.tier3
     def test_positive_arbitrary_file_repo_promotion(
         self, module_org, module_product, module_target_sat
     ):
@@ -3569,7 +3503,6 @@ class TestContentViewFileRepo:
 
         assert repo['name'] in expected_repo
 
-    @pytest.mark.tier3
     def test_positive_inc_update_should_not_fail(self, module_org, module_target_sat):
         """Incremental update after removing a package should not give a 400 error code
 

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -46,7 +46,6 @@ def content_view(module_org, sync_repo, module_target_sat):
 class TestContentViewFilter:
     """Content View Filter CLI tests"""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     @pytest.mark.parametrize('filter_content_type', ['rpm', 'package_group', 'erratum', 'modulemd'])
     def test_positive_create_with_name_by_cv_id(
@@ -79,7 +78,6 @@ class TestContentViewFilter:
         assert cvf['name'] == name
         assert cvf['type'] == filter_content_type
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('filter_content_type', ['rpm', 'package_group', 'erratum', 'modulemd'])
     def test_positive_create_with_content_type_by_cv_id(
         self, filter_content_type, module_org, content_view, module_target_sat
@@ -110,7 +108,6 @@ class TestContentViewFilter:
         )
         assert cvf['type'] == filter_content_type
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('inclusion', ['true', 'false'])
     def test_positive_create_with_inclusion_by_cv_id(
         self, inclusion, module_org, content_view, module_target_sat
@@ -142,7 +139,6 @@ class TestContentViewFilter:
         )
         assert cvf['inclusion'] == inclusion
 
-    @pytest.mark.tier1
     def test_positive_create_with_description_by_cv_id(
         self, module_org, content_view, module_target_sat
     ):
@@ -173,7 +169,6 @@ class TestContentViewFilter:
         assert cvf['description'] == description
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier1
     def test_positive_create_with_default_taxonomies(
         self, module_org, module_location, content_view, module_target_sat
     ):
@@ -210,7 +205,6 @@ class TestContentViewFilter:
             Defaults.delete({'param-name': 'organization_id'})
             Defaults.delete({'param-name': 'location_id'})
 
-    @pytest.mark.tier1
     def test_positive_list_by_name_and_org(self, module_org, content_view, module_target_sat):
         """Create new content view filter and try to list it by its name and
         organization it belongs
@@ -240,7 +234,6 @@ class TestContentViewFilter:
         assert len(cv_filters) >= 1
         assert cvf_name in [cvf['name'] for cvf in cv_filters]
 
-    @pytest.mark.tier1
     def test_positive_create_by_cv_name(self, module_org, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
         view by name. Use organization id for reference
@@ -267,7 +260,6 @@ class TestContentViewFilter:
             {'content-view-id': content_view['id'], 'name': cvf_name}
         )
 
-    @pytest.mark.tier1
     def test_positive_create_by_org_name(self, module_org, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
         view by name. Use organization name for reference
@@ -292,7 +284,6 @@ class TestContentViewFilter:
             {'content-view-id': content_view['id'], 'name': cvf_name}
         )
 
-    @pytest.mark.tier1
     def test_positive_create_by_org_label(self, module_org, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
         view by name. Use organization label for reference
@@ -317,7 +308,6 @@ class TestContentViewFilter:
             {'content-view-id': content_view['id'], 'name': cvf_name}
         )
 
-    @pytest.mark.tier1
     def test_positive_create_with_repo_by_id(
         self, module_org, sync_repo, content_view, module_target_sat
     ):
@@ -350,7 +340,6 @@ class TestContentViewFilter:
         assert len(cvf['repositories']) == 1
         assert cvf['repositories'][0]['name'] == sync_repo['name']
 
-    @pytest.mark.tier1
     def test_positive_create_with_repo_by_name(
         self, module_org, module_product, sync_repo, content_view, module_target_sat
     ):
@@ -386,7 +375,6 @@ class TestContentViewFilter:
         assert len(cvf['repositories']) == 1
         assert cvf['repositories'][0]['name'] == sync_repo['name']
 
-    @pytest.mark.tier1
     def test_positive_create_with_original_pkgs(self, sync_repo, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
         view that has repository assigned to it. Enable 'original packages'
@@ -415,7 +403,6 @@ class TestContentViewFilter:
         )
         assert cvf['repositories'][0]['name'] == sync_repo['name']
 
-    @pytest.mark.tier2
     def test_positive_create_with_repos_yum_and_docker(
         self, module_org, module_product, sync_repo, content_view, module_target_sat
     ):
@@ -461,7 +448,6 @@ class TestContentViewFilter:
         for repo in cvf['repositories']:
             assert repo['id'] in repos
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_invalid_name(
         self, name, module_org, content_view, module_target_sat
@@ -486,7 +472,6 @@ class TestContentViewFilter:
                 },
             )
 
-    @pytest.mark.tier1
     def test_negative_create_with_same_name(self, module_org, content_view, module_target_sat):
         """Try to create content view filter using same name twice
 
@@ -515,7 +500,6 @@ class TestContentViewFilter:
                 },
             )
 
-    @pytest.mark.tier1
     def test_negative_create_without_type(self, module_org, content_view, module_target_sat):
         """Try to create content view filter without providing required
         parameter 'type'
@@ -535,7 +519,6 @@ class TestContentViewFilter:
                 },
             )
 
-    @pytest.mark.tier1
     def test_negative_create_without_cv(self, module_target_sat):
         """Try to create content view filter without providing content
         view information which should be used as basis for filter
@@ -551,7 +534,6 @@ class TestContentViewFilter:
                 {'name': gen_string('utf8'), 'type': 'rpm'}
             )
 
-    @pytest.mark.tier1
     def test_negative_create_with_invalid_repo_id(
         self, module_org, content_view, module_target_sat
     ):
@@ -574,7 +556,6 @@ class TestContentViewFilter:
                 },
             )
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
     def test_positive_update_name(self, new_name, module_org, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
@@ -611,7 +592,6 @@ class TestContentViewFilter:
         )
         assert cvf['name'] == new_name
 
-    @pytest.mark.tier2
     def test_positive_update_repo_with_same_type(
         self, module_org, module_product, sync_repo, content_view, module_target_sat
     ):
@@ -663,7 +643,6 @@ class TestContentViewFilter:
         assert cvf['repositories'][0]['name'] != sync_repo['name']
         assert cvf['repositories'][0]['name'] == new_repo['name']
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_update_repo_with_different_type(
         self, module_org, module_product, sync_repo, content_view, module_target_sat
@@ -719,7 +698,6 @@ class TestContentViewFilter:
         assert cvf['repositories'][0]['name'] != sync_repo['name']
         assert cvf['repositories'][0]['name'] == docker_repo['name']
 
-    @pytest.mark.tier2
     def test_positive_update_inclusion(self, module_org, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
         view by id. Try to update that filter and assign opposite inclusion
@@ -757,7 +735,6 @@ class TestContentViewFilter:
         )
         assert cvf['inclusion'] == 'false'
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_with_name(self, new_name, content_view, module_target_sat):
         """Try to update content view filter using invalid names only
@@ -787,7 +764,6 @@ class TestContentViewFilter:
                 {'content-view-id': content_view['id'], 'name': new_name}
             )
 
-    @pytest.mark.tier1
     def test_negative_update_with_non_existent_repo_id(
         self, sync_repo, content_view, module_target_sat
     ):
@@ -817,7 +793,6 @@ class TestContentViewFilter:
                 }
             )
 
-    @pytest.mark.tier1
     def test_negative_update_with_invalid_repo_id(
         self, module_org, module_product, sync_repo, content_view, module_target_sat
     ):
@@ -851,7 +826,6 @@ class TestContentViewFilter:
                 }
             )
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_delete_by_name(self, name, module_org, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
@@ -885,7 +859,6 @@ class TestContentViewFilter:
                 {'content-view-id': content_view['id'], 'name': name}
             )
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_delete_by_id(self, module_org, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
@@ -915,7 +888,6 @@ class TestContentViewFilter:
                 {'content-view-id': content_view['id'], 'name': cvf_name}
             )
 
-    @pytest.mark.tier1
     def test_positive_delete_by_org_name(self, module_org, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
         view by id. Try to delete that filter using organization and content
@@ -951,7 +923,6 @@ class TestContentViewFilter:
                 {'content-view-id': content_view['id'], 'name': cvf_name}
             )
 
-    @pytest.mark.tier1
     def test_negative_delete_by_name(self, content_view, module_target_sat):
         """Try to delete non-existent filter using generated name
 
@@ -966,7 +937,6 @@ class TestContentViewFilter:
                 {'content-view-id': content_view['id'], 'name': gen_string('utf8')}
             )
 
-    @pytest.mark.tier2
     def test_positive_check_filters_applied(self, target_sat, module_org, content_view):
         """Ensure the applied filters are indicated and listed correctly in the CVV info.
 

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -145,7 +145,6 @@ def test_rhel_pxeless_discovery_provisioning(
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_provision_pxeless_bios_syslinux():
     """Provision and discover the pxe-less BIOS host from cli using SYSLINUX
     loader
@@ -183,7 +182,6 @@ def test_positive_provision_pxeless_bios_syslinux():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_provision_pxe_host_with_bios_syslinux():
     """Provision the pxe-based BIOS discovered host from cli using SYSLINUX
     loader
@@ -234,7 +232,6 @@ def test_positive_provision_pxe_host_with_bios_syslinux():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_delete():
     """Delete the selected discovered host
 
@@ -249,7 +246,6 @@ def test_positive_delete():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_refresh_facts_pxe_host():
     """Refresh the facts of pxe based discovered hosts by adding a new NIC
 
@@ -266,7 +262,6 @@ def test_positive_refresh_facts_pxe_host():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_refresh_facts_of_pxeless_host():
     """Refresh the facts of pxeless discovered hosts by adding a new NIC
 
@@ -283,7 +278,6 @@ def test_positive_refresh_facts_of_pxeless_host():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_reboot_pxe_host():
     """Reboot pxe based discovered hosts
 
@@ -300,7 +294,6 @@ def test_positive_reboot_pxe_host():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_reboot_pxeless_host():
     """Reboot pxe-less discovered hosts
 
@@ -317,7 +310,6 @@ def test_positive_reboot_pxeless_host():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_auto_provision_pxe_host():
     """Discover a pxe based host and auto-provision it with
     discovery rule and by enabling auto-provision flag
@@ -333,7 +325,6 @@ def test_positive_auto_provision_pxe_host():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_auto_provision_pxeless_host():
     """Discover a pxe-less host and auto-provision it with
     discovery rule and by enabling auto-provision flag
@@ -349,7 +340,6 @@ def test_positive_auto_provision_pxeless_host():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_assign_discovery_manager_role():
     """Assign 'Discovery_Manager' role to a normal user
 
@@ -365,7 +355,6 @@ def test_positive_assign_discovery_manager_role():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_assign_discovery_role():
     """Assign 'Discovery" role to a normal user
 
@@ -381,7 +370,6 @@ def test_positive_assign_discovery_role():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_update_discover_hostname_settings():
     """Update the hostname_prefix and Hostname_facts settings and
     discover a host.
@@ -397,7 +385,6 @@ def test_positive_update_discover_hostname_settings():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_list_facts():
     """Check if defined facts of a discovered host are
     correctly displayed under host's facts
@@ -416,7 +403,6 @@ def test_positive_list_facts():
     """
 
 
-@pytest.mark.tier1
 def test_positive_verify_updated_fdi_image(target_sat):
     """Verify foreman-discovery-image is built on latest up-to-date RHEL
 

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -89,7 +89,6 @@ class TestDiscoveryRule:
             _create_discoveryrule, org=class_org, loc=class_location, hostgroup=class_hostgroup
         )
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_create_with_name(self, name, discoveryrule_factory, target_sat):
         """Create Discovery Rule using different names
@@ -108,7 +107,6 @@ class TestDiscoveryRule:
         with pytest.raises(CLIReturnCodeError):
             target_sat.cli.DiscoveryRule.info({'id': rule.id})
 
-    @pytest.mark.tier1
     def test_positive_create_with_search(self, discoveryrule_factory):
         """Create Discovery Rule using different search queries
 
@@ -126,7 +124,6 @@ class TestDiscoveryRule:
         rule = discoveryrule_factory(options={'search': custom_query})
         assert rule.search == custom_query
 
-    @pytest.mark.tier2
     def test_positive_create_with_hostname(self, discoveryrule_factory):
         """Create Discovery Rule using valid hostname
 
@@ -140,7 +137,6 @@ class TestDiscoveryRule:
         rule = discoveryrule_factory(options={'hostname': host_name})
         assert rule['hostname-template'] == host_name
 
-    @pytest.mark.tier1
     def test_positive_create_and_update_with_org_loc_id(
         self, discoveryrule_factory, class_org, class_location, class_hostgroup, target_sat
     ):
@@ -182,7 +178,6 @@ class TestDiscoveryRule:
         assert new_loc.name == rule['locations'][0]['name']
         assert new_hostgroup.name == rule['host-group']['name']
 
-    @pytest.mark.tier2
     def test_positive_create_and_update_with_org_loc_name(
         self, discoveryrule_factory, class_org, class_location, class_hostgroup, target_sat
     ):
@@ -223,7 +218,6 @@ class TestDiscoveryRule:
         assert new_loc.name == rule['locations'][0]['name']
         assert new_hostgroup.name == rule['host-group']['name']
 
-    @pytest.mark.tier2
     def test_positive_create_with_hosts_limit(self, discoveryrule_factory):
         """Create Discovery Rule providing any number from range 1..100 for
         hosts limit option
@@ -238,7 +232,6 @@ class TestDiscoveryRule:
         rule = discoveryrule_factory(options={'hosts-limit': hosts_limit})
         assert rule['hosts-limit'] == hosts_limit
 
-    @pytest.mark.tier1
     def test_positive_create_and_update_with_priority(self, discoveryrule_factory, target_sat):
         """Create Discovery Rule providing any number from range 1..100 for
         priority option and update
@@ -261,7 +254,6 @@ class TestDiscoveryRule:
         rule = Box(target_sat.cli.DiscoveryRule.info({'id': rule.id}))
         assert rule.priority == str(rule_priority[0])
 
-    @pytest.mark.tier2
     def test_positive_create_disabled_rule(self, discoveryrule_factory):
         """Create Discovery Rule in disabled state
 
@@ -273,7 +265,6 @@ class TestDiscoveryRule:
         rule = discoveryrule_factory(options={'enabled': 'false'})
         assert rule.enabled == 'false'
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_invalid_name(self, name, discoveryrule_factory):
         """Create Discovery Rule with invalid names
@@ -289,7 +280,6 @@ class TestDiscoveryRule:
         with pytest.raises(CLIFactoryError):
             discoveryrule_factory(options={'name': name})
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize('name', **parametrized(invalid_hostnames_list()))
     def test_negative_create_with_invalid_hostname(self, name, discoveryrule_factory):
         """Create Discovery Rule with invalid hostname
@@ -307,7 +297,6 @@ class TestDiscoveryRule:
         with pytest.raises(CLIFactoryError):
             discoveryrule_factory(options={'hostname': name})
 
-    @pytest.mark.tier3
     def test_negative_create_with_too_long_limit(self, discoveryrule_factory):
         """Create Discovery Rule with too long host limit value
 
@@ -321,7 +310,6 @@ class TestDiscoveryRule:
         with pytest.raises(CLIFactoryError):
             discoveryrule_factory(options={'hosts-limit': '9999999999'})
 
-    @pytest.mark.tier1
     def test_negative_create_with_same_name(self, discoveryrule_factory):
         """Create Discovery Rule with name that already exists
 
@@ -336,7 +324,6 @@ class TestDiscoveryRule:
         with pytest.raises(CLIFactoryError):
             discoveryrule_factory(options={'name': name})
 
-    @pytest.mark.tier3
     def test_positive_update_discovery_params(self, discoveryrule_factory, class_org, target_sat):
         """Update discovery rule parameters
 
@@ -371,7 +358,6 @@ class TestDiscoveryRule:
         assert rule['hostname-template'] == new_hostname
         assert rule['hosts-limit'] == new_limit
 
-    @pytest.mark.tier1
     def test_positive_update_disable_enable(self, discoveryrule_factory, target_sat):
         """Update discovery rule enabled state. (Disabled->Enabled)
 
@@ -387,7 +373,6 @@ class TestDiscoveryRule:
         rule = Box(target_sat.cli.DiscoveryRule.info({'id': rule.id}))
         assert rule.enabled == 'true'
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_update_discovery_params(self, name, discoveryrule_factory, target_sat):
         """Update discovery rule name using invalid parameters
@@ -418,7 +403,6 @@ class TestDiscoveryRule:
                 }
             )
 
-    @pytest.mark.tier1
     def test_positive_delete(self, discoveryrule_factory, target_sat):
         """Delete existing Discovery Rule
 
@@ -479,7 +463,6 @@ class TestDiscoveryRuleRole:
             logger.exception(err)
             logger.error('Exception while deleting class scope user entity in teardown')
 
-    @pytest.mark.tier2
     def test_positive_crud_with_non_admin_user(
         self,
         class_org,
@@ -534,7 +517,6 @@ class TestDiscoveryRuleRole:
         with pytest.raises(CLIReturnCodeError):
             target_sat.cli.DiscoveryRule.info({'id': rule.id})
 
-    @pytest.mark.tier2
     def test_negative_delete_rule_with_non_admin_user(
         self,
         class_org,

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -94,7 +94,6 @@ class TestDockerManifest:
     :team: Phoenix-content
     """
 
-    @pytest.mark.tier2
     def test_positive_read_docker_tags(self, repo, module_target_sat):
         """docker manifest displays tags information for a docker manifest
 
@@ -132,7 +131,6 @@ class TestDockerRepository:
     :team: Phoenix-content
     """
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_docker_repository_names()))
     def test_positive_create_with_name(self, module_product, name, module_target_sat):
         """Create one Docker-type repository
@@ -151,7 +149,6 @@ class TestDockerRepository:
         assert repo['upstream-repository-name'] == settings.container.upstream_name
         assert repo['content-type'] == REPO_TYPE['docker']
 
-    @pytest.mark.tier2
     def test_positive_create_repos_using_same_product(
         self, module_org, module_product, module_target_sat
     ):
@@ -172,7 +169,6 @@ class TestDockerRepository:
         )
         assert repo_names.issubset({repo_['repo-name'] for repo_ in product['content']})
 
-    @pytest.mark.tier2
     def test_positive_create_repos_using_multiple_products(self, module_org, module_target_sat):
         """Create multiple Docker-type repositories on multiple
         products.
@@ -197,7 +193,6 @@ class TestDockerRepository:
             )
             assert repo_names == {repo_['repo-name'] for repo_ in product['content']}
 
-    @pytest.mark.tier1
     def test_positive_sync(self, repo, module_target_sat):
         """Create and sync a Docker-type repository
 
@@ -213,7 +208,6 @@ class TestDockerRepository:
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert int(repo['content-counts']['container-manifests']) > 0
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(valid_docker_repository_names()))
     def test_positive_update_name(self, repo, new_name, module_target_sat):
         """Create a Docker-type repository and update its name.
@@ -233,7 +227,6 @@ class TestDockerRepository:
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['name'] == new_name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_upstream_name', **parametrized(valid_docker_upstream_names()))
     def test_positive_update_upstream_name(self, repo, new_upstream_name, module_target_sat):
         """Create a Docker-type repository and update its upstream name.
@@ -257,7 +250,6 @@ class TestDockerRepository:
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['upstream-repository-name'] == new_upstream_name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_upstream_name', **parametrized(invalid_docker_upstream_names()))
     def test_negative_update_upstream_name(self, repo, new_upstream_name, module_target_sat):
         """Attempt to update upstream name for a Docker-type repository.
@@ -282,7 +274,6 @@ class TestDockerRepository:
             )
 
     @pytest.mark.skip_if_not_set('docker')
-    @pytest.mark.tier1
     def test_positive_create_with_long_upstream_name(self, module_product, module_target_sat):
         """Create a docker repository with upstream name longer than 30
         characters
@@ -306,7 +297,6 @@ class TestDockerRepository:
         assert repo['upstream-repository-name'] == settings.container.rh.upstream_name
 
     @pytest.mark.skip_if_not_set('docker')
-    @pytest.mark.tier1
     def test_positive_update_with_long_upstream_name(self, repo, module_target_sat):
         """Create a docker repository and update its upstream name with longer
         than 30 characters value
@@ -329,7 +319,6 @@ class TestDockerRepository:
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['upstream-repository-name'] == settings.container.rh.upstream_name
 
-    @pytest.mark.tier2
     def test_positive_update_url(self, repo, module_target_sat):
         """Create a Docker-type repository and update its URL.
 
@@ -343,7 +332,6 @@ class TestDockerRepository:
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['url'] == new_url
 
-    @pytest.mark.tier1
     def test_positive_delete_by_id(self, repo, module_target_sat):
         """Create and delete a Docker-type repository
 
@@ -358,7 +346,6 @@ class TestDockerRepository:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Repository.info({'id': repo['id']})
 
-    @pytest.mark.tier2
     def test_positive_delete_random_repo_by_id(self, module_org, module_target_sat):
         """Create Docker-type repositories on multiple products and
         delete a random repository from a random product.
@@ -397,7 +384,6 @@ class TestDockerContentView:
     :team: Phoenix-content
     """
 
-    @pytest.mark.tier2
     def test_positive_add_docker_repos_by_id(self, module_org, module_product, module_target_sat):
         """Add multiple Docker-type repositories to a non-composite CV.
 
@@ -421,7 +407,6 @@ class TestDockerContentView:
             repo['id'] for repo in content_view['container-image-repositories']
         }
 
-    @pytest.mark.tier2
     def test_positive_publish_with_docker_repo_composite(
         self, content_view, module_org, module_target_sat
     ):
@@ -460,7 +445,6 @@ class TestDockerContentView:
         comp_content_view = module_target_sat.cli.ContentView.info({'id': comp_content_view['id']})
         assert len(comp_content_view['versions']) == 1
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_promote_multiple_with_docker_repo_composite(
         self, content_view, module_org, module_target_sat
@@ -517,7 +501,6 @@ class TestDockerContentView:
             cvv = module_target_sat.cli.ContentView.version_info({'id': cvv['id']})
             assert len(cvv['lifecycle-environments']) == expected_lces
 
-    @pytest.mark.tier2
     def test_positive_product_name_change_after_promotion(self, module_org, module_target_sat):
         """Promote content view with Docker repository to lifecycle environment.
         Change product name. Verify that repository name on product changed
@@ -602,7 +585,6 @@ class TestDockerContentView:
             == expected_name
         )
 
-    @pytest.mark.tier2
     def test_positive_repo_name_change_after_promotion(self, module_org, module_target_sat):
         """Promote content view with Docker repository to lifecycle environment.
         Change repository name. Verify that Docker repository name on product
@@ -683,7 +665,6 @@ class TestDockerContentView:
             == expected_name
         )
 
-    @pytest.mark.tier2
     def test_negative_set_non_unique_name_pattern_and_promote(self, module_org, module_target_sat):
         """Set registry name pattern to one that does not guarantee uniqueness.
         Try to promote content view with multiple Docker repositories to
@@ -718,7 +699,6 @@ class TestDockerContentView:
                 {'id': content_view['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
             )
 
-    @pytest.mark.tier2
     def test_negative_promote_and_set_non_unique_name_pattern(
         self, module_org, module_product, module_target_sat
     ):
@@ -770,7 +750,6 @@ class TestDockerActivationKey:
     :team: Phoenix-subscriptions
     """
 
-    @pytest.mark.tier2
     def test_positive_add_docker_repo_cv(
         self, module_org, module_lce, content_view_promote, module_target_sat
     ):
@@ -792,7 +771,6 @@ class TestDockerActivationKey:
         )
         assert activation_key['content-view'] == content_view_promote['content-view-name']
 
-    @pytest.mark.tier2
     def test_positive_remove_docker_repo_cv(
         self, module_org, module_lce, content_view_promote, module_target_sat
     ):
@@ -836,7 +814,6 @@ class TestDockerActivationKey:
         activation_key = module_target_sat.cli.ActivationKey.info({'id': activation_key['id']})
         assert activation_key['content-view'] != content_view_promote['content-view-name']
 
-    @pytest.mark.tier2
     def test_positive_add_docker_repo_ccv(
         self, module_org, module_lce, content_view_publish, module_target_sat
     ):
@@ -883,7 +860,6 @@ class TestDockerActivationKey:
         )
         assert activation_key['content-view'] == comp_content_view['name']
 
-    @pytest.mark.tier2
     def test_positive_remove_docker_repo_ccv(
         self, module_org, module_lce, content_view_publish, module_target_sat
     ):

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -103,7 +103,6 @@ def valid_delete_params():
     ]
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_create_update_delete_domain(module_target_sat):
     """Create domain, update and delete domain and set parameters
@@ -163,7 +162,6 @@ def test_positive_create_update_delete_domain(module_target_sat):
         module_target_sat.cli.Domain.info({'id': domain['id']})
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_create_params()))
 def test_negative_create(options, module_target_sat):
     """Create domain with invalid values
@@ -180,7 +178,6 @@ def test_negative_create(options, module_target_sat):
         module_target_sat.cli_factory.make_domain(options)
 
 
-@pytest.mark.tier2
 def test_negative_create_with_invalid_dns_id(module_target_sat):
     """Attempt to register a domain with invalid id
 
@@ -202,7 +199,6 @@ def test_negative_create_with_invalid_dns_id(module_target_sat):
     assert len(messages) > 0
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_update_params()))
 def test_negative_update(module_domain, options, module_target_sat):
     """Update domain with invalid values
@@ -223,7 +219,6 @@ def test_negative_update(module_domain, options, module_target_sat):
         assert result[key] == getattr(module_domain, key)
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_set_params()))
 def test_negative_set_parameter(module_domain, options, module_target_sat):
     """Domain set-parameter with invalid values
@@ -245,7 +240,6 @@ def test_negative_set_parameter(module_domain, options, module_target_sat):
     assert len(domain['parameters']) == 0
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
 def test_negative_delete_by_id(entity_id, module_target_sat):
     """Create Domain then delete it by wrong ID

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -34,7 +34,6 @@ def module_locations(session_puppet_enabled_sat):
     )
 
 
-@pytest.mark.tier2
 def test_negative_list_with_parameters(
     module_puppet_org, module_locations, session_puppet_enabled_sat
 ):
@@ -72,7 +71,6 @@ def test_negative_list_with_parameters(
     assert len(results) == 0
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
 def test_negative_create_with_name(name, session_puppet_enabled_sat):
     """Don't create an Environment with invalid data.
@@ -87,7 +85,6 @@ def test_negative_create_with_name(name, session_puppet_enabled_sat):
         session_puppet_enabled_sat.cli.Environment.create({'name': name})
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 @pytest.mark.e2e
 def test_positive_CRUD_with_attributes(
@@ -161,7 +158,6 @@ def test_positive_CRUD_with_attributes(
         session_puppet_enabled_sat.cli.Environment.info({'id': environment['id']})
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
 def test_negative_delete_by_id(entity_id, session_puppet_enabled_sat):
     """Create Environment then delete it by wrong ID
@@ -178,7 +174,6 @@ def test_negative_delete_by_id(entity_id, session_puppet_enabled_sat):
         session_puppet_enabled_sat.cli.Environment.delete({'id': entity_id})
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
 def test_negative_update_name(new_name, session_puppet_enabled_sat):
     """Update the Environment with invalid values
@@ -198,7 +193,6 @@ def test_negative_update_name(new_name, session_puppet_enabled_sat):
     assert environment['name'] == result['name']
 
 
-@pytest.mark.tier1
 @pytest.mark.skipif(
     not settings.robottelo.repos_hosting_url,
     reason='Missing repos_hosting_url',

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -418,7 +418,6 @@ def cv_filter_cleanup(sat, filter_id, cv, org, lce):
     cv_publish_promote(sat, cv, org, lce)
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize('filter_by_hc', ['id', 'name'], ids=('hc_id', 'hc_name'))
 @pytest.mark.parametrize(
     'filter_by_org', ['id', 'name', 'title'], ids=('org_id', 'org_name', 'org_title')
@@ -482,7 +481,6 @@ def test_positive_install_by_host_collection_and_org(
         assert is_rpm_installed(host)
 
 
-@pytest.mark.tier3
 def test_negative_install_erratum_on_host_collection(
     module_sca_manifest_org, host_collection, module_target_sat
 ):
@@ -513,7 +511,6 @@ def test_negative_install_erratum_on_host_collection(
     assert 'Not supported. Use the remote execution equivalent' in error.value.stderr
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_list_affected_chosts(module_sca_manifest_org, errata_hosts, target_sat):
     """View a list of affected content hosts for an erratum.
@@ -544,7 +541,6 @@ def test_positive_list_affected_chosts(module_sca_manifest_org, errata_hosts, ta
     )
 
 
-@pytest.mark.tier3
 @pytest.mark.no_containers
 def test_install_errata_to_one_host(
     module_sca_manifest_org, errata_hosts, host_collection, target_sat
@@ -588,7 +584,6 @@ def test_install_errata_to_one_host(
     )
 
 
-@pytest.mark.tier3
 @pytest.mark.e2e
 def test_positive_list_affected_chosts_by_erratum_restrict_flag(
     target_sat,
@@ -732,7 +727,6 @@ def test_positive_list_affected_chosts_by_erratum_restrict_flag(
     assert errata['id'] in errata_ids, 'Errata not found in list of applicable errata'
 
 
-@pytest.mark.tier3
 def test_host_errata_search_commands(
     request,
     module_sca_manifest_org,
@@ -904,7 +898,6 @@ def test_host_errata_search_commands(
     assert errata_hosts[1].hostname not in result
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize('sort_by_date', ['issued', 'updated'], ids=('issued_date', 'updated_date'))
 @pytest.mark.parametrize(
     'filter_by_org',
@@ -941,7 +934,6 @@ def test_positive_list_filter_by_org_sort_by_date(
     )
 
 
-@pytest.mark.tier3
 def test_positive_list_filter_by_product_id(target_sat, products_with_repos):
     """Filter errata by product id
 
@@ -960,7 +952,6 @@ def test_positive_list_filter_by_product_id(target_sat, products_with_repos):
     check_errata(errata_ids)
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize('filter_by_product', ['id', 'name'], ids=('product_id', 'product_name'))
 @pytest.mark.parametrize(
     'filter_by_org', ['id', 'name', 'label'], ids=('org_id', 'org_name', 'org_label')
@@ -1003,7 +994,6 @@ def test_positive_list_filter_by_product_and_org(
     check_errata(errata_ids)
 
 
-@pytest.mark.tier3
 def test_negative_list_filter_by_product_name(products_with_repos, module_target_sat):
     """Attempt to Filter errata by product name
 
@@ -1025,7 +1015,6 @@ def test_negative_list_filter_by_product_name(products_with_repos, module_target
         )
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'filter_by_org', ['id', 'name', 'label'], ids=('org_id', 'org_name', 'org_label')
 )
@@ -1061,7 +1050,6 @@ def test_positive_list_filter_by_org(target_sat, products_with_repos, filter_by_
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 def test_positive_list_filter_by_cve(module_sca_manifest_org, rh_repo_module_manifest, target_sat):
     """Filter errata by CVE
 
@@ -1108,7 +1096,6 @@ def test_positive_list_filter_by_cve(module_sca_manifest_org, rh_repo_module_man
         }
 
 
-@pytest.mark.tier3
 def test_positive_check_errata_dates(module_sca_manifest_org, module_target_sat):
     """Check for errata dates in `hammer erratum list`
 
@@ -1227,7 +1214,6 @@ def errata_host(
     return rhel_contenthost
 
 
-@pytest.mark.tier2
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('8')
 def test_apply_errata_using_default_content_view(errata_host, module_sca_manifest_org, target_sat):
@@ -1278,7 +1264,6 @@ def test_apply_errata_using_default_content_view(errata_host, module_sca_manifes
     assert len(erratum) == 0
 
 
-@pytest.mark.tier2
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('8')
 def test_update_applicable_package_using_default_content_view(errata_host, target_sat):
@@ -1337,7 +1322,6 @@ def test_update_applicable_package_using_default_content_view(errata_host, targe
     assert len(applicable_packages) == 0
 
 
-@pytest.mark.tier2
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('8')
 def test_downgrade_applicable_package_using_default_content_view(errata_host, target_sat):
@@ -1387,7 +1371,6 @@ def test_downgrade_applicable_package_using_default_content_view(errata_host, ta
     assert FAKE_2_CUSTOM_PACKAGE_NAME in applicable_packages[0]['filename']
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('8')
 def test_install_applicable_package_to_registered_host(errata_host, target_sat):
     """Installing an older package to an already registered host should show the newer package
@@ -1434,7 +1417,6 @@ def test_install_applicable_package_to_registered_host(errata_host, target_sat):
     assert FAKE_2_CUSTOM_PACKAGE_NAME in applicable_packages[0]['filename']
 
 
-@pytest.mark.tier2
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('8')
 def test_downgrading_package_shows_errata_from_library(
@@ -1481,7 +1463,6 @@ def test_downgrading_package_shows_errata_from_library(
     assert settings.repos.yum_6.errata[2] in errata_ids
 
 
-@pytest.mark.tier2
 def test_errata_list_by_contentview_filter(module_sca_manifest_org, module_target_sat):
     """Hammer command to list errata should take filter ID into consideration.
 

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -18,8 +18,6 @@ import pytest
 from robottelo.config import settings
 from robottelo.utils.issue_handlers import is_open
 
-pytestmark = [pytest.mark.tier1]
-
 
 @pytest.mark.upgrade
 @pytest.mark.parametrize(

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -34,7 +34,6 @@ def function_role(target_sat):
     return target_sat.cli_factory.make_role()
 
 
-@pytest.mark.tier1
 def test_positive_create_with_permission(module_perms, function_role, target_sat):
     """Create a filter and assign it some permissions.
 
@@ -51,7 +50,6 @@ def test_positive_create_with_permission(module_perms, function_role, target_sat
     assert set(filter_['permissions'].split(", ")) == set(module_perms)
 
 
-@pytest.mark.tier1
 def test_positive_create_with_org(module_perms, function_role, target_sat):
     """Create a filter and assign it some permissions.
 
@@ -77,7 +75,6 @@ def test_positive_create_with_org(module_perms, function_role, target_sat):
     assert filter_['organizations'][0] == org['name']
 
 
-@pytest.mark.tier1
 def test_positive_create_with_loc(module_perms, function_role, module_target_sat):
     """Create a filter and assign it some permissions.
 
@@ -103,7 +100,6 @@ def test_positive_create_with_loc(module_perms, function_role, module_target_sat
     assert filter_['locations'][0] == loc['name']
 
 
-@pytest.mark.tier1
 def test_positive_delete(module_perms, function_role, module_target_sat):
     """Create a filter and delete it afterwards.
 
@@ -121,7 +117,6 @@ def test_positive_delete(module_perms, function_role, module_target_sat):
         module_target_sat.cli.Filter.info({'id': filter_['id']})
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_delete_role(module_perms, function_role, target_sat):
     """Create a filter and delete the role it points at.
@@ -145,7 +140,6 @@ def test_positive_delete_role(module_perms, function_role, target_sat):
         target_sat.cli.Filter.info({'id': filter_['id']})
 
 
-@pytest.mark.tier1
 def test_positive_update_permissions(module_perms, function_role, target_sat):
     """Create a filter and update its permissions.
 
@@ -169,7 +163,6 @@ def test_positive_update_permissions(module_perms, function_role, target_sat):
     assert set(filter_['permissions'].split(", ")) == set(new_perms)
 
 
-@pytest.mark.tier1
 def test_positive_update_role(module_perms, function_role, target_sat):
     """Create a filter and assign it to another role.
 
@@ -189,7 +182,6 @@ def test_positive_update_role(module_perms, function_role, target_sat):
     assert filter_['role'] == new_role['name']
 
 
-@pytest.mark.tier1
 def test_positive_update_org_loc(module_perms, function_role, target_sat):
     """Create a filter and assign it to another organization and location.
 

--- a/tests/foreman/cli/test_foremantask.py
+++ b/tests/foreman/cli/test_foremantask.py
@@ -16,7 +16,6 @@ import pytest
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_tasks_backup():
     """Check no tasks are backup by default when cleaning up tasks from the database and
     no /var/lib/foreman/tasks-backup created for backup tasks.

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -17,8 +17,6 @@ from functools import partial
 from fauxfactory import gen_string
 import pytest
 
-pytestmark = [pytest.mark.tier1]
-
 
 @pytest.mark.upgrade
 def test_positive_list_delete_by_name(module_target_sat):

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -25,8 +25,6 @@ from robottelo.logging import logger
 
 HAMMER_COMMANDS = json.loads(DataFile.HAMMER_COMMANDS_JSON.read_text())
 
-pytestmark = [pytest.mark.tier1]
-
 
 def fetch_command_info(command):
     """Fetch command info from expected commands info dictionary."""

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -286,7 +286,6 @@ def test_positive_search_all_field_sets(module_target_sat):
 
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.cli_host_subscription
-@pytest.mark.tier3
 def test_positive_host_list_with_cv_and_lce(
     target_sat,
     rhel_contenthost,
@@ -335,7 +334,6 @@ def test_positive_host_list_with_cv_and_lce(
 # -------------------------- CREATE SCENARIOS -------------------------
 @pytest.mark.e2e
 @pytest.mark.cli_host_create
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_create_and_delete(target_sat, module_lce_library, module_published_cv):
     """A host can be created and deleted
@@ -395,7 +393,6 @@ def test_positive_create_and_delete(target_sat, module_lce_library, module_publi
 
 @pytest.mark.e2e
 @pytest.mark.cli_host_create
-@pytest.mark.tier1
 def test_positive_crud_interface_by_id(target_sat, default_location, default_org):
     """New network interface can be added to existing host, listed and removed.
 
@@ -460,7 +457,6 @@ def test_positive_crud_interface_by_id(target_sat, default_location, default_org
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier2
 def test_negative_create_with_content_source(
     module_lce_library, module_org, module_published_cv, module_target_sat
 ):
@@ -486,7 +482,6 @@ def test_negative_create_with_content_source(
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier2
 def test_negative_update_content_source(
     module_default_proxy, module_lce_library, module_org, module_published_cv, module_target_sat
 ):
@@ -520,7 +515,6 @@ def test_negative_update_content_source(
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier1
 def test_positive_create_with_lce_and_cv(
     module_lce, module_org, module_promoted_cv, module_target_sat
 ):
@@ -556,7 +550,6 @@ def test_positive_create_with_lce_and_cv(
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier2
 def test_positive_create_with_openscap_proxy_id(
     module_default_proxy, module_org, module_target_sat
 ):
@@ -575,7 +568,6 @@ def test_positive_create_with_openscap_proxy_id(
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier1
 def test_negative_create_with_name(
     module_lce_library, module_org, module_published_cv, module_target_sat
 ):
@@ -600,7 +592,6 @@ def test_negative_create_with_name(
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier1
 def test_negative_create_with_unpublished_cv(module_lce, module_org, module_cv, module_target_sat):
     """Check if host can be created using unpublished cv
 
@@ -623,7 +614,6 @@ def test_negative_create_with_unpublished_cv(module_lce, module_org, module_cv, 
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_katello_and_openscap_loaded(target_sat):
     """Verify that command line arguments from both Katello
@@ -650,7 +640,6 @@ def test_positive_katello_and_openscap_loaded(target_sat):
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier3
 def test_positive_list_and_unregister(
     module_ak_with_cv, module_lce, module_org, rhel7_contenthost, target_sat
 ):
@@ -675,7 +664,6 @@ def test_positive_list_and_unregister(
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier3
 def test_positive_list_by_last_checkin(
     module_org, rhel7_contenthost, target_sat, module_ak_with_cv
 ):
@@ -702,7 +690,6 @@ def test_positive_list_by_last_checkin(
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier3
 def test_positive_list_infrastructure_hosts(
     module_org, rhel7_contenthost, target_sat, module_ak_with_cv
 ):
@@ -733,7 +720,6 @@ def test_positive_list_infrastructure_hosts(
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier2
 def test_positive_create_inherit_lce_cv(
     target_sat, module_published_cv, module_lce_library, module_org
 ):
@@ -770,7 +756,6 @@ def test_positive_create_inherit_lce_cv(
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier3
 def test_positive_create_inherit_nested_hostgroup(target_sat):
     """Create two nested host groups with the same name, but different
     parents. Then create host using any from these hostgroups title
@@ -826,7 +811,6 @@ def test_positive_create_inherit_nested_hostgroup(target_sat):
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier3
 def test_positive_list_with_nested_hostgroup(target_sat):
     """Create parent and nested host groups. Then create host using nested
     hostgroup and then find created host using list command
@@ -899,7 +883,6 @@ def test_positive_list_with_nested_hostgroup(target_sat):
 
 @pytest.mark.cli_host_create
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_negative_create_with_incompatible_pxe_loader():
     """Try to create host with a known OS and incompatible PXE loader
 
@@ -930,7 +913,6 @@ def test_negative_create_with_incompatible_pxe_loader():
 # -------------------------- UPDATE SCENARIOS -------------------------
 @pytest.mark.e2e
 @pytest.mark.cli_host_update
-@pytest.mark.tier1
 def test_positive_update_parameters_by_name(
     target_sat, function_host, module_architecture, module_location
 ):
@@ -993,7 +975,6 @@ def test_positive_update_parameters_by_name(
     assert host['operating-system']['medium']['name'] == new_medium.name
 
 
-@pytest.mark.tier1
 @pytest.mark.cli_host_update
 def test_negative_update_name(function_host, target_sat):
     """A host can not be updated with invalid or empty name
@@ -1011,7 +992,6 @@ def test_negative_update_name(function_host, target_sat):
     assert '{}.{}'.format(new_name, host['network']['domain']).lower() != host['name']
 
 
-@pytest.mark.tier1
 @pytest.mark.cli_host_update
 def test_negative_update_mac(function_host, target_sat):
     """A host can not be updated with invalid or empty MAC address
@@ -1029,7 +1009,6 @@ def test_negative_update_mac(function_host, target_sat):
     assert host['network']['mac'] != new_mac
 
 
-@pytest.mark.tier2
 @pytest.mark.cli_host_update
 def test_negative_update_arch(function_host, module_architecture, target_sat):
     """A host can not be updated with a architecture, which does not
@@ -1047,7 +1026,6 @@ def test_negative_update_arch(function_host, module_architecture, target_sat):
     assert host['operating-system']['architecture'] != module_architecture.name
 
 
-@pytest.mark.tier2
 @pytest.mark.cli_host_update
 def test_negative_update_os(target_sat, function_host, module_architecture):
     """A host can not be updated with a operating system, which is
@@ -1078,7 +1056,6 @@ def test_negative_update_os(target_sat, function_host, module_architecture):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.cli_host_update
 def test_hammer_host_info_output(target_sat, module_user):
     """Verify re-add of 'owner-id' in `hammer host info` output
@@ -1120,7 +1097,6 @@ def test_hammer_host_info_output(target_sat, module_user):
 
 
 @pytest.mark.cli_host_parameter
-@pytest.mark.tier1
 def test_positive_parameter_crud(function_host, target_sat):
     """Add, update and remove host parameter with valid name.
 
@@ -1152,7 +1128,6 @@ def test_positive_parameter_crud(function_host, target_sat):
 
 # -------------------------- HOST PARAMETER SCENARIOS -------------------------
 @pytest.mark.cli_host_parameter
-@pytest.mark.tier1
 def test_negative_add_parameter(function_host, target_sat):
     """Try to add host parameter with different invalid names.
 
@@ -1177,7 +1152,6 @@ def test_negative_add_parameter(function_host, target_sat):
 
 
 @pytest.mark.cli_host_parameter
-@pytest.mark.tier2
 def test_negative_view_parameter_by_non_admin_user(target_sat, function_host, function_user):
     """Attempt to view parameters with non admin user without Parameter
      permissions
@@ -1223,7 +1197,6 @@ def test_negative_view_parameter_by_non_admin_user(target_sat, function_host, fu
 
 
 @pytest.mark.cli_host_parameter
-@pytest.mark.tier2
 def test_positive_view_parameter_by_non_admin_user(target_sat, function_host, function_user):
     """Attempt to view parameters with non admin user that has
     Parameter::vew_params permission
@@ -1273,7 +1246,6 @@ def test_positive_view_parameter_by_non_admin_user(target_sat, function_host, fu
 
 
 @pytest.mark.cli_host_parameter
-@pytest.mark.tier2
 def test_negative_edit_parameter_by_non_admin_user(target_sat, function_host, function_user):
     """Attempt to edit parameter with non admin user that has
     Parameter::vew_params permission
@@ -1328,7 +1300,6 @@ def test_negative_edit_parameter_by_non_admin_user(target_sat, function_host, fu
 
 
 @pytest.mark.cli_host_parameter
-@pytest.mark.tier2
 def test_positive_set_multi_line_and_with_spaces_parameter_value(function_host, target_sat):
     """Check that host parameter value with multi-line and spaces is
     correctly restored from yaml format
@@ -1376,7 +1347,6 @@ def test_positive_set_multi_line_and_with_spaces_parameter_value(function_host, 
 
 # -------------------------- HOST PROVISION SCENARIOS -------------------------
 @pytest.mark.stubbed
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_provision_baremetal_with_bios_syslinux():
     """Provision RHEL system on a new BIOS BM Host with SYSLINUX loader
@@ -1413,7 +1383,6 @@ def test_positive_provision_baremetal_with_bios_syslinux():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_provision_baremetal_with_uefi_syslinux():
     """Provision RHEL system on a new UEFI BM Host with SYSLINUX loader
     from provided MAC address
@@ -1449,7 +1418,6 @@ def test_positive_provision_baremetal_with_uefi_syslinux():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_provision_baremetal_with_uefi_grub():
     """Provision a RHEL system on a new UEFI BM Host with GRUB loader from
     a provided MAC address
@@ -1488,7 +1456,6 @@ def test_positive_provision_baremetal_with_uefi_grub():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_provision_baremetal_with_uefi_grub2():
     """Provision a RHEL7+ system on a new UEFI BM Host with GRUB2 loader
@@ -1529,7 +1496,6 @@ def test_positive_provision_baremetal_with_uefi_grub2():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_provision_baremetal_with_uefi_secureboot():
     """Provision RHEL7+ on a new SecureBoot-enabled UEFI BM Host from
     provided MAC address
@@ -1619,7 +1585,6 @@ def yum_security_plugin(katello_host_tools_host):
 @pytest.mark.e2e
 @pytest.mark.cli_katello_host_tools
 @pytest.mark.rhel_ver_match('[^6].*')
-@pytest.mark.tier3
 def test_positive_report_package_installed_removed(
     katello_host_tools_host, setup_custom_repo, target_sat
 ):
@@ -1665,7 +1630,6 @@ def test_positive_report_package_installed_removed(
 
 @pytest.mark.cli_katello_host_tools
 @pytest.mark.rhel_ver_match('[^6].*')
-@pytest.mark.tier3
 def test_positive_package_applicability(katello_host_tools_host, setup_custom_repo, target_sat):
     """Ensure packages applicability is functioning properly
 
@@ -1729,7 +1693,6 @@ def test_positive_package_applicability(katello_host_tools_host, setup_custom_re
 @pytest.mark.rhel_ver_match('[^6].*')
 @pytest.mark.pit_client
 @pytest.mark.pit_server
-@pytest.mark.tier3
 def test_positive_erratum_applicability(
     katello_host_tools_host, setup_custom_repo, yum_security_plugin, target_sat
 ):
@@ -1797,7 +1760,6 @@ def test_positive_erratum_applicability(
 
 @pytest.mark.cli_katello_host_tools
 @pytest.mark.rhel_ver_match('[^6].*')
-@pytest.mark.tier3
 def test_positive_apply_security_erratum(katello_host_tools_host, setup_custom_repo, target_sat):
     """Apply security erratum to a host
 
@@ -1831,7 +1793,6 @@ def test_positive_apply_security_erratum(katello_host_tools_host, setup_custom_r
 
 
 @pytest.mark.cli_katello_host_tools
-@pytest.mark.tier3
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('[^6].*')
 def test_positive_install_package_via_rex(
@@ -1869,7 +1830,6 @@ def test_positive_install_package_via_rex(
 # -------------------------- HOST SUBSCRIPTION SUBCOMMAND SCENARIOS -------------------------
 @pytest.mark.rhel_ver_match('9')
 @pytest.mark.cli_host_subscription
-@pytest.mark.tier3
 def test_positive_register(
     module_org,
     module_promoted_cv,
@@ -1925,7 +1885,6 @@ def test_positive_register(
 
 @pytest.mark.rhel_ver_match('9')
 @pytest.mark.cli_host_subscription
-@pytest.mark.tier3
 def test_positive_without_attach_with_lce(
     target_sat,
     rhel_contenthost,
@@ -1974,7 +1933,6 @@ def test_positive_without_attach_with_lce(
 @pytest.mark.pit_client
 @pytest.mark.pit_server
 @pytest.mark.cli_host_subscription
-@pytest.mark.tier3
 @pytest.mark.e2e
 def test_syspurpose_end_to_end(
     target_sat,
@@ -2338,7 +2296,6 @@ def test_positive_multi_cv_host_repo_availability(
 
 
 # -------------------------- HOST ERRATA SUBCOMMAND SCENARIOS -------------------------
-@pytest.mark.tier1
 def test_positive_errata_list_of_sat_server(target_sat):
     """Check if errata list doesn't raise exception. Check BZ for details.
 
@@ -2356,7 +2313,6 @@ def test_positive_errata_list_of_sat_server(target_sat):
 
 
 # -------------------------- HOST ENC SUBCOMMAND SCENARIOS -------------------------
-@pytest.mark.tier1
 def test_positive_dump_enc_yaml(target_sat):
     """Dump host's ENC YAML. Check BZ for details.
 
@@ -2378,7 +2334,6 @@ def test_positive_dump_enc_yaml(target_sat):
 
 # -------------------------- HOST TRACE SUBCOMMAND SCENARIOS -------------------------
 @pytest.mark.pit_client
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6].*')
 def test_positive_tracer_list_and_resolve(tracer_host, target_sat):
     """Install tracer on client, downgrade the service, check from the satellite
@@ -2429,7 +2384,6 @@ def test_positive_tracer_list_and_resolve(tracer_host, target_sat):
 
 # ---------------------------- PUPPET ENABLED IN INSTALLER TESTS -----------------------
 @pytest.mark.cli_puppet_enabled
-@pytest.mark.tier1
 def test_positive_host_with_puppet(
     session_puppet_enabled_sat,
     session_puppet_enabled_proxy,
@@ -2515,7 +2469,6 @@ def function_host_content_source(
     return res
 
 
-@pytest.mark.tier2
 @pytest.mark.cli_puppet_enabled
 def test_positive_list_scparams(
     session_puppet_enabled_sat,
@@ -2562,7 +2515,6 @@ def test_positive_list_scparams(
 
 
 @pytest.mark.cli_puppet_enabled
-@pytest.mark.tier1
 def test_positive_create_with_puppet_class_name(
     session_puppet_enabled_sat,
     session_puppet_enabled_proxy,
@@ -2597,7 +2549,6 @@ def test_positive_create_with_puppet_class_name(
 
 
 @pytest.mark.cli_puppet_enabled
-@pytest.mark.tier2
 def test_positive_update_host_owner_and_verify_puppet_class_name(
     session_puppet_enabled_sat,
     session_puppet_enabled_proxy,
@@ -2649,7 +2600,6 @@ def test_positive_update_host_owner_and_verify_puppet_class_name(
 
 @pytest.mark.cli_puppet_enabled
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('[9]')
 @pytest.mark.no_containers
 def test_positive_create_and_update_with_content_source(
@@ -2718,7 +2668,6 @@ def test_positive_create_and_update_with_content_source(
 
 
 @pytest.mark.cli_host_create
-@pytest.mark.tier2
 def test_positive_create_host_with_lifecycle_environment_name(
     module_lce,
     module_org,
@@ -2831,7 +2780,6 @@ def test_host_registration_with_capsule_using_content_coherence(
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('9')
 @pytest.mark.cli_host_subscription
-@pytest.mark.tier3
 def test_positive_reregister_rhel(
     target_sat,
     rhel_contenthost,

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -43,7 +43,6 @@ def _make_fake_host_helper(module_org, sat):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 @pytest.mark.e2e
 def test_positive_end_to_end(module_org, module_target_sat):
     """Check if host collection can be created with name and description,
@@ -122,7 +121,6 @@ def test_positive_end_to_end(module_org, module_target_sat):
         module_target_sat.cli.HostCollection.info({'id': new_host_col['id']})
 
 
-@pytest.mark.tier1
 def test_positive_create_with_limit(module_org, module_target_sat):
     """Check if host collection can be created with correct limits
 
@@ -139,7 +137,6 @@ def test_positive_create_with_limit(module_org, module_target_sat):
         assert new_host_col['limit'] == limit
 
 
-@pytest.mark.tier1
 def test_positive_update_to_unlimited_hosts(module_org, module_target_sat):
     """Create Host Collection with a limit and update it to unlimited hosts
 
@@ -173,7 +170,6 @@ def test_positive_update_to_unlimited_hosts(module_org, module_target_sat):
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_create_with_name(module_org, name, module_target_sat):
     """Attempt to create host collection with invalid name of different
     types
@@ -192,7 +188,6 @@ def test_negative_create_with_name(module_org, name, module_target_sat):
         )
 
 
-@pytest.mark.tier1
 def test_positive_update_limit(module_org, module_target_sat):
     """Check if host collection limits can be updated
 
@@ -213,7 +208,6 @@ def test_positive_update_limit(module_org, module_target_sat):
         assert result['limit'] == limit
 
 
-@pytest.mark.tier2
 def test_positive_list_by_org_id(module_org, module_target_sat):
     """Check if host collection list can be filtered by organization id
 
@@ -235,7 +229,6 @@ def test_positive_list_by_org_id(module_org, module_target_sat):
     assert result[0]['id'] == new_host_col['id']
 
 
-@pytest.mark.tier2
 def test_positive_host_collection_host_pagination(module_org, module_target_sat):
     """Check if pagination configured on per-page param defined in hammer
     host-collection hosts command overrides global configuration defined
@@ -268,7 +261,6 @@ def test_positive_host_collection_host_pagination(module_org, module_target_sat)
         assert len(listed_hosts) == number
 
 
-@pytest.mark.tier2
 def test_positive_copy_by_id(module_org, module_target_sat):
     """Check if host collection can be cloned by id
 
@@ -291,7 +283,6 @@ def test_positive_copy_by_id(module_org, module_target_sat):
     assert result['name'] == new_name
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_register_host_ak_with_host_collection(module_org, module_ak_with_cv, target_sat):
     """Attempt to register a host using activation key with host collection

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -81,7 +81,6 @@ def hostgroup(content_source, module_org, module_target_sat):
     )
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
 def test_negative_create_with_name(name, module_target_sat):
     """Don't create an HostGroup with invalid data.
@@ -97,7 +96,6 @@ def test_negative_create_with_name(name, module_target_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_create_with_multiple_entities_and_delete(
     module_puppet_org, puppet_content_source, puppet_classes, session_puppet_enabled_sat
@@ -199,7 +197,6 @@ def test_positive_create_with_multiple_entities_and_delete(
             session_puppet_enabled_sat.cli.HostGroup.info({'id': hostgroup['id']})
 
 
-@pytest.mark.tier2
 def test_negative_create_with_content_source(module_org, module_target_sat):
     """Attempt to create a hostgroup with invalid content source specified
 
@@ -219,7 +216,6 @@ def test_negative_create_with_content_source(module_org, module_target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_update_hostgroup_with_puppet(
     request,
     module_puppet_org,
@@ -276,7 +272,6 @@ def test_positive_update_hostgroup_with_puppet(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_update_hostgroup(
     module_target_sat,
     module_org,
@@ -315,7 +310,6 @@ def test_positive_update_hostgroup(
     assert hostgroup['content-source']['name'] == new_content_source['name']
 
 
-@pytest.mark.tier2
 def test_negative_update_content_source(hostgroup, content_source, module_target_sat):
     """Attempt to update hostgroup's content source with invalid value
 
@@ -334,7 +328,6 @@ def test_negative_update_content_source(hostgroup, content_source, module_target
     assert hostgroup['content-source']['name'] == content_source['name']
 
 
-@pytest.mark.tier2
 def test_negative_update_name(hostgroup, module_target_sat):
     """Create HostGroup then fail to update its name
 
@@ -349,7 +342,6 @@ def test_negative_update_name(hostgroup, module_target_sat):
     assert hostgroup['name'] == result['name']
 
 
-@pytest.mark.tier2
 def test_negative_delete_by_id(module_target_sat):
     """Create HostGroup then delete it by wrong ID
 
@@ -362,7 +354,6 @@ def test_negative_delete_by_id(module_target_sat):
         module_target_sat.cli.HostGroup.delete({'id': entity_id})
 
 
-@pytest.mark.tier2
 def test_positive_created_nested_hostgroup(module_org, module_target_sat):
     """Create a nested host group using multiple parent hostgroup paths.
     e.g. ` hostgroup create --organization 'org_name' --name new3 --parent-title new_1/new_2`

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -20,7 +20,6 @@ from robottelo.constants import FAKE_0_YUM_REPO_PACKAGES_COUNT
 from robottelo.exceptions import CLIReturnCodeError
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_create_update_delete(module_org, module_location, target_sat):
     """Create new http-proxy with attributes, update and delete it.
@@ -85,7 +84,6 @@ def test_positive_create_update_delete(module_org, module_location, target_sat):
         target_sat.cli.HttpProxy.info({'id': updated_http_proxy['id']})
 
 
-@pytest.mark.tier3
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match(r'^(?!6$)\d+$')
 @pytest.mark.parametrize(
@@ -134,7 +132,6 @@ def test_insights_client_registration_with_http_proxy(
     assert rhel_contenthost.execute('insights-client --unregister').status == 0
 
 
-@pytest.mark.tier2
 @pytest.mark.run_in_one_thread
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.skipif((not settings.http_proxy.UN_AUTH_PROXY_URL), reason='Missing un_auth_proxy_url')
@@ -184,7 +181,6 @@ def test_positive_set_content_default_http_proxy(block_fake_repo_access, target_
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_assign_http_proxy_to_products(module_org, module_target_sat):
     """Assign http_proxy to Products and perform product sync.

--- a/tests/foreman/cli/test_jobtemplate.py
+++ b/tests/foreman/cli/test_jobtemplate.py
@@ -29,7 +29,6 @@ def module_template():
     ssh.command(f'touch {TEMPLATE_FILE_EMPTY}')
 
 
-@pytest.mark.tier1
 def test_positive_create_job_template(module_org, module_target_sat):
     """Create a simple Job Template
 
@@ -50,7 +49,6 @@ def test_positive_create_job_template(module_org, module_target_sat):
     assert module_target_sat.cli.JobTemplate.info({'name': template_name}) is not None
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
 def test_negative_create_job_template_with_invalid_name(module_org, name, module_target_sat):
     """Create Job Template with invalid name
@@ -74,7 +72,6 @@ def test_negative_create_job_template_with_invalid_name(module_org, name, module
         )
 
 
-@pytest.mark.tier1
 def test_negative_create_job_template_with_same_name(module_org, module_target_sat):
     """Create Job Template with duplicate name
 
@@ -102,7 +99,6 @@ def test_negative_create_job_template_with_same_name(module_org, module_target_s
         )
 
 
-@pytest.mark.tier1
 def test_negative_create_empty_job_template(module_org, module_target_sat):
     """Create Job Template with empty template file
 
@@ -123,7 +119,6 @@ def test_negative_create_empty_job_template(module_org, module_target_sat):
         )
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_delete_job_template(module_org, module_target_sat):
     """Delete a job template
@@ -147,7 +142,6 @@ def test_positive_delete_job_template(module_org, module_target_sat):
         module_target_sat.cli.JobTemplate.info({'name': template_name})
 
 
-@pytest.mark.tier2
 def test_positive_view_dump(module_org, module_target_sat):
     """Export contents of a job template
 

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -39,7 +39,6 @@ def ldap_tear_down(module_target_sat):
 class TestADAuthSource:
     """Implements Active Directory feature tests in CLI"""
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize('server_name', **parametrized(generate_strings_list()))
     @pytest.mark.usefixtures("ldap_tear_down")
@@ -82,7 +81,6 @@ class TestADAuthSource:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.LDAPAuthSource.info({'name': new_name})
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('member_group', ['foobargroup', 'foobar.group'])
     @pytest.mark.usefixtures("ldap_tear_down")
     def test_positive_refresh_usergroup_with_ad(self, member_group, ad_data, module_target_sat):
@@ -162,7 +160,6 @@ class TestIPAAuthSource:
         for user_group in user_groups:
             user_group.delete()
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('server_name', **parametrized(generate_strings_list()))
     @pytest.mark.upgrade
     @pytest.mark.e2e
@@ -206,7 +203,6 @@ class TestIPAAuthSource:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.LDAPAuthSource.info({'name': new_name})
 
-    @pytest.mark.tier3
     @pytest.mark.usefixtures("ldap_tear_down")
     def test_usergroup_sync_with_refresh(self, default_ipa_host, module_target_sat):
         """Verify the refresh functionality in Ldap Auth Source
@@ -294,7 +290,6 @@ class TestIPAAuthSource:
             ).list()
         assert 'Missing one of the required permissions' in error.value.message
 
-    @pytest.mark.tier3
     @pytest.mark.usefixtures("ldap_tear_down")
     def test_usergroup_with_usergroup_sync(self, default_ipa_host, module_target_sat):
         """Verify the usergroup-sync functionality in Ldap Auth Source
@@ -375,7 +370,6 @@ class TestIPAAuthSource:
 class TestOpenLdapAuthSource:
     """Implements OpenLDAP Auth Source tests in CLI"""
 
-    @pytest.mark.tier2
     @pytest.mark.e2e
     @pytest.mark.parametrize('server_name', **parametrized(generate_strings_list()))
     @pytest.mark.upgrade

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -33,7 +33,6 @@ def module_lce(module_org, class_target_sat):
 
 
 # Issues validation
-@pytest.mark.tier2
 def test_positive_list_subcommand(module_org, module_target_sat):
     """List subcommand returns standard output
 
@@ -55,7 +54,6 @@ def test_positive_list_subcommand(module_org, module_target_sat):
     assert len(result) > 0
 
 
-@pytest.mark.tier2
 def test_positive_search_lce_via_UTF8(module_org, module_target_sat):
     """Search lifecycle environment via its name containing UTF-8
     chars
@@ -80,7 +78,6 @@ def test_positive_search_lce_via_UTF8(module_org, module_target_sat):
 
 
 # CRUD
-@pytest.mark.tier1
 def test_positive_lce_crud(module_org, module_target_sat):
     """CRUD test case for lifecycle environment for name, description, label, registry name pattern,
     and unauthenticated pull
@@ -143,7 +140,6 @@ def test_positive_lce_crud(module_org, module_target_sat):
         )
 
 
-@pytest.mark.tier1
 def test_positive_create_with_organization_label(module_org, module_target_sat):
     """Create lifecycle environment, specifying organization label
 
@@ -161,7 +157,6 @@ def test_positive_create_with_organization_label(module_org, module_target_sat):
     assert new_lce['organization'] == module_org.label
 
 
-@pytest.mark.tier1
 def test_positve_list_paths(module_org, module_target_sat):
     """List the environment paths under a given organization
 
@@ -204,7 +199,6 @@ class LifeCycleEnvironmentPaginationTestCase:
 
         self.lces_count += 1  # include default 'Library' lce
 
-    @pytest.mark.tier2
     def test_positive_list_all_with_per_page(self, target_sat):
         """Attempt to list more than 20 lifecycle environment with per-page
         option.
@@ -226,7 +220,6 @@ class LifeCycleEnvironmentPaginationTestCase:
         env_name_set = {env['name'] for env in lifecycle_environments}
         assert env_name_set == set(self.env_names)
 
-    @pytest.mark.tier2
     def test_positive_list_with_pagination(self, target_sat):
         """Make sure lces list can be displayed with different items per page
         value

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -138,7 +138,6 @@ class TestLocation:
     """Tests for Location via Hammer CLI"""
 
     @pytest.mark.e2e
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_create_update_delete(self, request, target_sat):
         """Create new location with attributes, update and delete it
@@ -218,7 +217,6 @@ class TestLocation:
         with pytest.raises(CLIReturnCodeError):
             target_sat.cli.Location.info({'id': location['id']})
 
-    @pytest.mark.tier1
     def test_positive_create_with_parent(self, request, target_sat):
         """Create new location with parent location specified
 
@@ -236,7 +234,6 @@ class TestLocation:
         location = _location(request, target_sat, {'parent-id': parent_location['id']})
         assert location['parent'] == parent_location['name']
 
-    @pytest.mark.tier1
     def test_negative_create_with_same_name(self, request, target_sat):
         """Try to create location using same name twice
 
@@ -252,7 +249,6 @@ class TestLocation:
         with pytest.raises(CLIFactoryError):
             _location(request, target_sat, options={'name': name})
 
-    @pytest.mark.tier1
     def test_negative_create_with_user_by_name(self, request, target_sat):
         """Try to create new location with incorrect user assigned to it
         Use user login as a parameter
@@ -267,7 +263,6 @@ class TestLocation:
             _location(request, target_sat, options={'users': gen_string('utf8', 80)})
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_add_and_remove_capsule(self, request, target_sat):
         """Add a capsule to location and remove it
@@ -294,7 +289,6 @@ class TestLocation:
         location = target_sat.cli.Location.info({'name': location['name']})
         assert proxy['name'] not in location['smart-proxies']
 
-    @pytest.mark.tier1
     def test_positive_add_update_remove_parameter(self, request, target_sat):
         """Add, update and remove parameter to location
 
@@ -330,7 +324,6 @@ class TestLocation:
         assert len(location['parameters']) == 0
         assert param_name.lower() not in location['parameters']
 
-    @pytest.mark.tier2
     def test_positive_update_parent(self, request, target_sat):
         """Update location's parent location
 
@@ -352,7 +345,6 @@ class TestLocation:
         location = target_sat.cli.Location.info({'id': location['id']})
         assert location['parent'] == parent_location_2['name']
 
-    @pytest.mark.tier1
     def test_negative_update_parent_with_child(self, request, target_sat):
         """Attempt to set child location as a parent and vice versa
 

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -31,7 +31,6 @@ def cut_lines(start_line, end_line, source_file, out_file, host):
     )
 
 
-@pytest.mark.tier4
 def test_positive_logging_from_foreman_core(target_sat):
     """Check that GET command to Hosts API is logged and has request ID.
 
@@ -70,7 +69,6 @@ def test_positive_logging_from_foreman_core(target_sat):
     assert GET_line_found, "The GET command to list hosts was not found in logs."
 
 
-@pytest.mark.tier4
 def test_positive_logging_from_foreman_proxy(target_sat):
     """Check PUT to Smart Proxy API to refresh the features is logged and has request ID.
 
@@ -129,7 +127,6 @@ def test_positive_logging_from_foreman_proxy(target_sat):
             break
 
 
-@pytest.mark.tier4
 def test_positive_logging_from_candlepin(module_org, module_sca_manifest, target_sat):
     """Check logging after manifest upload.
 
@@ -170,7 +167,6 @@ def test_positive_logging_from_candlepin(module_org, module_sca_manifest, target
     assert POST_line_found, "The POST command to candlepin was not found in logs."
 
 
-@pytest.mark.tier4
 def test_positive_logging_from_dynflow(module_org, target_sat):
     """Check POST to repositories API is logged while enabling a repo \
         and it has the request ID.
@@ -211,7 +207,6 @@ def test_positive_logging_from_dynflow(module_org, target_sat):
     assert POST_line_found, "The POST command to enable a repo was not found in logs."
 
 
-@pytest.mark.tier4
 def test_positive_logging_from_pulp3(module_org, target_sat):
     """
     Verify Pulp3 logs are getting captured using pulp3 correlation ID

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -25,7 +25,6 @@ OSES = ['Archlinux', 'Debian', 'Gentoo', 'Redhat', 'Solaris', 'Suse', 'Windows']
 class TestMedium:
     """Test class for Medium CLI"""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list().values()))
     def test_positive_crud_with_name(self, name, module_target_sat):
         """Check if Medium can be created, updated, deleted
@@ -49,7 +48,6 @@ class TestMedium:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Medium.info({'id': medium['id']})
 
-    @pytest.mark.tier1
     def test_positive_create_with_location(self, module_target_sat):
         """Check if medium with location can be created
 
@@ -64,7 +62,6 @@ class TestMedium:
         medium = module_target_sat.cli_factory.make_medium({'location-ids': location['id']})
         assert location['name'] in medium['locations']
 
-    @pytest.mark.tier1
     def test_positive_create_with_organization_by_id(self, module_target_sat):
         """Check if medium with organization can be created
 
@@ -79,7 +76,6 @@ class TestMedium:
         medium = module_target_sat.cli_factory.make_medium({'organization-ids': org['id']})
         assert org['name'] in medium['organizations']
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_remove_os(self, module_target_sat):
         """Check if Medium can be associated with operating system and then removed from media

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -32,7 +32,6 @@ class TestModel:
         """Shared model for tests"""
         return target_sat.cli_factory.make_model()
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         ('name', 'new_name'),
@@ -60,7 +59,6 @@ class TestModel:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Model.info({'id': model['id']})
 
-    @pytest.mark.tier1
     def test_positive_create_with_vendor_class(self, module_target_sat):
         """Check if Model can be created with specific vendor class
 
@@ -74,7 +72,6 @@ class TestModel:
         model = module_target_sat.cli_factory.make_model({'vendor-class': vendor_class})
         assert model['vendor-class'] == vendor_class
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_name(self, name, module_target_sat):
         """Don't create an Model with invalid data.
@@ -90,7 +87,6 @@ class TestModel:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Model.create({'name': name})
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, class_model, new_name, module_target_sat):
         """Fail to update shared model name
@@ -108,7 +104,6 @@ class TestModel:
         result = module_target_sat.cli.Model.info({'id': class_model['id']})
         assert class_model['name'] == result['name']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
     def test_negative_delete_by_id(self, entity_id, module_target_sat):
         """Delete model by wrong ID

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -140,7 +140,6 @@ class TestOperatingSystem:
         with pytest.raises(CLIReturnCodeError):
             target_sat.cli.OperatingSys.info({'id': os['id']})
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     def test_positive_create_with_name(self, name, target_sat):
         """Create Operating System for all variations of name
@@ -156,7 +155,6 @@ class TestOperatingSystem:
         os = target_sat.cli_factory.make_os({'name': name})
         assert os['name'] == name
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
     def test_negative_create_with_name(self, name, target_sat):
         """Create Operating System using invalid names
@@ -172,7 +170,6 @@ class TestOperatingSystem:
         with pytest.raises(CLIReturnCodeError):
             target_sat.cli.OperatingSys.create({'name': name})
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
     def test_negative_update_name(self, new_name, target_sat):
         """Negative update of system name
@@ -191,7 +188,6 @@ class TestOperatingSystem:
         result = target_sat.cli.OperatingSys.info({'id': os['id']})
         assert result['name'] == os['name']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('test_data', **parametrized(negative_delete_data()))
     def test_negative_delete_by_id(self, test_data, target_sat):
         """Delete Operating System using invalid data
@@ -213,7 +209,6 @@ class TestOperatingSystem:
         assert os['id'] == result['id']
         assert os['name'] == result['name']
 
-    @pytest.mark.tier2
     def test_positive_add_arch(self, target_sat):
         """Add Architecture to operating system
 
@@ -231,7 +226,6 @@ class TestOperatingSystem:
         assert len(os['architectures']) == 1
         assert architecture['name'] == os['architectures'][0]
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_add_template(self, target_sat):
         """Add provisioning template to operating system
@@ -253,7 +247,6 @@ class TestOperatingSystem:
         assert default_template_name in os['templates']
         assert provision_template_name in os['templates']
 
-    @pytest.mark.tier2
     def test_positive_add_ptable(self, target_sat):
         """Add partition table to operating system
 
@@ -273,7 +266,6 @@ class TestOperatingSystem:
         assert len(os['partition-tables']) == 1
         assert os['partition-tables'][0] == ptable_name
 
-    @pytest.mark.tier2
     def test_positive_update_parameters_attributes(self, target_sat):
         """Update os-parameters-attributes to operating system
 
@@ -299,7 +291,6 @@ class TestOperatingSystem:
         assert param_value == os['parameters'][0]['value']
 
 
-@pytest.mark.tier2
 def test_positive_os_list_with_default_organization_set(target_sat):
     """list operating systems when the default organization is set
 

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -52,7 +52,6 @@ def proxy(target_sat):
     target_sat.cli.Proxy.delete({'id': proxy['id']})
 
 
-@pytest.mark.tier2
 def test_positive_no_duplicate_lines(module_target_sat):
     """hammer organization <info,list> --help types information
     doubled
@@ -77,7 +76,6 @@ def test_positive_no_duplicate_lines(module_target_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 def test_positive_CRD(module_target_sat):
     """Create organization with valid name, label and description
 
@@ -134,7 +132,6 @@ def test_positive_CRD(module_target_sat):
         result = module_target_sat.cli.Org.info({'id': org['id']})
 
 
-@pytest.mark.tier2
 def test_positive_create_with_system_admin_user(module_target_sat):
     """Create organization using user with system admin role
 
@@ -154,7 +151,6 @@ def test_positive_create_with_system_admin_user(module_target_sat):
     assert result['name'] == org_name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_add_and_remove_subnets(module_org, module_target_sat):
     """add and remove a subnet from organization
@@ -182,7 +178,6 @@ def test_positive_add_and_remove_subnets(module_org, module_target_sat):
     assert len(org_info['subnets']) == 0, "Failed to remove subnets"
 
 
-@pytest.mark.tier2
 def test_positive_add_and_remove_users(module_org, module_target_sat):
     """Add and remove (admin) user to organization
 
@@ -229,7 +224,6 @@ def test_positive_add_and_remove_users(module_org, module_target_sat):
     assert admin_user['login'] not in org_info['users'], "Failed to remove admin user by id"
 
 
-@pytest.mark.tier2
 def test_positive_add_and_remove_hostgroups(module_org, module_target_sat):
     """add and remove a hostgroup from an organization
 
@@ -266,7 +260,6 @@ def test_positive_add_and_remove_hostgroups(module_org, module_target_sat):
 
 
 @pytest.mark.skip_if_not_set('libvirt')
-@pytest.mark.tier2
 @pytest.mark.libvirt_discovery
 @pytest.mark.upgrade
 def test_positive_add_and_remove_compute_resources(module_org, module_target_sat):
@@ -314,7 +307,6 @@ def test_positive_add_and_remove_compute_resources(module_org, module_target_sat
     )
 
 
-@pytest.mark.tier2
 def test_positive_add_and_remove_media(module_org, module_target_sat):
     """Add and remove medium to organization
 
@@ -341,7 +333,6 @@ def test_positive_add_and_remove_media(module_org, module_target_sat):
     assert media[1]['name'] not in org_info['installation-media'], "Failed to remove medium by id"
 
 
-@pytest.mark.tier2
 def test_positive_add_and_remove_templates(module_org, module_target_sat):
     """Add and remove provisioning templates to organization
 
@@ -397,7 +388,6 @@ def test_positive_add_and_remove_templates(module_org, module_target_sat):
     )
 
 
-@pytest.mark.tier2
 def test_positive_add_and_remove_domains(module_org, module_target_sat):
     """Add and remove domains to organization
 
@@ -424,7 +414,6 @@ def test_positive_add_and_remove_domains(module_org, module_target_sat):
     assert len(org_info['domains']) == 0, "Failed to remove domains"
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_add_and_remove_lce(module_org, module_target_sat):
     """Remove a lifecycle environment from organization
@@ -454,7 +443,6 @@ def test_positive_add_and_remove_lce(module_org, module_target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_add_and_remove_capsules(proxy, module_org, module_target_sat):
     """Add and remove a capsule from organization
@@ -487,7 +475,6 @@ def test_positive_add_and_remove_capsules(proxy, module_org, module_target_sat):
     assert proxy['name'] not in org_info['smart-proxies'], "Failed to add capsule by name"
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_add_and_remove_locations(module_org, module_target_sat):
     """Add and remove a locations from organization
@@ -528,7 +515,6 @@ def test_positive_add_and_remove_locations(module_org, module_target_sat):
     assert locations[1]['name'] not in found_locations, "Failed to remove locations"
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_add_and_remove_parameter(module_org, module_target_sat):
     """Remove a parameter from organization
@@ -569,7 +555,6 @@ def test_positive_add_and_remove_parameter(module_org, module_target_sat):
     assert param_name.lower() not in org_info['parameters']
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
 def test_negative_create_with_invalid_name(name, module_target_sat):
     """Try to create an organization with invalid name, but valid label and
@@ -591,7 +576,6 @@ def test_negative_create_with_invalid_name(name, module_target_sat):
         )
 
 
-@pytest.mark.tier1
 def test_negative_create_same_name(module_org, module_target_sat):
     """Create a new organization with same name, description, and label.
 
@@ -611,7 +595,6 @@ def test_negative_create_same_name(module_org, module_target_sat):
         )
 
 
-@pytest.mark.tier1
 def test_positive_update(module_org, module_target_sat):
     """Update organization name and description
 
@@ -636,7 +619,6 @@ def test_positive_update(module_org, module_target_sat):
     assert org['description'] == new_desc
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
 def test_negative_update_name(new_name, module_org, module_target_sat):
     """Fail to update organization name for invalid values.
@@ -651,7 +633,6 @@ def test_negative_update_name(new_name, module_org, module_target_sat):
         module_target_sat.cli.Org.update({'id': module_org.id, 'new-name': new_name})
 
 
-@pytest.mark.tier2
 def test_positive_create_user_with_timezone(module_target_sat):
     """Create and remove user with valid timezone in an organization
 

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -41,7 +41,6 @@ class TestOpenScap:
         scap_profile_ids = default_content['scap-content-profiles'][0]['id']
         return scap_id, scap_profile_ids
 
-    @pytest.mark.tier1
     def test_positive_list_default_content_with_admin(self, module_target_sat):
         """List the default scap content with admin account
 
@@ -69,7 +68,6 @@ class TestOpenScap:
         scap_contents = [content['title'] for content in module_target_sat.cli.Scapcontent.list()]
         assert f'Red Hat rhel{module_target_sat.os_version.major} default content' in scap_contents
 
-    @pytest.mark.tier1
     def test_negative_list_default_content_with_viewer_role(
         self, scap_content, default_viewer_role, module_target_sat
     ):
@@ -103,7 +101,6 @@ class TestOpenScap:
                 default_viewer_role.login, default_viewer_role.password
             ).info({'title': scap_content['title']})
 
-    @pytest.mark.tier1
     def test_positive_view_scap_content_info_admin(self, module_target_sat):
         """View info of scap content with admin account
 
@@ -132,7 +129,6 @@ class TestOpenScap:
         result = module_target_sat.cli.Scapcontent.info({'title': title})
         assert result['title'] == title
 
-    @pytest.mark.tier1
     def test_negative_info_scap_content(self, module_target_sat):
         """View info of scap content with invalid ID as parameter
 
@@ -159,7 +155,6 @@ class TestOpenScap:
             module_target_sat.cli.Scapcontent.info({'id': invalid_scap_id})
 
     @pytest.mark.parametrize('title', **parametrized(valid_data_list()))
-    @pytest.mark.tier1
     def test_positive_create_scap_content_with_valid_title(self, title, module_target_sat):
         """Create scap-content with valid title
 
@@ -190,7 +185,6 @@ class TestOpenScap:
         )
         assert scap_content['title'] == title
 
-    @pytest.mark.tier1
     def test_negative_create_scap_content_with_same_title(self, module_target_sat):
         """Create scap-content with same title
 
@@ -229,7 +223,6 @@ class TestOpenScap:
             )
 
     @pytest.mark.parametrize('title', **parametrized(invalid_names_list()))
-    @pytest.mark.tier1
     def test_negative_create_scap_content_with_invalid_title(self, title, module_target_sat):
         """Create scap-content with invalid title
 
@@ -259,7 +252,6 @@ class TestOpenScap:
             )
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    @pytest.mark.tier1
     def test_positive_create_scap_content_with_valid_originalfile_name(
         self, name, module_target_sat
     ):
@@ -292,7 +284,6 @@ class TestOpenScap:
         assert scap_content['original-filename'] == name
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    @pytest.mark.tier1
     def test_negative_create_scap_content_with_invalid_originalfile_name(
         self,
         name,
@@ -328,7 +319,6 @@ class TestOpenScap:
             )
 
     @pytest.mark.parametrize('title', **parametrized(valid_data_list()))
-    @pytest.mark.tier1
     def test_negative_create_scap_content_without_dsfile(self, title, module_target_sat):
         """Create scap-content without scap data stream xml file
 
@@ -354,7 +344,6 @@ class TestOpenScap:
         with pytest.raises(CLIFactoryError):
             module_target_sat.cli_factory.scapcontent({'title': title})
 
-    @pytest.mark.tier1
     def test_positive_update_scap_content_with_newtitle(
         self,
         module_target_sat,
@@ -390,7 +379,6 @@ class TestOpenScap:
         result = module_target_sat.cli.Scapcontent.info({'title': new_title}, output_format='json')
         assert result['title'] == new_title
 
-    @pytest.mark.tier1
     def test_positive_delete_scap_content_with_id(self, module_target_sat):
         """Delete a scap content with id as parameter
 
@@ -419,7 +407,6 @@ class TestOpenScap:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Scapcontent.info({'id': scap_content['id']})
 
-    @pytest.mark.tier1
     def test_positive_delete_scap_content_with_title(self, module_target_sat):
         """Delete a scap content with title as parameter
 
@@ -451,7 +438,6 @@ class TestOpenScap:
             module_target_sat.cli.Scapcontent.info({'title': scap_content['title']})
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    @pytest.mark.tier2
     def test_postive_create_scap_policy_with_valid_name(
         self, name, scap_content, module_target_sat
     ):
@@ -493,7 +479,6 @@ class TestOpenScap:
             module_target_sat.cli.Scappolicy.info({'name': scap_policy['name']})
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    @pytest.mark.tier2
     def test_negative_create_scap_policy_with_invalid_name(
         self, name, scap_content, module_target_sat
     ):
@@ -530,7 +515,6 @@ class TestOpenScap:
                 }
             )
 
-    @pytest.mark.tier2
     def test_negative_create_scap_policy_without_content(self, scap_content, module_target_sat):
         """Create scap policy without scap content
 
@@ -561,7 +545,6 @@ class TestOpenScap:
                 }
             )
 
-    @pytest.mark.tier2
     def test_positive_associate_scap_policy_with_hostgroups(self, scap_content, module_target_sat):
         """Associate hostgroups to scap policy
 
@@ -636,7 +619,6 @@ class TestOpenScap:
         assert db_out.status == 0
         assert "(0 rows)" in db_out.stdout
 
-    @pytest.mark.tier2
     def test_positive_associate_scap_policy_with_hostgroup_via_ansible(
         self, scap_content, module_target_sat
     ):
@@ -679,7 +661,6 @@ class TestOpenScap:
 
     @pytest.mark.parametrize('deploy', **parametrized(['manual', 'ansible']))
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     def test_positive_associate_scap_policy_with_tailoringfiles(
         self, deploy, scap_content, tailoring_file_path, module_target_sat
     ):
@@ -769,7 +750,6 @@ class TestOpenScap:
 
     @pytest.mark.parametrize('deploy', **parametrized(['manual', 'ansible']))
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     @pytest.mark.e2e
     def test_positive_scap_policy_end_to_end(self, deploy, scap_content, module_target_sat):
         """List all scap policies and read info using id, name
@@ -832,7 +812,6 @@ class TestOpenScap:
             module_target_sat.cli.Scappolicy.info({'id': scap_policy['id']})
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     def test_positive_update_scap_policy_with_hostgroup(self, scap_content, module_target_sat):
         """Update scap policy by addition of hostgroup
 
@@ -878,7 +857,6 @@ class TestOpenScap:
         # Assert if the deployment is updated
         assert scap_info['deployment-option'] == 'ansible'
 
-    @pytest.mark.tier2
     def test_positive_update_scap_policy_period(self, scap_content, module_target_sat):
         """Update scap policy by updating the period strategy
         from monthly to weekly
@@ -924,7 +902,6 @@ class TestOpenScap:
         assert scap_info['period'] == OSCAP_PERIOD['monthly'].lower()
         assert scap_info['day-of-month'] == '15'
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_update_scap_policy_with_content(self, scap_content, module_target_sat):
         """Update the scap policy by updating the scap content
@@ -971,7 +948,6 @@ class TestOpenScap:
         assert scap_info['scap-content-id'] == scap_id
         assert scap_info['scap-content-profile-id'] == scap_profile_id
 
-    @pytest.mark.tier2
     def test_positive_associate_scap_policy_with_single_server(
         self, scap_content, module_target_sat
     ):
@@ -1016,7 +992,6 @@ class TestOpenScap:
         assert host_name in [host['name'] for host in hosts]
 
     @pytest.mark.stubbed
-    @pytest.mark.tier4
     def test_positive_list_arf_reports(self):
         """List all arf-reports
 
@@ -1042,7 +1017,6 @@ class TestOpenScap:
 
     @pytest.mark.upgrade
     @pytest.mark.stubbed
-    @pytest.mark.tier4
     def test_positive_info_arf_report(self):
         """View information of arf-report
 
@@ -1068,7 +1042,6 @@ class TestOpenScap:
         """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier4
     def test_positive_delete_arf_report(self):
         """Delete an arf-report
 

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -28,7 +28,6 @@ class TestTailoringFiles:
     """Implements Tailoring Files tests in CLI."""
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    @pytest.mark.tier1
     def test_positive_create(self, tailoring_file_path, name, module_target_sat):
         """Create new Tailoring Files using different values types as name
 
@@ -51,7 +50,6 @@ class TestTailoringFiles:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.TailoringFiles.info({'id': tailoring_file['id']})
 
-    @pytest.mark.tier1
     def test_positive_create_with_space(self, tailoring_file_path, module_target_sat):
         """Create tailoring files with space in name
 
@@ -71,7 +69,6 @@ class TestTailoringFiles:
         )
         assert tailoring_file['name'] == name
 
-    @pytest.mark.tier1
     def test_positive_get_info_of_tailoring_file(self, tailoring_file_path, module_target_sat):
         """Get information of tailoring file
 
@@ -96,7 +93,6 @@ class TestTailoringFiles:
         result = module_target_sat.cli.TailoringFiles.info({'name': name})
         assert result['name'] == name
 
-    @pytest.mark.tier1
     def test_positive_list_tailoring_file(self, tailoring_file_path, module_target_sat):
         """List all created tailoring files
 
@@ -120,7 +116,6 @@ class TestTailoringFiles:
         result = module_target_sat.cli.TailoringFiles.list()
         assert name in [tailoringfile['name'] for tailoringfile in result]
 
-    @pytest.mark.tier1
     def test_negative_create_with_invalid_file(self, target_sat):
         """Create Tailoring files with invalid file
 
@@ -142,7 +137,6 @@ class TestTailoringFiles:
             )
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    @pytest.mark.tier1
     def test_negative_create_with_invalid_name(self, tailoring_file_path, name, module_target_sat):
         """Create Tailoring files with invalid name
 
@@ -164,7 +158,6 @@ class TestTailoringFiles:
             )
 
     @pytest.mark.stubbed
-    @pytest.mark.tier2
     def test_negative_associate_tailoring_file_with_different_scap(self):
         """Associate a tailoring file with different scap content
 
@@ -183,7 +176,6 @@ class TestTailoringFiles:
         :CaseImportance: Medium
         """
 
-    @pytest.mark.tier2
     def test_positive_download_tailoring_file(self, tailoring_file_path, target_sat):
         """Download the tailoring file from satellite
 
@@ -214,7 +206,6 @@ class TestTailoringFiles:
         assert result.status == 0
         assert file_path == result.stdout.strip()
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_delete_tailoring_file(self, tailoring_file_path, module_target_sat):
         """Delete tailoring file
@@ -238,7 +229,6 @@ class TestTailoringFiles:
             module_target_sat.cli.TailoringFiles.info({'id': tailoring_file['id']})
 
     @pytest.mark.stubbed
-    @pytest.mark.tier4
     @pytest.mark.upgrade
     def test_positive_oscap_run_with_tailoring_file_and_capsule(self):
         """End-to-End Oscap run with tailoring files and default capsule
@@ -263,7 +253,6 @@ class TestTailoringFiles:
         """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier4
     @pytest.mark.upgrade
     def test_positive_oscap_run_with_tailoring_file_and_external_capsule(self):
         """End-to-End Oscap run with tailoring files and external capsule
@@ -288,7 +277,6 @@ class TestTailoringFiles:
         """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier4
     @pytest.mark.upgrade
     def test_positive_fetch_tailoring_file_information_from_arfreports(self):
         """Fetch Tailoring file Information from Arf-reports

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -23,7 +23,6 @@ pytestmark = [
     pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     ),
-    pytest.mark.tier3,
     pytest.mark.stubbed,
 ]
 

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -24,7 +24,6 @@ from robottelo.utils.datafactory import generate_strings_list, parametrized
 class TestPartitionTable:
     """Partition Table CLI tests."""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(generate_strings_list(length=1)))
     def test_positive_create_with_one_character_name(self, name, target_sat):
         """Create Partition table with 1 character in name
@@ -42,7 +41,6 @@ class TestPartitionTable:
         ptable = target_sat.cli_factory.make_partition_table({'name': name})
         assert ptable['name'] == name
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         ('name', 'new_name'),
@@ -76,7 +74,6 @@ class TestPartitionTable:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.PartitionTable.info({'name': ptable['name']})
 
-    @pytest.mark.tier1
     def test_positive_create_with_content(self, module_target_sat):
         """Create a Partition Table with content
 
@@ -93,7 +90,6 @@ class TestPartitionTable:
         ptable_content = module_target_sat.cli.PartitionTable().dump({'id': ptable['id']})
         assert content in ptable_content
 
-    @pytest.mark.tier1
     def test_positive_delete_by_id(self, module_target_sat):
         """Create a Partition Table then delete it by its ID
 
@@ -108,7 +104,6 @@ class TestPartitionTable:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.PartitionTable.info({'id': ptable['id']})
 
-    @pytest.mark.tier2
     def test_positive_add_remove_os_by_id(self, module_target_sat):
         """Create a partition table then add and remove an operating system to it using
         IDs for association
@@ -131,7 +126,6 @@ class TestPartitionTable:
         ptable = module_target_sat.cli.PartitionTable.info({'id': ptable['id']})
         assert os['title'] not in ptable['operating-systems']
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_add_remove_os_by_name(self, module_target_sat):
         """Create a partition table then add and remove an operating system to it using

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -14,10 +14,9 @@
 
 import pytest
 
-pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]
-
 
 @pytest.mark.pit_server
+@pytest.mark.upgrade
 @pytest.mark.parametrize('switch_user', [False, True], ids=['root', 'non-root'])
 def test_positive_ping(target_sat, switch_user):
     """hammer ping return code

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -26,7 +26,6 @@ from robottelo.utils.datafactory import (
 )
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_CRUD(module_org, target_sat):
@@ -112,7 +111,6 @@ def test_positive_CRUD(module_org, target_sat):
         target_sat.cli.Product.info({'id': product['id'], 'organization-id': module_org.id})
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
 def test_negative_create_with_name(name, module_org, module_target_sat):
     """Check that only valid names can be used
@@ -129,7 +127,6 @@ def test_negative_create_with_name(name, module_org, module_target_sat):
         module_target_sat.cli_factory.make_product({'name': name, 'organization-id': module_org.id})
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize(
     'label', **parametrized([gen_string(e, 15) for e in ('latin1', 'utf8', 'html')])
 )
@@ -155,7 +152,6 @@ def test_negative_create_with_label(label, module_org, module_target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_product_list_with_default_settings(module_org, target_sat):
     """Listing product of an organization apart from default organization using hammer
@@ -211,7 +207,6 @@ def test_product_list_with_default_settings(module_org, target_sat):
         assert not [res for res in result if res['parameter'] == 'organization_id']
 
 
-@pytest.mark.tier2
 def test_positive_product_sync_state(module_org, module_target_sat):
     """hammer product info shows correct sync state.
 

--- a/tests/foreman/cli/test_provisioning.py
+++ b/tests/foreman/cli/test_provisioning.py
@@ -17,7 +17,6 @@ import pytest
 
 @pytest.mark.stubbed
 @pytest.mark.on_premises_provisioning
-@pytest.mark.tier3
 def test_rhel_pxe_provisioning_on_libvirt():
     """Provision RHEL system via PXE on libvirt and make sure it behaves
 

--- a/tests/foreman/cli/test_provisioningtemplate.py
+++ b/tests/foreman/cli/test_provisioningtemplate.py
@@ -97,7 +97,6 @@ def test_positive_end_to_end_crud(
         module_target_sat.cli.Template.info({'id': template['id']})
 
 
-@pytest.mark.tier1
 @pytest.mark.parametrize('role_name', ['Manager', 'Organization admin'])
 def test_positive_update_with_role(module_target_sat, module_location, module_org, role_name):
     """Create template providing the initial name, then update its name
@@ -137,7 +136,6 @@ def test_positive_update_with_role(module_target_sat, module_location, module_or
     assert new_name == template['name']
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_create_locked(module_target_sat):
     """Check that locked Template can be created
@@ -155,7 +153,6 @@ def test_positive_create_locked(module_target_sat):
     assert new_template['locked'] == 'yes'
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_add_remove_os_by_id(module_target_sat, module_os_with_minor):
     """Check if operating system can be added and removed to a template
@@ -179,7 +176,6 @@ def test_positive_add_remove_os_by_id(module_target_sat, module_os_with_minor):
     assert os_string not in new_template['operating-systems']
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_create_with_content(module_target_sat):
     """Check if Template can be created with specific content
@@ -198,7 +194,6 @@ def test_positive_create_with_content(module_target_sat):
     assert content in template_content
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_clone(module_target_sat):
     """Assure ability to clone a provisioning template

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -17,7 +17,6 @@ import pytest
 from robottelo.config import settings
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason="Missing repos_hosting_url")
 def test_positive_list_smart_class_parameters(

--- a/tests/foreman/cli/test_realm.py
+++ b/tests/foreman/cli/test_realm.py
@@ -20,7 +20,6 @@ import pytest
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 
 
-@pytest.mark.tier1
 def test_negative_create_name_only(module_target_sat):
     """Create a realm with just a name parameter
 
@@ -32,7 +31,6 @@ def test_negative_create_name_only(module_target_sat):
         module_target_sat.cli_factory.realm({'name': gen_string('alpha', random.randint(1, 30))})
 
 
-@pytest.mark.tier1
 def test_negative_create_invalid_proxy_id(module_target_sat):
     """Create a realm with an invalid proxy ID
 
@@ -50,7 +48,6 @@ def test_negative_create_invalid_proxy_id(module_target_sat):
         )
 
 
-@pytest.mark.tier1
 def test_negative_create_invalid_realm_type(module_target_sat):
     """Create a realm with an invalid type
 
@@ -69,7 +66,6 @@ def test_negative_create_invalid_realm_type(module_target_sat):
         )
 
 
-@pytest.mark.tier1
 def test_negative_create_invalid_location(module_target_sat):
     """Create a realm with an invalid location
 
@@ -88,7 +84,6 @@ def test_negative_create_invalid_location(module_target_sat):
         )
 
 
-@pytest.mark.tier1
 def test_negative_create_invalid_organization(module_target_sat):
     """Create a realm with an invalid organization
 
@@ -107,7 +102,6 @@ def test_negative_create_invalid_organization(module_target_sat):
         )
 
 
-@pytest.mark.tier2
 def test_negative_delete_nonexistent_realm_name(module_target_sat):
     """Delete a realm with a name that does not exist
 
@@ -119,7 +113,6 @@ def test_negative_delete_nonexistent_realm_name(module_target_sat):
         module_target_sat.cli.Realm.delete({'name': gen_string('alpha', random.randint(1, 30))})
 
 
-@pytest.mark.tier2
 def test_negative_delete_nonexistent_realm_id(module_target_sat):
     """Delete a realm with an ID that does not exist
 
@@ -131,7 +124,6 @@ def test_negative_delete_nonexistent_realm_id(module_target_sat):
         module_target_sat.cli.Realm.delete({'id': 0})
 
 
-@pytest.mark.tier2
 def test_negative_info_nonexistent_realm_name(module_target_sat):
     """Get info for a realm with a name that does not exist
 
@@ -143,7 +135,6 @@ def test_negative_info_nonexistent_realm_name(module_target_sat):
         module_target_sat.cli.Realm.info({'name': gen_string('alpha', random.randint(1, 30))})
 
 
-@pytest.mark.tier2
 def test_negative_info_nonexistent_realm_id(module_target_sat):
     """Get info for a realm with an ID that does not exist
 

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -24,8 +24,6 @@ from robottelo.constants import CLIENT_PORT
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.utils.issue_handlers import is_open
 
-pytestmark = pytest.mark.tier1
-
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
@@ -171,7 +169,6 @@ def test_upgrade_katello_ca_consumer_rpm(module_org, module_location, target_sat
 
 
 @pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.tier3
 def test_negative_register_twice(module_ak_with_cv, module_org, rhel_contenthost, target_sat):
     """Attempt to register a host twice to Satellite
 
@@ -192,7 +189,6 @@ def test_negative_register_twice(module_ak_with_cv, module_org, rhel_contenthost
 
 
 @pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.tier3
 def test_positive_force_register_twice(module_ak_with_cv, module_org, rhel_contenthost, target_sat):
     """Register a host twice to Satellite, with force=true
 
@@ -231,7 +227,6 @@ def test_positive_force_register_twice(module_ak_with_cv, module_org, rhel_conte
     )
 
 
-@pytest.mark.tier1
 def test_negative_global_registration_without_ak(module_target_sat):
     """Attempt to register a host without ActivationKey
 

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -91,7 +91,6 @@ def assert_job_invocation_status(sat, invocation_command_id, client_hostname, st
 class TestRemoteExecution:
     """Implements job execution tests in CLI."""
 
-    @pytest.mark.tier3
     @pytest.mark.pit_client
     @pytest.mark.pit_server
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
@@ -134,7 +133,6 @@ class TestRemoteExecution:
         assert 'Exit' in out
         assert 'Internal Server Error' not in out
 
-    @pytest.mark.tier3
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_negative_run_default_job_template(
         self, module_org, rex_contenthost, module_target_sat
@@ -177,7 +175,6 @@ class TestRemoteExecution:
         )
         assert 'Exit status: 23' in out
 
-    @pytest.mark.tier3
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_timeout_to_kill(self, module_org, rex_contenthost, module_target_sat):
         """Use timeout to kill setting to cancel the job
@@ -222,7 +219,6 @@ class TestRemoteExecution:
         )
         assert 'Timeout for execution passed, trying to stop the job' in out
 
-    @pytest.mark.tier3
     @pytest.mark.pit_client
     @pytest.mark.pit_server
     @pytest.mark.rhel_ver_list([7, 8, 9])
@@ -329,7 +325,6 @@ class TestRemoteExecution:
         )
         assert 'Permission denied' in out
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'multi_global_param_update',
         [
@@ -423,7 +418,6 @@ class TestRemoteExecution:
             f'''stat -c '%G' /home/{username}/{filename}''',
         )
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'multi_setting_update',
         [
@@ -516,7 +510,6 @@ class TestRemoteExecution:
         # assert the file is in the effective user's group
         assert username == result.stdout.strip('\n')
 
-    @pytest.mark.tier3
     @pytest.mark.e2e
     @pytest.mark.rhel_ver_match('[^6].*')
     def test_positive_run_custom_job_template(self, rex_contenthost, module_org, target_sat):
@@ -547,7 +540,6 @@ class TestRemoteExecution:
         )
         assert_job_invocation_result(target_sat, invocation_command['id'], client.hostname)
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_run_default_job_template_multiple_hosts(
@@ -585,7 +577,6 @@ class TestRemoteExecution:
         result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
         assert result['success'] == '2', output_msgs
 
-    @pytest.mark.tier3
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     @pytest.mark.skipif(
@@ -649,7 +640,6 @@ class TestRemoteExecution:
         result = client.run(f'rpm -q {" ".join(packages)}')
         assert result.status == len(packages)
 
-    @pytest.mark.tier3
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     @pytest.mark.skipif(
@@ -700,7 +690,6 @@ class TestRemoteExecution:
         result = client.run('dnf grouplist --installed')
         assert remove not in result.stdout
 
-    @pytest.mark.tier3
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     @pytest.mark.skipif(
@@ -738,7 +727,6 @@ class TestRemoteExecution:
         result = client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}')
         assert result.status == 0
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize('feature', **parametrized(valid_feature_names()))
     def test_positive_match_feature_templates(self, target_sat, feature):
         """Verify the `feature` names match the correct templates
@@ -752,7 +740,6 @@ class TestRemoteExecution:
         result = target_sat.cli.RemoteExecutionFeature.info({'id': feature['label']})
         assert result['job-template-name'] == feature['jt_name']
 
-    @pytest.mark.tier3
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_run_recurring_job_with_max_iterations(self, rex_contenthost, target_sat):
         """Run default job template multiple times with max iteration
@@ -783,7 +770,6 @@ class TestRemoteExecution:
         assert rec_logic['state'] == 'finished'
         assert rec_logic['iteration'] == '2'
 
-    @pytest.mark.tier3
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_time_expressions(self, rex_contenthost, target_sat):
         """Test various expressions for extended cronline syntax
@@ -850,7 +836,6 @@ class TestRemoteExecution:
                 f'Job was not scheduled as expected using {exp[0]}'
             )
 
-    @pytest.mark.tier3
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_run_scheduled_job_template(self, rex_contenthost, target_sat):
         """Schedule a job to be ran against a host
@@ -879,7 +864,6 @@ class TestRemoteExecution:
             f'resource_type = JobInvocation and resource_id = {invocation_command["id"]}'
         )
 
-    @pytest.mark.tier3
     @pytest.mark.rhel_ver_list([8, 9])
     def test_recurring_with_unreachable_host(self, module_target_sat, rhel_contenthost):
         """Run a recurring task against a host that is not reachable and verify it gets rescheduled
@@ -985,7 +969,6 @@ class TestRexUsers:
         class_target_sat.cli.User.add_role({'login': rexinfra, 'role': 'Remote Execution Manager'})
         return (rexinfra, password)
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'infra_host',
@@ -1092,7 +1075,6 @@ class TestAsyncSSHProviderRex:
     """Tests related to remote execution via async ssh provider"""
 
     @pytest.mark.no_containers
-    @pytest.mark.tier3
     @pytest.mark.e2e
     @pytest.mark.upgrade
     def test_positive_run_job_on_host_registered_to_async_ssh_provider(
@@ -1151,7 +1133,6 @@ class TestAsyncSSHProviderRex:
 class TestPullProviderRex:
     """Tests related to remote execution via pull provider (mqtt)"""
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     @pytest.mark.no_containers
     @pytest.mark.parametrize(
@@ -1248,7 +1229,6 @@ class TestPullProviderRex:
         assert_job_invocation_result(module_target_sat, invocation_command['id'], client.hostname)
         result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
 
-    @pytest.mark.tier3
     @pytest.mark.no_containers
     @pytest.mark.parametrize(
         'setting_update',
@@ -1351,7 +1331,6 @@ class TestPullProviderRex:
                 }
             )
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     @pytest.mark.e2e
     @pytest.mark.pit_client
@@ -1484,7 +1463,6 @@ class TestPullProviderRex:
         )
         assert 'Permission denied' in out
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     @pytest.mark.no_containers
     def test_positive_run_pull_job_on_offline_host(
@@ -1561,7 +1539,6 @@ class TestPullProviderRex:
         sleep(60)
         assert_job_invocation_result(module_target_sat, invocation_command['id'], client.hostname)
 
-    @pytest.mark.tier3
     @pytest.mark.e2e
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -30,7 +30,6 @@ def run_puppet_agent(session_puppet_enabled_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 def test_positive_CRD_satellite(run_puppet_agent, session_puppet_enabled_sat):
     """Test puppet-agent creates a report for satellite when its run, read and delete by its ID
 

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -79,7 +79,6 @@ def local_ak(module_sca_manifest_org, local_environment, local_content_view, mod
     )
 
 
-@pytest.mark.tier2
 def test_positive_report_help(module_target_sat):
     """hammer level of help included in test:
      Base level hammer help includes report-templates,
@@ -124,7 +123,6 @@ def test_positive_report_help(module_target_sat):
     )
 
 
-@pytest.mark.tier1
 @pytest.mark.e2e
 def test_positive_end_to_end_crud_and_list(target_sat):
     """CRUD test + list test for report templates
@@ -203,7 +201,6 @@ def test_positive_end_to_end_crud_and_list(target_sat):
     ],
     ids=['v1', 'v2'],
 )
-@pytest.mark.tier2
 def test_positive_generate_report_check_for_injection(
     module_target_sat, module_org, module_location, content
 ):
@@ -240,7 +237,6 @@ def test_positive_generate_report_check_for_injection(
     )
 
 
-@pytest.mark.tier1
 def test_positive_generate_report_nofilter_and_with_filter(module_target_sat):
     """Generate Host Status report without filter and with filter
 
@@ -288,7 +284,6 @@ def test_positive_generate_report_nofilter_and_with_filter(module_target_sat):
     assert host2['name'] not in [item.split(',')[0] for item in result.splitlines()]
 
 
-@pytest.mark.tier2
 def test_positive_lock_and_unlock_report(module_target_sat):
     """Lock and unlock report template
 
@@ -321,7 +316,6 @@ def test_positive_lock_and_unlock_report(module_target_sat):
     assert result[0]['name'] == new_name
 
 
-@pytest.mark.tier2
 def test_positive_report_add_userinput(module_target_sat):
     """Add user input to template
 
@@ -345,7 +339,6 @@ def test_positive_report_add_userinput(module_target_sat):
     assert result['template-inputs'][0]['name'] == template_input['name']
 
 
-@pytest.mark.tier2
 def test_positive_dump_report(module_target_sat):
     """Export report template
 
@@ -368,7 +361,6 @@ def test_positive_dump_report(module_target_sat):
     assert content in result
 
 
-@pytest.mark.tier2
 def test_positive_clone_locked_report(module_target_sat):
     """Clone locked report template
 
@@ -399,7 +391,6 @@ def test_positive_clone_locked_report(module_target_sat):
     assert result_info['default'] == 'yes'
 
 
-@pytest.mark.tier2
 def test_positive_generate_report_sanitized(module_target_sat):
     """Generate report template where there are values in comma outputted
     which might brake CSV format
@@ -449,7 +440,6 @@ def test_positive_generate_report_sanitized(module_target_sat):
     assert f'{host["name"]},"{host["operating-system"]["operating-system"]["name"]}"' in result
 
 
-@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_positive_applied_errata():
     """Generate an Applied Errata report, then generate it by using schedule --wait and then
@@ -475,7 +465,6 @@ def test_positive_applied_errata():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_generate_email_compressed():
     """Generate an Applied Errata report, get it by e-mail, compressed
@@ -495,7 +484,6 @@ def test_positive_generate_email_compressed():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_generate_email_uncompressed():
     """Generate an Applied Errata report, get it by e-mail, uncompressed
@@ -516,7 +504,6 @@ def test_positive_generate_email_uncompressed():
     """
 
 
-@pytest.mark.tier2
 def test_negative_create_report_without_name(module_target_sat):
     """Try to create a report template with empty name
 
@@ -536,7 +523,6 @@ def test_negative_create_report_without_name(module_target_sat):
         module_target_sat.cli_factory.report_template({'name': ''})
 
 
-@pytest.mark.tier2
 def test_negative_delete_locked_report(module_target_sat):
     """Try to delete a locked report template
 
@@ -561,7 +547,6 @@ def test_negative_delete_locked_report(module_target_sat):
         module_target_sat.cli.ReportTemplate.delete({'name': report_template['name']})
 
 
-@pytest.mark.tier2
 def test_negative_bad_email(module_target_sat):
     """Report can't be generated when incorrectly formed mail specified
 
@@ -586,7 +571,6 @@ def test_negative_bad_email(module_target_sat):
         )
 
 
-@pytest.mark.tier3
 def test_negative_nonauthor_of_report_cant_download_it(module_target_sat):
     """The resulting report should only be downloadable by
        the user that generated it or admin. Check.
@@ -690,7 +674,6 @@ def test_negative_nonauthor_of_report_cant_download_it(module_target_sat):
         ).report_data({'id': report_template['name'], 'job-id': job_id})
 
 
-@pytest.mark.tier2
 def test_positive_generate_with_name_and_org(module_target_sat):
     """Generate Host Status report, specifying template name and organization
 
@@ -723,7 +706,6 @@ def test_positive_generate_with_name_and_org(module_target_sat):
     assert host['name'] in [item.split(',')[0] for item in result.split('\n')]
 
 
-@pytest.mark.tier2
 def test_positive_generate_ansible_template(module_target_sat):
     """Report template named 'Ansible Inventory' (default name is specified in settings)
     must be present in Satellite 6.7 and later in order to provide enhanced functionality
@@ -785,7 +767,6 @@ def test_positive_generate_ansible_template(module_target_sat):
     assert host['name'] in [item.split(',')[1] for item in report_data.split('\n') if len(item) > 0]
 
 
-@pytest.mark.tier3
 def test_positive_generate_hostpkgcompare(
     module_sca_manifest_org, local_ak, local_content_view, local_environment, target_sat
 ):
@@ -895,7 +876,6 @@ def test_positive_generate_hostpkgcompare(
                 )
 
 
-@pytest.mark.tier3
 def test_negative_generate_hostpkgcompare_nonexistent_host(module_target_sat):
     """Try to generate 'Host - compare content hosts packages' report
     with nonexistent hosts inputs
@@ -925,7 +905,6 @@ def test_negative_generate_hostpkgcompare_nonexistent_host(module_target_sat):
 
 
 @pytest.mark.rhel_ver_list([7, 8, 9])
-@pytest.mark.tier3
 def test_positive_generate_installed_packages_report(
     module_sca_manifest_org,
     local_ak,

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -123,7 +123,6 @@ def gpg_key(module_org, module_target_sat):
 class TestRepository:
     """Repository CLI tests."""
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -153,7 +152,6 @@ class TestRepository:
         """
         assert repo.get('upstream-repository-name') == repo_options['docker-upstream-name']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(
@@ -185,7 +183,6 @@ class TestRepository:
         with pytest.raises(CLIReturnCodeError):
             target_sat.cli.Repository.info({'id': repo['id']})
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'url': url} for url in YUM_REPOS]),
@@ -205,7 +202,6 @@ class TestRepository:
         for key in 'url', 'content-type':
             assert repo.get(key) == repo_options[key]
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -250,7 +246,6 @@ class TestRepository:
         new_repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert new_repo['sync']['status'] == 'Success'
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -272,7 +267,6 @@ class TestRepository:
         """
         assert repo.get('download-policy') == repo_options['download-policy']
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -297,7 +291,6 @@ class TestRepository:
         """
         assert repo.get('mirroring-policy') == MIRRORING_POLICIES[repo_options['mirroring-policy']]
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'content-type': 'yum'}]), indirect=True
     )
@@ -317,7 +310,6 @@ class TestRepository:
         assert default_dl_policy
         assert repo.get('download-policy') == default_dl_policy[0]['value']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'content-type': 'yum'}]), indirect=True
     )
@@ -340,7 +332,6 @@ class TestRepository:
         result = target_sat.cli.Repository.info({'id': repo['id']})
         assert result.get('download-policy') == 'on_demand'
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'download-policy': 'on_demand'}]),
@@ -362,7 +353,6 @@ class TestRepository:
         result = target_sat.cli.Repository.info({'id': repo['id']})
         assert result['download-policy'] == 'immediate'
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_create_with_gpg_key_by_id(self, repo_options, gpg_key, target_sat):
         """Check if repository can be created with gpg key ID
@@ -381,7 +371,6 @@ class TestRepository:
         assert repo['gpg-key']['name'] == gpg_key['name']
 
     # Comment out test until https://bugzilla.redhat.com/show_bug.cgi?id=2008656 is resolved
-    # @pytest.mark.tier1
     # def test_positive_create_with_gpg_key_by_name(
     #         self, repo_options, module_org, module_product, gpg_key
     # ):
@@ -397,7 +386,6 @@ class TestRepository:
     #     assert repo['gpg-key']['id'] == gpg_key['id']
     #     assert repo['gpg-key']['name'] == gpg_key['name']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'publish-via-http': use_http} for use_http in ('true', 'yes', '1')]),
@@ -416,7 +404,6 @@ class TestRepository:
         """
         assert repo.get('publish-via-http') == 'yes'
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'publish-via-http': use_http} for use_http in ('false', 'no', '0')]),
@@ -435,7 +422,6 @@ class TestRepository:
         """
         assert repo.get('publish-via-http') == 'no'
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -466,7 +452,6 @@ class TestRepository:
         for key in 'content-type', 'checksum-type':
             assert repo.get(key) == repo_options[key]
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(
@@ -496,7 +481,6 @@ class TestRepository:
         for key in 'url', 'content-type', 'name':
             assert repo.get(key) == repo_options[key]
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(
@@ -527,7 +511,6 @@ class TestRepository:
         for key in 'url', 'content-type', 'name':
             assert repo.get(key) == repo_options[key]
 
-    @pytest.mark.tier1
     def test_positive_create_repo_with_new_organization_and_location(self, target_sat):
         """Check if error is thrown when creating a Repo with a new Organization and Location.
 
@@ -564,7 +547,6 @@ class TestRepository:
         )
         assert result.status == 1
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'name': name} for name in invalid_values_list()]),
@@ -584,7 +566,6 @@ class TestRepository:
         with pytest.raises(CLIFactoryError):
             target_sat.cli_factory.make_repository(repo_options)
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'url': f'http://{gen_string("alpha")}{punctuation}.com'}]),
@@ -606,7 +587,6 @@ class TestRepository:
         with pytest.raises(CLIFactoryError):
             module_target_sat.cli_factory.make_repository(repo_options)
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'download-policy': gen_string('alpha', 5)}]),
@@ -628,7 +608,6 @@ class TestRepository:
         with pytest.raises(CLIFactoryError):
             module_target_sat.cli_factory.make_repository(repo_options)
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'content-type': 'yum'}]), indirect=True
     )
@@ -650,7 +629,6 @@ class TestRepository:
                 {'id': repo['id'], 'download-policy': gen_string('alpha', 5)}
             )
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(
@@ -683,7 +661,6 @@ class TestRepository:
         ):
             module_target_sat.cli_factory.make_repository(repo_options)
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
@@ -709,7 +686,6 @@ class TestRepository:
         assert repo['sync']['status'] == 'Success'
         assert int(repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(
@@ -746,7 +722,6 @@ class TestRepository:
 
         assert "Error: 401, message='Unauthorized'" in response.stderr
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -793,7 +768,6 @@ class TestRepository:
             )['content']
         )
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -828,7 +802,6 @@ class TestRepository:
         new_repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert new_repo['sync']['status'] == 'Success'
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(
@@ -869,7 +842,6 @@ class TestRepository:
             'unexpected change of tags count'
         )
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(
@@ -912,7 +884,6 @@ class TestRepository:
             'unexpected change of tags count'
         )
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(
@@ -946,7 +917,6 @@ class TestRepository:
                 assert tag in repo['included-container-image-tags']
         assert int(repo['content-counts']['container-tags']) == 1
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'url': settings.repos.yum_1.url}]),
@@ -1006,7 +976,6 @@ class TestRepository:
             ]
         ),
     )
-    @pytest.mark.tier2
     def test_mirror_on_sync_removes_rpm(self, module_org, repo, repo_options_2, module_target_sat):
         """
             Check that a package removed upstream is removed downstream when the repo
@@ -1065,7 +1034,6 @@ class TestRepository:
         assert repo_2['sync']['status'] == 'Success'
         assert repo_2['content-counts']['packages'] == '31'
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(
@@ -1098,7 +1066,6 @@ class TestRepository:
         assert repo['sync']['status'] == 'Success'
         assert repo['content-counts']['srpms'] == '0', 'content not ignored correctly'
 
-    @pytest.mark.tier1
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -1119,7 +1086,6 @@ class TestRepository:
         result = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert result['url'] == settings.repos.yum_2.url
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'new_repo_options',
         **parametrized([{'url': f'http://{gen_string("alpha")}{punctuation}'}]),
@@ -1146,7 +1112,6 @@ class TestRepository:
         result = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert result['url'] == repo['url']
 
-    @pytest.mark.tier1
     def test_positive_update_gpg_key(self, repo_options, module_org, repo, gpg_key, target_sat):
         """Update the original gpg key
 
@@ -1167,7 +1132,6 @@ class TestRepository:
         result = target_sat.cli.Repository.info({'id': repo['id']})
         assert result['gpg-key']['id'] == gpg_key_new['id']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'mirroring-policy': policy} for policy in MIRRORING_POLICIES]),
@@ -1190,7 +1154,6 @@ class TestRepository:
         result = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert result['mirroring-policy'] == MIRRORING_POLICIES[repo_options['mirroring-policy']]
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'publish-via-http': 'no'}]), indirect=True
     )
@@ -1209,7 +1172,6 @@ class TestRepository:
         result = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert result['publish-via-http'] == 'yes'
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'download-policy': 'immediate'}]),
@@ -1235,7 +1197,6 @@ class TestRepository:
         result = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert result['checksum-type'] == checksum_type
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized(
@@ -1266,7 +1227,6 @@ class TestRepository:
         with pytest.raises(CLIFactoryError):
             module_target_sat.cli_factory.make_repository(repo_options)
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'url': settings.repos.yum_1.url}]),
@@ -1292,7 +1252,6 @@ class TestRepository:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Repository.info({'id': repo['id']})
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -1349,7 +1308,6 @@ class TestRepository:
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['content-counts']['packages'] == '0'
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -1381,7 +1339,6 @@ class TestRepository:
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['content-counts']['packages'] == '0'
 
-    @pytest.mark.tier1
     def test_positive_upload_content(self, repo, target_sat):
         """Create repository and upload content
 
@@ -1415,7 +1372,6 @@ class TestRepository:
             == 1
         )
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
@@ -1456,7 +1412,6 @@ class TestRepository:
         new_repo = target_sat.cli.Repository.info({'id': new_repo['id']})
         assert int(new_repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT + 1
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'url': settings.repos.yum_1.url}]),
@@ -1614,7 +1569,6 @@ class TestRepository:
         )
         assert len(repos) == 0
 
-    @pytest.mark.tier2
     def test_positive_upload_remove_srpm_content(self, repo, target_sat):
         """Create repository, upload and remove an SRPM content
 
@@ -1662,7 +1616,6 @@ class TestRepository:
         )
 
     @pytest.mark.upgrade
-    @pytest.mark.tier2
     @pytest.mark.e2e
     def test_positive_srpm_list_end_to_end(self, repo, target_sat):
         """Create repository,  upload, list and remove an SRPM content
@@ -1751,7 +1704,6 @@ class TestRepository:
             target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['srpms']
         ) == len(target_sat.cli.Srpm.list({'repository-id': repo['id']}))
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'url': settings.repos.module_stream_1.url}]),
@@ -1816,7 +1768,6 @@ class TestRepository:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Repository.info({'id': repo['id']})
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'url': settings.repos.module_stream_1.url}]),
@@ -1855,7 +1806,6 @@ class TestRepository:
             key: value for key, value in actual_result.items() if key in expected_result
         }
 
-    @pytest.mark.tier1
     def test_negative_update_red_hat_repo(self, function_sca_manifest_org, module_target_sat):
         """Updates to Red Hat products fail.
 
@@ -1903,7 +1853,6 @@ class TestRepository:
         )
         assert repo_info['url'] in [repo.get('url') for repo in repo_list]
 
-    @pytest.mark.tier1
     def test_positive_accessible_content_status(
         self, module_org, module_ak_with_synced_repo, rhel7_contenthost, target_sat
     ):
@@ -1929,7 +1878,6 @@ class TestRepository:
         )
         assert 'accessible_content HTTP/1.1" 304' in access_log.stdout
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'url': CUSTOM_RPM_SHA}]),
@@ -1954,7 +1902,6 @@ class TestRepository:
         sha_repo = module_target_sat.cli.Repository.info({'id': sha_repo['id']})
         assert sha_repo['sync']['status'] == 'Success'
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'yum', 'url': CUSTOM_3RD_PARTY_REPO}]),
@@ -1984,7 +1931,6 @@ class TestRepository:
 # class TestOstreeRepository:
 #     """Ostree Repository CLI tests."""
 #
-#     @pytest.mark.tier1
 #     @pytest.mark.parametrize(
 #         'repo_options',
 #         **parametrized(
@@ -2017,7 +1963,6 @@ class TestRepository:
 #         assert repo['content-type'] == 'ostree'
 #
 #     @pytest.mark.skip_if_open("BZ:1716429")
-#     @pytest.mark.tier1
 #     @pytest.mark.parametrize(
 #         'repo_options',
 #         **parametrized(
@@ -2052,7 +1997,6 @@ class TestRepository:
 #         ):
 #             make_repository(repo_options)
 #
-#     @pytest.mark.tier1
 #     @pytest.mark.parametrize(
 #         'repo_options',
 #         **parametrized(
@@ -2084,7 +2028,6 @@ class TestRepository:
 #         ):
 #             make_repository(repo_options)
 #
-#     @pytest.mark.tier2
 #     @pytest.mark.upgrade
 #     @pytest.mark.skip_if_open("BZ:1625783")
 #     @pytest.mark.parametrize(
@@ -2102,8 +2045,7 @@ class TestRepository:
 #         :parametrized: yes
 #
 #         :expectedresults: Ostree repository is created and synced
-
-
+#
 #         :BZ: 1625783
 #         """
 #         # Synchronize it
@@ -2112,7 +2054,6 @@ class TestRepository:
 #         repo = Repository.info({'id': repo['id']})
 #         assert repo['sync']['status'] == 'Success'
 #
-#     @pytest.mark.tier1
 #     @pytest.mark.parametrize(
 #         'repo_options',
 #         **parametrized(
@@ -2141,7 +2082,6 @@ class TestRepository:
 #         with pytest.raises(CLIReturnCodeError):
 #             Repository.info({'name': repo['name']})
 #
-#     @pytest.mark.tier1
 #     @pytest.mark.upgrade
 #     @pytest.mark.parametrize(
 #         'repo_options',
@@ -2169,7 +2109,6 @@ class TestRepository:
 class TestSRPMRepository:
     """Tests specific to using repositories containing source RPMs."""
 
-    @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated SRPM repository")
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
@@ -2191,7 +2130,6 @@ class TestSRPMRepository:
         assert result.status == 0
         assert result.stdout
 
-    @pytest.mark.tier2
     @pytest.mark.skip("Uses deprecated SRPM repository")
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
@@ -2218,7 +2156,6 @@ class TestSRPMRepository:
         assert result.status == 0
         assert result.stdout
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.skip("Uses deprecated SRPM repository")
     @pytest.mark.parametrize(
@@ -2257,7 +2194,6 @@ class TestSRPMRepository:
 class TestAnsibleCollectionRepository:
     """Ansible Collections repository tests"""
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -2297,7 +2233,6 @@ class TestAnsibleCollectionRepository:
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['sync']['status'] == 'Success'
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -2350,7 +2285,6 @@ class TestAnsibleCollectionRepository:
 class TestMD5Repository:
     """Tests specific to using MD5 signed repositories containing RPMs."""
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_MD5_REPO}]), indirect=True
@@ -2387,7 +2321,6 @@ class TestMD5Repository:
 class TestFileRepository:
     """Specific tests for File Repositories"""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
@@ -2430,7 +2363,6 @@ class TestFileRepository:
         )
         assert filesearch[0].name == RPM_TO_UPLOAD
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -2477,7 +2409,6 @@ class TestFileRepository:
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['content-counts']['files'] == '0'
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
@@ -2517,7 +2448,6 @@ class TestFileRepository:
         assert repo['sync']['status'] == 'Success'
         assert repo['content-counts']['files'] == '2'
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'file', 'url': f'file://{CUSTOM_LOCAL_FOLDER}'}]),
@@ -2554,7 +2484,6 @@ class TestFileRepository:
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert int(repo['content-counts']['files']) > 1
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'file', 'url': f'file://{CUSTOM_LOCAL_FOLDER}'}]),
@@ -2594,7 +2523,6 @@ class TestFileRepository:
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert int(repo['content-counts']['files']) > 1
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
@@ -2664,7 +2592,6 @@ class TestFileRepository:
         assert 'Second File' in textfile.text
 
 
-@pytest.mark.tier2
 def test_positive_syncable_yum_format_repo_import(target_sat, module_org):
     """Verify that you can import syncable yum format repositories
 

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -16,7 +16,7 @@ import pytest
 
 from robottelo.constants import PRDS, REPOSET
 
-pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.tier1]
+pytestmark = pytest.mark.run_in_one_thread
 
 
 @pytest.fixture

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -25,7 +25,6 @@ inventory_sync_task = 'InventorySync::Async::InventoryFullSync'
 generate_report_jobs = 'ForemanInventoryUpload::Async::GenerateAllReportsJob'
 
 
-@pytest.mark.tier3
 @pytest.mark.e2e
 def test_positive_inventory_generate_upload_cli(
     rhcloud_manifest_org, rhcloud_registered_hosts, module_target_sat
@@ -97,7 +96,6 @@ def test_positive_inventory_generate_upload_cli(
 @pytest.mark.e2e
 @pytest.mark.pit_server
 @pytest.mark.pit_client
-@pytest.mark.tier3
 def test_positive_inventory_recommendation_sync(
     rhcloud_manifest_org,
     rhcloud_registered_hosts,
@@ -141,7 +139,6 @@ def test_positive_inventory_recommendation_sync(
 @pytest.mark.e2e
 @pytest.mark.pit_server
 @pytest.mark.pit_client
-@pytest.mark.tier3
 def test_positive_sync_inventory_status(
     rhcloud_manifest_org,
     rhcloud_registered_hosts,
@@ -190,7 +187,6 @@ def test_positive_sync_inventory_status(
     assert task_output[0].output['host_statuses']['disconnect'] == 0
 
 
-@pytest.mark.tier3
 def test_positive_sync_inventory_status_missing_host_ip(
     rhcloud_manifest_org,
     rhcloud_registered_hosts,
@@ -329,7 +325,6 @@ def test_rhcloud_external_links():
     """
 
 
-@pytest.mark.tier3
 def test_positive_generate_all_reports_job(target_sat):
     """Generate all reports job via foreman-rake console:
 

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -27,7 +27,6 @@ from robottelo.utils.datafactory import generate_strings_list, parametrized
 class TestRole:
     """Test class for Roles CLI"""
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         ('name', 'new_name'),
         **parametrized(
@@ -59,7 +58,6 @@ class TestRole:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Role.info({'id': role['id']})
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_create_with_permission(self, module_target_sat):
         """Create new role with a set of permission
@@ -86,7 +84,6 @@ class TestRole:
             permissions
         )
 
-    @pytest.mark.tier1
     def test_positive_list_filters_by_id(self, module_target_sat):
         """Create new role with a filter and list it by role id
 
@@ -111,7 +108,6 @@ class TestRole:
         assert role['name'] == filter_['role']
         assert module_target_sat.cli.Role.filters({'id': role['id']})[0]['id'] == filter_['id']
 
-    @pytest.mark.tier1
     def test_positive_list_filters_by_name(self, module_target_sat):
         """Create new role with a filter and list it by role name
 
@@ -136,7 +132,6 @@ class TestRole:
         assert role['name'] == filter_['role']
         assert module_target_sat.cli.Role.filters({'name': role['name']})[0]['id'] == filter_['id']
 
-    @pytest.mark.tier1
     def test_negative_list_filters_without_parameters(self, module_target_sat):
         """Try to list filter without specifying role id or name
 
@@ -176,7 +171,6 @@ class TestRole:
             'permissions': permissions,
         }
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize('per_page', [1, 5, 20])
     def test_positive_list_filters_with_pagination(
@@ -217,7 +211,6 @@ class TestRole:
             len(make_role_with_permissions['permissions']) % per_page or per_page
         )
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_delete_cloned_builtin(self, module_target_sat):
         """Clone a builtin role and attempt to delete it
@@ -251,7 +244,6 @@ class TestSystemAdmin:
         class_target_sat.cli.Settings.set({'name': "outofsync_interval", 'value': "30"})
 
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     @pytest.mark.e2e
     def test_system_admin_role_end_to_end(self, target_sat):
         """Test System admin role with a end to end workflow

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -251,7 +251,6 @@ def function_exporter_user(target_sat, function_org):
 class TestRepositoryExport:
     """Tests for exporting a repository via CLI"""
 
-    @pytest.mark.tier3
     def test_positive_export_version_custom_repo(
         self, target_sat, export_import_cleanup_module, module_org, module_synced_custom_repo
     ):
@@ -309,7 +308,6 @@ class TestRepositoryExport:
         )
         assert '2.0' in target_sat.validate_pulp_filepath(module_org, PULP_EXPORT_DIR)
 
-    @pytest.mark.tier3
     def test_positive_export_library_custom_repo(
         self,
         target_sat,
@@ -365,7 +363,6 @@ class TestRepositoryExport:
         ).incrementalLibrary({'organization-id': function_org.id})
         assert '2.0' in target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR)
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
@@ -418,7 +415,6 @@ class TestRepositoryExport:
         # Verify export directory is not empty
         assert target_sat.validate_pulp_filepath(function_sca_manifest_org, PULP_EXPORT_DIR) != ''
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_export_repository_docker(
         self, target_sat, export_import_cleanup_function, function_org, function_synced_docker_repo
@@ -453,7 +449,6 @@ class TestRepositoryExport:
         )
         assert '2.0' in target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR)
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_export_version_docker(
         self, target_sat, export_import_cleanup_function, function_org, function_synced_docker_repo
@@ -577,7 +572,6 @@ def _create_cv(cv_name, repo, module_org, sat, publish=True):
 class TestContentViewSync:
     """Implements Content View Export Import tests in CLI"""
 
-    @pytest.mark.tier3
     @pytest.mark.e2e
     def test_positive_export_import_cv_end_to_end(
         self,
@@ -660,7 +654,6 @@ class TestContentViewSync:
         )
 
     @pytest.mark.upgrade
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
         ['rhae2'],
@@ -764,7 +757,6 @@ class TestContentViewSync:
         assert len(imported_packages)
         assert len(cv_packages) == len(imported_packages)
 
-    @pytest.mark.tier3
     def test_positive_export_import_filtered_cvv(
         self,
         class_export_entities,
@@ -856,7 +848,6 @@ class TestContentViewSync:
         assert len(imported_packages) == 1
         assert len(export_packages) == len(imported_packages)
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_export_import_promoted_cv(
         self,
@@ -930,7 +921,6 @@ class TestContentViewSync:
         lce = importing_cv_id['lifecycle-environments'][0]['name']
         assert lce == 'Library'
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     @pytest.mark.e2e
     @pytest.mark.parametrize(
@@ -1032,7 +1022,6 @@ class TestContentViewSync:
             'Exported and imported counts do not match'
         )
 
-    @pytest.mark.tier2
     def test_positive_export_cv_with_on_demand_repo(
         self, export_import_cleanup_module, target_sat, module_org
     ):
@@ -1139,7 +1128,6 @@ class TestContentViewSync:
         assert "Generated" in result
         assert target_sat.validate_pulp_filepath(module_org, PULP_EXPORT_DIR) != ''
 
-    @pytest.mark.tier2
     def test_negative_import_same_cv_twice(
         self,
         target_sat,
@@ -1191,7 +1179,6 @@ class TestContentViewSync:
             f'delete {export_cv_name} 1.0 and try again.'
         ) in error.value.message
 
-    @pytest.mark.tier2
     def test_negative_import_invalid_path(self, module_org, module_target_sat):
         """Import cv that doesn't exist in path
 
@@ -1216,7 +1203,6 @@ class TestContentViewSync:
             '--metadata-file option'
         ) in error.value.message
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
         ['rhae2'],
@@ -1309,7 +1295,6 @@ class TestContentViewSync:
             )
         assert 'content_view not found' in error.value.message, 'The imported CV should be gone'
 
-    @pytest.mark.tier3
     def test_postive_export_cv_with_mixed_content_repos(
         self,
         export_import_cleanup_function,
@@ -1377,7 +1362,6 @@ class TestContentViewSync:
         # Verify export directory is not empty
         assert target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR) != ''
 
-    @pytest.mark.tier3
     def test_postive_export_import_cv_with_mixed_content_syncable(
         self,
         export_import_cleanup_function,
@@ -1463,7 +1447,6 @@ class TestContentViewSync:
         assert exported_packages == imported_packages, 'Imported RPMs do not match the export'
         assert exported_files == imported_files, 'Imported Files do not match the export'
 
-    @pytest.mark.tier3
     def test_postive_export_cv_syncable_with_permissions(
         self,
         request,
@@ -1534,7 +1517,6 @@ class TestContentViewSync:
             ]
         ), 'Unexpected permission for one or more exported files'
 
-    @pytest.mark.tier3
     def test_postive_export_import_cv_with_file_content(
         self,
         target_sat,
@@ -1606,7 +1588,6 @@ class TestContentViewSync:
         assert len(imported_files)
         assert len(exported_files) == len(imported_files)
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
         ['rhae2'],
@@ -1707,7 +1688,6 @@ class TestContentViewSync:
         )['versions']
         assert len(importing_cvv) == 1
 
-    @pytest.mark.tier3
     def test_postive_export_import_ansible_collection_repo(
         self,
         target_sat,
@@ -1770,7 +1750,6 @@ class TestContentViewSync:
         assert len(import_product['content']) == 1
         assert import_product['content'][0]['content-type'] == "ansible_collection"
 
-    @pytest.mark.tier3
     def test_postive_export_import_repo_with_GPG(
         self,
         target_sat,
@@ -1837,7 +1816,6 @@ class TestContentViewSync:
         assert imported_gpg
         assert imported_gpg['content'] == gpg_key.content
 
-    @pytest.mark.tier3
     def test_postive_export_import_chunked_repo(
         self,
         target_sat,
@@ -1897,7 +1875,6 @@ class TestContentViewSync:
             'Unexpected package count after import'
         )
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
         ['rhae2'],
@@ -1970,7 +1947,6 @@ class TestContentViewSync:
             'appropriate subscriptions before importing content.'
         ) in error.value.message
 
-    @pytest.mark.tier2
     def test_positive_import_content_for_disconnected_sat_with_existing_content(
         self,
         target_sat,
@@ -2046,7 +2022,6 @@ class TestContentViewSync:
         )['versions']
         assert len(importing_cvv) >= 1
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
         ['rhae2'],
@@ -2135,7 +2110,6 @@ class TestContentViewSync:
                 f'{repomd_refs - drive_files}'
             )
 
-    @pytest.mark.tier3
     def test_postive_export_import_with_long_name(
         self,
         target_sat,
@@ -2235,7 +2209,6 @@ class TestContentViewSync:
         )
         assert exported_packages == imported_packages
 
-    @pytest.mark.tier3
     def test_postive_export_import_large_cv(
         self,
         request,
@@ -2308,7 +2281,6 @@ class TestInterSatelliteSync:
     """Implements InterSatellite Sync tests in CLI"""
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_reimport_repo(self):
         """Packages missing from upstream are removed from downstream on reimport.
@@ -2328,7 +2300,6 @@ class TestInterSatelliteSync:
 
         """
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
         ['rhae2'],
@@ -2403,7 +2374,6 @@ class TestInterSatelliteSync:
             in error.value.message
         ), 'Unexpected error message'
 
-    @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_export_import_incremental_yum_repo(
         self,
@@ -2488,7 +2458,6 @@ class TestInterSatelliteSync:
         export_cc['packages'] = str(int(export_cc['packages']) + 1)
         assert import_repo['content-counts'] == export_cc, 'Import counts do not match the export.'
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
         ['rhae2'],
@@ -2579,7 +2548,6 @@ class TestInterSatelliteSync:
             'Not every import task succeeded'
         )
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
         ['rhae2'],
@@ -2709,7 +2677,6 @@ class TestInterSatelliteSync:
         )
 
     @pytest.mark.e2e
-    @pytest.mark.tier3
     @pytest.mark.pit_server
     @pytest.mark.pit_client
     @pytest.mark.no_containers
@@ -2948,7 +2915,6 @@ def _set_downstream_org(
 class TestNetworkSync:
     """Implements Network Sync scenarios."""
 
-    @pytest.mark.tier2
     @pytest.mark.pit_server
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
@@ -3048,7 +3014,6 @@ class TestPodman:
         )
         assert result.status == 0
 
-    @pytest.mark.tier3
     def test_postive_export_import_podman_repo(
         self,
         target_sat,

--- a/tests/foreman/cli/test_settings.py
+++ b/tests/foreman/cli/test_settings.py
@@ -32,7 +32,6 @@ from robottelo.utils.datafactory import (
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_negative_update_hostname_with_empty_fact():
     """Update the Hostname_facts settings without any string(empty values)
 
@@ -44,7 +43,6 @@ def test_negative_update_hostname_with_empty_fact():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
 def test_positive_update_hostname_prefix_without_value(setting_update, module_target_sat):
     """Update the Hostname_prefix settings without any string(empty values)
@@ -61,7 +59,6 @@ def test_positive_update_hostname_prefix_without_value(setting_update, module_ta
         module_target_sat.cli.Settings.set({'name': "discovery_prefix", 'value': ""})
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_prefix'], indirect=True)
 def test_positive_update_hostname_default_prefix(setting_update, module_target_sat):
     """Update the default set prefix of hostname_prefix setting
@@ -79,7 +76,6 @@ def test_positive_update_hostname_default_prefix(setting_update, module_target_s
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_update_hostname_default_facts():
     """Update the default set fact of hostname_facts setting with list of
     facts like: bios_vendor,uuid
@@ -93,7 +89,6 @@ def test_positive_update_hostname_default_facts():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_negative_discover_host_with_invalid_prefix():
     """Update the hostname_prefix with invalid string like
     -mac, 1mac or ^%$
@@ -107,7 +102,6 @@ def test_negative_discover_host_with_invalid_prefix():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text(setting_update, module_target_sat):
     """Updates parameter "login_text" in settings
@@ -129,7 +123,6 @@ def test_positive_update_login_page_footer_text(setting_update, module_target_sa
     assert login_text["value"] == login_text_value
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text_without_value(setting_update, module_target_sat):
     """Updates parameter "login_text" without any string (empty value)
@@ -150,7 +143,6 @@ def test_positive_update_login_page_footer_text_without_value(setting_update, mo
     assert login_text['value'] == ''
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text_with_long_string(setting_update, module_target_sat):
     """Attempt to update parameter "Login_page_footer_text"
@@ -177,7 +169,6 @@ def test_positive_update_login_page_footer_text_with_long_string(setting_update,
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_update_email_delivery_method_smtp():
     """Check Updating SMTP params through settings subcommand
 
@@ -203,7 +194,6 @@ def test_positive_update_email_delivery_method_smtp():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['delivery_method'], indirect=True)
 def test_positive_update_email_delivery_method_sendmail(setting_update, module_target_sat):
     """Check Updating Sendmail params through settings subcommand
@@ -233,7 +223,6 @@ def test_positive_update_email_delivery_method_sendmail(setting_update, module_t
         assert module_target_sat.cli.Settings.list({'search': f'name={key}'})[0]['value'] == value
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['email_reply_address'], indirect=True)
 def test_positive_update_email_reply_address(setting_update, module_target_sat):
     """Check email reply address is updated
@@ -260,7 +249,6 @@ def test_positive_update_email_reply_address(setting_update, module_target_sat):
     assert updated_email_address == email_address
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['email_reply_address'], indirect=True)
 def test_negative_update_email_reply_address(setting_update, module_target_sat):
     """Check email reply address is not updated
@@ -284,7 +272,6 @@ def test_negative_update_email_reply_address(setting_update, module_target_sat):
         )
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['email_subject_prefix'], indirect=True)
 def test_positive_update_email_subject_prefix(setting_update, module_target_sat):
     """Check email subject prefix is updated
@@ -309,7 +296,6 @@ def test_positive_update_email_subject_prefix(setting_update, module_target_sat)
     assert email_subject_prefix_value == email_subject_prefix['value']
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['email_subject_prefix'], indirect=True)
 def test_negative_update_email_subject_prefix(setting_update, module_target_sat):
     """Check email subject prefix is not updated
@@ -340,7 +326,6 @@ def test_negative_update_email_subject_prefix(setting_update, module_target_sat)
     assert email_subject_prefix == email_subject_prefix_original
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('send_welcome_email_value', ["true", "false"])
 @pytest.mark.parametrize('setting_update', ['send_welcome_email'], indirect=True)
 def test_positive_update_send_welcome_email(
@@ -369,7 +354,6 @@ def test_positive_update_send_welcome_email(
     assert send_welcome_email_value == host_value
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('rss_enable_value', ["true", "false"])
 @pytest.mark.parametrize('setting_update', ['rss_enable'], indirect=True)
 def test_positive_enable_disable_rssfeed(setting_update, rss_enable_value, module_target_sat):
@@ -390,7 +374,6 @@ def test_positive_enable_disable_rssfeed(setting_update, rss_enable_value, modul
     assert rss_setting["value"] == rss_enable_value
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['rss_url'], indirect=True)
 def test_positive_update_rssfeed_url(setting_update, module_target_sat):
     """Check if the RSS feed URL is updated
@@ -416,7 +399,6 @@ def test_positive_update_rssfeed_url(setting_update, module_target_sat):
 
 
 @pytest.mark.parametrize('value', **xdist_adapter(invalid_boolean_strings()))
-@pytest.mark.tier2
 def test_negative_update_send_welcome_email(value, module_target_sat):
     """Check email send welcome email is updated
 
@@ -438,7 +420,6 @@ def test_negative_update_send_welcome_email(value, module_target_sat):
         module_target_sat.cli.Settings.set({'name': 'send_welcome_email', 'value': value})
 
 
-@pytest.mark.tier3
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('setting_update', ['failed_login_attempts_limit'], indirect=True)
 def test_positive_failed_login_attempts_limit(setting_update, target_sat):

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -64,7 +64,6 @@ def invalid_missing_attributes():
     ]
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_CRUD(module_target_sat):
     """Create, update and delete subnet
@@ -145,7 +144,6 @@ def test_positive_CRUD(module_target_sat):
         module_target_sat.cli.Subnet.info({'id': subnet['id']})
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_missing_attributes()))
 def test_negative_create_with_attributes(options, module_target_sat):
     """Create subnet with invalid or missing required attributes
@@ -162,7 +160,6 @@ def test_negative_create_with_attributes(options, module_target_sat):
         module_target_sat.cli_factory.make_subnet(options)
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.parametrize('pool', **parametrized(invalid_addr_pools()))
 def test_negative_create_with_address_pool(pool, module_target_sat):
@@ -186,7 +183,6 @@ def test_negative_create_with_address_pool(pool, module_target_sat):
         module_target_sat.cli_factory.make_subnet(options)
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_missing_attributes()))
 def test_negative_update_attributes(request, options, module_target_sat):
     """Update subnet with invalid or missing required attributes
@@ -210,7 +206,6 @@ def test_negative_update_attributes(request, options, module_target_sat):
         assert subnet[key] == result[key]
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('options', **parametrized(invalid_addr_pools()))
 def test_negative_update_address_pool(request, options, module_target_sat):
     """Update subnet with invalid address pool
@@ -238,7 +233,6 @@ def test_negative_update_address_pool(request, options, module_target_sat):
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_set_parameter_option_presence():
     """Presence of set parameter option in command
 
@@ -254,7 +248,6 @@ def test_positive_set_parameter_option_presence():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 def test_positive_create_with_parameter():
     """Subnet with parameters can be created
 
@@ -272,7 +265,6 @@ def test_positive_create_with_parameter():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 def test_positive_create_with_parameter_and_multiple_values():
     """Subnet parameters can be created with multiple values
 
@@ -292,7 +284,6 @@ def test_positive_create_with_parameter_and_multiple_values():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 def test_positive_create_with_parameter_and_multiple_names():
     """Subnet parameters can be created with multiple names with valid
     separators
@@ -313,7 +304,6 @@ def test_positive_create_with_parameter_and_multiple_names():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 def test_negative_create_with_parameter_and_invalid_separator():
     """Subnet parameters can not be created with multiple names with
     invalid separators
@@ -334,7 +324,6 @@ def test_negative_create_with_parameter_and_invalid_separator():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_create_with_multiple_parameters():
     """Subnet with more than one parameters
@@ -354,7 +343,6 @@ def test_positive_create_with_multiple_parameters():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 def test_negative_create_with_duplicated_parameters():
     """Subnet with more than one parameters with duplicate names
 
@@ -374,7 +362,6 @@ def test_negative_create_with_duplicated_parameters():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_inherit_subnet_parmeters_in_host():
     """Host inherits parameters from subnet
@@ -396,7 +383,6 @@ def test_positive_inherit_subnet_parmeters_in_host():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_negative_inherit_subnet_parmeters_in_host():
     """Host does not inherits parameters from subnet for non primary
     interface
@@ -418,7 +404,6 @@ def test_negative_inherit_subnet_parmeters_in_host():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_subnet_parameters_override_from_host():
     """Subnet parameters values can be overridden from host
 
@@ -444,7 +429,6 @@ def test_positive_subnet_parameters_override_from_host():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_subnet_parameters_override_impact_on_subnet():
     """Override subnet parameter from host impact on subnet parameter
@@ -467,7 +451,6 @@ def test_positive_subnet_parameters_override_impact_on_subnet():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 def test_positive_update_parameter():
     """Subnet parameter can be updated
 
@@ -486,7 +469,6 @@ def test_positive_update_parameter():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 def test_negative_update_parameter():
     """Subnet parameter can not be updated with invalid names
 
@@ -505,7 +487,6 @@ def test_negative_update_parameter():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_update_subnet_parameter_host_impact():
     """Update in parameter name and value from subnet component updates
         the parameter in host inheriting that subnet
@@ -526,7 +507,6 @@ def test_positive_update_subnet_parameter_host_impact():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 def test_positive_delete_subnet_parameter():
     """Subnet parameter can be deleted
 
@@ -544,7 +524,6 @@ def test_positive_delete_subnet_parameter():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_delete_multiple_parameters():
     """Multiple subnet parameters can be deleted at once
@@ -563,7 +542,6 @@ def test_positive_delete_multiple_parameters():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_delete_subnet_parameter_host_impact():
     """Deleting parameter from subnet component deletes the parameter in
         host inheriting that subnet
@@ -584,7 +562,6 @@ def test_positive_delete_subnet_parameter_host_impact():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_delete_subnet_parameter_overrided_host_impact():
     """Deleting parameter from subnet component doesnt deletes its
         overridden parameter in host inheriting that subnet

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -40,7 +40,6 @@ def golden_ticket_host_setup(request, module_sca_manifest_org, module_target_sat
     )
 
 
-@pytest.mark.tier1
 def test_positive_manifest_upload(function_sca_manifest_org, module_target_sat):
     """upload manifest
 
@@ -56,7 +55,6 @@ def test_positive_manifest_upload(function_sca_manifest_org, module_target_sat):
     )
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_manifest_delete(function_sca_manifest_org, module_target_sat):
     """Delete uploaded manifest
@@ -78,7 +76,6 @@ def test_positive_manifest_delete(function_sca_manifest_org, module_target_sat):
     )
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_enable_manifest_reposet(function_sca_manifest_org, module_target_sat):
     """enable repository set
@@ -111,7 +108,6 @@ def test_positive_enable_manifest_reposet(function_sca_manifest_org, module_targ
     )
 
 
-@pytest.mark.tier3
 def test_positive_manifest_history(function_sca_manifest_org, module_target_sat):
     """upload manifest and check history
 
@@ -127,7 +123,6 @@ def test_positive_manifest_history(function_sca_manifest_org, module_target_sat)
     assert f'{org.name} file imported successfully.' in ''.join(history)
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_manifest_refresh(function_sca_manifest_org, module_target_sat):
     """upload manifest and refresh
@@ -149,7 +144,6 @@ def test_positive_manifest_refresh(function_sca_manifest_org, module_target_sat)
     )
 
 
-@pytest.mark.tier2
 def test_positive_subscription_list(function_sca_manifest_org, module_target_sat):
     """Verify that subscription list contains start and end date
 
@@ -170,7 +164,6 @@ def test_positive_subscription_list(function_sca_manifest_org, module_target_sat
         assert column in subscription_list[0]
 
 
-@pytest.mark.tier2
 def test_positive_delete_manifest_as_another_user(target_sat, function_sca_manifest):
     """Verify that uploaded manifest if visible and deletable
         by a different user than the one who uploaded it
@@ -206,7 +199,6 @@ def test_positive_delete_manifest_as_another_user(target_sat, function_sca_manif
     assert len(target_sat.cli.Subscription.list({'organization-id': org.id})) == 0
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_subscription_status_disabled_golden_ticket():
     """Verify that Content host Subscription status is set to 'Disabled'
@@ -250,7 +242,6 @@ def test_positive_candlepin_events_processed_by_STOMP():
     """
 
 
-@pytest.mark.tier2
 def test_positive_auto_attach_disabled_golden_ticket(
     module_org, module_location, golden_ticket_host_setup, rhel7_contenthost_class, target_sat
 ):

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -115,7 +115,6 @@ def validate_repo_content(sat, repo, content_types, after_sync=True):
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_name(module_org, name, module_target_sat):
     """Check if syncplan can be created with random names
 
@@ -135,7 +134,6 @@ def test_positive_create_with_name(module_org, name, module_target_sat):
 
 
 @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 def test_positive_create_with_description(module_org, desc, module_target_sat):
     """Check if syncplan can be created with random description
 
@@ -155,7 +153,6 @@ def test_positive_create_with_description(module_org, desc, module_target_sat):
 
 
 @pytest.mark.parametrize('test_data', **parametrized(valid_name_interval_create_tests()))
-@pytest.mark.tier1
 def test_positive_create_with_interval(module_org, test_data, module_target_sat):
     """Check if syncplan can be created with varied intervals
 
@@ -181,7 +178,6 @@ def test_positive_create_with_interval(module_org, test_data, module_target_sat)
 
 
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-@pytest.mark.tier1
 def test_negative_create_with_name(module_org, name, module_target_sat):
     """Check if syncplan can be created with random invalid names
 
@@ -200,7 +196,6 @@ def test_negative_create_with_name(module_org, name, module_target_sat):
 
 
 @pytest.mark.parametrize('new_desc', **parametrized(valid_data_list()))
-@pytest.mark.tier2
 def test_positive_update_description(module_org, new_desc, module_target_sat):
     """Check if syncplan description can be updated
 
@@ -219,7 +214,6 @@ def test_positive_update_description(module_org, new_desc, module_target_sat):
 
 
 @pytest.mark.parametrize('test_data', **parametrized(valid_name_interval_update_tests()))
-@pytest.mark.tier1
 def test_positive_update_interval(module_org, test_data, request, target_sat):
     """Check if syncplan interval can be updated
 
@@ -248,7 +242,6 @@ def test_positive_update_interval(module_org, test_data, request, target_sat):
     assert result['interval'] == test_data['new-interval']
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_update_sync_date(module_org, request, target_sat):
     """Check if syncplan sync date can be updated
@@ -289,7 +282,6 @@ def test_positive_update_sync_date(module_org, request, target_sat):
     ), 'Sync date was not updated'
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_create_sync_date_custom_timezone(module_org, request, target_sat):
     """Check if syncplan sync date accepts supplied timezone
@@ -322,7 +314,6 @@ def test_positive_create_sync_date_custom_timezone(module_org, request, target_s
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_delete_by_id(module_org, module_target_sat, name):
     """Check if syncplan can be created and deleted
@@ -343,7 +334,6 @@ def test_positive_delete_by_id(module_org, module_target_sat, name):
         module_target_sat.cli.SyncPlan.info({'id': new_sync_plan['id']})
 
 
-@pytest.mark.tier1
 def test_positive_info_enabled_field_is_displayed(module_org, request, target_sat):
     """Check if Enabled field is displayed in sync-plan info output
 
@@ -360,7 +350,6 @@ def test_positive_info_enabled_field_is_displayed(module_org, request, target_sa
     assert result.get('enabled') is not None
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_info_with_assigned_product(module_org, module_target_sat):
     """Verify that sync plan info command returns list of products which
@@ -398,7 +387,6 @@ def test_positive_info_with_assigned_product(module_org, module_target_sat):
     assert {prod['name'] for prod in updated_plan['products']} == {prod1, prod2}
 
 
-@pytest.mark.tier4
 @pytest.mark.upgrade
 def test_negative_synchronize_custom_product_past_sync_date(module_org, request, target_sat):
     """Verify product won't get synced immediately after adding association
@@ -426,7 +414,6 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org, request,
         validate_task_status(target_sat, repo['id'], module_org.id, max_tries=2)
 
 
-@pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_custom_product_past_sync_date(module_org, request, target_sat):
     """Create a sync plan with a past datetime as a sync date, add a
@@ -478,7 +465,6 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request,
     validate_repo_content(target_sat, repo, ['errata', 'package-groups', 'packages'])
 
 
-@pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_custom_product_future_sync_date(module_org, request, target_sat):
     """Create a sync plan with sync date in a future and sync one custom
@@ -535,7 +521,6 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     validate_repo_content(target_sat, repo, ['errata', 'package-groups', 'packages'])
 
 
-@pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_custom_products_future_sync_date(module_org, request, target_sat):
     """Create a sync plan with sync date in a future and sync multiple
@@ -609,7 +594,6 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_rh_product_past_sync_date(
     target_sat, function_sca_manifest_org, request
@@ -676,7 +660,6 @@ def test_positive_synchronize_rh_product_past_sync_date(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_rh_product_future_sync_date(
     target_sat, function_sca_manifest_org, request
@@ -749,7 +732,6 @@ def test_positive_synchronize_rh_product_future_sync_date(
     validate_repo_content(target_sat, repo, ['errata', 'packages'])
 
 
-@pytest.mark.tier3
 def test_positive_synchronize_custom_product_weekly_recurrence(module_org, request, target_sat):
     """Create a weekly sync plan with a past datetime as a sync date,
     add a custom product and verify the product gets synchronized on

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -52,7 +52,6 @@ class TestTemplateSyncTestCase:
             f'[ -f example_template.erb ] || wget {FOREMAN_TEMPLATE_TEST_TEMPLATE}'
         )
 
-    @pytest.mark.tier2
     def test_positive_import_force_locked_template(
         self, module_org, create_import_export_local_dir, target_sat
     ):
@@ -105,7 +104,6 @@ class TestTemplateSyncTestCase:
             pytest.fail('The template is not imported for force test')
 
     @pytest.mark.e2e
-    @pytest.mark.tier2
     @pytest.mark.skip_if_not_set('git')
     @pytest.mark.parametrize(
         'url',
@@ -172,7 +170,6 @@ class TestTemplateSyncTestCase:
         decoded = base64.b64decode(git_file['content'])
         assert content != decoded
 
-    @pytest.mark.tier2
     @pytest.mark.skip_if_not_set('git')
     @pytest.mark.parametrize(
         'url',
@@ -229,7 +226,6 @@ class TestTemplateSyncTestCase:
         )
         assert exported_count == git_count
 
-    @pytest.mark.tier2
     def test_positive_export_filtered_templates_to_temp_dir(self, module_org, target_sat):
         """Assure templates can be exported to /tmp directory without right permissions
 

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -60,7 +60,6 @@ class TestUser:
         return {role['id']: role for role in roles_helper()}
 
     @pytest.mark.parametrize('email', **parametrized(valid_emails_list()))
-    @pytest.mark.tier2
     def test_positive_CRUD(self, email, module_target_sat):
         """Create User with various parameters, updating and deleting
 
@@ -131,7 +130,6 @@ class TestUser:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.User.info({'login': user['login']})
 
-    @pytest.mark.tier1
     @pytest.mark.upgrade
     def test_positive_CRUD_admin(self, target_sat):
         """Create an Admin user
@@ -157,7 +155,6 @@ class TestUser:
         with pytest.raises(CLIReturnCodeError):
             target_sat.cli.User.info({'id': user['id']})
 
-    @pytest.mark.tier1
     def test_positive_create_with_default_loc(self, target_sat):
         """Check if user with default location can be created
 
@@ -174,7 +171,6 @@ class TestUser:
         assert location['name'] in user['locations']
         assert location['name'] == user['default-location']
 
-    @pytest.mark.tier1
     def test_positive_create_with_defaut_org(self, module_target_sat):
         """Check if user with default organization can be created
 
@@ -192,7 +188,6 @@ class TestUser:
         assert org['name'] in user['organizations']
         assert org['name'] == user['default-organization']
 
-    @pytest.mark.tier2
     def test_positive_create_with_orgs_and_update(self, module_target_sat):
         """Create User associated to multiple Organizations, update them
 
@@ -215,7 +210,6 @@ class TestUser:
         for org in orgs:
             assert org['name'] in user['organizations']
 
-    @pytest.mark.tier1
     def test_negative_delete_internal_admin(self, module_target_sat):
         """Attempt to delete internal admin user
 
@@ -229,7 +223,6 @@ class TestUser:
             module_target_sat.cli.User.delete({'login': settings.server.admin_username})
         assert module_target_sat.cli.User.info({'login': settings.server.admin_username})
 
-    @pytest.mark.tier2
     def test_positive_last_login_for_new_user(self, module_target_sat):
         """Create new user with admin role and check last login updated for that user
 
@@ -267,7 +260,6 @@ class TestUser:
         )
         assert after_login_time > before_login_time
 
-    @pytest.mark.tier1
     def test_positive_update_all_locales(self, module_target_sat):
         """Update Language in My Account
 
@@ -286,7 +278,6 @@ class TestUser:
             module_target_sat.cli.User.update({'id': user['id'], 'locale': locale})
             assert locale == module_target_sat.cli.User.info({'id': user['id']})['locale']
 
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_add_and_delete_roles(self, module_roles, module_target_sat):
         """Add multiple roles to User, then delete them
@@ -339,7 +330,6 @@ class TestSshKeyInUser:
         """Create an user"""
         return module_target_sat.api.User().create()
 
-    @pytest.mark.tier1
     def test_positive_CRD_ssh_key(self, module_user, module_target_sat):
         """SSH Key can be added to a User, listed and deletd
 
@@ -366,7 +356,6 @@ class TestSshKeyInUser:
         result = module_target_sat.cli.User.ssh_keys_list({'user-id': module_user.id})
         assert ssh_name not in [i['name'] for i in result]
 
-    @pytest.mark.tier1
     def test_positive_create_ssh_key_super_admin_from_file(self, target_sat):
         """SSH Key can be added to Super Admin user from file
 
@@ -392,7 +381,6 @@ class TestSshKeyInUser:
 class TestPersonalAccessToken:
     """Implement personal access token for the users"""
 
-    @pytest.mark.tier2
     def test_personal_access_token_admin_user(self, target_sat):
         """Personal access token for admin user
 
@@ -425,7 +413,6 @@ class TestPersonalAccessToken:
         command_output = target_sat.execute(curl_command)
         assert f'Unable to authenticate user {user["login"]}' in command_output.stdout
 
-    @pytest.mark.tier2
     def test_positive_personal_access_token_user_with_role(self, target_sat):
         """Personal access token for user with a role
 
@@ -462,7 +449,6 @@ class TestPersonalAccessToken:
         )
         assert 'Access denied' in command_output.stdout
 
-    @pytest.mark.tier2
     def test_expired_personal_access_token(self, target_sat):
         """Personal access token expired for the user.
 
@@ -499,7 +485,6 @@ class TestPersonalAccessToken:
         )
         assert f'Unable to authenticate user {user["login"]}' in command_output.stdout
 
-    @pytest.mark.tier2
     def test_custom_personal_access_token_role(self, target_sat):
         """Personal access token for non admin user with custom role
 
@@ -547,7 +532,6 @@ class TestPersonalAccessToken:
         )
         assert f'Unable to authenticate user {user["login"]}' in command_output.stdout
 
-    @pytest.mark.tier2
     def test_negative_personal_access_token_invalid_date(self, target_sat):
         """Personal access token with invalid expire date.
 

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -26,7 +26,6 @@ def function_user_group(target_sat):
     return target_sat.cli_factory.usergroup()
 
 
-@pytest.mark.tier1
 def test_positive_CRUD(module_target_sat):
     """Create new user group with valid elements that attached group.
        List the user group, update and delete it.
@@ -79,7 +78,6 @@ def test_positive_CRUD(module_target_sat):
         module_target_sat.cli.UserGroup.info({'name': user_group['name']})
 
 
-@pytest.mark.tier1
 def test_positive_create_with_multiple_elements(module_target_sat):
     """Create new user group using multiple users, roles and user
        groups attached to that group.
@@ -103,7 +101,6 @@ def test_positive_create_with_multiple_elements(module_target_sat):
     assert sorted(sub_user_groups) == sorted(ug['usergroup'] for ug in user_group['user-groups'])
 
 
-@pytest.mark.tier2
 def test_positive_add_and_remove_elements(module_target_sat):
     """Create new user group. Add and remove several element from the group.
 
@@ -147,7 +144,6 @@ def test_positive_add_and_remove_elements(module_target_sat):
     assert len(user_group['user-groups']) == 0
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_remove_user_assigned_to_usergroup(module_target_sat):
     """Create new user and assign it to user group. Then remove that user.
@@ -168,7 +164,6 @@ def test_positive_remove_user_assigned_to_usergroup(module_target_sat):
     assert user['login'] not in user_group['users']
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize("ldap_auth_source", ["AD"], indirect=True)
 def test_positive_automate_bz1426957(ldap_auth_source, function_user_group, target_sat):
     """Verify role is properly reflected on AD user.
@@ -208,7 +203,6 @@ def test_positive_automate_bz1426957(ldap_auth_source, function_user_group, targ
     target_sat.cli.LDAPAuthSource.delete({'id': ldap_auth_source[1].id})
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize("ldap_auth_source", ["AD"], indirect=True)
 def test_negative_automate_bz1437578(ldap_auth_source, function_user_group, module_target_sat):
     """Verify error message on usergroup create with 'Domain Users' on AD user.

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -30,7 +30,6 @@ def lce(function_sca_manifest_org, target_sat):
     )
 
 
-@pytest.mark.tier4
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.parametrize('cdn', [True, False], ids=['cdn', 'no_cdn'])
 @pytest.mark.parametrize('distro', DISTROS_SUPPORTED)

--- a/tests/foreman/cli/test_webhook.py
+++ b/tests/foreman/cli/test_webhook.py
@@ -56,7 +56,6 @@ def assert_created(options, hook):
 
 
 class TestWebhook:
-    @pytest.mark.tier3
     @pytest.mark.pit_server
     @pytest.mark.e2e
     def test_positive_end_to_end(self, webhook_factory, class_target_sat):

--- a/tests/foreman/destructive/test_capsule.py
+++ b/tests/foreman/destructive/test_capsule.py
@@ -21,7 +21,6 @@ from robottelo.utils.installer import InstallerCommand
 pytestmark = [pytest.mark.destructive]
 
 
-@pytest.mark.tier1
 def test_positive_capsule_certs_generate_with_special_char(target_sat):
     """Verify capsule-certs-generate with special character in organization
 

--- a/tests/foreman/destructive/test_capsule_loadbalancer.py
+++ b/tests/foreman/destructive/test_capsule_loadbalancer.py
@@ -187,7 +187,6 @@ def loadbalancer_setup(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_loadbalancer_install_package(
     loadbalancer_setup, setup_capsules, rhel_contenthost, module_org, module_location, request
@@ -253,7 +252,6 @@ def test_loadbalancer_install_package(
 
 
 @pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.tier1
 def test_client_register_through_lb(
     loadbalancer_setup,
     rhel_contenthost,

--- a/tests/foreman/destructive/test_capsulecontent.py
+++ b/tests/foreman/destructive/test_capsulecontent.py
@@ -23,7 +23,6 @@ from robottelo import constants
 pytestmark = [pytest.mark.destructive]
 
 
-@pytest.mark.tier4
 @pytest.mark.skip_if_not_set('capsule')
 def test_positive_sync_without_deadlock(
     target_sat,
@@ -141,7 +140,6 @@ def test_positive_sync_without_deadlock(
     assert f"'package_group': {repo.content_counts['package_group']}" in updated_content
 
 
-@pytest.mark.tier4
 @pytest.mark.skip_if_not_set('capsule')
 def test_positive_sync_without_deadlock_after_rpm_trim_changelog(
     target_sat,

--- a/tests/foreman/destructive/test_contentview.py
+++ b/tests/foreman/destructive/test_contentview.py
@@ -50,7 +50,6 @@ def module_big_repos(module_target_sat, module_sca_manifest_org):
     return repos
 
 
-@pytest.mark.tier4
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('reboot', [True, False], ids=['vm_reboot', 'fm_restart'])
 def test_positive_reboot_recover_cv_publish(

--- a/tests/foreman/destructive/test_foreman_rake.py
+++ b/tests/foreman/destructive/test_foreman_rake.py
@@ -17,7 +17,6 @@ import pytest
 pytestmark = pytest.mark.destructive
 
 
-@pytest.mark.tier3
 def test_positive_katello_reimport(target_sat):
     """Close loop bug for running katello:reimport.  Making sure
     that katello:reimport works and doesn't throw an error.

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -25,7 +25,6 @@ class TestHostCockpit:
 
     @pytest.mark.upgrade
     @pytest.mark.rhel_ver_match('[^6].*')
-    @pytest.mark.tier2
     @pytest.mark.no_containers
     def test_positive_cockpit(self, cockpit_host, class_cockpit_sat, class_org):
         """Install cockpit plugin and test whether webconsole button and cockpit integration works.

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -85,7 +85,6 @@ infoblox_plugin_opts = {
 }
 
 
-@pytest.mark.tier4
 @pytest.mark.parametrize(
     ('command_args', 'command_opts', 'rpm_command'),
     params,

--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -192,7 +192,6 @@ def test_positive_generate_capsule_certs_using_relative_path(cert_setup_destruct
     assert satellite.execute('test -e root/capsule_cert/capsule_certs_Rel.tar')
 
 
-@pytest.mark.tier1
 def test_positive_validate_capsule_certificate(capsule_certs_teardown):
     """Check that Capsules cert handles additional proxy names.
 

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -99,7 +99,7 @@ def external_user_count(module_target_sat):
 def groups_teardown(module_target_sat):
     """teardown for groups created for external/remote groups"""
     yield
-    # tier down groups
+    # teardown groups
     for group_name in ('sat_users', 'sat_admins', EXTERNAL_GROUP_NAME):
         user_groups = module_target_sat.api.UserGroup().search(
             query={'search': f'name="{group_name}"'}

--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -18,7 +18,6 @@ from robottelo.config import settings
 pytestmark = pytest.mark.destructive
 
 
-@pytest.mark.tier3
 @pytest.mark.no_containers
 @pytest.mark.pit_client
 @pytest.mark.rhel_ver_match('[^6]')

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -922,7 +922,7 @@ def filtered_api_paths():
 class TestAvailableURLs:
     """Tests for ``api/v2``."""
 
-    pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]
+    pytestmark = pytest.mark.upgrade
 
     @pytest.fixture(scope='class')
     def api_url(self):
@@ -984,7 +984,7 @@ class TestAvailableURLs:
 class TestEndToEnd:
     """End-to-end tests using the ``API`` path."""
 
-    pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]
+    pytestmark = pytest.mark.upgrade
 
     def test_positive_find_default_org(self, class_target_sat):
         """Check if 'Default Organization' is present
@@ -1025,7 +1025,6 @@ class TestEndToEnd:
         assert results[0].login == 'admin'
 
     @pytest.mark.skip_if_not_set('libvirt')
-    @pytest.mark.tier4
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     @pytest.mark.e2e

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -20,7 +20,6 @@ from robottelo.config import settings
 from robottelo.constants.repos import CUSTOM_RPM_REPO
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_cli_find_default_org(module_target_sat):
     """Check if 'Default Organization' is present
@@ -33,7 +32,6 @@ def test_positive_cli_find_default_org(module_target_sat):
     assert result['name'] == constants.DEFAULT_ORG
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_cli_find_default_loc(module_target_sat):
     """Check if 'Default Location' is present
@@ -46,7 +44,6 @@ def test_positive_cli_find_default_loc(module_target_sat):
     assert result['name'] == constants.DEFAULT_LOC
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_cli_find_admin_user(module_target_sat):
     """Check if Admin User is present
@@ -62,7 +59,6 @@ def test_positive_cli_find_admin_user(module_target_sat):
 
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('7')
-@pytest.mark.tier4
 @pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -16,7 +16,6 @@ import pytest
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_dhcp_ip_range():
     """Check host get IP from Infoblox IP range while provisioning a host
@@ -33,7 +32,6 @@ def test_dhcp_ip_range():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_dns_records():
     """Check DNS records are updated via infoblox DNS plugin

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -349,7 +349,6 @@ def sat_non_default_install(module_sat_ready_rhels):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 @pytest.mark.pit_server
 @pytest.mark.build_sanity
 def test_capsule_installation(
@@ -460,7 +459,6 @@ def test_capsule_installation(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 def test_foreman_rails_cache_store(sat_non_default_install):
     """Test foreman-rails-cache-store option
 
@@ -484,7 +482,6 @@ def test_foreman_rails_cache_store(sat_non_default_install):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 def test_content_guarded_distributions_option(
     sat_default_install, sat_non_default_install, module_sca_manifest
 ):
@@ -543,7 +540,6 @@ def test_content_guarded_distributions_option(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier1
 def test_positive_selinux_foreman_module(target_sat):
     """Check if SELinux foreman module is installed on Satellite
 
@@ -563,7 +559,6 @@ def test_positive_selinux_foreman_module(target_sat):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier1
 @pytest.mark.parametrize('service', SATELLITE_SERVICES)
 def test_positive_check_installer_service_running(target_sat, service):
     """Check if a service is running
@@ -583,7 +578,6 @@ def test_positive_check_installer_service_running(target_sat, service):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier1
 def test_positive_check_installer_hammer_ping(target_sat):
     """Check if hammer ping reports all services as ok
 
@@ -606,7 +600,6 @@ def test_positive_check_installer_hammer_ping(target_sat):
             assert 'ok' in line
 
 
-@pytest.mark.tier3
 def test_installer_cap_pub_directory_accessibility(capsule_configured):
     """Verify the public directory accessibility from capsule url after disabling it from the
     custom-hiera
@@ -693,7 +686,6 @@ def test_installer_capsule_with_enabled_ansible(module_capsule_configured_ansibl
     assert callbacks_enabled.stdout.strip('" \n') == downstream_callback
 
 
-@pytest.mark.tier1
 @pytest.mark.build_sanity
 @pytest.mark.first_sanity
 @pytest.mark.pit_server

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -165,7 +165,6 @@ def host(
     return rhel7_contenthost_module
 
 
-@pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_noapply_api(
     module_sca_manifest_org, module_cv, custom_repo, host, dev_lce, module_target_sat
@@ -214,7 +213,6 @@ def test_positive_noapply_api(
     )
 
 
-@pytest.mark.tier3
 def test_positive_incremental_update_time(module_target_sat, module_sca_manifest_org):
     """Incremental update should not take a long time.
 

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -252,7 +252,6 @@ def prepare_scap_client_and_prerequisites(
 
 @pytest.mark.e2e
 @pytest.mark.upgrade
-@pytest.mark.tier4
 @pytest.mark.rhel_ver_match('[^6].*')
 @pytest.mark.pit_server
 @pytest.mark.pit_client
@@ -321,7 +320,6 @@ def test_positive_oscap_run_via_ansible(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier4
 @pytest.mark.rhel_ver_list([8])
 def test_positive_oscap_remediation(
     module_org, default_proxy, content_view, lifecycle_env, target_sat, rex_contenthost
@@ -410,7 +408,6 @@ def test_positive_oscap_remediation(
 
 
 @pytest.mark.rhel_ver_list([7, 8, 9])
-@pytest.mark.tier4
 def test_positive_oscap_run_via_ansible_bz_1814988(
     module_org, default_proxy, lifecycle_env, target_sat, rex_contenthost
 ):
@@ -484,7 +481,6 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier4
 def test_positive_has_arf_report_summary_page():
     """OSCAP ARF Report now has summary page
 
@@ -502,7 +498,6 @@ def test_positive_has_arf_report_summary_page():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier4
 def test_positive_view_full_report_button():
     """'View full Report' button should exist for OSCAP Reports.
 
@@ -521,7 +516,6 @@ def test_positive_view_full_report_button():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier4
 def test_positive_download_xml_button():
     """'Download xml' button should exist for OSCAP Reports
     to be downloaded in xml format.
@@ -541,7 +535,6 @@ def test_positive_download_xml_button():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier4
 def test_positive_select_oscap_proxy():
     """Oscap-Proxy select box should exist while filling hosts
     and host-groups form.
@@ -559,7 +552,6 @@ def test_positive_select_oscap_proxy():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier4
 def test_positive_delete_multiple_arf_reports():
     """Multiple arf reports deletion should be possible.
 
@@ -579,7 +571,6 @@ def test_positive_delete_multiple_arf_reports():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier4
 def test_positive_reporting_emails_of_oscap_reports():
     """Email Reporting of oscap reports should be possible.
 

--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -19,7 +19,6 @@ from robottelo.config import robottelo_tmp_dir
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
     """Test satellite-maintain maintenance-mode subcommand
 

--- a/tests/foreman/sys/test_dynflow.py
+++ b/tests/foreman/sys/test_dynflow.py
@@ -16,7 +16,6 @@ import pytest
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 def test_positive_setup_dynflow(target_sat):
     """Set dynflow parameters, restart it and check it adheres to them
 

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -184,7 +184,6 @@ def test_positive_ansible_modules_installation(target_sat):
 
 @pytest.mark.e2e
 @pytest.mark.pit_server
-@pytest.mark.tier1
 def test_positive_import_run_roles(sync_roles, target_sat):
     """Import a FAM role and run the role on the Satellite
 

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -133,7 +133,6 @@ class TestKatelloCertsCheck:
                     options.append(i)
         assert set(options) == expected_result
 
-    @pytest.mark.tier1
     def test_positive_validate_katello_certs_check_output(self, cert_setup_teardown):
         """Validate that katello-certs-check generates correct output.
 
@@ -160,7 +159,6 @@ class TestKatelloCertsCheck:
         self.validate_output(result, cert_data)
 
     @pytest.mark.parametrize(('error', 'cert_file', 'key_file', 'ca_file'), invalid_inputs)
-    @pytest.mark.tier1
     def test_katello_certs_check_output_invalid_input(
         self,
         cert_setup_teardown,
@@ -200,7 +198,6 @@ class TestKatelloCertsCheck:
         else:
             pytest.fail('Failed to receive the error for invalid katello-cert-check')
 
-    @pytest.mark.tier1
     def test_negative_check_expiration_of_certificate(self, cert_setup_teardown):
         """Check expiration of certificate.
 
@@ -239,7 +236,6 @@ class TestKatelloCertsCheck:
         target_sat.execute("date -s 'last year'")
 
     @pytest.mark.stubbed
-    @pytest.mark.tier1
     def test_negative_validate_certificate_subject(self):
         """Validate certificate subject.
 

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -84,7 +84,6 @@ def test_pulp_service_definitions(target_sat):
     assert result.status == 0
 
 
-@pytest.mark.tier1
 def test_pulp_workers_status(target_sat):
     """Ensure pulpcore-workers are in active (running) state
 
@@ -101,7 +100,6 @@ def test_pulp_workers_status(target_sat):
     assert all('Active: active (running)' in r for r in result)
 
 
-@pytest.mark.tier1
 def test_pulp_status(target_sat):
     """Test pulp status via pulp-cli.
 

--- a/tests/foreman/sys/test_webpack.py
+++ b/tests/foreman/sys/test_webpack.py
@@ -12,10 +12,7 @@
 
 """
 
-import pytest
 
-
-@pytest.mark.tier2
 def test_positive_webpack5(target_sat):
     """Check whether Webpack 5 was used at packaging time
 

--- a/tests/foreman/ui/test_acs.py
+++ b/tests/foreman/ui/test_acs.py
@@ -60,7 +60,6 @@ def acs_setup(class_target_sat, class_sca_manifest_org):
     return class_target_sat, class_sca_manifest_org
 
 
-@pytest.mark.tier2
 def test_acs_subpath_not_required(acs_setup):
     """
     This test verifies that the subpath field isn't mandatory for ACS creation.

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -25,7 +25,6 @@ from robottelo.utils.datafactory import parametrized, valid_data_list
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end_crud(session, module_org, module_target_sat):
     """Perform end to end testing for activation key component
@@ -62,7 +61,6 @@ def test_positive_end_to_end_crud(session, module_org, module_target_sat):
 
 @pytest.mark.no_containers
 @pytest.mark.e2e
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'repos_collection',
@@ -106,7 +104,6 @@ def test_positive_end_to_end_register(
         assert ak_values['content_hosts']['table'][0]['Name'] == rhel7_contenthost.hostname
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.parametrize('cv_name', **parametrized(valid_data_list('ui')))
 def test_positive_create_with_cv(session, module_org, cv_name, target_sat):
@@ -131,7 +128,6 @@ def test_positive_create_with_cv(session, module_org, cv_name, target_sat):
         assert ak['details']['content_view'] == cv_name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_search_scoped(session, module_org, target_sat):
     """Test scoped search for different activation key parameters
@@ -169,7 +165,6 @@ def test_positive_search_scoped(session, module_org, target_sat):
             assert session.activationkey.search(f'{query_type} = {query_value}')[0]['Name'] == name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_create_with_host_collection(session, module_org, module_target_sat):
     """Create Activation key with Host Collection
@@ -188,7 +183,6 @@ def test_positive_create_with_host_collection(session, module_org, module_target
         assert ak['host_collections']['resources']['assigned'][0]['Name'] == hc.name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_create_with_envs(session, module_org, target_sat):
     """Create Activation key with lifecycle environment
@@ -213,7 +207,6 @@ def test_positive_create_with_envs(session, module_org, target_sat):
         assert ak['details']['lce'][env_name][env_name]
 
 
-@pytest.mark.tier2
 def test_positive_add_host_collection_non_admin(module_org, test_name, target_sat):
     """Test that host collection can be associated to Activation Keys by
     non-admin user.
@@ -248,7 +241,6 @@ def test_positive_add_host_collection_non_admin(module_org, test_name, target_sa
         assert ak['host_collections']['resources']['assigned'][0]['Name'] == hc.name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_remove_host_collection_non_admin(module_org, test_name, target_sat):
     """Test that host collection can be removed from Activation Keys by
@@ -286,7 +278,6 @@ def test_positive_remove_host_collection_non_admin(module_org, test_name, target
         assert not ak['host_collections']['resources']['assigned']
 
 
-@pytest.mark.tier2
 def test_positive_delete_with_env(session, module_org, target_sat):
     """Create Activation key with environment and delete it
 
@@ -307,7 +298,6 @@ def test_positive_delete_with_env(session, module_org, target_sat):
         assert session.activationkey.search(name)[0]['Name'] != name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_delete_with_cv(session, module_org, target_sat):
     """Create Activation key with content view and delete it
@@ -332,7 +322,6 @@ def test_positive_delete_with_cv(session, module_org, target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_update_env(session, module_org, target_sat):
     """Update Environment in an Activation key
 
@@ -359,7 +348,6 @@ def test_positive_update_env(session, module_org, target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.parametrize('cv2_name', **parametrized(valid_data_list('ui')))
 def test_positive_update_cv(session, module_org, cv2_name, target_sat):
     """Update Content View in an Activation key
@@ -399,7 +387,6 @@ def test_positive_update_cv(session, module_org, cv2_name, target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_update_rh_product(function_sca_manifest_org, session, target_sat):
     """Update Content View in an Activation key
 
@@ -453,7 +440,6 @@ def test_positive_update_rh_product(function_sca_manifest_org, session, target_s
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_add_rh_product(function_sca_manifest_org, session, target_sat):
     """Test that RH product can be associated to Activation Keys
 
@@ -487,7 +473,6 @@ def test_positive_add_rh_product(function_sca_manifest_org, session, target_sat)
         assert rh_repo['reposet'] == ak['Repository Name']
 
 
-@pytest.mark.tier2
 def test_positive_add_custom_product(session, module_org, target_sat):
     """Test that custom product can be associated to Activation Keys
 
@@ -517,7 +502,6 @@ def test_positive_add_custom_product(session, module_org, target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_add_rh_and_custom_products(target_sat, function_sca_manifest_org, session):
     """Test that RH/Custom product can be associated to Activation keys
@@ -571,7 +555,6 @@ def test_positive_add_rh_and_custom_products(target_sat, function_sca_manifest_o
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_fetch_product_content(target_sat, function_sca_manifest_org, session):
     """Associate RH & custom product with AK and fetch AK's product content
@@ -618,7 +601,6 @@ def test_positive_fetch_product_content(target_sat, function_sca_manifest_org, s
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_access_non_admin_user(session, test_name, target_sat):
     """Access activation key that has specific name and assigned environment by
@@ -711,7 +693,6 @@ def test_positive_access_non_admin_user(session, test_name, target_sat):
         )
 
 
-@pytest.mark.tier2
 def test_positive_remove_user(session, module_org, test_name, module_target_sat):
     """Delete any user who has previously created an activation key
     and check that activation key still exists
@@ -740,7 +721,6 @@ def test_positive_remove_user(session, module_org, test_name, module_target_sat)
         assert session.activationkey.search(ak_name)[0]['Name'] == ak_name
 
 
-@pytest.mark.tier2
 def test_positive_add_docker_repo_cv(session, module_org, module_target_sat):
     """Add docker repository to a non-composite content view and
     publish it. Then create an activation key and associate it with the
@@ -773,7 +753,6 @@ def test_positive_add_docker_repo_cv(session, module_org, module_target_sat):
         assert ak['details']['lce'][lce.name][lce.name]
 
 
-@pytest.mark.tier2
 def test_positive_add_docker_repo_ccv(session, module_org, module_target_sat):
     """Add docker repository to a non-composite content view and publish it.
     Then add this content view to a composite content view and publish it.
@@ -813,7 +792,6 @@ def test_positive_add_docker_repo_ccv(session, module_org, module_target_sat):
         assert ak['details']['lce'][lce.name][lce.name]
 
 
-@pytest.mark.tier3
 def test_positive_add_host(session, module_org, rhel_contenthost, target_sat):
     """Test that hosts can be associated to Activation Keys
 
@@ -845,7 +823,6 @@ def test_positive_add_host(session, module_org, rhel_contenthost, target_sat):
         assert ak['content_hosts']['table'][0]['Name'] == rhel_contenthost.hostname
 
 
-@pytest.mark.tier3
 def test_positive_delete_with_system(session, rhel_contenthost, target_sat):
     """Delete an Activation key which has registered systems
 
@@ -883,7 +860,6 @@ def test_positive_delete_with_system(session, rhel_contenthost, target_sat):
         assert session.activationkey.search(name)[0]['Name'] != name
 
 
-@pytest.mark.tier3
 def test_negative_usage_limit(session, module_org, target_sat):
     """Test that Usage limit actually limits usage
 
@@ -919,7 +895,6 @@ def test_negative_usage_limit(session, module_org, target_sat):
 
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('^6')
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_add_multiple_aks_to_system(session, module_org, rhel_contenthost, target_sat):
@@ -973,7 +948,6 @@ def test_positive_add_multiple_aks_to_system(session, module_org, rhel_contentho
             assert ak['content_hosts']['table'][0]['Name'] == rhel_contenthost.hostname
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_host_associations(session, target_sat):
@@ -1020,7 +994,6 @@ def test_positive_host_associations(session, target_sat):
 
 
 @pytest.mark.no_containers
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_service_level_subscription_with_custom_product(
     session, function_sca_manifest_org, rhel7_contenthost, target_sat

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -30,7 +30,6 @@ class TestAnsibleCfgMgmt:
     :CaseComponent: Ansible-ConfigurationManagement
     """
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize('auth_type', ['admin', 'non-admin'])
     def test_positive_create_delete_variable_with_overrides(
         self, request, function_org, target_sat, auth_type
@@ -104,7 +103,6 @@ class TestAnsibleCfgMgmt:
             session.ansiblevariables.delete(key)
             assert not session.ansiblevariables.search(key)
 
-    @pytest.mark.tier2
     def test_positive_host_role_information(self, target_sat, function_host):
         """Assign Ansible Role to a Host and verify that the information
         in the new UI is displayed correctly
@@ -229,7 +227,6 @@ class TestAnsibleCfgMgmt:
                 (v['Name'], v['Ansible role'], v['Type'], v['Value']) for v in variable_table
             ]
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize('setting_update', ['ansible_roles_to_ignore'], indirect=True)
     def test_positive_ansible_roles_ignore_list(self, target_sat, setting_update):
         """Verify that the ignore list setting prevents selected roles from being available for import
@@ -253,7 +250,6 @@ class TestAnsibleCfgMgmt:
             )
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     def test_positive_set_ansible_role_order_per_host(self):
         """Verify that role run order can be set and this order is respected when roles are run
 
@@ -272,7 +268,6 @@ class TestAnsibleCfgMgmt:
         """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     def test_positive_set_ansible_role_order_per_hostgroup(self):
         """Verify that role run order can be set and that this order is respected when roles are run
 
@@ -292,7 +287,6 @@ class TestAnsibleCfgMgmt:
         :CaseAutomation: NotAutomated
         """
 
-    @pytest.mark.tier2
     def test_positive_assign_and_remove_ansible_role_to_host(self, target_sat, function_host):
         """Add and remove the role(s) of a Host
 
@@ -339,7 +333,6 @@ class TestAnsibleCfgMgmt:
                 == 'No roles assigned directly to the host'
             )
 
-    @pytest.mark.tier2
     def test_positive_assign_and_remove_ansible_role_to_hostgroup(
         self,
         target_sat,
@@ -396,7 +389,6 @@ class TestAnsibleCfgMgmt:
             session.hostgroup.delete(name)
             assert not target_sat.api.HostGroup().search(query={'search': f'name={name}'})
 
-    @pytest.mark.tier3
     def test_positive_non_admin_user_access_with_usergroup(
         self,
         request,
@@ -537,7 +529,6 @@ class TestAnsibleREX:
     :CaseComponent: Ansible-RemoteExecution
     """
 
-    @pytest.mark.tier2
     @pytest.mark.pit_server
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_match('[^6]')
@@ -720,7 +711,6 @@ class TestAnsibleREX:
             assert len(session.configreport.read()['table']) == 0
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     def test_positive_ansible_job_check_mode(self):
         """Run a job on a host with enable_roles_check_mode parameter enabled
 
@@ -738,7 +728,6 @@ class TestAnsibleREX:
         """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier3
     def test_positive_install_ansible_collection_via_job_invocation(self):
         """Verify that Ansible collections can be installed on hosts via job invocations
 
@@ -758,7 +747,6 @@ class TestAnsibleREX:
         """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier2
     def test_positive_schedule_recurring_host_job(self):
         """Using the new Host UI, schedule a recurring job on a Host
 
@@ -778,7 +766,6 @@ class TestAnsibleREX:
         """
 
     @pytest.mark.stubbed
-    @pytest.mark.tier2
     def test_positive_schedule_recurring_hostgroup_job(self):
         """Using the new recurring job scheduler, schedule a recurring job on a Hostgroup
 

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -16,7 +16,6 @@ from fauxfactory import gen_string
 import pytest
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, target_sat):
     """Perform end to end testing for architecture component

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -24,7 +24,6 @@ def module_org(module_target_sat):
 pytestmark = [pytest.mark.run_in_one_thread]
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_create_event(session, module_org, module_location, module_target_sat):
     """When new host is created, corresponding audit entry appear in the application
@@ -69,7 +68,6 @@ def test_positive_create_event(session, module_org, module_location, module_targ
         assert summary.get('Location') == module_location.name
 
 
-@pytest.mark.tier2
 def test_positive_audit_comment(session, module_org):
     """When new partition table with audit comment is created, that message can be seen in
     corresponding audit entry
@@ -102,7 +100,6 @@ def test_positive_audit_comment(session, module_org):
         assert values['comment'] == audit_comment
 
 
-@pytest.mark.tier2
 def test_positive_update_event(session, module_org, module_target_sat):
     """When existing content view is updated, corresponding audit entry appear
     in the application
@@ -134,7 +131,6 @@ def test_positive_update_event(session, module_org, module_target_sat):
         assert values['action_summary'][0]['column2'] == new_name
 
 
-@pytest.mark.tier2
 def test_positive_delete_event(session, module_org, module_target_sat):
     """When existing architecture is deleted, corresponding audit entry appear
     in the application
@@ -159,7 +155,6 @@ def test_positive_delete_event(session, module_org, module_target_sat):
         assert values['action_summary'][0]['column1'] == architecture.name
 
 
-@pytest.mark.tier2
 def test_positive_add_event(session, module_org, module_target_sat):
     """When content view is published and proper lifecycle environment added to it,
     corresponding audit entry appear in the application

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -55,7 +55,6 @@ def ui_entity(module_org, module_location, request):
     return entity
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, ui_entity):
     """Perform end to end testing for bookmark component
@@ -88,7 +87,6 @@ def test_positive_end_to_end(session, ui_entity):
         assert not session.bookmark.search(new_name)
 
 
-@pytest.mark.tier2
 def test_positive_create_bookmark_public(
     session, ui_entity, default_viewer_role, test_name, module_target_sat
 ):
@@ -130,7 +128,6 @@ def test_positive_create_bookmark_public(
         assert not session.bookmark.search(nonpublic_name)
 
 
-@pytest.mark.tier2
 def test_positive_update_bookmark_public(
     session, ui_entity, default_viewer_role, ui_user, test_name, target_sat
 ):
@@ -201,7 +198,6 @@ def test_positive_update_bookmark_public(
         assert not non_admin_session.bookmark.search(public_name)
 
 
-@pytest.mark.tier2
 def test_negative_delete_bookmark(ui_entity, default_viewer_role, test_name, module_target_sat):
     """Simple removal of a bookmark query without permissions
 
@@ -233,7 +229,6 @@ def test_negative_delete_bookmark(ui_entity, default_viewer_role, test_name, mod
         assert non_admin_session.bookmark.search(bookmark.name)[0]['Name'] == bookmark.name
 
 
-@pytest.mark.tier2
 def test_negative_create_with_duplicate_name(session, ui_entity, module_target_sat):
     """Create bookmark with duplicate name
 

--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -17,7 +17,6 @@ import pytest
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_location, module_org, module_target_sat):
     """Perform end to end testing for compute profile component

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -47,7 +47,6 @@ def rhev_data():
     return ret
 
 
-@pytest.mark.tier2
 def test_positive_end_to_end(session, rhev_data, module_target_sat):
     """Perform end to end testing for compute resource RHEV.
 
@@ -90,7 +89,6 @@ def test_positive_end_to_end(session, rhev_data, module_target_sat):
         )
 
 
-@pytest.mark.tier2
 def test_positive_add_resource(session, rhev_data):
     """Create new RHEV Compute Resource using APIv4
 
@@ -122,7 +120,6 @@ def test_positive_add_resource(session, rhev_data):
         assert resource_values['name'] == name
 
 
-@pytest.mark.tier2
 def test_positive_edit_resource_description(session, rhev_data):
     """Edit RHEV Compute Resource with another description
 
@@ -155,7 +152,6 @@ def test_positive_edit_resource_description(session, rhev_data):
         assert resource_values['description'] == new_description
 
 
-@pytest.mark.tier2
 def test_positive_list_resource_vms(session, rhev_data):
     """List VMs for RHEV Compute Resource
 
@@ -184,7 +180,6 @@ def test_positive_list_resource_vms(session, rhev_data):
         assert vm['Name'].read() == rhev_data['vm_name']
 
 
-@pytest.mark.tier2
 @pytest.mark.run_in_one_thread
 def test_positive_resource_vm_power_management(session, rhev_data):
     """Read current RHEV Compute Resource virtual machine power status and
@@ -230,7 +225,6 @@ def test_positive_resource_vm_power_management(session, rhev_data):
         assert session.computeresource.vm_status(name, rhev_data['vm_name']) is not status
 
 
-@pytest.mark.tier3
 def test_positive_VM_import(session, module_org, module_location, rhev_data, module_target_sat):
     """Import an existing VM as a Host
 
@@ -319,7 +313,6 @@ def test_positive_VM_import(session, module_org, module_location, rhev_data, mod
     module_target_sat.api.Host(name=rhev_data['vm_name']).search()[0].delete()
 
 
-@pytest.mark.tier3
 def test_positive_update_organization(session, rhev_data, module_location, module_target_sat):
     """Update a rhev Compute Resource organization
 
@@ -368,7 +361,6 @@ def test_positive_update_organization(session, rhev_data, module_location, modul
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 def test_positive_image_end_to_end(session, rhev_data, target_sat):
     """Perform end to end testing for compute resource RHV component image.
 
@@ -427,7 +419,6 @@ def test_positive_image_end_to_end(session, rhev_data, target_sat):
         )
 
 
-@pytest.mark.tier2
 def test_positive_associate_with_custom_profile(session, rhev_data):
     """ "Associate custom default (3-Large) compute profile to RHV compute resource.
 
@@ -514,7 +505,6 @@ def test_positive_associate_with_custom_profile(session, rhev_data):
                 assert provided_value == expected_value
 
 
-@pytest.mark.tier3
 def test_positive_associate_with_custom_profile_with_template(session, rhev_data):
     """Associate custom default (3-Large) compute profile to rhev compute
      resource, with template

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -76,7 +76,6 @@ def module_azure_hg(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier4
 @pytest.mark.parametrize('sat_azure', ['sat'], indirect=True)
 def test_positive_end_to_end_azurerm_ft_host_provision(
     sat_azure,
@@ -153,7 +152,6 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -41,7 +41,6 @@ def module_ec2_settings():
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.skip_if_not_set('http_proxy')
 def test_positive_default_end_to_end_with_custom_profile(
     session, module_org, module_location, module_ec2_settings, module_target_sat
@@ -143,7 +142,6 @@ def test_positive_default_end_to_end_with_custom_profile(
         assert not session.computeresource.search(new_cr_name)
 
 
-@pytest.mark.tier2
 def test_positive_create_ec2_with_custom_region(session, module_ec2_settings):
     """Create a new ec2 compute resource with custom region
 

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -30,7 +30,6 @@ from robottelo.constants import (
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skip_if_not_set('http_proxy', 'gce')
 def test_positive_default_end_to_end_with_custom_profile(
@@ -142,7 +141,6 @@ def test_positive_default_end_to_end_with_custom_profile(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier4
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('gce')
 @pytest.mark.parametrize('sat_gce', ['sat', 'puppet_sat'], indirect=True)
@@ -227,7 +225,6 @@ def test_positive_gce_provision_end_to_end(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier4
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('gce')

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -30,7 +30,6 @@ pytestmark = [pytest.mark.skip_if_not_set('libvirt')]
 LIBVIRT_URL = LIBVIRT_RESOURCE_URL % settings.libvirt.libvirt_hostname
 
 
-@pytest.mark.tier2
 @pytest.mark.e2e
 def test_positive_end_to_end(session, module_target_sat, module_org, module_location):
     """Perform end to end testing for compute resource Libvirt component.
@@ -119,7 +118,6 @@ def test_positive_end_to_end(session, module_target_sat, module_org, module_loca
 
 @pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
-@pytest.mark.tier4
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_end_to_end(

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -82,7 +82,6 @@ def get_vmware_datastore_summary_string(vmware, vmwareclient):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier1
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
 def test_positive_cr_end_to_end(session, module_org, module_location, vmware, module_target_sat):
     """Perform end-to-end testing for compute resource VMware component.
@@ -154,7 +153,6 @@ def test_positive_cr_end_to_end(session, module_org, module_location, vmware, mo
         assert not session.computeresource.search(new_cr_name)
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
 def test_positive_retrieve_virtual_machine_list(session, vmware):
     """List the virtual machine list from vmware compute resource
@@ -190,7 +188,6 @@ def test_positive_retrieve_virtual_machine_list(session, vmware):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
 def test_positive_image_end_to_end(session, target_sat, vmware):
     """Perform end to end testing for compute resource VMware component image.
@@ -248,7 +245,6 @@ def test_positive_image_end_to_end(session, target_sat, vmware):
         )
 
 
-@pytest.mark.tier2
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
 def test_positive_resource_vm_power_management(session, vmware):
@@ -294,7 +290,6 @@ def test_positive_resource_vm_power_management(session, vmware):
 
 @pytest.mark.e2e
 @pytest.mark.upgrade
-@pytest.mark.tier2
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
 def test_positive_vmware_custom_profile_end_to_end(
     session, vmware, request, target_sat, get_vmware_datastore_summary_string
@@ -425,7 +420,6 @@ def test_positive_vmware_custom_profile_end_to_end(
         assert not session.computeresource.search(cr_name)
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
 def test_positive_virt_card(session, target_sat, module_location, module_org, vmware):
     """Check to see that the Virtualization card appears for an imported VM
@@ -562,7 +556,6 @@ def test_positive_virt_card(session, target_sat, module_location, module_org, vm
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
 @pytest.mark.parametrize('provision_method', ['build'])
 @pytest.mark.rhel_ver_match('[8]')
-@pytest.mark.tier3
 def test_positive_provision_end_to_end(
     request,
     module_sca_manifest_org,

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -22,7 +22,6 @@ def module_puppet_class(session_puppet_enabled_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_class):
     """Perform end to end testing for config group component

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -44,7 +44,6 @@ def module_repository(module_product, module_target_sat):
     return repo
 
 
-@pytest.mark.tier2
 def test_positive_search(session, module_org, module_product, module_repository):
     """Search for a docker image tag and reads details of it
 

--- a/tests/foreman/ui/test_contentcredentials.py
+++ b/tests/foreman/ui/test_contentcredentials.py
@@ -32,7 +32,6 @@ def gpg_path():
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, target_sat, module_org, gpg_content):
     """Perform end to end testing for gpg key component
@@ -81,7 +80,6 @@ def test_positive_end_to_end(session, target_sat, module_org, gpg_content):
         assert session.contentcredential.search(new_name)[0]['Name'] != new_name
 
 
-@pytest.mark.tier2
 def test_positive_search_scoped(session, target_sat, gpg_content, module_org):
     """Search for gpgkey by organization id parameter
 
@@ -109,7 +107,6 @@ def test_positive_search_scoped(session, target_sat, gpg_content, module_org):
         )
 
 
-@pytest.mark.tier2
 def test_positive_add_empty_product(session, target_sat, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate
     it with empty (no repos) custom product
@@ -128,7 +125,6 @@ def test_positive_add_empty_product(session, target_sat, module_org, gpg_content
         assert values['products']['table'][0]['Used as'] == CONTENT_CREDENTIALS_TYPES['gpg']
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_product_with_repo(session, target_sat, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
@@ -162,7 +158,6 @@ def test_positive_add_product_with_repo(session, target_sat, module_org, gpg_con
         assert values['repositories']['table'][0]['Used as'] == CONTENT_CREDENTIALS_TYPES['gpg']
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_product_with_repos(session, target_sat, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
@@ -190,7 +185,6 @@ def test_positive_add_product_with_repos(session, target_sat, module_org, gpg_co
         }
 
 
-@pytest.mark.tier2
 def test_positive_add_repo_from_product_with_repo(session, target_sat, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     to repository from custom product that has one repository
@@ -220,7 +214,6 @@ def test_positive_add_repo_from_product_with_repo(session, target_sat, module_or
         assert values['repositories']['table'][0]['Product'] == product.name
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_repo_from_product_with_repos(session, target_sat, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
@@ -250,7 +243,6 @@ def test_positive_add_repo_from_product_with_repos(session, target_sat, module_o
         assert values['repositories']['table'][0]['Name'] == repo1.name
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_product_and_search(session, target_sat, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key
@@ -286,7 +278,6 @@ def test_positive_add_product_and_search(session, target_sat, module_org, gpg_co
         assert product_values['details']['repos_count'] == '1'
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.usefixtures('allow_repo_discovery')
@@ -341,7 +332,6 @@ def test_positive_update_key_for_product_using_repo_discovery(session, gpg_path)
         assert product_values['details']['gpg_key'] == new_name
 
 
-@pytest.mark.tier2
 def test_positive_update_key_for_empty_product(session, target_sat, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
     with empty (no repos) custom product then update the key
@@ -370,7 +360,6 @@ def test_positive_update_key_for_empty_product(session, target_sat, module_org, 
         assert values['products']['table'][0]['Name'] == product.name
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_update_key_for_product_with_repo(session, target_sat, module_org, gpg_content):
     """Create gpg key with valid name and valid gpg key then associate it
@@ -400,7 +389,6 @@ def test_positive_update_key_for_product_with_repo(session, target_sat, module_o
         assert values['repositories']['table'][0]['Name'] == repo.name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_update_key_for_product_with_repos(session, target_sat, module_org, gpg_content):
@@ -433,7 +421,6 @@ def test_positive_update_key_for_product_with_repos(session, target_sat, module_
         }
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_update_key_for_repo_from_product_with_repo(
     session, target_sat, module_org, gpg_content
@@ -469,7 +456,6 @@ def test_positive_update_key_for_repo_from_product_with_repo(
         assert values['repositories']['table'][0]['Name'] == repo.name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_update_key_for_repo_from_product_with_repos(

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -120,7 +120,6 @@ def get_rhel_lifecycle_support(rhel_version):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -245,7 +244,6 @@ def test_positive_end_to_end(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -330,7 +328,6 @@ def test_positive_end_to_end_bulk_update(session, default_location, vm, target_s
         session.contenthost.delete(vm.hostname)
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -368,7 +365,6 @@ def test_negative_install_package(session, default_location, vm):
         assert result['overview']['job_status'] == 'Failed'
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
@@ -406,7 +402,6 @@ def test_positive_remove_package(session, default_location, vm):
         assert not packages
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -443,7 +438,6 @@ def test_positive_upgrade_package(session, default_location, vm):
         assert packages[0]['Installed Package'] == FAKE_2_CUSTOM_PACKAGE
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
@@ -483,7 +477,6 @@ def test_positive_install_package_group(session, default_location, vm):
             assert packages[0]['Installed Package'] == package
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -520,7 +513,6 @@ def test_positive_remove_package_group(session, default_location, vm):
             assert not session.contenthost.search_package(vm.hostname, package)
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -563,7 +555,6 @@ def test_positive_search_errata_non_admin(
         }
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
@@ -624,7 +615,6 @@ def test_positive_ensure_errata_applicability_with_host_reregistered(session, de
         }
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -683,7 +673,6 @@ def test_positive_host_re_registration_with_host_rename(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
@@ -775,7 +764,6 @@ def test_positive_check_ignore_facts_os_setting(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -900,7 +888,6 @@ def test_module_stream_actions_on_content_host(
         assert module_stream[0]['Status'] == ''
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -965,7 +952,6 @@ def test_module_streams_customize_action(session, default_location, vm_module_st
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -1042,7 +1028,6 @@ def test_install_modular_errata(session, default_location, vm_module_streams):
         assert module_stream[0]['Name'] == module_name
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -1107,7 +1092,6 @@ def test_module_status_update_from_content_host_to_satellite(
         )
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -1191,7 +1175,6 @@ def test_module_status_update_without_force_upload_package_profile(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -1265,7 +1248,6 @@ def test_module_stream_update_from_satellite(session, default_location, vm_modul
         )
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -1305,7 +1287,6 @@ def test_syspurpose_attributes_empty(session, default_location, vm_module_stream
             assert details[spname] == ''
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -1348,7 +1329,6 @@ def test_set_syspurpose_attributes_cli(session, default_location, vm_module_stre
             assert details[spname] == spdata[1]
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -1395,7 +1375,6 @@ def test_unset_syspurpose_attributes_cli(session, default_location, vm_module_st
             assert details[spname] == ''
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
     [
@@ -1438,7 +1417,6 @@ def test_syspurpose_bulk_action(session, default_location, vm):
             assert val in result.stdout
 
 
-@pytest.mark.tier3
 def test_pagination_multiple_hosts_multiple_pages(session, module_host_template, target_sat):
     """Create hosts to fill more than one page, sort on OS, check pagination.
 
@@ -1495,7 +1473,6 @@ def test_pagination_multiple_hosts_multiple_pages(session, module_host_template,
         assert int(total_items_found) >= host_num
 
 
-@pytest.mark.tier3
 def test_search_for_virt_who_hypervisors(session, default_location, module_target_sat):
     """
     Search the virt_who hypervisors with hypervisor=True or hypervisor=False.

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -13,12 +13,10 @@
 """
 
 from fauxfactory import gen_string
-import pytest
 
 from robottelo.constants import FAKE_FILE_NEW_NAME, REPOS, DataFile
 
 
-@pytest.mark.tier2
 def test_positive_create_cv(session, target_sat):
     """Able to create cv and search for it
 
@@ -38,7 +36,6 @@ def test_positive_create_cv(session, target_sat):
         assert session.contentview_new.search(cv)[0]['Name'] == cv
 
 
-@pytest.mark.tier2
 def test_version_table_read(session, function_sca_manifest_org, target_sat):
     """Able to read CV version package details, which includes the Epoch tab
 
@@ -79,7 +76,6 @@ def test_version_table_read(session, function_sca_manifest_org, target_sat):
         assert response[0]['Arch'] == packages['results'][0]['arch']
 
 
-@pytest.mark.tier2
 def test_no_blank_page_on_language_switch(session, target_sat, module_org):
     """Able to view the new CV UI when the language is set to something other
     than English
@@ -110,7 +106,6 @@ def test_no_blank_page_on_language_switch(session, target_sat, module_org):
         assert session.contentview_new.read_french_lang_cv()
 
 
-@pytest.mark.tier2
 def test_file_cv_display(session, target_sat, module_org, module_product):
     """Content-> Files displays only the Content Views associated with that file
 

--- a/tests/foreman/ui/test_contentview_old.py
+++ b/tests/foreman/ui/test_contentview_old.py
@@ -63,7 +63,6 @@ def module_prod(module_org, module_target_sat):
     return module_target_sat.api.Product(organization=module_org).create()
 
 
-@pytest.mark.tier2
 def test_positive_add_custom_content(session, module_target_sat):
     """Associate custom content in a view
 
@@ -89,7 +88,6 @@ def test_positive_add_custom_content(session, module_target_sat):
         assert cv['repositories']['resources']['assigned'][0]['Name'] == repo_name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_target_sat, module_org, target_sat):
     """Create content view with yum repo, publish it and promote it to Library
@@ -128,7 +126,6 @@ def test_positive_end_to_end(session, module_target_sat, module_org, target_sat)
         assert f'Promoted to {env_name}' in result['Status']
 
 
-@pytest.mark.tier2
 def test_positive_publish_version_changes_in_source_env(session, module_target_sat, module_org):
     """When publishing new version to environment, version gets updated
 
@@ -179,7 +176,6 @@ def test_positive_publish_version_changes_in_source_env(session, module_target_s
         ]
 
 
-@pytest.mark.tier2
 def test_positive_repo_count_for_composite_cv(session, module_target_sat, module_org, target_sat):
     """Create some content views with synchronized repositories and
     promoted to one lce. Add them to composite content view and check repo
@@ -225,7 +221,6 @@ def test_positive_repo_count_for_composite_cv(session, module_target_sat, module
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_create_composite(
     session, module_prod, module_entitlement_manifest_org, target_sat
@@ -279,7 +274,6 @@ def test_positive_create_composite(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_add_rh_content(
     session, module_target_sat, function_entitlement_manifest_org, target_sat
 ):
@@ -314,7 +308,6 @@ def test_positive_add_rh_content(
         assert cv['repositories']['resources']['assigned'][0]['Name'] == rh_repo['name']
 
 
-@pytest.mark.tier2
 def test_positive_add_docker_repo(session, module_target_sat, module_org, module_prod):
     """Add one Docker-type repository to a non-composite content view
 
@@ -336,7 +329,6 @@ def test_positive_add_docker_repo(session, module_target_sat, module_org, module
         assert cv['docker_repositories']['resources']['assigned'][0]['Name'] == repo.name
 
 
-@pytest.mark.tier2
 def test_positive_add_docker_repos(session, module_target_sat, module_org, module_prod):
     """Add multiple Docker-type repositories to a non-composite
     content view.
@@ -368,7 +360,6 @@ def test_positive_add_docker_repos(session, module_target_sat, module_org, modul
         }
 
 
-@pytest.mark.tier2
 def test_positive_add_synced_docker_repo(session, module_target_sat, module_org, module_prod):
     """Create and sync a docker repository, then add it to content view
 
@@ -394,7 +385,6 @@ def test_positive_add_synced_docker_repo(session, module_target_sat, module_org,
         assert cv['docker_repositories']['resources']['assigned'][0]['Sync State'] == 'Success'
 
 
-@pytest.mark.tier2
 def test_positive_add_docker_repo_to_ccv(session, module_target_sat, module_org, module_prod):
     """Add one docker repository to a composite content view
 
@@ -424,7 +414,6 @@ def test_positive_add_docker_repo_to_ccv(session, module_target_sat, module_org,
         assert '1 Repositories' in ccv['content_views']['resources']['assigned'][0]['Content']
 
 
-@pytest.mark.tier2
 def test_positive_add_docker_repos_to_ccv(session, module_target_sat, module_org, module_prod):
     """Add multiple docker repositories to a composite content view.
 
@@ -461,7 +450,6 @@ def test_positive_add_docker_repos_to_ccv(session, module_target_sat, module_org
         )
 
 
-@pytest.mark.tier2
 def test_positive_publish_with_docker_repo(session, module_target_sat, module_org, module_prod):
     """Add docker repository to content view and publish it once.
 
@@ -486,7 +474,6 @@ def test_positive_publish_with_docker_repo(session, module_target_sat, module_or
         assert cv['versions']['table'][0]['Version'] == VERSION
 
 
-@pytest.mark.tier2
 def test_positive_publish_with_docker_repo_composite(
     session, module_target_sat, module_org, module_prod
 ):
@@ -518,7 +505,6 @@ def test_positive_publish_with_docker_repo_composite(
         assert '1 Repositories' in ccv['content_views']['resources']['assigned'][0]['Content']
 
 
-@pytest.mark.tier2
 def test_positive_publish_multiple_with_docker_repo(
     session, module_target_sat, module_org, module_prod
 ):
@@ -543,7 +529,6 @@ def test_positive_publish_multiple_with_docker_repo(
             assert result['Version'] == f'Version {version + 1}.0'
 
 
-@pytest.mark.tier2
 def test_positive_publish_multiple_with_docker_repo_composite(
     session, module_target_sat, module_org, module_prod
 ):
@@ -573,7 +558,6 @@ def test_positive_publish_multiple_with_docker_repo_composite(
             assert result['Version'] == f'Version {version + 1}.0'
 
 
-@pytest.mark.tier2
 def test_positive_promote_with_docker_repo(session, module_target_sat, module_org, module_prod):
     """Add docker repository to content view and publish it.
     Then promote it to the next available lifecycle environment.
@@ -599,7 +583,6 @@ def test_positive_promote_with_docker_repo(session, module_target_sat, module_or
         assert lce.name in result['Environments']
 
 
-@pytest.mark.tier2
 def test_positive_promote_multiple_with_docker_repo(
     session, module_target_sat, module_org, module_prod
 ):
@@ -628,7 +611,6 @@ def test_positive_promote_multiple_with_docker_repo(
             assert lce.name in result['Environments']
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_promote_multiple_with_docker_repo_composite(
     session, module_target_sat, module_org, module_prod
@@ -661,7 +643,6 @@ def test_positive_promote_multiple_with_docker_repo_composite(
             assert lce.name in result['Environments']
 
 
-@pytest.mark.tier2
 def test_negative_add_components_to_non_composite(session, module_target_sat):
     """Attempt to associate components to a non-composite content view
 
@@ -683,7 +664,6 @@ def test_negative_add_components_to_non_composite(session, module_target_sat):
         assert 'Could not find "Content Views" tab' in str(context.value)
 
 
-@pytest.mark.tier2
 def test_positive_add_unpublished_cv_to_composite(session, module_target_sat):
     """Attempt to associate unpublished non-composite content view with
     composite content view.
@@ -714,7 +694,6 @@ def test_positive_add_unpublished_cv_to_composite(session, module_target_sat):
         session.contentview.add_cv(composite_cv_name, unpublished_cv_name)
 
 
-@pytest.mark.tier3
 def test_positive_add_non_composite_cv_to_composite(session, module_target_sat):
     """Attempt to associate both published and unpublished non-composite
     content views with composite content view.
@@ -773,7 +752,6 @@ def test_positive_add_non_composite_cv_to_composite(session, module_target_sat):
         assert result['Version'] == VERSION
 
 
-@pytest.mark.tier3
 def test_positive_check_composite_cv_addition_list_versions(session, module_target_sat):
     """Create new content view and publish two times. After that remove
     first content view version from the list and try to add that view to
@@ -812,7 +790,6 @@ def test_positive_check_composite_cv_addition_list_versions(session, module_targ
         assert cv_values[0]['Version'] == 'Always Use Latest (Currently 2.0) 2.0'
 
 
-@pytest.mark.tier2
 def test_negative_add_dupe_repos(session, module_target_sat, module_org, target_sat):
     """attempt to associate the same repo multiple times within a
     content view
@@ -837,7 +814,6 @@ def test_negative_add_dupe_repos(session, module_target_sat, module_org, target_
         assert 'checkbox' in error_message
 
 
-@pytest.mark.tier2
 def test_positive_publish_with_custom_content(session, module_target_sat, module_org, target_sat):
     """Attempt to publish a content view containing custom content
 
@@ -863,7 +839,6 @@ def test_positive_publish_with_custom_content(session, module_target_sat, module
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_publish_with_rh_content(
     session, module_target_sat, function_entitlement_manifest_org, target_sat
 ):
@@ -899,7 +874,6 @@ def test_positive_publish_with_rh_content(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_publish_composite_with_custom_content(
     session, function_entitlement_manifest_org, target_sat
@@ -983,7 +957,6 @@ def test_positive_publish_composite_with_custom_content(
         assert ccv['versions']['table'][0]['Version'] == VERSION
 
 
-@pytest.mark.tier2
 def test_positive_publish_version_changes_in_target_env(
     session, module_target_sat, module_org, target_sat
 ):
@@ -1043,7 +1016,6 @@ def test_positive_publish_version_changes_in_target_env(
             assert lce.name in result['Environments']
 
 
-@pytest.mark.tier2
 def test_positive_promote_with_custom_content(session, module_target_sat, module_org, target_sat):
     """Attempt to promote a content view containing custom content,
         check dashboard
@@ -1086,7 +1058,6 @@ def test_positive_promote_with_custom_content(session, module_target_sat, module
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_promote_with_rh_content(
     session, module_target_sat, function_entitlement_manifest_org, target_sat
 ):
@@ -1123,7 +1094,6 @@ def test_positive_promote_with_rh_content(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_promote_composite_with_custom_content(
     session, function_entitlement_manifest_org, target_sat
@@ -1216,7 +1186,6 @@ def test_positive_promote_composite_with_custom_content(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_publish_rh_content_with_errata_by_date_filter(
     session, module_target_sat, target_sat
 ):
@@ -1263,7 +1232,6 @@ def test_positive_publish_rh_content_with_errata_by_date_filter(
         assert not version.get('errata') or not len(version['errata']['table'])
 
 
-@pytest.mark.tier3
 def test_negative_add_same_package_filter_twice(session, module_target_sat, module_org, target_sat):
     """Update version of package inside exclusive cv package filter
 
@@ -1300,7 +1268,6 @@ def test_negative_add_same_package_filter_twice(session, module_target_sat, modu
             assert 'This package filter rule already exists.' in str(context.value)
 
 
-@pytest.mark.tier2
 def test_positive_remove_cv_version_from_default_env(
     session, module_target_sat, module_org, target_sat
 ):
@@ -1338,7 +1305,6 @@ def test_positive_remove_cv_version_from_default_env(
         assert ENVIRONMENT not in cvv['Environments']
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_remove_promoted_cv_version_from_default_env(
     session, module_target_sat, module_org, target_sat
@@ -1385,7 +1351,6 @@ def test_positive_remove_promoted_cv_version_from_default_env(
         assert cvv['yum_repositories']['table'][0]['Name']
 
 
-@pytest.mark.tier2
 def test_positive_remove_qe_promoted_cv_version_from_default_env(
     session, module_target_sat, module_org, target_sat
 ):
@@ -1441,7 +1406,6 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(
         assert all(item in cvv_table[0]['Environments'] for item in [dev_lce.name, qe_lce.name])
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.parametrize(
     'repos_collection',
@@ -1515,7 +1479,6 @@ def test_positive_remove_cv_version_from_env(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_delete_cv_promoted_to_multi_env(
     session, module_target_sat, module_org, target_sat
@@ -1560,7 +1523,6 @@ def test_positive_delete_cv_promoted_to_multi_env(
         assert cv not in lce_values['content_views']['resources']
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_delete_composite_version(session, module_target_sat, module_org, target_sat):
     """Delete a composite content-view version associated to 'Library'
@@ -1596,7 +1558,6 @@ def test_positive_delete_composite_version(session, module_target_sat, module_or
         assert ENVIRONMENT not in cvv['Environments']
 
 
-@pytest.mark.tier2
 def test_positive_delete_non_default_version(session, module_target_sat, target_sat):
     """Delete a content-view version associated to non-default
     environment
@@ -1631,7 +1592,6 @@ def test_positive_delete_non_default_version(session, module_target_sat, target_
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_delete_version_with_ak(session, module_target_sat):
     """Delete a content-view version that had associated activation key to it
 
@@ -1667,7 +1627,6 @@ def test_positive_delete_version_with_ak(session, module_target_sat):
         assert session.contentview.search_version(cv.name, VERSION)[0]['Version'] != VERSION
 
 
-@pytest.mark.tier2
 def test_positive_clone_within_same_env(session, module_target_sat, module_org, target_sat):
     """attempt to create new content view based on existing
     view within environment
@@ -1697,7 +1656,6 @@ def test_positive_clone_within_same_env(session, module_target_sat, module_org, 
         assert copy_cv['repositories']['resources']['assigned'][0]['Name'] == repo_name
 
 
-@pytest.mark.tier2
 def test_positive_clone_within_diff_env(session, module_target_sat, module_org, target_sat):
     """attempt to create new content view based on existing
     view, inside a different environment
@@ -1741,7 +1699,6 @@ def test_positive_clone_within_diff_env(session, module_target_sat, module_org, 
         assert lce.name not in result['Environments']
 
 
-@pytest.mark.tier2
 def test_positive_remove_filter(session, module_target_sat, module_org):
     """Create empty content views filter and remove it
 
@@ -1767,7 +1724,6 @@ def test_positive_remove_filter(session, module_target_sat, module_org):
         assert not session.contentviewfilter.search(cv.name, filter_name)
 
 
-@pytest.mark.tier2
 def test_positive_add_package_filter(session, module_target_sat, module_org, target_sat):
     """Add package to content views filter
 
@@ -1810,7 +1766,6 @@ def test_positive_add_package_filter(session, module_target_sat, module_org, tar
         assert expected_packages == actual_packages
 
 
-@pytest.mark.tier3
 def test_positive_add_package_inclusion_filter_and_publish(
     session, module_target_sat, module_org, target_sat
 ):
@@ -1857,7 +1812,6 @@ def test_positive_add_package_inclusion_filter_and_publish(
         assert not packages[0]['Name']
 
 
-@pytest.mark.tier3
 def test_positive_add_package_exclusion_filter_and_publish(
     session, module_target_sat, module_org, target_sat
 ):
@@ -1904,7 +1858,6 @@ def test_positive_add_package_exclusion_filter_and_publish(
         assert not packages[0]['Name']
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_remove_package_from_exclusion_filter(
     session, module_target_sat, module_org, target_sat
@@ -1953,7 +1906,6 @@ def test_positive_remove_package_from_exclusion_filter(
         assert packages[0]['Name'] == package_name
 
 
-@pytest.mark.tier3
 def test_positive_update_inclusive_filter_package_version(
     session, module_target_sat, module_org, target_sat
 ):
@@ -2018,7 +1970,6 @@ def test_positive_update_inclusive_filter_package_version(
         assert packages[0]['Version'] == '5.21'
 
 
-@pytest.mark.tier3
 def test_positive_update_exclusive_filter_package_version(
     session, module_target_sat, module_org, target_sat
 ):
@@ -2083,7 +2034,6 @@ def test_positive_update_exclusive_filter_package_version(
         assert packages[0]['Version'] == '0.71'
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_all_security_errata_by_date_range_filter(
     session, module_target_sat, module_org, target_sat
@@ -2136,7 +2086,6 @@ def test_positive_add_all_security_errata_by_date_range_filter(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 def test_positive_edit_rh_custom_spin(session, module_target_sat, target_sat):
     """Edit content views for a custom rh spin.  For example, modify a filter.
 
@@ -2196,7 +2145,6 @@ def test_positive_edit_rh_custom_spin(session, module_target_sat, target_sat):
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_promote_with_rh_custom_spin(session, module_target_sat, target_sat):
     """attempt to promote a content view containing a custom RH
     spin - i.e., contains filters.
@@ -2241,7 +2189,6 @@ def test_positive_promote_with_rh_custom_spin(session, module_target_sat, target
         assert f'Promoted to {lce.name}' in result['Status']
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_all_security_errata_by_id_filter(session, module_target_sat, module_org):
     """Create erratum filter to include only security errata and publish new
@@ -2288,7 +2235,6 @@ def test_positive_add_all_security_errata_by_id_filter(session, module_target_sa
         )
 
 
-@pytest.mark.tier3
 def test_positive_add_errata_filter(session, module_target_sat, module_org, target_sat):
     """add errata to content views filter
 
@@ -2325,7 +2271,6 @@ def test_positive_add_errata_filter(session, module_target_sat, module_org, targ
         }
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_module_stream_filter(session, module_target_sat, module_org, target_sat):
     """add module stream filter in a content view
@@ -2367,7 +2312,6 @@ def test_positive_add_module_stream_filter(session, module_target_sat, module_or
         }
 
 
-@pytest.mark.tier3
 def test_positive_add_package_group_filter(session, module_target_sat, module_org, target_sat):
     """add package group to content views filter
 
@@ -2400,7 +2344,6 @@ def test_positive_add_package_group_filter(session, module_target_sat, module_or
         assert cvf['content_tabs']['assigned'][0]['Name'] == package_group
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_update_filter_affected_repos(session, module_target_sat, module_org, target_sat):
     """Update content view package filter affected repos
@@ -2469,7 +2412,6 @@ def test_positive_update_filter_affected_repos(session, module_target_sat, modul
         assert packages[0]['Version'] == '3.10.232'
 
 
-@pytest.mark.tier3
 def test_positive_search_composite(session, module_target_sat):
     """Search for content view by its composite property criteria
 
@@ -2491,7 +2433,6 @@ def test_positive_search_composite(session, module_target_sat):
         }
 
 
-@pytest.mark.tier3
 def test_positive_publish_with_repo_with_disabled_http(
     session, module_target_sat, module_org, target_sat
 ):
@@ -2537,7 +2478,6 @@ def test_positive_publish_with_repo_with_disabled_http(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 @pytest.mark.parametrize(
     'repos_collection',
     [
@@ -2579,7 +2519,6 @@ def test_positive_subscribe_system_with_custom_content(
         )
 
 
-@pytest.mark.tier3
 def test_positive_delete_with_kickstart_repo_and_host_group(
     session, target_sat, smart_proxy_location
 ):
@@ -2657,7 +2596,6 @@ def test_positive_delete_with_kickstart_repo_and_host_group(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier3
 def test_positive_rh_mixed_content_end_to_end(
     session, module_prod, module_entitlement_manifest_org, target_sat
 ):
@@ -2706,7 +2644,6 @@ def test_positive_rh_mixed_content_end_to_end(
         assert session.contentview.search_version(cv_name, VERSION)[0]['Version'] != VERSION
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_errata_inc_update_list_package(session, module_target_sat, target_sat):
     """Publish incremental update with a new errata for a custom repo
@@ -2765,7 +2702,6 @@ def test_positive_errata_inc_update_list_package(session, module_target_sat, tar
         assert set(result[4:]).issubset(packages)
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_composite_child_inc_update(
     session, module_target_sat, rhel7_contenthost, target_sat
@@ -2884,7 +2820,6 @@ def test_positive_composite_child_inc_update(
         assert FAKE_2_CUSTOM_PACKAGE in packages_data
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_module_stream_end_to_end(session, module_target_sat, module_org, target_sat):
     """Create content view with custom module_stream contents, publish and promote it
@@ -2931,7 +2866,6 @@ def test_positive_module_stream_end_to_end(session, module_target_sat, module_or
         assert session.contentview.search(cv_name)[0]['Name'] != cv_name
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_search_module_streams_in_content_view(
     session, module_target_sat, module_org, target_sat
@@ -2968,7 +2902,6 @@ def test_positive_search_module_streams_in_content_view(
             assert module_streams[0]['Stream'] == module_version
 
 
-@pytest.mark.tier2
 def test_positive_non_admin_user_actions(
     session, module_target_sat, module_org, test_name, target_sat
 ):
@@ -3063,7 +2996,6 @@ def test_positive_non_admin_user_actions(
             assert cv.get(tab_name) is not None
 
 
-@pytest.mark.tier2
 def test_positive_readonly_user_actions(module_org, test_name, target_sat):
     """Attempt to view content views
 
@@ -3111,7 +3043,6 @@ def test_positive_readonly_user_actions(module_org, test_name, target_sat):
         assert cv_values['repositories']['resources']['assigned'][0]['Name'] == yum_repo.name
 
 
-@pytest.mark.tier2
 def test_negative_read_only_user_actions(
     session, module_target_sat, module_org, test_name, target_sat
 ):
@@ -3225,7 +3156,6 @@ def test_negative_read_only_user_actions(
         assert 'failed to reach [Delete]' in str(context.value)
 
 
-@pytest.mark.tier2
 def test_negative_non_readonly_user_actions(module_org, test_name, target_sat):
     """Attempt to view content views
 
@@ -3291,7 +3221,6 @@ def test_negative_non_readonly_user_actions(module_org, test_name, target_sat):
         assert 'Navigation failed to reach [All]' in str(context.value)
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_conservative_solve_dependencies(
     session, module_target_sat, module_org, target_sat
@@ -3370,7 +3299,6 @@ def test_positive_conservative_solve_dependencies(
             assert not package[0]['Name']
 
 
-@pytest.mark.tier2
 def test_positive_conservative_dep_solving_with_multiversion_packages(
     session, module_org, target_sat
 ):
@@ -3440,7 +3368,6 @@ def test_positive_conservative_dep_solving_with_multiversion_packages(
         assert package[0]['Version'] == '0.71'
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_depsolve_with_module_errata(session, module_target_sat, module_org, target_sat):
     """Allowing users to filter module streams in content views.  This test case does not test
@@ -3517,7 +3444,6 @@ def test_positive_depsolve_with_module_errata(session, module_target_sat, module
         assert result['errata']['table'][0]['Errata ID'] == settings.repos.yum_10.errata[0]
 
 
-@pytest.mark.tier2
 def test_positive_filter_by_pkg_group_name(session, module_target_sat, module_org, target_sat):
     """Publish a filtered version of a Content View, filtering on the package group's name.
 
@@ -3557,7 +3483,6 @@ def test_positive_filter_by_pkg_group_name(session, module_target_sat, module_or
         assert expected_packages == [pkg['Name'] for pkg in result['rpm_packages']['table']]
 
 
-@pytest.mark.tier3
 def test_positive_inc_update_should_not_fail(session, module_target_sat, module_org):
     """Incremental update after removing a package should not give a 400 error code
 
@@ -3614,7 +3539,6 @@ def test_positive_inc_update_should_not_fail(session, module_target_sat, module_
         assert packages[0]['Name'] == package1_name
 
 
-@pytest.mark.tier2
 def test_positive_no_duplicate_key_violate_unique_constraint_using_filters(
     session, module_entitlement_manifest_org, target_sat
 ):
@@ -3731,7 +3655,6 @@ def test_positive_no_duplicate_key_violate_unique_constraint_using_filters(
         assert packages_check['rpm_packages']['table'][1]['Name'] == packages[3]
 
 
-@pytest.mark.tier2
 def test_positive_inc_publish_cv(session, module_target_sat, module_org):
     """Ensure that the content count gets updated when doing incremental update
 

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -20,7 +20,6 @@ from robottelo.constants import FAKE_7_CUSTOM_PACKAGE
 from robottelo.utils.datafactory import gen_string
 
 
-@pytest.mark.tier2
 def test_positive_host_configuration_status(session, target_sat):
     """Check if the Host Configuration Status Widget links are working
 
@@ -88,7 +87,6 @@ def test_positive_host_configuration_status(session, target_sat):
                 assert len(values['table']) == 0
 
 
-@pytest.mark.tier2
 def test_positive_host_configuration_chart(session, target_sat):
     """Check if the Host Configuration Chart is working in the Dashboard UI
 
@@ -114,7 +112,6 @@ def test_positive_host_configuration_chart(session, target_sat):
 
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_task_status(session, target_sat):
     """Check if the Task Status is working in the Dashboard UI and
         filter from Tasks index page is working correctly
@@ -172,7 +169,6 @@ def test_positive_task_status(session, target_sat):
 @pytest.mark.upgrade
 @pytest.mark.no_containers
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 @pytest.mark.parametrize(
@@ -258,7 +254,6 @@ def test_positive_user_access_with_host_filter(
         assert settings.repos.yum_3.errata[25] in [e['Errata'].split()[0] for e in errata_values]
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_sync_overview_widget(session, module_product, module_target_sat):
     """Check if the Sync Overview widget is working in the Dashboard UI

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -47,7 +47,6 @@ def _is_host_reachable(host, retries=12, iteration_sleep=5, expect_reachable=Tru
     return bool(result.status)
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.on_premises_provisioning
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
@@ -128,7 +127,6 @@ def test_positive_provision_pxe_host(
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.on_premises_provisioning
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
@@ -248,7 +246,6 @@ def test_positive_custom_provision_pxe_host(
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')
 
 
-@pytest.mark.tier3
 def test_positive_update_name(
     session, discovery_org, discovery_location, module_discovery_hostgroup, discovered_host
 ):
@@ -286,7 +283,6 @@ def test_positive_update_name(
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.on_premises_provisioning
 @pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
@@ -360,7 +356,6 @@ def test_positive_auto_provision_host_with_rule(
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')
 
 
-@pytest.mark.tier3
 def test_positive_delete(session, discovery_org, discovery_location, discovered_host):
     """Delete the selected discovered host
 
@@ -380,7 +375,6 @@ def test_positive_delete(session, discovery_org, discovery_location, discovered_
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')
 
 
-@pytest.mark.tier3
 def test_positive_update_default_taxonomies(session, discovery_org, discovery_location, target_sat):
     """Change the default organization and location of more than one
     discovered hosts from 'Select Action' drop down

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -64,7 +64,6 @@ def gen_int32(min_value=1):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 def test_positive_crud_with_non_admin_user(
     module_location, manager_user, module_org, module_target_sat
 ):
@@ -124,7 +123,6 @@ def test_positive_crud_with_non_admin_user(
         assert 'No Discovery Rules found in this context' in dr_val
 
 
-@pytest.mark.tier2
 def test_negative_delete_rule_with_non_admin_user(
     request, module_location, module_org, module_target_sat, reader_user
 ):
@@ -167,7 +165,6 @@ def test_negative_delete_rule_with_non_admin_user(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 def test_positive_list_host_based_on_rule_search_query(
     request, session, module_org, module_location, module_discovery_env, target_sat
 ):
@@ -250,7 +247,6 @@ def test_positive_list_host_based_on_rule_search_query(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_location, module_target_sat):
     """Perform end to end testing for discovery rule component.

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -23,7 +23,6 @@ def valid_domain_name():
     return list(valid_domain_names(interface='ui').values())[0]
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize(
     'param_value', [gen_string('alpha', 255), ''], ids=['long_value', 'blank_value']
 )
@@ -47,7 +46,6 @@ def test_positive_set_parameter(session, valid_domain_name, param_value):
     )
 
 
-@pytest.mark.tier2
 def test_negative_set_parameter(session, valid_domain_name):
     """Set a parameter in a domain with 256 chars in name and value.
 
@@ -68,7 +66,6 @@ def test_negative_set_parameter(session, valid_domain_name):
         assert 'Name is too long' in str(context.value)
 
 
-@pytest.mark.tier2
 def test_negative_set_parameter_same(session, valid_domain_name):
     """Again set the same parameter for domain with name and value.
 
@@ -89,7 +86,6 @@ def test_negative_set_parameter_same(session, valid_domain_name):
         assert 'Name has already been taken' in str(context.value)
 
 
-@pytest.mark.tier2
 def test_positive_remove_parameter(session, valid_domain_name):
     """Remove a selected domain parameter
 
@@ -111,7 +107,6 @@ def test_positive_remove_parameter(session, valid_domain_name):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(
     session, module_org, module_location, valid_domain_name, module_target_sat

--- a/tests/foreman/ui/test_eol_banner.py
+++ b/tests/foreman/ui/test_eol_banner.py
@@ -36,7 +36,6 @@ def check_links(session):
 
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_eol_banner_e2e(session, target_sat, test_name):
     """Check if the EOL banner is displayed correctly
 

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -291,7 +291,6 @@ def registered_contenthost(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.parametrize('registered_contenthost', [[CUSTOM_REPO_URL]], indirect=True)
 @pytest.mark.no_containers
@@ -484,7 +483,6 @@ def test_end_to_end(
         assert FAKE_2_CUSTOM_PACKAGE in _package_version
 
 
-@pytest.mark.tier2
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.parametrize('registered_contenthost', [[CUSTOM_REPO_3_URL]], indirect=True)
@@ -707,7 +705,6 @@ def test_host_content_errata_tab_pagination(
         )
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_list(target_sat, session):
     """View all errata in an Org
@@ -770,7 +767,6 @@ def test_positive_list(target_sat, session):
         )
 
 
-@pytest.mark.tier2
 def test_positive_list_permission(
     test_name,
     module_target_sat,
@@ -832,7 +828,6 @@ def test_positive_list_permission(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.no_containers
 def test_positive_apply_for_all_hosts(
@@ -965,7 +960,6 @@ def test_positive_apply_for_all_hosts(
                 assert packages_rows[0]['Installed Package'] == FAKE_2_CUSTOM_PACKAGE
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.rhel_ver_match('8')
 def test_positive_view_cve(session, module_product, module_sca_manifest_org, target_sat):
@@ -1000,7 +994,6 @@ def test_positive_view_cve(session, module_product, module_sca_manifest_org, tar
         assert errata_values['details']['cves'] == 'N/A'
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_filter_by_environment(
     module_sca_manifest_org,
@@ -1085,7 +1078,6 @@ def test_positive_filter_by_environment(
             )
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'registered_contenthost',
@@ -1160,7 +1152,6 @@ def test_positive_content_host_previous_env(
         assert content_host_erratum[0]['Id'] == CUSTOM_REPO_ERRATA_ID
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.parametrize(
     'registered_contenthost',
@@ -1192,7 +1183,6 @@ def test_positive_check_errata(session, registered_contenthost):
         assert read_errata['Content']['Errata']['table'][0]['Errata'] == CUSTOM_REPO_ERRATA_ID
 
 
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[8, 9]')
 @pytest.mark.parametrize(
     'registered_contenthost',
@@ -1264,7 +1254,6 @@ def test_positive_host_content_library(
         assert all_chost_erratum[0]['Id'] == CUSTOM_REPO_ERRATA_ID
 
 
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.parametrize(
     'registered_contenthost',
@@ -1329,7 +1318,6 @@ def test_positive_errata_search_type(session, module_sca_manifest_org, registere
         assert errata_ids == sorted(FAKE_11_YUM_ENHANCEMENT_ERRATUM)
 
 
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.parametrize(
     'registered_contenthost',
@@ -1435,7 +1423,6 @@ def test_positive_show_count_on_host_pages(session, module_org, registered_conte
             )
 
 
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.parametrize(
     'registered_contenthost',
@@ -1506,7 +1493,6 @@ def test_positive_check_errata_counts_by_type_on_host_details_page(
         assert errata_type_counts['Enhancement'] == 1
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.parametrize('setting_update', ['errata_status_installable'], indirect=True)
@@ -1610,7 +1596,6 @@ def test_positive_filtered_errata_status_installable_param(
             assert expected_values[key] in actual_values[key], 'Expected text not found'
 
 
-@pytest.mark.tier3
 def test_content_host_errata_search_commands(
     module_product,
     target_sat,

--- a/tests/foreman/ui/test_hardwaremodel.py
+++ b/tests/foreman/ui/test_hardwaremodel.py
@@ -15,7 +15,6 @@ import pytest
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, host_ui_options, module_target_sat):
     """Perform end to end testing for hardware model component

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -160,7 +160,6 @@ def new_host_ui(target_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 def test_positive_end_to_end(session, module_global_params, target_sat, host_ui_options):
     """Create a new Host with parameters, config group. Check host presence on
         the dashboard. Update name with 'new' prefix and delete.
@@ -224,7 +223,6 @@ def test_positive_end_to_end(session, module_global_params, target_sat, host_ui_
         assert not target_sat.api.Host().search(query={'search': f'name="{new_host_name}"'})
 
 
-@pytest.mark.tier4
 def test_positive_read_from_details_page(session, module_host_template):
     """Create new Host and read all its content through details page
 
@@ -256,7 +254,6 @@ def test_positive_read_from_details_page(session, module_host_template):
         assert 'Admin User' in values['properties']['properties_table']['Owner']
 
 
-@pytest.mark.tier4
 def test_positive_read_from_edit_page(session, host_ui_options):
     """Create new Host and read all its content through edit page
 
@@ -300,7 +297,6 @@ def test_positive_read_from_edit_page(session, host_ui_options):
         assert values['additional_information']['enabled'] is True
 
 
-@pytest.mark.tier2
 def test_positive_assign_taxonomies(
     session, module_org, smart_proxy_location, target_sat, function_org, function_location_with_org
 ):
@@ -361,7 +357,6 @@ def test_positive_assign_taxonomies(
 
 
 @pytest.mark.skip_if_not_set('oscap')
-@pytest.mark.tier2
 def test_positive_assign_compliance_policy(
     session, scap_policy, second_scap_policy, target_sat, function_host
 ):
@@ -425,7 +420,6 @@ def test_positive_assign_compliance_policy(
 
 
 @pytest.mark.skipif((settings.ui.webdriver != 'chrome'), reason='Only tested on Chrome')
-@pytest.mark.tier3
 def test_positive_export(session, target_sat, function_org, function_location):
     """Create few hosts and export them via UI
 
@@ -453,7 +447,6 @@ def test_positive_export(session, target_sat, function_org, function_location):
 @pytest.mark.skipif(
     (settings.ui.webdriver != 'chrome'), reason='Currently only chrome is supported'
 )
-@pytest.mark.tier3
 def test_positive_export_selected_columns(target_sat, current_sat_location):
     """Select certain columns in the hosts table and check that they are exported in the CSV file.
 
@@ -511,7 +504,6 @@ def test_positive_export_selected_columns(target_sat, current_sat_location):
             )
 
 
-@pytest.mark.tier4
 def test_positive_create_with_inherited_params(
     session, target_sat, function_org, function_location_with_org
 ):
@@ -551,7 +543,6 @@ def test_positive_create_with_inherited_params(
         )
 
 
-@pytest.mark.tier4
 def test_negative_delete_primary_interface(session, host_ui_options):
     """Attempt to delete primary interface of a host
 
@@ -573,7 +564,6 @@ def test_negative_delete_primary_interface(session, host_ui_options):
         assert 'Interface Delete button is disabled' in str(context.value)
 
 
-@pytest.mark.tier2
 def test_positive_view_hosts_with_non_admin_user(
     test_name, module_org, smart_proxy_location, target_sat
 ):
@@ -613,7 +603,6 @@ def test_positive_view_hosts_with_non_admin_user(
         assert content_host['breadcrumb'] == created_host.name
 
 
-@pytest.mark.tier3
 def test_positive_remove_parameter_non_admin_user(
     test_name, module_org, smart_proxy_location, target_sat, expected_permissions
 ):
@@ -663,7 +652,6 @@ def test_positive_remove_parameter_non_admin_user(
         assert not values['parameters']['host_params']
 
 
-@pytest.mark.tier3
 def test_negative_remove_parameter_non_admin_user(
     test_name, module_org, smart_proxy_location, target_sat, expected_permissions
 ):
@@ -717,7 +705,6 @@ def test_negative_remove_parameter_non_admin_user(
         assert 'Remove Parameter' in str(context.value)
 
 
-@pytest.mark.tier3
 def test_positive_check_permissions_affect_create_procedure(
     test_name, smart_proxy_location, target_sat, function_org, function_role, expected_permissions
 ):
@@ -840,7 +827,6 @@ def test_positive_check_permissions_affect_create_procedure(
             assert create_values[tab_name][field_name] == host_field['expected_value']
 
 
-@pytest.mark.tier2
 def test_positive_search_by_parameter(session, module_org, smart_proxy_location, target_sat):
     """Search for the host by global parameter assigned to it
 
@@ -871,7 +857,6 @@ def test_positive_search_by_parameter(session, module_org, smart_proxy_location,
         assert values[0]['Name'] == param_host.name
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.no_containers
 def test_positive_search_by_reported_data(
@@ -916,7 +901,6 @@ def test_positive_search_by_reported_data(
             )
 
 
-@pytest.mark.tier2
 @pytest.mark.usefixtures('function_host')
 def test_positive_search_by_configuration_status_alias(target_sat):
     """
@@ -954,7 +938,6 @@ def test_positive_search_by_configuration_status_alias(target_sat):
             )
 
 
-@pytest.mark.tier4
 def test_positive_search_by_parameter_with_different_values(
     session, module_org, smart_proxy_location, target_sat
 ):
@@ -987,7 +970,6 @@ def test_positive_search_by_parameter_with_different_values(
             assert values[0]['Name'] == host.name
 
 
-@pytest.mark.tier2
 def test_positive_search_by_parameter_with_prefix(
     session, smart_proxy_location, target_sat, function_org
 ):
@@ -1022,7 +1004,6 @@ def test_positive_search_by_parameter_with_prefix(
         assert {value['Name'] for value in values} == {param_host.name, additional_host.name}
 
 
-@pytest.mark.tier2
 def test_positive_search_by_parameter_with_operator(
     session, smart_proxy_location, target_sat, function_org
 ):
@@ -1061,7 +1042,6 @@ def test_positive_search_by_parameter_with_operator(
         assert {value['Name'] for value in values} == {param_host.name, additional_host.name}
 
 
-@pytest.mark.tier2
 def test_positive_search_with_org_and_loc_context(
     session, target_sat, function_org, function_location
 ):
@@ -1087,7 +1067,6 @@ def test_positive_search_with_org_and_loc_context(
         assert session.host.search(host.name)[0]['Name'] == host.name
 
 
-@pytest.mark.tier2
 def test_positive_search_by_org(session, smart_proxy_location, target_sat):
     """Search for host by specifying host's organization name
 
@@ -1107,7 +1086,6 @@ def test_positive_search_by_org(session, smart_proxy_location, target_sat):
         assert session.host.search(f'organization = "{org.name}"')[0]['Name'] == host.name
 
 
-@pytest.mark.tier2
 def test_positive_validate_inherited_cv_lce_ansiblerole(session, target_sat, module_host_template):
     """Create a host with hostgroup specified via CLI. Make sure host
     inherited hostgroup's lifecycle environment, content view and both
@@ -1180,7 +1158,6 @@ def test_positive_validate_inherited_cv_lce_ansiblerole(session, target_sat, mod
         assert host.name in [host.name for host in matching_hosts]
 
 
-@pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_bulk_delete_host(session, smart_proxy_location, target_sat, function_org):
     """Delete multiple hosts from the list
@@ -1218,7 +1195,6 @@ def test_positive_bulk_delete_host(session, smart_proxy_location, target_sat, fu
 
 
 # ------------------------------ NEW HOST UI DETAILS ----------------------------
-@pytest.mark.tier4
 def test_positive_read_details_page_from_new_ui(session, host_ui_options):
     """Create new Host and read all its content through details page
 
@@ -1242,7 +1218,6 @@ def test_positive_read_details_page_from_new_ui(session, host_ui_options):
         assert values['overview']['details']['details']['comment'] == 'Host with fake data'
 
 
-@pytest.mark.tier4
 def test_positive_manage_table_columns(
     target_sat, test_name, ui_hosts_columns_user, current_sat_org, current_sat_location
 ):
@@ -1289,7 +1264,6 @@ def test_positive_manage_table_columns(
             assert (column in displayed_columns) is is_displayed
 
 
-@pytest.mark.tier2
 def test_all_hosts_manage_columns(target_sat, new_host_ui):
     """Verify that the manage columns widget changes the columns appropriately
 
@@ -1324,7 +1298,6 @@ def test_all_hosts_manage_columns(target_sat, new_host_ui):
             assert (column in displayed_columns) is is_displayed
 
 
-@pytest.mark.tier4
 def test_positive_host_details_read_templates(
     session, target_sat, current_sat_org, current_sat_location
 ):
@@ -1358,7 +1331,6 @@ def test_positive_host_details_read_templates(
     assert set(api_templates) == set(ui_templates)
 
 
-@pytest.mark.tier4
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
@@ -1471,7 +1443,6 @@ def test_positive_update_delete_package(
         assert result.status != 0
 
 
-@pytest.mark.tier4
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
@@ -1551,7 +1522,6 @@ def test_positive_apply_erratum(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier4
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
@@ -1661,7 +1631,6 @@ def module_puppet_enabled_proxy_with_loc(
     session_puppet_enabled_proxy.update(['location'])
 
 
-@pytest.mark.tier3
 def test_positive_inherit_puppet_env_from_host_group_when_action(
     session_puppet_enabled_sat, module_puppet_org, module_puppet_loc, module_puppet_environment
 ):
@@ -1711,7 +1680,6 @@ def test_positive_inherit_puppet_env_from_host_group_when_action(
         assert values['host']['puppet_environment'] == module_puppet_environment.name
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.usefixtures('module_puppet_enabled_proxy_with_loc')
 def test_positive_create_with_puppet_class(
@@ -1772,7 +1740,6 @@ def test_positive_create_with_puppet_class(
         )
 
 
-@pytest.mark.tier2
 def test_positive_inherit_puppet_env_from_host_group_when_create(
     session_puppet_enabled_sat, module_env_search, module_puppet_org, module_puppet_loc
 ):
@@ -1815,7 +1782,6 @@ def test_positive_inherit_puppet_env_from_host_group_when_create(
         assert values['host']['inherit_puppet_environment'] is False
 
 
-@pytest.mark.tier3
 @pytest.mark.usefixtures('module_puppet_enabled_proxy_with_loc')
 def test_positive_set_multi_line_and_with_spaces_parameter_value(
     session_puppet_enabled_sat,
@@ -1885,7 +1851,6 @@ def test_positive_set_multi_line_and_with_spaces_parameter_value(
 
 
 @pytest.mark.pit_client
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('[^6].*')
 def test_positive_tracer_enable_reload(tracer_install_host, target_sat):
     """Using the new Host UI,enable tracer and verify that the page reloads
@@ -1927,7 +1892,6 @@ def test_positive_tracer_enable_reload(tracer_install_host, target_sat):
         assert tracer['title'] == "No applications to restart"
 
 
-@pytest.mark.tier2
 def test_all_hosts_delete(target_sat, function_org, function_location, new_host_ui):
     """Create a host and delete it through All Hosts UI
 
@@ -1957,7 +1921,6 @@ def test_all_hosts_delete(target_sat, function_org, function_location, new_host_
         session.all_hosts.manage_table_columns({header: True for header in stripped_headers})
 
 
-@pytest.mark.tier2
 def test_all_hosts_bulk_delete(target_sat, function_org, function_location, new_host_ui):
     """Create several hosts, and delete them via Bulk Actions in All Hosts UI
 
@@ -1977,7 +1940,6 @@ def test_all_hosts_bulk_delete(target_sat, function_org, function_location, new_
         assert session.all_hosts.bulk_delete_all()
 
 
-@pytest.mark.tier2
 def test_all_hosts_bulk_cve_reassign(
     target_sat, module_org, module_location, module_lce, module_cv, new_host_ui
 ):
@@ -2030,7 +1992,6 @@ def test_all_hosts_bulk_cve_reassign(
             assert row['Lifecycle environment'] == lce2.name
 
 
-@pytest.mark.tier2
 def test_all_hosts_redirect_button(target_sat):
     """Verify that the New UI button on the old Host page correctly redirects
     to the All Hosts UI
@@ -2048,7 +2009,6 @@ def test_all_hosts_redirect_button(target_sat):
         assert "/new/hosts" in url
 
 
-@pytest.mark.tier2
 def test_all_hosts_bulk_build_management(target_sat, function_org, function_location, new_host_ui):
     """Create several hosts, and manage them via Build Management in All Host UI
 
@@ -2236,7 +2196,6 @@ def test_change_content_source(session, change_content_source_prep, rhel_content
         )
 
 
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('8')
 def test_positive_page_redirect_after_update(target_sat, current_sat_location):
     """Check that page redirects correctly after editing a host without making any changes.
@@ -2262,7 +2221,6 @@ def test_positive_page_redirect_after_update(target_sat, current_sat_location):
         assert client.hostname in session.browser.url
 
 
-@pytest.mark.tier3
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('8')
 def test_host_status_honors_taxonomies(
@@ -2649,7 +2607,6 @@ def test_positive_manage_packages(
     indirect=True,
 )
 @pytest.mark.no_containers
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('8')
 def test_all_hosts_manage_errata(
     session,

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -203,7 +203,6 @@ def _get_content_repository_urls(repos_collection, lce, content_view, module_tar
     return repos_urls
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(module_target_sat, module_org_with_parameter, smart_proxy_location):
     """Perform end to end testing for host collection component
@@ -250,7 +249,6 @@ def test_positive_end_to_end(module_target_sat, module_org_with_parameter, smart
         assert not session.hostcollection.search(new_name)
 
 
-@pytest.mark.tier2
 def test_negative_install_via_remote_execution(
     module_target_sat, module_org_with_parameter, smart_proxy_location
 ):
@@ -289,7 +287,6 @@ def test_negative_install_via_remote_execution(
         assert {host.name for host in hosts} == {host['Host'] for host in job_values['hosts_table']}
 
 
-@pytest.mark.tier2
 def test_negative_install_via_custom_remote_execution(
     module_target_sat, module_org_with_parameter, smart_proxy_location
 ):
@@ -329,7 +326,6 @@ def test_negative_install_via_custom_remote_execution(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier3
 def test_positive_add_host(session, module_target_sat):
     """Check if host can be added to Host Collection
 
@@ -359,7 +355,6 @@ def test_positive_add_host(session, module_target_sat):
         assert hc_values['hosts']['resources']['assigned'][0]['Name'] == host.name
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_install_package(
     session, module_org_with_parameter, smart_proxy_location, vm_content_hosts, vm_host_collection
@@ -383,7 +378,6 @@ def test_positive_install_package(
         assert _is_package_installed(vm_content_hosts, constants.FAKE_0_CUSTOM_PACKAGE_NAME)
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_remove_package(
     session, module_org_with_parameter, smart_proxy_location, vm_content_hosts, vm_host_collection
@@ -410,7 +404,6 @@ def test_positive_remove_package(
         )
 
 
-@pytest.mark.tier3
 def test_positive_upgrade_package(
     session, module_org_with_parameter, smart_proxy_location, vm_content_hosts, vm_host_collection
 ):
@@ -434,7 +427,6 @@ def test_positive_upgrade_package(
         assert _is_package_installed(vm_content_hosts, constants.FAKE_2_CUSTOM_PACKAGE)
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_install_package_group(
     session, module_org_with_parameter, smart_proxy_location, vm_content_hosts, vm_host_collection
@@ -460,7 +452,6 @@ def test_positive_install_package_group(
             assert _is_package_installed(vm_content_hosts, package)
 
 
-@pytest.mark.tier3
 def test_positive_remove_package_group(
     session, module_org_with_parameter, smart_proxy_location, vm_content_hosts, vm_host_collection
 ):
@@ -490,7 +481,6 @@ def test_positive_remove_package_group(
             assert not _is_package_installed(vm_content_hosts, package, expect_installed=False)
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_install_errata(
     session, module_org_with_parameter, smart_proxy_location, vm_content_hosts, vm_host_collection
@@ -517,7 +507,6 @@ def test_positive_install_errata(
         assert _is_package_installed(vm_content_hosts, constants.FAKE_2_CUSTOM_PACKAGE)
 
 
-@pytest.mark.tier3
 def test_positive_change_assigned_content(
     session,
     module_org_with_parameter,
@@ -626,7 +615,6 @@ def test_positive_change_assigned_content(
             assert set(expected_repo_urls) == set(client_repo_urls)
 
 
-@pytest.mark.tier3
 def test_negative_hosts_limit(module_target_sat, module_org_with_parameter, smart_proxy_location):
     """Check that Host limit actually limits usage
 
@@ -676,7 +664,6 @@ def test_negative_hosts_limit(module_target_sat, module_org_with_parameter, smar
         )
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
@@ -724,7 +711,6 @@ def test_positive_install_module_stream(
         )
 
 
-@pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -20,7 +20,6 @@ from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_location, module_target_sat):
     """Perform end to end testing for host group component
 
@@ -67,7 +66,6 @@ def test_positive_end_to_end(session, module_org, module_location, module_target
         assert not module_target_sat.api.HostGroup().search(query={'search': f'name={new_name}'})
 
 
-@pytest.mark.tier2
 def test_negative_delete_with_discovery_rule(
     session, module_org, module_location, module_target_sat
 ):
@@ -99,7 +97,6 @@ def test_negative_delete_with_discovery_rule(
         assert session.hostgroup.search(hostgroup.name)[0]['Name'] == hostgroup.name
 
 
-@pytest.mark.tier2
 def test_create_with_config_group(module_puppet_org, module_puppet_loc, session_puppet_enabled_sat):
     """Create new host group with assigned config group to it
 
@@ -130,7 +127,6 @@ def test_create_with_config_group(module_puppet_org, module_puppet_loc, session_
         assert hostgroup_values['puppet_enc']['config_groups']['assigned'][0] == config_group.name
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_create_with_puppet_class(module_puppet_org, module_puppet_loc, session_puppet_enabled_sat):
     """Create new host group with assigned puppet class to it
@@ -195,7 +191,6 @@ def test_positive_create_new_host():
     pass
 
 
-@pytest.mark.tier2
 def test_positive_nested_host_groups(
     session, module_org, module_lce, module_published_cv, module_ak_cv_lce, target_sat
 ):
@@ -268,7 +263,6 @@ def test_positive_nested_host_groups(
         assert not target_sat.api.HostGroup().search(query={'search': f'name={child_hg_name}'})
 
 
-@pytest.mark.tier2
 def test_positive_clone_host_groups(
     session, module_org, module_lce, module_published_cv, module_ak_cv_lce, target_sat
 ):

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -34,7 +34,6 @@ def function_spec_char_user(target_sat, session_auth_proxy):
     session_auth_proxy.remove_user(name)
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_create_update_delete(module_org, module_location, target_sat):
     """Create new http-proxy with attributes, update and delete it.
@@ -78,7 +77,6 @@ def test_positive_create_update_delete(module_org, module_location, target_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_assign_http_proxy_to_products_repositories(
     module_org, module_location, target_sat
@@ -201,7 +199,6 @@ def test_positive_assign_http_proxy_to_products_repositories(
         )
 
 
-@pytest.mark.tier1
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('setting_update', ['content_default_http_proxy'], indirect=True)
 def test_set_default_http_proxy(module_org, module_location, setting_update, target_sat):
@@ -247,7 +244,6 @@ def test_set_default_http_proxy(module_org, module_location, setting_update, tar
         assert result['table'][0]['Value'] == "Empty"
 
 
-@pytest.mark.tier1
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('setting_update', ['content_default_http_proxy'], indirect=True)
 def test_check_http_proxy_value_repository_details(
@@ -313,7 +309,6 @@ def test_check_http_proxy_value_repository_details(
         assert repo_values['repo_content']['http_proxy_policy'] == 'Global Default (None)'
 
 
-@pytest.mark.tier3
 @pytest.mark.run_in_one_thread
 def test_http_proxy_containing_special_characters(
     request,
@@ -398,7 +393,6 @@ def test_http_proxy_containing_special_characters(
         assert repo.content_counts['rpm'] > 0, 'Where is my content?!'
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -17,7 +17,6 @@ import pytest
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_location, target_sat):
     """Perform end to end testing for Job Template component.
 
@@ -221,7 +220,6 @@ def test_positive_end_to_end(session, module_org, module_location, target_sat):
     ],
     ids=['v1', 'v2'],
 )
-@pytest.mark.tier2
 def test_positive_preview_template_check_for_injection(
     module_target_sat, module_org, module_location, rhel_contenthost, module_ak_with_cv, content
 ):

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -88,7 +88,7 @@ def external_user_count(target_sat):
 def groups_teardown(target_sat):
     """teardown for groups created for external/remote groups"""
     yield
-    # tier down groups
+    # teardown groups
     for group_name in ('sat_users', 'sat_admins', EXTERNAL_GROUP_NAME):
         user_groups = target_sat.api.UserGroup().search(query={'search': f'name="{group_name}"'})
         if user_groups:
@@ -120,7 +120,6 @@ def generate_otp(secret):
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
-@pytest.mark.tier2
 def test_positive_end_to_end(session, ldap_auth_source, ldap_tear_down):
     """Perform end to end testing for LDAP authentication component
 
@@ -159,7 +158,6 @@ def test_positive_end_to_end(session, ldap_auth_source, ldap_tear_down):
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_create_org_and_loc(session, ldap_auth_source, ldap_tear_down, target_sat):
     """Create LDAP auth_source with org and loc assigned.
@@ -220,7 +218,6 @@ def test_positive_create_org_and_loc(session, ldap_auth_source, ldap_tear_down, 
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
-@pytest.mark.tier2
 def test_positive_add_katello_role(
     test_name, session, ldap_usergroup_name, ldap_auth_source, ldap_tear_down, target_sat
 ):
@@ -271,7 +268,6 @@ def test_positive_add_katello_role(
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_update_external_roles(
     test_name, session, ldap_usergroup_name, ldap_auth_source, ldap_tear_down, target_sat
 ):
@@ -339,7 +335,6 @@ def test_positive_update_external_roles(
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_delete_external_roles(
     test_name, session, ldap_usergroup_name, ldap_tear_down, ldap_auth_source, target_sat
@@ -405,7 +400,6 @@ def test_positive_delete_external_roles(
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
-@pytest.mark.tier2
 def test_positive_update_external_user_roles(
     test_name, session, ldap_usergroup_name, ldap_tear_down, ldap_auth_source, target_sat
 ):
@@ -480,7 +474,6 @@ def test_positive_update_external_user_roles(
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
-@pytest.mark.tier2
 def test_positive_add_admin_role_with_org_loc(
     test_name,
     session,
@@ -541,7 +534,6 @@ def test_positive_add_admin_role_with_org_loc(
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD_2019', 'IPA'], indirect=True)
-@pytest.mark.tier2
 def test_positive_add_foreman_role_with_org_loc(
     test_name,
     session,
@@ -609,7 +601,6 @@ def test_positive_add_foreman_role_with_org_loc(
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
-@pytest.mark.tier2
 def test_positive_add_katello_role_with_org(
     test_name,
     session,
@@ -680,7 +671,6 @@ def test_positive_add_katello_role_with_org(
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_create_user_in_ldap_mode(session, ldap_auth_source, ldap_tear_down):
     """Create User in ldap mode
@@ -704,7 +694,6 @@ def test_positive_create_user_in_ldap_mode(session, ldap_auth_source, ldap_tear_
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
-@pytest.mark.tier2
 def test_positive_login_user_no_roles(test_name, ldap_tear_down, ldap_auth_source, target_sat):
     """Login with LDAP Auth for user with no roles/rights
 
@@ -729,7 +718,6 @@ def test_positive_login_user_no_roles(test_name, ldap_tear_down, ldap_auth_sourc
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_login_user_basic_roles(
     test_name, session, ldap_tear_down, ldap_auth_source, target_sat
@@ -769,7 +757,6 @@ def test_positive_login_user_basic_roles(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_login_user_password_otp(
     auth_source_ipa, default_ipa_host, test_name, ldap_tear_down, target_sat
 ):
@@ -802,7 +789,6 @@ def test_positive_login_user_password_otp(
     assert users[0].login == default_ipa_host.ipa_otp_username
 
 
-@pytest.mark.tier2
 def test_negative_login_user_with_invalid_password_otp(
     auth_source_ipa, default_ipa_host, test_name, ldap_tear_down, target_sat
 ):
@@ -831,7 +817,6 @@ def test_negative_login_user_with_invalid_password_otp(
 
 
 @pytest.mark.parametrize("ldap_auth_source", ["AD", "IPA", "OPENLDAP"], indirect=True)
-@pytest.mark.tier2
 def test_positive_test_connection_functionality(session, ldap_auth_source):
     """Verify for a positive test connection response
 
@@ -851,7 +836,6 @@ def test_positive_test_connection_functionality(session, ldap_auth_source):
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
-@pytest.mark.tier2
 def test_negative_login_with_incorrect_password(test_name, ldap_auth_source, target_sat):
     """Attempt to login in Satellite an user with the wrong password
 
@@ -877,7 +861,6 @@ def test_negative_login_with_incorrect_password(test_name, ldap_auth_source, tar
         assert error.typename == 'NavigationTriesExceeded'
 
 
-@pytest.mark.tier2
 def test_negative_login_with_disable_user(
     default_ipa_host, auth_source_ipa, ldap_tear_down, target_sat
 ):
@@ -899,7 +882,6 @@ def test_negative_login_with_disable_user(
         assert error.typename == 'NavigationTriesExceeded'
 
 
-@pytest.mark.tier2
 def test_email_of_the_user_should_be_copied(
     session, default_ipa_host, auth_source_ipa, ldap_tear_down, target_sat
 ):
@@ -931,7 +913,6 @@ def test_email_of_the_user_should_be_copied(
         assert user_value['user']['mail'] == result
 
 
-@pytest.mark.tier2
 def test_deleted_idm_user_should_not_be_able_to_login(
     target_sat, default_ipa_host, auth_source_ipa, ldap_tear_down
 ):
@@ -959,7 +940,6 @@ def test_deleted_idm_user_should_not_be_able_to_login(
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
-@pytest.mark.tier2
 def test_onthefly_functionality(session, ldap_auth_source, ldap_tear_down, target_sat):
     """User will not be created automatically in Satellite if onthefly is
     disabled
@@ -1044,7 +1024,6 @@ def test_timeout_and_cac_card_ejection():
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
-@pytest.mark.tier2
 def test_login_failure_if_internal_user_exist(
     session, test_name, ldap_auth_source, module_org, module_location, ldap_tear_down, target_sat
 ):
@@ -1085,7 +1064,6 @@ def test_login_failure_if_internal_user_exist(
         target_sat.api.User(id=user.id).delete()
 
 
-@pytest.mark.tier2
 def test_userlist_with_external_admin(
     session,
     auth_source_ipa,
@@ -1170,7 +1148,6 @@ def test_userlist_with_external_admin(
         assert remote_admin_session.user.search(idm_users_user)[0]['Username'] == idm_users_user
 
 
-@pytest.mark.tier2
 def test_positive_group_sync_open_ldap_authsource(
     test_name,
     session,
@@ -1220,7 +1197,6 @@ def test_positive_group_sync_open_ldap_authsource(
         assert user_name.capitalize() in current_user
 
 
-@pytest.mark.tier2
 def test_verify_group_permissions(
     session,
     auth_source_ipa,
@@ -1273,7 +1249,6 @@ def test_verify_group_permissions(
         assert location.name == location_name
 
 
-@pytest.mark.tier2
 def test_verify_ldap_filters_ipa(
     session, ipa_add_user, auth_source_ipa, default_ipa_host, ldap_tear_down, target_sat
 ):

--- a/tests/foreman/ui/test_leapp_client.py
+++ b/tests/foreman/ui/test_leapp_client.py
@@ -17,7 +17,6 @@ import pytest
 from robottelo.constants import RHEL8_VER, RHEL9_VER
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize(
     'upgrade_path',
     [

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -29,7 +29,6 @@ from robottelo.utils.datafactory import gen_string
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_end_to_end(session):
     """Perform end to end testing for lifecycle environment component
 
@@ -65,7 +64,6 @@ def test_positive_end_to_end(session):
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_create_chain(session):
     """Create Content Environment in a chain
 
@@ -85,7 +83,6 @@ def test_positive_create_chain(session):
         assert lce_path_name in lce_values['lce'][lce_name]
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_search_lce_content_view_packages_by_full_name(session, module_org, target_sat):
     """Search Lifecycle Environment content view packages by full name
@@ -136,7 +133,6 @@ def test_positive_search_lce_content_view_packages_by_full_name(session, module_
                 assert result[0]['Name'] == package['name']
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_search_lce_content_view_packages_by_name(session, module_org, target_sat):
     """Search Lifecycle Environment content view packages by name
@@ -184,7 +180,6 @@ def test_positive_search_lce_content_view_packages_by_name(session, module_org, 
                 assert entry['Name'].startswith(package['name'])
 
 
-@pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_search_lce_content_view_module_streams_by_name(session, module_org, target_sat):
     """Search Lifecycle Environment content view module streams by name
@@ -229,7 +224,6 @@ def test_positive_search_lce_content_view_module_streams_by_name(session, module
                 assert entry['Name'].startswith(module['name'])
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_custom_user_view_lce(session, test_name, target_sat):
     """As a custom user attempt to view a lifecycle environment created

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -20,7 +20,6 @@ from robottelo.constants import ANY_CONTEXT, INSTALL_MEDIUM_URL, LIBVIRT_RESOURC
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, target_sat):
     """Perform end to end testing for location component
@@ -103,7 +102,6 @@ def test_positive_end_to_end(session, target_sat):
         assert not session.location.search(location_name)
 
 
-@pytest.mark.tier2
 def test_positive_create_with_all_users(session, target_sat):
     """Create location and do not add user to it. Check
     'all users' setting.
@@ -133,7 +131,6 @@ def test_positive_create_with_all_users(session, target_sat):
         # assert loc.name in user_values['locations']['resources']['assigned']
 
 
-@pytest.mark.tier2
 def test_positive_add_org_hostgroup_template(session, target_sat):
     """Add a organization, hostgroup, provisioning template by using
        the location name
@@ -175,7 +172,6 @@ def test_positive_add_org_hostgroup_template(session, target_sat):
 
 
 @pytest.mark.skip_if_not_set('libvirt')
-@pytest.mark.tier2
 def test_positive_update_compresource(session, target_sat):
     """Add/Remove compute resource from/to location
 

--- a/tests/foreman/ui/test_media.py
+++ b/tests/foreman/ui/test_media.py
@@ -19,7 +19,6 @@ from robottelo.constants import INSTALL_MEDIUM_URL
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_location):
     """Perform end to end testing for media component

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -40,7 +40,6 @@ def module_yum_repo(module_product, module_target_sat):
     return yum_repo
 
 
-@pytest.mark.tier2
 def test_positive_module_stream_details_search_in_repo(session, module_org, module_yum_repo):
     """Create product with yum repository assigned to it. Search for
     module_streams inside of it

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -19,7 +19,6 @@ from robottelo.utils.datafactory import gen_string
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_location, target_sat):
     """Create all possible entities that required for operating system and then
     test all scenarios like create/read/update/delete for it
@@ -140,7 +139,6 @@ def test_positive_end_to_end(session, module_org, module_location, target_sat):
         assert not session.operatingsystem.search(new_description)
 
 
-@pytest.mark.tier2
 def test_positive_verify_os_name(session, target_sat):
     """Check that the Operating System name is displayed correctly
 

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -45,7 +45,6 @@ def module_repos_col(request, module_sca_manifest_org, module_lce, module_target
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_target_sat):
     """Perform end to end testing for organization component
@@ -163,7 +162,6 @@ def test_positive_end_to_end(session, module_target_sat):
         assert not session.organization.search(new_name)
 
 
-@pytest.mark.tier2
 def test_positive_search_scoped(session):
     """Test scoped search functionality for organization by label
 
@@ -193,7 +191,6 @@ def test_positive_search_scoped(session):
             assert session.organization.search(query)[0]['Name'] == org_name
 
 
-@pytest.mark.tier2
 def test_positive_create_with_all_users(session, module_target_sat):
     """Create organization and new user. Check 'all users' setting for
     organization.
@@ -225,7 +222,6 @@ def test_positive_create_with_all_users(session, module_target_sat):
 
 
 @pytest.mark.skip_if_not_set('libvirt')
-@pytest.mark.tier2
 def test_positive_update_compresource(session, module_target_sat):
     """Add/Remove compute resource from/to organization.
 
@@ -251,7 +247,6 @@ def test_positive_update_compresource(session, module_target_sat):
         assert resource_name in org_values['compute_resources']['resources']['unassigned']
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_delete_with_manifest_lces(session, target_sat, function_sca_manifest_org):
     """Create Organization with valid values and upload manifest.
@@ -275,7 +270,6 @@ def test_positive_delete_with_manifest_lces(session, target_sat, function_sca_ma
         assert not session.organization.search(org.name)
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_download_debug_cert_after_refresh(session, target_sat, function_sca_manifest_org):
     """Create organization with valid manifest. Download debug
@@ -301,7 +295,6 @@ def test_positive_download_debug_cert_after_refresh(session, target_sat, functio
         )
 
 
-@pytest.mark.tier2
 def test_positive_errata_view_organization_switch(
     session, module_org, module_lce, module_repos_col, module_target_sat
 ):
@@ -329,7 +322,6 @@ def test_positive_errata_view_organization_switch(
         assert not session.errata.search(CUSTOM_REPO_ERRATA_ID, applicable=False)
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_product_view_organization_switch(session, module_org, module_product):
     """Verify product created in one organization is not visible in another

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -18,7 +18,6 @@ from robottelo.constants import DataFile
 from robottelo.utils.datafactory import gen_string
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_end_to_end(
     session, oscap_content_path, target_sat, default_org, default_location
@@ -65,7 +64,6 @@ def test_positive_end_to_end(
         assert not session.oscapcontent.search(new_title)
 
 
-@pytest.mark.tier1
 def test_negative_create_with_same_name(session, oscap_content_path, default_org, default_location):
     """Create OpenScap content with same name
 
@@ -100,7 +98,6 @@ def test_negative_create_with_same_name(session, oscap_content_path, default_org
         assert 'has already been taken' in str(context.value)
 
 
-@pytest.mark.tier1
 def test_external_disa_scap_content(session, default_org, default_location):
     """Create OpenScap content with external DISA SCAP content.
 

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -25,7 +25,6 @@ def module_host_group(default_location, default_org, module_target_sat):
     ).create()
 
 
-@pytest.mark.tier2
 def test_positive_check_dashboard(
     session,
     module_host_group,
@@ -99,7 +98,6 @@ def test_positive_check_dashboard(
         # assert policy_details['HostBreakdownChart']['hosts_breakdown'] == '100%Not audited'
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_end_to_end(
     session,

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -17,7 +17,6 @@ import pytest
 from robottelo.utils.datafactory import gen_string
 
 
-@pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_end_to_end(
     session, tailoring_file_path, default_org, default_location, module_target_sat
@@ -59,7 +58,6 @@ def test_positive_end_to_end(
         )
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_download_tailoring_file():
     """Download the tailoring file from satellite
@@ -80,7 +78,6 @@ def test_positive_download_tailoring_file():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier4
 def test_positive_oscap_run_with_tailoring_file_and_external_capsule():
     """End-to-End Oscap run with tailoring files and external capsule
 
@@ -108,7 +105,6 @@ def test_positive_oscap_run_with_tailoring_file_and_external_capsule():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier4
 def test_positive_fetch_tailoring_file_information_from_arfreports():
     """Fetch Tailoring file Information from Arf-reports
 

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -141,7 +141,6 @@ def test_positive_parse_package_name_url(
         session.browser.close_window()
 
 
-@pytest.mark.tier2
 def test_positive_search_in_repo(session, module_org, module_yum_repo):
     """Create product with yum repository assigned to it. Search for
     packages inside of it
@@ -161,7 +160,6 @@ def test_positive_search_in_repo(session, module_org, module_yum_repo):
         ].startswith('cheetah')
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_search_in_multiple_repos(session, module_org, module_yum_repo, module_yum_repo2):
     """Create product with two different yum repositories assigned to it.
@@ -191,7 +189,6 @@ def test_positive_search_in_multiple_repos(session, module_org, module_yum_repo,
         assert not session.package.search('name = tiger', repository=module_yum_repo2.name)
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_check_package_details(session, module_org, module_yum_repo):
     """Create product with yum repository assigned to it. Search for
@@ -232,7 +229,6 @@ def test_positive_check_package_details(session, module_org, module_yum_repo):
         assert expected_package_details == package_details
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_check_custom_package_details(session, module_org, module_yum_repo):
     """Upload custom rpm package to repository. Search for package
@@ -259,7 +255,6 @@ def test_positive_check_custom_package_details(session, module_org, module_yum_r
         assert repo_details['filename'] == RPM_TO_UPLOAD
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_rh_repo_search_and_check_file_list(session, module_org, module_rh_repo):
     """Synchronize one of RH repos (for example Satellite Capsule). Search

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -23,7 +23,6 @@ def template_data():
     return DataFile.PARTITION_SCRIPT_DATA_FILE.read_text()
 
 
-@pytest.mark.tier2
 def test_positive_create_default_for_organization(session):
     """Create new partition table with enabled 'default' option. Check
     that newly created organization has that partition table assigned to it
@@ -50,7 +49,6 @@ def test_positive_create_default_for_organization(session):
         assert session.partitiontable.search(name)[0]['Name'] == name
 
 
-@pytest.mark.tier2
 def test_positive_create_custom_organization(session):
     """Create new partition table with disabled 'default' option. Check
     that newly created organization does not contain that partition table.
@@ -77,7 +75,6 @@ def test_positive_create_custom_organization(session):
         assert not session.partitiontable.search(name)
 
 
-@pytest.mark.tier2
 def test_positive_create_default_for_location(session):
     """Create new partition table with enabled 'default' option. Check
     that newly created location has that partition table assigned to it
@@ -104,7 +101,6 @@ def test_positive_create_default_for_location(session):
         assert session.partitiontable.search(name)[0]['Name'] == name
 
 
-@pytest.mark.tier2
 def test_positive_create_custom_location(session):
     """Create new partition table with disabled 'default' option. Check
     that newly created location does not contain that partition table.
@@ -131,7 +127,6 @@ def test_positive_create_custom_location(session):
         assert not session.partitiontable.search(name)
 
 
-@pytest.mark.tier2
 def test_positive_delete_with_lock_and_unlock(session):
     """Create new partition table and lock it, try delete unlock and retry
 
@@ -160,7 +155,6 @@ def test_positive_delete_with_lock_and_unlock(session):
         assert not session.partitiontable.search(name)
 
 
-@pytest.mark.tier2
 def test_positive_clone(session):
     """Create new partition table and clone it
 
@@ -193,7 +187,6 @@ def test_positive_clone(session):
         assert pt['template']['os_family_selection']['os_family'] == os_family
 
 
-@pytest.mark.tier2
 @pytest.mark.e2e
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_location, template_data):

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -32,7 +32,6 @@ def module_org(module_target_sat):
     return module_target_sat.api.Organization().create()
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_end_to_end(session, module_org, module_target_sat):
     """Perform end to end testing for product component
@@ -96,7 +95,6 @@ def test_positive_end_to_end(session, module_org, module_target_sat):
 
 
 @pytest.mark.parametrize('product_name', **parametrized(valid_data_list('ui')))
-@pytest.mark.tier2
 def test_positive_create_in_different_orgs(session, product_name, module_target_sat):
     """Create Product with same name but in different organizations
 
@@ -117,7 +115,6 @@ def test_positive_create_in_different_orgs(session, product_name, module_target_
             assert product_values['details']['description'] == org.name
 
 
-@pytest.mark.tier2
 def test_positive_product_create_with_create_sync_plan(session, module_org, module_target_sat):
     """Perform Sync Plan Create from Product Create Page
 
@@ -161,7 +158,6 @@ def test_positive_product_create_with_create_sync_plan(session, module_org, modu
         assert session.product.search(product_name)[0]['Name'] != product_name
 
 
-@pytest.mark.tier2
 def test_positive_bulk_action_advanced_sync(session, module_org, module_target_sat):
     """Advanced sync is available as a bulk action in the product.
 

--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -40,7 +40,6 @@ def clone_setup(target_sat, module_org, module_location):
     }
 
 
-@pytest.mark.tier2
 def test_positive_clone(module_org, module_location, target_sat, clone_setup):
     """Assure ability to clone a provisioning template
 
@@ -69,7 +68,6 @@ def test_positive_clone(module_org, module_location, target_sat, clone_setup):
         assert set(clone_setup['os_list']) == {f'{os.name} {os.major}' for os in assigned_oses}
 
 
-@pytest.mark.tier2
 def test_positive_clone_locked(target_sat):
     """Assure ability to clone a locked provisioning template
 
@@ -94,7 +92,6 @@ def test_positive_clone_locked(target_sat):
         ), f'Template {clone_name} expected to exist but is not included in the search'
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.e2e
 def test_positive_end_to_end(module_org, module_location, template_data, target_sat):
@@ -174,7 +171,6 @@ def test_positive_end_to_end(module_org, module_location, template_data, target_
         ), f'Provisioning template {new_name} expected to be removed but is included in the search'
 
 
-@pytest.mark.tier2
 def test_positive_verify_supported_templates_rhlogo(target_sat, module_org, module_location):
     """Verify presense of RH logo on supported provisioning template
 

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -17,7 +17,6 @@ import pytest
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_org, module_puppet_loc):
     """Perform end to end testing for puppet class component

--- a/tests/foreman/ui/test_puppetenvironment.py
+++ b/tests/foreman/ui/test_puppetenvironment.py
@@ -20,7 +20,6 @@ from robottelo.utils.datafactory import gen_string
 
 @pytest.mark.e2e
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_org, module_puppet_loc):
     """Perform end to end testing for puppet environment component
 
@@ -53,7 +52,6 @@ def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_org, modu
         assert not session.puppetenvironment.search(new_name)
 
 
-@pytest.mark.tier2
 def test_positive_availability_for_host_and_hostgroup_in_multiple_orgs(
     session_puppet_enabled_sat, module_puppet_loc
 ):

--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -27,8 +27,6 @@ from robottelo.constants import (
 )
 from robottelo.utils.issue_handlers import is_open
 
-pytestmark = pytest.mark.tier1
-
 
 def test_positive_verify_default_values_for_global_registration(
     module_target_sat,
@@ -66,7 +64,6 @@ def test_positive_verify_default_values_for_global_registration(
     assert cmd['advanced']['force'] is False
 
 
-@pytest.mark.tier2
 def test_positive_org_loc_change_for_registration(
     module_activation_key,
     module_sca_manifest_org,
@@ -136,7 +133,6 @@ def test_negative_global_registration_without_ak(
 @pytest.mark.e2e
 @pytest.mark.no_containers
 @pytest.mark.pit_client
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
 def test_positive_global_registration_end_to_end(
     module_activation_key,
@@ -276,7 +272,6 @@ def test_positive_global_registration_end_to_end(
             assert interface_result.execution
 
 
-@pytest.mark.tier2
 def test_global_registration_form_populate(
     function_sca_manifest_org,
     function_activation_key,
@@ -361,7 +356,6 @@ def test_global_registration_form_populate(
         assert new_ak.name in cmd['general']['activation_keys']
 
 
-@pytest.mark.tier2
 @pytest.mark.pit_client
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.no_containers
@@ -428,7 +422,6 @@ def test_global_registration_with_gpg_repo_and_default_package(
     assert repo_url in result.stdout
 
 
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_match('9')
 def test_global_re_registration_host_with_force_ignore_error_options(
     module_activation_key, rhel_contenthost, module_target_sat, module_org
@@ -469,7 +462,6 @@ def test_global_re_registration_host_with_force_ignore_error_options(
     assert result.status == 0
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('8')
 def test_global_registration_token_restriction(
     module_activation_key, rhel_contenthost, module_target_sat, module_org
@@ -567,7 +559,6 @@ def test_positive_host_registration_with_non_admin_user(
         assert rhel_contenthost.subscription_config['server']['port'] == constants.CLIENT_PORT
 
 
-@pytest.mark.tier2
 def test_positive_global_registration_form(
     module_activation_key, module_org, smart_proxy_location, default_os, target_sat
 ):
@@ -629,7 +620,6 @@ def test_positive_global_registration_form(
         assert pair in cmd
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('8')
 def test_global_registration_with_capsule_host(
     capsule_configured,
@@ -726,7 +716,6 @@ def test_global_registration_with_capsule_host(
     assert module_org.name in result.stdout
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_match('[^6].*')
 def test_subscription_manager_install_from_repository(
     module_activation_key, module_os, rhel_contenthost, target_sat, module_org

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -26,7 +26,6 @@ from robottelo.utils.datafactory import (
 )
 
 
-@pytest.mark.tier4
 def test_positive_hostgroups_full_nested_names(
     module_org,
     smart_proxy_location,
@@ -151,7 +150,6 @@ def test_positive_run_default_job_template(
         assert job_name in [job['Name'] for job in success_jobs]
 
 
-@pytest.mark.tier4
 @pytest.mark.rhel_ver_match('8')
 def test_rex_through_host_details(session, target_sat, rex_contenthost, module_org):
     """Run remote execution using the new host details page
@@ -190,7 +188,6 @@ def test_rex_through_host_details(session, target_sat, rex_contenthost, module_o
         assert recent_jobs['recent_jobs']['finished']['table'][0]['column2'] == "succeeded"
 
 
-@pytest.mark.tier4
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.parametrize(
     'ui_user', [{'admin': True}, {'admin': False}], indirect=True, ids=['adminuser', 'nonadminuser']
@@ -254,7 +251,6 @@ def test_positive_run_custom_job_template(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier3
 @pytest.mark.rhel_ver_list([8])
 def test_positive_run_job_template_multiple_hosts(
     session, module_org, target_sat, rex_contenthosts
@@ -303,7 +299,6 @@ def test_positive_run_job_template_multiple_hosts(
 
 
 @pytest.mark.rhel_ver_match('8')
-@pytest.mark.tier3
 def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_contenthost):
     """Schedule a job to be ran against a host by ip
 
@@ -393,7 +388,6 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
         assert job_status['overview']['hosts_table'][0]['Status'] == 'success'
 
 
-@pytest.mark.tier2
 @pytest.mark.rhel_ver_list('8')
 @pytest.mark.usefixtures('setting_update')
 @pytest.mark.parametrize('setting_update', ['lab_features=true'], indirect=True)

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -69,7 +69,6 @@ def module_setup_content(module_sca_manifest_org, module_target_sat):
     return org, ak, cv, lce
 
 
-@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_negative_create_report_without_name(session):
     """A report template with empty name can't be created
@@ -90,7 +89,6 @@ def test_negative_create_report_without_name(session):
     """
 
 
-@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_negative_cannot_delete_locked_report(session):
     """Edit a report template
@@ -110,7 +108,6 @@ def test_negative_cannot_delete_locked_report(session):
     """
 
 
-@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_positive_preview_report(session):
     """Preview a report
@@ -132,7 +129,6 @@ def test_positive_preview_report(session):
     """
 
 
-@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_location):
     """Perform end to end testing for report template component's CRUD operations
 
@@ -230,7 +226,6 @@ def test_positive_end_to_end(session, module_org, module_location):
 
 @pytest.mark.rhel_ver_list([7, 8, 9])
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_generate_registered_hosts_report(
     session, target_sat, module_setup_content, rhel_contenthost
 ):
@@ -269,7 +264,6 @@ def test_positive_generate_registered_hosts_report(
 
 
 @pytest.mark.upgrade
-@pytest.mark.tier2
 def test_positive_generate_subscriptions_report_json(
     session, module_org, module_setup_content, module_target_sat
 ):
@@ -308,7 +302,6 @@ def test_positive_generate_subscriptions_report_json(
         assert sorted(list(subscription.keys())) == keys_expected
 
 
-@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_positive_applied_errata(session):
     """Generate an Applied Errata report
@@ -324,7 +317,6 @@ def test_positive_applied_errata(session):
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_datetime_picker(session):
     """Generate an Applied Errata report with date filled
@@ -345,7 +337,6 @@ def test_datetime_picker(session):
     """
 
 
-@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_positive_autocomplete(session):
     """Check if host field suggests matching hosts on typing
@@ -364,7 +355,6 @@ def test_positive_autocomplete(session):
     """
 
 
-@pytest.mark.tier2
 def test_positive_schedule_generation_and_get_mail(
     session, module_sca_manifest_org, module_location, target_sat
 ):
@@ -440,7 +430,6 @@ def test_positive_schedule_generation_and_get_mail(
         assert sorted(list(subscription.keys())) == keys_expected
 
 
-@pytest.mark.tier3
 @pytest.mark.stubbed
 def test_negative_bad_email(session):
     """Generate a report and request the result be sent to
@@ -458,7 +447,6 @@ def test_negative_bad_email(session):
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_negative_nonauthor_of_report_cant_download_it(session):
     """The resulting report should only be downloadable by
@@ -479,7 +467,6 @@ def test_negative_nonauthor_of_report_cant_download_it(session):
 
 
 @pytest.mark.rhel_ver_list([7, 8, 9])
-@pytest.mark.tier3
 def test_positive_generate_all_installed_packages_report(
     session, module_setup_content, rhel_contenthost, target_sat
 ):
@@ -530,7 +517,6 @@ def test_positive_generate_all_installed_packages_report(
     assert FAKE_1_CUSTOM_PACKAGE in tree_result
 
 
-@pytest.mark.tier2
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('[^6]')
 def test_positive_installable_errata_with_user(

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -50,7 +50,6 @@ def module_prod(module_org, module_target_sat):
     return module_target_sat.api.Product(organization=module_org).create()
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_create_in_different_orgs(session, module_org, module_target_sat):
@@ -83,7 +82,6 @@ def test_positive_create_in_different_orgs(session, module_org, module_target_sa
             assert values['label'] == org.label
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_create_as_non_admin_user(module_org, test_name, target_sat):
     """Create a repository as a non admin user
@@ -134,7 +132,6 @@ def test_positive_create_as_non_admin_user(module_org, test_name, target_sat):
         assert session.repository.search(product.name, repo_name)[0]['Name'] == repo_name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_create_yum_repo_same_url_different_orgs(session, module_prod, module_target_sat):
@@ -172,7 +169,6 @@ def test_positive_create_yum_repo_same_url_different_orgs(session, module_prod, 
         assert repo_packages_count == new_repo_packages_count
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_name, target_sat):
@@ -243,7 +239,6 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
         assert session.repository.search(prod.name, repo.name)[0]['Name'] == repo.name
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.usefixtures('allow_repo_discovery')
@@ -289,7 +284,6 @@ def test_positive_discover_repo_via_new_and_existing_product(
         assert repo_name_1 in session.repository.search(product_name, repo_name_1)[0]['Name']
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_sync_yum_repo_and_verify_content_checksum(session, module_org, module_target_sat):
@@ -323,7 +317,6 @@ def test_positive_sync_yum_repo_and_verify_content_checksum(session, module_org,
         assert result['task']['result'] == 'success'
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_resync_custom_repo_after_invalid_update(session, module_org, module_target_sat):
     """Create Custom yum repo and sync it via the repos page. Then try to
@@ -355,7 +348,6 @@ def test_positive_resync_custom_repo_after_invalid_update(session, module_org, m
         assert result['result'] == 'success'
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_resynchronize_rpm_repo(session, module_prod, module_target_sat):
     """Check that repository content is resynced after packages were removed
@@ -388,7 +380,6 @@ def test_positive_resynchronize_rpm_repo(session, module_prod, module_target_sat
         assert int(repo_values['content_counts']['Packages']) >= 1
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_end_to_end_custom_yum_crud(session, module_org, module_prod, module_target_sat):
@@ -452,7 +443,6 @@ def test_positive_end_to_end_custom_yum_crud(session, module_org, module_prod, m
         assert not session.repository.search(module_prod.name, new_repo_name)
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_end_to_end_custom_module_streams_crud(session, module_org, module_prod):
@@ -492,7 +482,6 @@ def test_positive_end_to_end_custom_module_streams_crud(session, module_org, mod
         assert not session.repository.search(module_prod.name, repo_name)
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_upstream_with_credentials(session, module_prod):
     """Create repository with upstream username and password update them and then clear them.
@@ -554,7 +543,6 @@ def test_positive_upstream_with_credentials(session, module_prod):
 
 
 # TODO: un-comment when OSTREE functionality is restored in Satellite 6.11
-# @pytest.mark.tier2
 # @pytest.mark.upgrade
 # @pytest.mark.skipif(
 #   (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
@@ -595,7 +583,6 @@ def test_positive_upstream_with_credentials(session, module_prod):
 #         assert not session.repository.search(module_prod.name, new_repo_name)
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_sync_ansible_collection_gallaxy_repo(session, module_prod):
     """Sync ansible collection repository from ansible gallaxy
@@ -629,7 +616,6 @@ def test_positive_sync_ansible_collection_gallaxy_repo(session, module_prod):
         assert result['result'] == 'success'
 
 
-@pytest.mark.tier2
 def test_positive_no_errors_on_repo_scan(target_sat, function_sca_manifest_org):
     """Scan repos for RHEL Server Extras, then check the production log
     for a specific error
@@ -653,7 +639,6 @@ def test_positive_no_errors_on_repo_scan(target_sat, function_sca_manifest_org):
         assert result.status == 1
 
 
-@pytest.mark.tier2
 def test_positive_reposet_disable(session, target_sat, function_sca_manifest_org):
     """Enable RH repo, sync it and then disable
 
@@ -692,7 +677,6 @@ def test_positive_reposet_disable(session, target_sat, function_sca_manifest_org
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 def test_positive_reposet_disable_after_manifest_deleted(
     session, function_sca_manifest_org, target_sat
 ):
@@ -747,7 +731,6 @@ def test_positive_reposet_disable_after_manifest_deleted(
         )
 
 
-@pytest.mark.tier2
 def test_positive_delete_random_docker_repo(session, module_org, module_target_sat):
     """Create Docker-type repositories on multiple products and
     delete a random repository from a random product.
@@ -777,7 +760,6 @@ def test_positive_delete_random_docker_repo(session, module_org, module_target_s
             assert session.repository.search(product_name, repo_name)[0]['Name'] == repo_name
 
 
-@pytest.mark.tier2
 def test_positive_delete_rhel_repo(session, module_sca_manifest_org, target_sat):
     """Enable and sync a Red Hat Repository, and then delete it
 
@@ -823,7 +805,6 @@ def test_positive_delete_rhel_repo(session, module_sca_manifest_org, target_sat)
         )
 
 
-@pytest.mark.tier2
 def test_recommended_repos(session, module_sca_manifest_org):
     """list recommended repositories using On/Off 'Recommended Repositories' toggle.
 
@@ -854,7 +835,6 @@ def test_recommended_repos(session, module_sca_manifest_org):
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_upload_resigned_rpm():
     """Re-sign and re-upload an rpm that already exists in a repository.
 
@@ -881,7 +861,6 @@ def test_positive_upload_resigned_rpm():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_remove_srpm_change_checksum():
     """Re-sync a repository that has had an srpm removed and repodata checksum type changed from
     sha1 to sha256.
@@ -904,7 +883,6 @@ def test_positive_remove_srpm_change_checksum():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier1
 def test_positive_repo_discovery_change_ssl():
     """Verify that repository created via repo discovery has expected Verify SSL value.
 
@@ -928,7 +906,6 @@ def test_positive_repo_discovery_change_ssl():
     pass
 
 
-@pytest.mark.tier1
 def test_positive_remove_credentials(session, function_product, function_org, function_location):
     """User can remove the upstream_username and upstream_password from a repository in the UI.
 
@@ -971,7 +948,6 @@ def test_positive_remove_credentials(session, function_product, function_org, fu
         assert not repo_values['repo_content']['upstream_authorization']
 
 
-@pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_sync_status_persists_after_task_delete(session, module_prod, module_org, target_sat):
     """Red Hat repositories displayed correctly on Sync Status page.
@@ -1029,7 +1005,6 @@ def test_sync_status_persists_after_task_delete(session, module_prod, module_org
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_sync_status_repo_display():
     """Red Hat repositories displayed correctly on Sync Status page.
 
@@ -1049,7 +1024,6 @@ def test_positive_sync_status_repo_display():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_search_enabled_kickstart_repos():
     """Red Hat Repositories should show enabled repositories list with search criteria
     'Enabled/Both' and type 'Kickstart'.
@@ -1073,7 +1047,6 @@ def test_positive_search_enabled_kickstart_repos():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_rpm_metadata_display():
     """RPM dependencies should display correctly in UI.
 
@@ -1102,7 +1075,6 @@ def test_positive_rpm_metadata_display():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier2
 def test_positive_select_org_in_any_context():
     """When attempting to check Sync Status from 'Any Context' the user
     should be properly routed away from the 'Select An Organization' page
@@ -1127,7 +1099,6 @@ def test_positive_select_org_in_any_context():
     pass
 
 
-@pytest.mark.tier2
 def test_positive_sync_sha_repo(session, module_org, module_target_sat):
     """Sync repository with 'sha' checksum, which uses 'sha1' in particular actually
 
@@ -1154,7 +1125,6 @@ def test_positive_sync_sha_repo(session, module_org, module_target_sat):
         assert result['result'] == 'success'
 
 
-@pytest.mark.tier2
 def test_positive_able_to_disable_and_enable_rhel_repos(
     session, function_sca_manifest_org, target_sat
 ):

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -107,7 +107,6 @@ def fixture_setup_rhc_satellite(
 
 
 @pytest.mark.e2e
-@pytest.mark.tier3
 @pytest.mark.pit_server
 def test_positive_configure_cloud_connector(
     session,

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -32,7 +32,6 @@ def create_insights_vulnerability(insights_vm):
 @pytest.mark.e2e
 @pytest.mark.pit_server
 @pytest.mark.pit_client
-@pytest.mark.tier3
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list(r'^[\d]+$')
 def test_rhcloud_insights_e2e(
@@ -211,7 +210,6 @@ def test_host_sorting_based_on_recommendation_count():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([7, 8, 9])
 def test_host_details_page(

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -55,7 +55,6 @@ def common_assertion(report_path, inventory_data, org, satellite):
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 def test_rhcloud_inventory_e2e(
     inventory_settings,
     rhcloud_manifest_org,
@@ -134,7 +133,6 @@ def test_rhcloud_inventory_e2e(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 def test_rh_cloud_inventory_settings(
     module_target_sat,
     inventory_settings,
@@ -310,7 +308,6 @@ def test_failed_inventory_upload():
     """
 
 
-@pytest.mark.tier2
 def test_rhcloud_inventory_without_manifest(session, module_org, target_sat):
     """Verify that proper error message is given when no manifest is imported in an organization.
 

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -22,7 +22,6 @@ from robottelo.utils.datafactory import gen_string
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_location, module_target_sat):
     """Perform end to end testing for role component
@@ -95,7 +94,6 @@ def test_positive_end_to_end(session, module_org, module_location, module_target
         assert not session.role.search(cloned_role_name)
 
 
-@pytest.mark.tier2
 def test_positive_assign_cloned_role(session):
     """Clone role and assign it to user
 
@@ -130,7 +128,6 @@ def test_positive_assign_cloned_role(session):
         assert user['roles']['resources']['assigned'] == [cloned_role_name]
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_delete_cloned_builtin(session):
     """Delete cloned builtin role
@@ -154,7 +151,6 @@ def test_positive_delete_cloned_builtin(session):
         assert not session.role.search(cloned_role_name)
 
 
-@pytest.mark.tier2
 def test_positive_create_filter_without_override(
     session, module_org, module_location, test_name, module_target_sat
 ):
@@ -238,7 +234,6 @@ def test_positive_create_filter_without_override(
             session.architecture.create({'name': gen_string('alpha')})
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_create_non_overridable_filter(
     session, module_org, module_location, test_name, module_target_sat
@@ -303,7 +298,6 @@ def test_positive_create_non_overridable_filter(
             session.organization.create({'name': gen_string('alpha'), 'label': gen_string('alpha')})
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_create_overridable_filter(
     session, module_org, module_location, test_name, module_target_sat
@@ -415,7 +409,6 @@ def test_positive_create_overridable_filter(
         )
 
 
-@pytest.mark.tier2
 def test_positive_create_with_21_filters(session):
     """Make sure it's possible to create more than 20 filters inside single role
 
@@ -459,7 +452,6 @@ def test_positive_create_with_21_filters(session):
         assert assigned_filters == used_filters
 
 
-@pytest.mark.tier2
 def test_positive_create_with_sc_parameter_permission(session_puppet_enabled_sat):
     """Create role filter with few permissions for smart class parameters.
 
@@ -489,7 +481,6 @@ def test_positive_create_with_sc_parameter_permission(session_puppet_enabled_sat
         assert set(assigned_permissions) == set(permissions)
 
 
-@pytest.mark.tier2
 def test_positive_create_filter_admin_user_with_locs(test_name, module_target_sat):
     """Attempt to create a role filter by admin user, who has 6+ locations assigned.
 
@@ -527,7 +518,6 @@ def test_positive_create_filter_admin_user_with_locs(test_name, module_target_sa
         assert set(assigned_permissions[resource_type]) == set(permissions)
 
 
-@pytest.mark.tier2
 def test_positive_create_filter_admin_user_with_orgs(test_name, module_target_sat):
     """Attempt to create a role filter by admin user, who has 10 organizations assigned.
 

--- a/tests/foreman/ui/test_search.py
+++ b/tests/foreman/ui/test_search.py
@@ -140,7 +140,6 @@ def search_user(request):
     return request.getfixturevalue(request.param)
 
 
-@pytest.mark.tier2
 def test_positive_vertical_navigation_search_end_to_end(
     search_user,
     module_target_sat,

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -44,7 +44,6 @@ def add_content_views_to_composite(composite_cv, org, repo, module_target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 @pytest.mark.parametrize('setting_update', ['restrict_composite_view'], indirect=True)
 def test_positive_update_restrict_composite_view(
     session, setting_update, repo_setup, module_target_sat
@@ -92,7 +91,6 @@ def test_positive_update_restrict_composite_view(
                     session.contentview.delete(content_view_name)
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['http_proxy'], indirect=True)
 def test_positive_httpd_proxy_url_update(session, setting_update):
     """Update the http_proxy_url should pass successfully.
@@ -115,10 +113,9 @@ def test_positive_httpd_proxy_url_update(session, setting_update):
         assert result['table'][0]['Value'] == param_value
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['foreman_url'], indirect=True)
 def test_negative_validate_foreman_url_error_message(session, setting_update):
-    """Updates some settings with invalid values (an exceptional tier2 test)
+    """Updates some settings with invalid values
 
     :id: 7c75083d-1b4d-4744-aaa4-6fb9e93ab3c2
 
@@ -137,7 +134,6 @@ def test_negative_validate_foreman_url_error_message(session, setting_update):
         assert err_msg in str(context.value)
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['host_dmi_uuid_duplicates'], indirect=True)
 def test_positive_host_dmi_uuid_duplicates(session, setting_update):
     """Check the setting host_dmi_uuid_duplicates value update.
@@ -160,7 +156,6 @@ def test_positive_host_dmi_uuid_duplicates(session, setting_update):
         assert result['table'][0]['Value'].strip('[]') == property_value
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['register_hostname_fact'], indirect=True)
 def test_positive_register_hostname_fact_update(session, setting_update):
     """Check the settings of register_hostname_fact value update.
@@ -181,7 +176,6 @@ def test_positive_register_hostname_fact_update(session, setting_update):
         assert result['table'][0]['Value'] == property_value
 
 
-@pytest.mark.tier3
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
 def test_positive_update_login_page_footer_text(session, setting_update):
     """Testing to update parameter Login_page_footer_text with long length
@@ -236,7 +230,6 @@ def test_positive_update_login_page_footer_text(session, setting_update):
         assert not result["login_text"]
 
 
-@pytest.mark.tier3
 def test_negative_settings_access_to_non_admin(module_target_sat):
     """Check non admin users can't access Administer -> Settings tab
 
@@ -269,7 +262,6 @@ def test_negative_settings_access_to_non_admin(module_target_sat):
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_update_email_delivery_method_smtp():
     """Updating SMTP params on Email tab
 
@@ -302,7 +294,6 @@ def test_positive_update_email_delivery_method_smtp():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 @pytest.mark.upgrade
 def test_negative_update_email_delivery_method_smtp():
     """Updating SMTP params on Email tab fail
@@ -335,7 +326,6 @@ def test_negative_update_email_delivery_method_smtp():
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 def test_positive_update_email_delivery_method_sendmail(session, target_sat):
     """Updating Sendmail params on Email tab
 
@@ -398,7 +388,6 @@ def test_positive_update_email_delivery_method_sendmail(session, target_sat):
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_negative_update_email_delivery_method_sendmail():
     """Updating Sendmail params on Email tab fail
 
@@ -426,7 +415,6 @@ def test_negative_update_email_delivery_method_sendmail():
 
 
 @pytest.mark.stubbed
-@pytest.mark.tier3
 def test_positive_email_yaml_config_precedence():
     """Check configuration file /etc/foreman/email.yaml takes precedence
     over UI. This behaviour will be default until Foreman 1.16. This
@@ -455,7 +443,6 @@ def test_positive_email_yaml_config_precedence():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_hostname'], indirect=True)
 def test_negative_update_hostname_with_empty_fact(session, setting_update):
     """Update the Hostname_facts settings without any string(empty values)
@@ -485,7 +472,6 @@ def test_negative_update_hostname_with_empty_fact(session, setting_update):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier3
 @pytest.mark.parametrize('setting_update', ['entries_per_page'], indirect=True)
 def test_positive_entries_per_page(session, setting_update):
     """Update the per page entry in the settings.
@@ -521,7 +507,6 @@ def test_positive_entries_per_page(session, setting_update):
         assert str(total_pages) == page_content["Pagination"]['_total_pages'].split()[-1]
 
 
-@pytest.mark.tier2
 def test_positive_setting_display_fqdn_for_hosts(session, target_sat):
     """Verify setting display_fqdn_for_hosts set as Yes/No, and FQDN is used for host's name
     if it's set to Yes else not, according to setting set.
@@ -556,7 +541,6 @@ def test_positive_setting_display_fqdn_for_hosts(session, target_sat):
         assert values['breadcrumb'] == full_name
 
 
-@pytest.mark.tier2
 def test_positive_show_unsupported_templates(request, target_sat, module_org, module_location):
     """Verify setting show_unsupported_templates with new custom template
 

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -67,7 +67,6 @@ def module_domain(session_puppet_enabled_sat, module_host):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_classes, sc_params_list):
     """Perform end to end testing for smart class parameter component
 
@@ -167,7 +166,6 @@ def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_classes, 
         )
 
 
-@pytest.mark.tier2
 def test_positive_create_matcher_attribute_priority(
     session_puppet_enabled_sat,
     module_puppet_org,
@@ -262,7 +260,6 @@ def test_positive_create_matcher_attribute_priority(
         assert output_scp == str([module_domain.name, module_host.mac])
 
 
-@pytest.mark.tier2
 def test_positive_create_matcher_avoid_duplicate(
     session_puppet_enabled_sat,
     module_puppet_org,
@@ -348,7 +345,6 @@ def test_positive_create_matcher_avoid_duplicate(
         assert output_scp == [20, 80, 90, 100]
 
 
-@pytest.mark.tier2
 def test_positive_update_matcher_from_attribute(
     session_puppet_enabled_sat, module_puppet_org, module_puppet_loc, sc_params_list, module_host
 ):
@@ -418,7 +414,6 @@ def test_positive_update_matcher_from_attribute(
         assert property_matcher['Value']['value'] == new_override_value
 
 
-@pytest.mark.tier2
 def test_positive_impact_parameter_delete_attribute(
     session_puppet_enabled_sat, sc_params_list, module_env_search, module_puppet_classes
 ):
@@ -481,7 +476,6 @@ def test_positive_impact_parameter_delete_attribute(
         assert session.sc_parameter.search(sc_param.parameter)[0]['Number of Overrides'] == '0'
 
 
-@pytest.mark.tier2
 def test_positive_hidden_value_in_attribute(
     session_puppet_enabled_sat, module_puppet_org, module_puppet_loc, sc_params_list, module_host
 ):

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -28,7 +28,6 @@ def module_dom(module_target_sat, module_org, module_location):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_target_sat, module_dom):
     """Perform end to end testing for subnet component in ipv6 network

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -65,7 +65,6 @@ def golden_ticket_host_setup(function_sca_manifest_org, module_target_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, function_sca_manifest, target_sat):
     """Upload a manifest with minimal input parameters, attempt to
@@ -139,7 +138,6 @@ def test_positive_end_to_end(session, function_sca_manifest, target_sat):
         assert results.stdout == ''
 
 
-@pytest.mark.tier2
 def test_positive_access_with_non_admin_user_without_manifest(test_name, target_sat):
     """Access subscription page with non admin user that has the necessary
     permissions to check that there is no manifest uploaded.
@@ -178,7 +176,6 @@ def test_positive_access_with_non_admin_user_without_manifest(test_name, target_
         assert not session.subscription.has_manifest
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_access_with_non_admin_user_with_manifest(
     test_name, function_sca_manifest_org, target_sat
@@ -218,7 +215,6 @@ def test_positive_access_with_non_admin_user_with_manifest(
         )
 
 
-@pytest.mark.tier2
 def test_positive_access_manifest_as_another_admin_user(
     test_name, target_sat, function_sca_manifest
 ):
@@ -260,7 +256,6 @@ def test_positive_access_manifest_as_another_admin_user(
         assert not session.subscription.has_manifest
 
 
-@pytest.mark.tier3
 def test_positive_view_vdc_subscription_products(
     session, rhel7_contenthost, target_sat, function_sca_manifest_org
 ):
@@ -320,7 +315,6 @@ def test_positive_view_vdc_subscription_products(
 
 
 @pytest.mark.skip_if_not_set('libvirt')
-@pytest.mark.tier3
 def test_positive_view_vdc_guest_subscription_products(
     session, rhel7_contenthost, target_sat, function_sca_manifest_org
 ):
@@ -400,7 +394,6 @@ def test_positive_view_vdc_guest_subscription_products(
         assert product_name in content_products
 
 
-@pytest.mark.tier3
 def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(
     session, function_org, function_sca_manifest
 ):

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -37,7 +37,6 @@ def module_custom_product(module_org, module_target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_sync_rh_repos(session, target_sat, module_sca_manifest_org):
     """Create Content RedHat Sync with two repos.
@@ -73,7 +72,6 @@ def test_positive_sync_rh_repos(session, target_sat, module_sca_manifest_org):
         assert all([result == 'Syncing Complete.' for result in results])
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_sync_custom_ostree_repo(session, module_custom_product, module_target_sat):
@@ -100,7 +98,6 @@ def test_positive_sync_custom_ostree_repo(session, module_custom_product, module
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_sync_rh_ostree_repo(session, target_sat, module_sca_manifest_org):
     """Sync CDN based ostree repository.
@@ -132,7 +129,6 @@ def test_positive_sync_rh_ostree_repo(session, target_sat, module_sca_manifest_o
         assert results[0] == 'Syncing Complete.'
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_sync_docker_via_sync_status(session, module_org, module_target_sat):
     """Create custom docker repo and sync it via the sync status page.

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -45,7 +45,6 @@ def validate_repo_content(repo, content_types, after_sync=True):
             )
 
 
-@pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, target_sat):
     """Perform end to end scenario for sync plan component
 
@@ -100,7 +99,6 @@ def test_positive_end_to_end(session, module_org, target_sat):
         assert plan_name not in session.syncplan.search(plan_name)
 
 
-@pytest.mark.tier2
 def test_positive_end_to_end_custom_cron(session):
     """Perform end to end scenario for sync plan component with custom cron
 
@@ -144,7 +142,6 @@ def test_positive_end_to_end_custom_cron(session):
         assert plan_name not in session.syncplan.search(plan_name)
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_search_scoped(session, request, target_sat):
     """Test scoped search for different sync plan parameters
@@ -179,7 +176,6 @@ def test_positive_search_scoped(session, request, target_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.tier3
 def test_positive_synchronize_custom_product_custom_cron_real_time(session, module_org, target_sat):
     """Create a sync plan with real datetime as a sync date,
     add a custom product and verify the product gets synchronized
@@ -242,7 +238,6 @@ def test_positive_synchronize_custom_product_custom_cron_real_time(session, modu
         assert plan_name not in session.syncplan.search(plan_name)
 
 
-@pytest.mark.tier3
 def test_positive_synchronize_custom_product_custom_cron_past_sync_date(
     session, module_org, target_sat
 ):

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -31,7 +31,6 @@ def templates_loc(templates_org, module_target_sat):
 git = settings.git
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_import_templates(session, templates_org, templates_loc):
     """Import template(s) from external source to satellite
@@ -88,7 +87,6 @@ def test_positive_import_templates(session, templates_org, templates_loc):
         assert f'name: {import_template}' in pt['template']['template_editor']['editor']
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_export_templates(session, create_import_export_local_dir, target_sat):
     """Export the satellite templates to local directory
@@ -136,7 +134,6 @@ def test_positive_export_templates(session, create_import_export_local_dir, targ
     assert result.status == 0
 
 
-@pytest.mark.tier2
 @pytest.mark.skip_if_not_set('git')
 @pytest.mark.parametrize(
     'url',

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -21,7 +21,6 @@ from robottelo.constants import DEFAULT_ORG, PERMISSIONS, ROLES
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.pit_server
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, target_sat, test_name, module_org, module_location):
@@ -96,7 +95,6 @@ def test_positive_end_to_end(session, target_sat, test_name, module_org, module_
         assert not deletehostsession.user.search(new_name)
 
 
-@pytest.mark.tier2
 def test_positive_create_with_multiple_roles(session, target_sat):
     """Create User with multiple roles
 
@@ -126,7 +124,6 @@ def test_positive_create_with_multiple_roles(session, target_sat):
         assert set(user['roles']['resources']['assigned']) == {role1, role2}
 
 
-@pytest.mark.tier2
 def test_positive_create_with_all_roles(session):
     """Create User and assign all available roles to it
 
@@ -151,7 +148,6 @@ def test_positive_create_with_all_roles(session):
         assert set(user['roles']['resources']['assigned']) == set(ROLES)
 
 
-@pytest.mark.tier2
 def test_positive_create_with_multiple_orgs(session, target_sat):
     """Create User associated to multiple Orgs
 
@@ -185,7 +181,6 @@ def test_positive_create_with_multiple_orgs(session, target_sat):
         }
 
 
-@pytest.mark.tier2
 def test_positive_update_with_multiple_roles(session, target_sat):
     """Update User with multiple roles
 
@@ -211,7 +206,6 @@ def test_positive_update_with_multiple_roles(session, target_sat):
         assert set(user['roles']['resources']['assigned']) == set(role_names)
 
 
-@pytest.mark.tier2
 def test_positive_update_with_all_roles(session):
     """Update User with all roles
 
@@ -236,7 +230,6 @@ def test_positive_update_with_all_roles(session):
         assert set(user['roles']['resources']['assigned']) == set(ROLES)
 
 
-@pytest.mark.tier2
 def test_positive_update_orgs(session, target_sat):
     """Assign a User to multiple Orgs
 
@@ -263,7 +256,6 @@ def test_positive_update_orgs(session, target_sat):
         assert set(user['organizations']['resources']['assigned']) == set(org_names)
 
 
-@pytest.mark.tier2
 def test_positive_create_product_with_limited_user_permission(
     session, target_sat, test_name, module_org, module_location
 ):
@@ -307,7 +299,6 @@ def test_positive_create_product_with_limited_user_permission(
         assert newsession.product.search(product_name)[0]['Name'] == product_name
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_personal_access_token_admin():
     """Personal access token for admin
@@ -327,7 +318,6 @@ def test_personal_access_token_admin():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_personal_access_token_user_with_role():
     """Personal access token for user with a role
@@ -350,7 +340,6 @@ def test_positive_personal_access_token_user_with_role():
     """
 
 
-@pytest.mark.tier2
 @pytest.mark.stubbed
 def test_expired_personal_access_token():
     """Personal access token expired for the user.

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -16,7 +16,6 @@ from fauxfactory import gen_string, gen_utf8
 import pytest
 
 
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_delete_with_user(session, module_org, module_location, module_target_sat):
     """Delete a Usergroup that contains a user
@@ -44,7 +43,6 @@ def test_positive_delete_with_user(session, module_org, module_location, module_
 
 
 @pytest.mark.e2e
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_location, module_target_sat):
     """Perform end to end testing for usergroup component

--- a/tests/foreman/ui/test_webhook.py
+++ b/tests/foreman/ui/test_webhook.py
@@ -13,10 +13,8 @@
 """
 
 from fauxfactory import gen_string, gen_url
-import pytest
 
 
-@pytest.mark.tier1
 def test_positive_end_to_end(session, target_sat):
     """Perform end to end testing for webhooks.
 

--- a/tests/foreman/virtwho/api/test_esx_sca.py
+++ b/tests/foreman/virtwho/api/test_esx_sca.py
@@ -25,7 +25,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforEsx:
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
@@ -47,7 +46,6 @@ class TestVirtWhoConfigforEsx:
         )
         assert virt_who_instance == 'ok'
 
-    @pytest.mark.tier2
     def test_positive_debug_option(
         self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
@@ -71,7 +69,6 @@ class TestVirtWhoConfigforEsx:
             )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
 
-    @pytest.mark.tier2
     def test_positive_interval_option(
         self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
@@ -104,7 +101,6 @@ class TestVirtWhoConfigforEsx:
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
@@ -128,7 +124,6 @@ class TestVirtWhoConfigforEsx:
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('filter_type', ['whitelist', 'blacklist'])
     @pytest.mark.parametrize('option_type', ['edit', 'create'])
     def test_positive_filter_option(
@@ -227,7 +222,6 @@ class TestVirtWhoConfigforEsx:
                 assert result.blacklist == regex
                 assert result.exclude_host_parents == regex
 
-    @pytest.mark.tier2
     def test_positive_proxy_option(
         self, module_sca_manifest_org, default_location, form_data_api, target_sat
     ):
@@ -302,7 +296,6 @@ class TestVirtWhoConfigforEsx:
             query={'search': f"name={form_data_api['name']}"}
         )
 
-    @pytest.mark.tier2
     def test_positive_configure_organization_list(
         self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
@@ -323,7 +316,6 @@ class TestVirtWhoConfigforEsx:
         search_result = virtwho_config_api.get_organization_configs(data={'per_page': '1000'})
         assert [item for item in search_result['results'] if item['name'] == form_data_api['name']]
 
-    @pytest.mark.tier2
     def test_positive_deploy_configure_hypervisor_password_with_special_characters(
         self, module_sca_manifest_org, form_data_api, target_sat
     ):
@@ -374,7 +366,6 @@ class TestVirtWhoConfigforEsx:
             query={'search': f"name={form_data_api['name']}"}
         )
 
-    @pytest.mark.tier2
     def test_positive_remove_env_option(
         self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -23,7 +23,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforHyperv:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
@@ -44,7 +43,6 @@ class TestVirtWhoConfigforHyperv:
         )
         assert virt_who_instance == 'ok'
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -21,7 +21,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforKubevirt:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
@@ -42,7 +41,6 @@ class TestVirtWhoConfigforKubevirt:
         )
         assert virt_who_instance == 'ok'
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -21,7 +21,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforLibvirt:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
@@ -42,7 +41,6 @@ class TestVirtWhoConfigforLibvirt:
         )
         assert virt_who_instance == 'ok'
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -24,7 +24,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforNutanix:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, default_org, virtwho_config_api, target_sat, deploy_type_api
@@ -45,7 +44,6 @@ class TestVirtWhoConfigforNutanix:
         )
         assert virt_who_instance == 'ok'
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
@@ -69,7 +67,6 @@ class TestVirtWhoConfigforNutanix:
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
     def test_positive_prism_central_deploy_configure_by_id_script(
         self, module_sca_manifest_org, form_data_api, target_sat, deploy_type
@@ -113,7 +110,6 @@ class TestVirtWhoConfigforNutanix:
         )
         assert virt_who_instance == 'ok'
 
-    @pytest.mark.tier2
     def test_positive_prism_central_prism_central_option(
         self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -39,7 +39,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforEsx:
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'deploy_type_cli',
@@ -65,7 +64,6 @@ class TestVirtWhoConfigforEsx:
         ]['status']
         assert virt_who_instance == 'OK'
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
@@ -90,7 +88,6 @@ class TestVirtWhoConfigforEsx:
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
-    @pytest.mark.tier2
     def test_positive_debug_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
@@ -112,7 +109,6 @@ class TestVirtWhoConfigforEsx:
             )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
 
-    @pytest.mark.tier2
     def test_positive_name_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
@@ -135,7 +131,6 @@ class TestVirtWhoConfigforEsx:
             {'id': virtwho_config_cli['id'], 'new-name': form_data_cli['name']}
         )
 
-    @pytest.mark.tier2
     def test_positive_interval_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
@@ -165,7 +160,6 @@ class TestVirtWhoConfigforEsx:
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('filter_type', ['whitelist', 'blacklist'])
     @pytest.mark.parametrize('option_type', ['edit', 'create'])
     def test_positive_filter_option(
@@ -257,7 +251,6 @@ class TestVirtWhoConfigforEsx:
                 assert get_configure_option('exclude_hosts', config_file) == regex
                 assert get_configure_option('exclude_host_parents', config_file) == regex
 
-    @pytest.mark.tier2
     def test_positive_proxy_option(
         self,
         module_sca_manifest_org,
@@ -342,7 +335,6 @@ class TestVirtWhoConfigforEsx:
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
 
-    @pytest.mark.tier2
     def test_positive_rhsm_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
@@ -366,7 +358,6 @@ class TestVirtWhoConfigforEsx:
         assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
         assert get_configure_option('rhsm_prefix', config_file) == '/rhsm'
 
-    @pytest.mark.tier2
     def test_positive_post_hypervisors(self, function_org, target_sat):
         """Post large json file to /rhsm/hypervisors"
 
@@ -392,7 +383,6 @@ class TestVirtWhoConfigforEsx:
             else:
                 assert result.status_code == 200
 
-    @pytest.mark.tier2
     def test_positive_foreman_packages_protection(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
@@ -420,7 +410,6 @@ class TestVirtWhoConfigforEsx:
         ]['status']
         assert virt_who_instance == 'OK'
 
-    @pytest.mark.tier2
     def test_positive_deploy_configure_hypervisor_password_with_special_characters(
         self, module_sca_manifest_org, form_data_cli, target_sat
     ):
@@ -472,7 +461,6 @@ class TestVirtWhoConfigforEsx:
         target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config_cli['name']})
         assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data_cli['name']))
 
-    @pytest.mark.tier2
     def test_positive_remove_env_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
@@ -510,7 +498,6 @@ class TestVirtWhoConfigforEsx:
         result = target_sat.execute(f'grep "{env_warning}" /var/log/messages')
         assert result.status == 1
 
-    @pytest.mark.tier2
     def test_positive_rhsm_username_option(
         self, module_sca_manifest_org, form_data_cli, target_sat
     ):
@@ -599,7 +586,6 @@ class TestVirtWhoConfigforEsx:
                 restart_virtwho_service()
                 assert not check_message_in_rhsm_log(messages[1])
 
-    @pytest.mark.tier2
     def test_positive_post_hypervisors_with_fake_different_org_simultaneous(
         self, module_sca_manifest_org, form_data_cli, target_sat
     ):

--- a/tests/foreman/virtwho/cli/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/cli/test_hyperv_sca.py
@@ -23,7 +23,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforHyperv:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, virtwho_config_cli, target_sat, deploy_type_cli
@@ -44,8 +43,6 @@ class TestVirtWhoConfigforHyperv:
         ]['status']
         assert virt_who_instance == 'OK'
 
-    @pytest.mark.tier2
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):

--- a/tests/foreman/virtwho/cli/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt_sca.py
@@ -21,7 +21,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforKubevirt:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, virtwho_config_cli, target_sat, deploy_type_cli
@@ -42,7 +41,6 @@ class TestVirtWhoConfigforKubevirt:
         ]['status']
         assert virt_who_instance == 'OK'
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):

--- a/tests/foreman/virtwho/cli/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_libvirt_sca.py
@@ -21,7 +21,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforLibvirt:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, virtwho_config_cli, target_sat, deploy_type_cli
@@ -42,7 +41,6 @@ class TestVirtWhoConfigforLibvirt:
         ]['status']
         assert virt_who_instance == 'OK'
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):

--- a/tests/foreman/virtwho/cli/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/cli/test_nutanix_sca.py
@@ -24,7 +24,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforNutanix:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, virtwho_config_cli, target_sat, deploy_type_cli
@@ -45,7 +44,6 @@ class TestVirtWhoConfigforNutanix:
         ]['status']
         assert virt_who_instance == 'OK'
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
@@ -70,7 +68,6 @@ class TestVirtWhoConfigforNutanix:
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
     def test_positive_prism_central_deploy_configure_by_id_script(
         self, module_sca_manifest_org, target_sat, form_data_cli, deploy_type
@@ -115,7 +112,6 @@ class TestVirtWhoConfigforNutanix:
         ]['status']
         assert virt_who_instance == 'OK'
 
-    @pytest.mark.tier2
     def test_positive_prism_element_prism_central_option(
         self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -38,7 +38,6 @@ from robottelo.utils.virtwho import (
 
 @pytest.mark.usefixtures('delete_host')
 class TestVirtwhoConfigforEsx:
-    @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
@@ -70,7 +69,6 @@ class TestVirtwhoConfigforEsx:
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
         hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
-    @pytest.mark.tier2
     def test_positive_debug_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):
@@ -99,7 +97,6 @@ class TestVirtwhoConfigforEsx:
         )
         assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '0'
 
-    @pytest.mark.tier2
     def test_positive_interval_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):
@@ -135,7 +132,6 @@ class TestVirtwhoConfigforEsx:
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):
@@ -163,7 +159,6 @@ class TestVirtwhoConfigforEsx:
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('filter_type', ['whitelist', 'blacklist'])
     @pytest.mark.parametrize('option_type', ['edit', 'create'])
     def test_positive_filtering_option(
@@ -255,7 +250,6 @@ class TestVirtwhoConfigforEsx:
                     assert regex == get_configure_option('exclude_hosts', config_file)
                     assert regex == get_configure_option('exclude_host_parents', config_file)
 
-    @pytest.mark.tier2
     def test_positive_last_checkin_status(
         self,
         module_sca_manifest_org,
@@ -297,7 +291,6 @@ class TestVirtwhoConfigforEsx:
             <= 300
         )
 
-    @pytest.mark.tier2
     def test_positive_remove_env_option(
         self, module_sca_manifest_org, virtwho_config_ui, form_data_ui, target_sat, org_session
     ):
@@ -335,7 +328,6 @@ class TestVirtwhoConfigforEsx:
         result = target_sat.execute(f'grep "{env_warning}" /var/log/messages')
         assert result.status == 1
 
-    @pytest.mark.tier2
     def test_positive_virtwho_roles(self, org_session):
         """Verify the default roles for virtwho configure
 
@@ -368,7 +360,6 @@ class TestVirtwhoConfigforEsx:
                 assigned_permissions = org_session.filter.read_permissions(role_name)
                 assert sorted(assigned_permissions) == sorted(role_filters)
 
-    @pytest.mark.tier2
     def test_positive_delete_configure(self, module_sca_manifest_org, org_session, form_data_ui):
         """Verify when a config is deleted the associated user is deleted.
 
@@ -400,7 +391,6 @@ class TestVirtwhoConfigforEsx:
             restart_virtwho_service()
             assert get_virtwho_status() == 'logerror'
 
-    @pytest.mark.tier2
     def test_positive_virtwho_reporter_role(
         self, module_sca_manifest_org, org_session, test_name, form_data_ui
     ):
@@ -458,7 +448,6 @@ class TestVirtwhoConfigforEsx:
             org_session.user.delete(username)
             assert not org_session.user.search(username)
 
-    @pytest.mark.tier2
     def test_positive_virtwho_viewer_role(
         self, module_sca_manifest_org, org_session, test_name, form_data_ui
     ):
@@ -522,7 +511,6 @@ class TestVirtwhoConfigforEsx:
             org_session.user.delete(username)
             assert not org_session.user.search(username)
 
-    @pytest.mark.tier2
     def test_positive_virtwho_manager_role(
         self, module_sca_manifest_org, org_session, test_name, form_data_ui
     ):
@@ -586,7 +574,6 @@ class TestVirtwhoConfigforEsx:
             org_session.user.delete(username)
             assert not org_session.user.search(username)
 
-    @pytest.mark.tier2
     def test_positive_deploy_configure_hypervisor_password_with_special_characters(
         self, module_sca_manifest_org, form_data_ui, target_sat, org_session
     ):
@@ -638,7 +625,6 @@ class TestVirtwhoConfigforEsx:
             org_session.virtwho_configure.delete(name)
             assert not org_session.virtwho_configure.search(name)
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_password_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -24,7 +24,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtwhoConfigforHyperv:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
@@ -55,7 +54,6 @@ class TestVirtwhoConfigforHyperv:
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
         hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -24,7 +24,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtwhoConfigforKubevirt:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
@@ -55,7 +54,6 @@ class TestVirtwhoConfigforKubevirt:
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
         hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -24,7 +24,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtwhoConfigforLibvirt:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
@@ -55,7 +54,6 @@ class TestVirtwhoConfigforLibvirt:
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
         hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -28,7 +28,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtwhoConfigforNutanix:
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
@@ -59,7 +58,6 @@ class TestVirtwhoConfigforNutanix:
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
         hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
-    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):
@@ -90,7 +88,6 @@ class TestVirtwhoConfigforNutanix:
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
-    @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
     def test_positive_prism_central_deploy_configure_by_id_script(
         self, module_sca_manifest_org, org_session, form_data_ui, deploy_type
@@ -139,7 +136,6 @@ class TestVirtwhoConfigforNutanix:
             org_session.virtwho_configure.delete(name)
             assert not org_session.virtwho_configure.search(name)
 
-    @pytest.mark.tier2
     def test_positive_prism_central_prism_flavor_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):
@@ -169,7 +165,6 @@ class TestVirtwhoConfigforNutanix:
         )
         assert get_configure_option('prism_central', config_file) == 'true'
 
-    @pytest.mark.tier2
     def test_positive_ahv_internal_debug_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):

--- a/tests/robottelo/test_hammer.py
+++ b/tests/robottelo/test_hammer.py
@@ -458,7 +458,7 @@ class TestParseInfo:
                 '    Last Checkin: 2019-12-13 00:00:00 UTC',
                 '    Release Version:',
                 '    Autoheal: true',
-                '    Registered To: tier3',
+                '    Registered To: keziah',
                 '    Registered At: 2019-12-13 00:00:00 UTC',
                 '    Registered by Activation Keys:',
                 '     1) ak1',
@@ -522,7 +522,7 @@ class TestParseInfo:
                 'last-checkin': '2019-12-13 00:00:00 UTC',
                 'release-version': '',
                 'autoheal': 'true',
-                'registered-to': 'tier3',
+                'registered-to': 'keziah',
                 'registered-at': '2019-12-13 00:00:00 UTC',
                 'registered-by-activation-keys': ['ak1'],
                 'system-purpose': {

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -92,7 +92,6 @@ class TestScenarioPositiveGCEHostComputeResource:
         return googleclient.get_vm(name='{}'.format(self.fullhostname.replace('.', '-')))
 
     @pytest.mark.pre_upgrade
-    @pytest.mark.tier1
     def test_pre_create_gce_cr_and_host(
         self,
         class_host,


### PR DESCRIPTION
For a while, we've been talking about removing the tier markers since they no longer serve a purpose with our current methods of test selection.

This change does just that, remove all tier markers and their uses.

Fixes: #17940