### PR TITLE
[6.17.z] small fix for API AK creation in upgrade tests

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -445,7 +445,7 @@ def test_positive_fetch_product_content(
     cvv.promote(data={'environment_ids': module_lce.id})
 
     ak = module_target_sat.api.ActivationKey(
-        content_view=cv, organization=module_org, environment=module_lce.name
+        content_view=cv.id, organization=module_org.id, environment=module_lce.id
     ).create()
     ak_content = ak.product_content()['results']
     assert {custom_repo.product.id, rh_repo.product.id} == {


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17939

### Problem Statement
API test for AK Creation was failing with below error
Error-
```
requests.exceptions.HTTPError: ('404 Client Error: Not Found for url: https://satellite.redhat.com/katello/api/v2/activation_keys', {'displayMessage': "Couldn't find content view environment with content view ID '30' and environment ID 'yywhcYLvgOI'", 'errors': ["Couldn't find content view environment with content view ID '30' and environment ID 'yywhcYLvgOI'"]})
```

### Solution
update input parameters, environment need env_id

### Related Issues
N/A

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_activationkey.py -k 'test_positive_fetch_product_content'
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->