### PR TITLE
[6.17] Add UI and CLI test verifying LCE display order matches promotion order

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3359,31 +3359,34 @@ class TestContentView:
 
         :CaseImportance: High
         """
-	# Create 4 LCEs prior one to each other
-	lces_list = []
-	for i in range(4):
-	    if i == 0:
-	        lces_list.append(
-	            target_sat.cli_factory.make_lifecycle_environment(
-	                {'organization-id': function_org.id}
-	            )
-	        )
-	    else:
-	        lces_list.append(
-	            target_sat.cli_factory.make_lifecycle_environment(
-	                {'organization-id': function_org.id, 'prior': lces_list[i-1].name}
-	            )
-	        )
+        # Create 4 LCEs prior one to each other
+        lces_list = []
+        for i in range(4):
+            if i == 0:
+                lces_list.append(
+                    target_sat.cli_factory.make_lifecycle_environment(
+                        {'organization-id': function_org.id}
+                    )
+                )
+            else:
+                lces_list.append(
+                    target_sat.cli_factory.make_lifecycle_environment(
+                        {'organization-id': function_org.id, 'prior': lces_list[i - 1].name}
+                    )
+                )
         cv = target_sat.cli_factory.make_content_view({'organization-id': function_org.id})
         target_sat.cli.ContentView.publish({'id': cv['id']})
         cv_version = target_sat.cli.ContentView.info({'id': cv['id']})['versions'][0]
         # Promote the CV to all the LCEs, in order
-	for lce in lces_list:
-	    target_sat.cli.ContentView.version_promote(
-	        {'id': cv_version['id'], 'to-lifecycle-environment-id': lce['id']}
-	    )
+        for lce in lces_list:
+            target_sat.cli.ContentView.version_promote(
+                {'id': cv_version['id'], 'to-lifecycle-environment-id': lce['id']}
+            )
         cvv = target_sat.cli.ContentView.version_list({'content-view-id': cv['id']})[0]
-	assert cvv['lifecycle-environments'] == f"Library, {', '.join([lce['name'] for lce in lces_list])}"
+        assert (
+            cvv['lifecycle-environments']
+            == f"Library, {', '.join([lce['name'] for lce in lces_list])}"
+        )
 
 
 class TestContentViewFileRepo:

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -392,7 +392,6 @@ def test_cv_lce_order(session, module_target_sat, function_sca_manifest_org, mod
         results = session.contentview_new.publish(
             entity_name=cv.name,
             promote=True,
-            multi_promote=True,
             lce={
                 f"{lces_list[0].name}": True,
                 f"{lces_list[1].name}": True,


### PR DESCRIPTION
### Problem Statement
Adds automation for https://issues.redhat.com/browse/SAT-28538. Requires: https://github.com/SatelliteQE/airgun/pull/1763

### Solution
Ui and CLI test verifying the LCE display order matches the promotion order.
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_contentview.py::test_cv_lce_order tests/foreman/cli/test_contentview.py::test_cv_lce_order
airgun: 1763
```