### PR TITLE
[6.17.z] Customer case automation for SAT-19933 and SAT-25949

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1905,7 +1905,8 @@ VMWARE_CONSTANTS = {
 HAMMER_CONFIG = "~/.hammer/cli.modules.d/foreman.yml"
 HAMMER_SESSIONS = "~/.hammer/sessions"
 
-INSTALLER_CONFIG_FILE = '/etc/foreman-installer/scenarios.d/satellite.yaml'
+SATELLITE_INSTALLER_CONFIG = '/etc/foreman-installer/scenarios.d/satellite.yaml'
+CAPSULE_INSTALLER_CONFIG = '/etc/foreman-installer/scenarios.d/capsule.yaml'
 SATELLITE_ANSWER_FILE = "/etc/foreman-installer/scenarios.d/satellite-answers.yaml"
 CAPSULE_ANSWER_FILE = "/etc/foreman-installer/scenarios.d/capsule-answers.yaml"
 MAINTAIN_HAMMER_YML = "/etc/foreman-maintain/foreman-maintain-hammer.yml"

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -18,8 +18,14 @@ import re
 from fauxfactory import gen_string
 import pytest
 
-from robottelo import constants
 from robottelo.config import settings
+from robottelo.constants import (
+    CAPSULE_ANSWER_FILE,
+    CAPSULE_INSTALLER_CONFIG,
+    FAKE_0_YUM_REPO_PACKAGES_COUNT,
+    SATELLITE_ANSWER_FILE,
+    SATELLITE_INSTALLER_CONFIG,
+)
 from robottelo.content_info import get_repo_files_by_url
 from robottelo.hosts import Satellite
 
@@ -430,12 +436,21 @@ def test_positive_backup_restore(
 
     :customerscenario: true
 
-    :Verifies: SAT-23093
+    :Verifies: SAT-23093, SAT-19933, SAT-25949
 
     :BZ: 2172540, 1978764, 1979045
     """
-    subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
     instance = get_instance_name(sat_maintain)
+    custom_answer_file = '/root/custom-answers.yaml'
+    answer_file = SATELLITE_ANSWER_FILE if instance == 'satellite' else CAPSULE_ANSWER_FILE
+    installer_config = (
+        SATELLITE_INSTALLER_CONFIG if instance == 'satellite' else CAPSULE_INSTALLER_CONFIG
+    )
+    result = sat_maintain.execute(
+        f'cp {answer_file} {custom_answer_file}; sed -i "s|{answer_file}|{custom_answer_file}|g" {installer_config}; satellite-installer'
+    )
+    assert result.status == 0
+    subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
     result = sat_maintain.cli.Backup.run_backup(
         backup_dir=subdir,
         backup_type=backup_type,
@@ -452,13 +467,15 @@ def test_positive_backup_restore(
 
     expected_files = get_exp_files(sat_maintain, skip_pulp)
     assert set(files).issuperset(expected_files), assert_msg
-
-    # Check if certificate tar file is present in Capsule backup.
+    config_files = sat_maintain.execute(
+        f"tar -tf {backup_dir}/config_files.tar.gz"
+    ).stdout.splitlines()
     if instance == 'capsule':
-        cert_file = sat_maintain.execute(
-            f'tar -tvf {backup_dir}/config_files.tar.gz | grep {sat_maintain.hostname}'
-        ).stdout
-        assert f'{sat_maintain.hostname}-certs.tar' in cert_file
+        assert f'root/{sat_maintain.hostname}-certs.tar' in config_files
+    else:
+        assert f'root/{sat_maintain.hostname}-certs.tar' not in config_files
+        assert 'etc/ansible/ansible.cfg' in config_files
+    assert custom_answer_file[1:] in config_files
 
     # Run restore
     if not skip_pulp:
@@ -496,7 +513,7 @@ def test_positive_backup_restore(
             module_target_sat.hostname, module_capsule_configured.hostname
         )
         repo_files = get_repo_files_by_url(repo_path)
-        assert len(repo_files) == constants.FAKE_0_YUM_REPO_PACKAGES_COUNT
+        assert len(repo_files) == FAKE_0_YUM_REPO_PACKAGES_COUNT
 
     if not skip_pulp:
         assert int(sat_maintain.run('find /var/lib/pulp/media/artifact -type f | wc -l').stdout) > 0

--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -15,7 +15,7 @@
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import INSTALLER_CONFIG_FILE
+from robottelo.constants import SATELLITE_INSTALLER_CONFIG
 
 
 def last_y_stream_version(release):
@@ -101,7 +101,7 @@ def test_negative_pre_update_tuning_profile_check(request, custom_host):
     )
     # Change to correct tuning profile (default or medium)
     custom_host.execute(
-        f'sed -i "s/tuning: development/tuning: {profile}/g" {INSTALLER_CONFIG_FILE};'
+        f'sed -i "s/tuning: development/tuning: {profile}/g" {SATELLITE_INSTALLER_CONFIG};'
         f'satellite-installer'
     )
     # Check that the update check fails due to system requirements


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17888

### Problem Statement
Add customer case automation for: 
- Backups do not take a backup of Ansible configuration files under /etc/ansible - SAT-19933
- satellite-maintain backup command does not include custom answers file in the backup archive - SAT-25949 

### Related Issues
- SAT-19933
- SAT-31843
- SAT-25949
- SAT-31861

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->