### PR TITLE
[6.16.z] Fix groups setting location after #16536

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1298,7 +1298,7 @@ def test_verify_ldap_filters_ipa(
         ldapsession.task.read_all()
 
     # updating the authsource with filter
-    group_name = default_ipa_host.groups[0]
+    group_name = default_ipa_host.groups.admins
     ldap_data = f"(memberOf=cn={group_name},{default_ipa_host.group_base_dn})"
     session.ldapauthentication.update(auth_source_ipa.name, {'account.ldap_filter': ldap_data})
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17947

Settings structure has been changed in https://github.com/SatelliteQE/robottelo/pull/16536 , fix in this test