### PR TITLE
[6.17.z] [6.17] Bootc UI Tests + CLI Test improvement, and some fixes

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -292,6 +292,7 @@ def bootc_host():
     with Broker(
         workflow='deploy-bootc',
         host_class=ContentHost,
+        target_template='tpl-bootc-rhel-10.0',
         deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
     ) as host:
         assert (

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -79,6 +79,12 @@ class Host(Base):
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
+    def bootc_images(cls, options=None):
+        """List booted bootc container images for hosts"""
+        cls.command_sub = 'bootc images'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
     def disassociate(cls, options):
         """Disassociate the host from a CR."""
         cls.command_sub = 'disassociate'

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2004,16 +2004,16 @@ def test_syspurpose_end_to_end(
 
 
 @pytest.mark.e2e
-def test_positive_register_read_bootc(target_sat, bootc_host, function_ak_with_cv, function_org):
-    """Register a bootc host and validate the information
+def test_positive_bootc_cli_actions(target_sat, bootc_host, function_ak_with_cv, function_org):
+    """Register a bootc host and validate CLI information
 
     :id: d9557843-4cc7-4e70-a035-7b2c4008dd5e
 
-    :expectedresults: Upon registering a Bootc host, the facts are attached to the host, and are accurate.
+    :expectedresults: Upon registering a Bootc host, the facts are attached to the host, and are accurate. Hammer host bootc also returns proper info.
 
     :CaseComponent:Hosts-Content
 
-    :Verifies:SAT-27168, SAT-27170
+    :Verifies:SAT-27168, SAT-27170, SAT-30211
 
     :CaseImportance: Critical
     """
@@ -2025,6 +2025,11 @@ def test_positive_register_read_bootc(target_sat, bootc_host, function_ak_with_c
     assert bootc_info['running-image-digest'] == bootc_dummy_info['bootc.booted.digest']
     assert bootc_info['rollback-image'] == bootc_dummy_info['bootc.rollback.image']
     assert bootc_info['rollback-image-digest'] == bootc_dummy_info['bootc.rollback.digest']
+    # Verify hammer host bootc images
+    booted_images_info = target_sat.cli.Host.bootc_images()[0]
+    assert booted_images_info['running-image'] == bootc_dummy_info['bootc.booted.image']
+    assert booted_images_info['running-image-digest'] == bootc_dummy_info['bootc.booted.digest']
+    assert int(booted_images_info['host-count']) > 0
 
 
 # -------------------------- MULTI-CV SCENARIOS -------------------------

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2071,7 +2071,7 @@ def test_all_hosts_bulk_build_management(target_sat, function_org, function_loca
 
 
 def test_bootc_booted_container_images(target_sat, bootc_host, function_ak_with_cv, function_org):
-    """Create a bootc host, and read it's information via the Booted Container Images UI
+    """Create a bootc host, and read its information via the Booted Container Images UI
 
     :id: c15f02a2-05e0-447a-bbcc-aace08d40d1a
 
@@ -2100,6 +2100,120 @@ def test_bootc_booted_container_images(target_sat, bootc_host, function_ak_with_
             == bootc_dummy_info['bootc.booted.digest']
         )
         assert booted_container_image_info[1]['Hosts'] == '1'
+
+
+def test_bootc_host_details(target_sat, bootc_host, function_ak_with_cv, function_org):
+    """Create a bootc host, and read it's information via the Host Details UI
+
+    :id: 842356e9-8798-421d-aca6-0a1774c3f22b
+
+    :expectedresults: Host Details UI contains the proper information for a bootc host
+
+    :CaseComponent:Hosts-Content
+
+    :Verifies:SAT-27171
+
+    :Team: Phoenix-subscriptions
+    """
+    bootc_dummy_info = json.loads(DUMMY_BOOTC_FACTS)
+    assert bootc_host.register(function_org, None, function_ak_with_cv.name, target_sat).status == 0
+    assert bootc_host.subscribed
+
+    with target_sat.ui_session() as session:
+        session.organization.select(function_org.name)
+        values = session.host_new.get_details(bootc_host.hostname, widget_names='details.bootc')
+        assert (
+            values['details']['bootc']['details']['running_image']
+            == bootc_dummy_info['bootc.booted.image']
+        )
+        assert (
+            values['details']['bootc']['details']['running_image_digest']
+            == bootc_dummy_info['bootc.booted.digest']
+        )
+        assert (
+            values['details']['bootc']['details']['rollback_image']
+            == bootc_dummy_info['bootc.rollback.image']
+        )
+        assert (
+            values['details']['bootc']['details']['rollback_image_digest']
+            == bootc_dummy_info['bootc.rollback.digest']
+        )
+
+
+def test_bootc_rex_job(target_sat, bootc_host, function_ak_with_cv, function_org):
+    """Run all bootc rex job (switch, upgrade, rollback, status) through Host Details UI
+
+    :id: ef92a5f7-8cc7-4849-822c-90ea68b10554
+
+    :expectedresults: Host Details UI links to the proper template, which runs successfully for all templates
+
+    :CaseComponent: Hosts-Content
+
+    :Verifies:SAT-27154, SAT-27158
+
+    :Team: Phoenix-subscriptions
+    """
+    BOOTC_SWITCH_TARGET = "images.paas.redhat.com/bootc/rhel-bootc:latest-10.0"
+    BOOTC_BASE_IMAGE = "localhost/tpl-bootc-rhel-10.0:latest"
+    assert bootc_host.register(function_org, None, function_ak_with_cv.name, target_sat).status == 0
+    assert bootc_host.subscribed
+
+    with target_sat.ui_session() as session:
+        session.organization.select(function_org.name)
+        # bootc status
+        session.host_new.run_bootc_job(bootc_host.hostname, 'status')
+        task_result = target_sat.wait_for_tasks(
+            search_query=(f'Remote action: Run Bootc status on {bootc_host.hostname}'),
+            search_rate=2,
+            max_tries=30,
+        )
+        task_status = target_sat.api.ForemanTask(id=task_result[0].id).poll()
+        assert task_status['result'] == 'success'
+        assert f'image: {BOOTC_BASE_IMAGE}' in task_status['humanized']['output']
+        assert 'Successfully updated the system facts.' in task_status['humanized']['output']
+        # bootc switch
+        session.host_new.run_bootc_job(
+            bootc_host.hostname, 'switch', job_options=BOOTC_SWITCH_TARGET
+        )
+        task_result = target_sat.wait_for_tasks(
+            search_query=(f'Remote action: Run Bootc switch on {bootc_host.hostname}'),
+            search_rate=2,
+            max_tries=30,
+        )
+        task_status = target_sat.api.ForemanTask(id=task_result[0].id).poll()
+        assert task_status['result'] == 'success'
+        assert 'Successfully updated the system facts.' in task_status['humanized']['output']
+        assert f'Queued for next boot: {BOOTC_SWITCH_TARGET}' in task_status['humanized']['output']
+        # bootc upgrade
+        session.host_new.run_bootc_job(bootc_host.hostname, 'upgrade')
+        task_result = target_sat.wait_for_tasks(
+            search_query=(f'Remote action: Run Bootc upgrade on {bootc_host.hostname}'),
+            search_rate=2,
+            max_tries=30,
+        )
+        task_status = target_sat.api.ForemanTask(id=task_result[0].id).poll()
+        assert task_status['result'] == 'success'
+        assert 'Successfully updated the system facts.' in task_status['humanized']['output']
+        assert f'No changes in {BOOTC_SWITCH_TARGET}' in task_status['humanized']['output']
+        # reboot the host, to ensure there is a rollback image
+        bootc_host.execute('reboot')
+        bootc_host.wait_for_connection()
+        # bootc rollback
+        session.host_new.run_bootc_job(bootc_host.hostname, 'rollback')
+        task_result = target_sat.wait_for_tasks(
+            search_query=(f'Remote action: Run Bootc rollback on {bootc_host.hostname}'),
+            search_rate=2,
+            max_tries=30,
+        )
+        task_status = target_sat.api.ForemanTask(id=task_result[0].id).poll()
+        assert task_status['result'] == 'success'
+        assert 'Next boot: rollback deployment' in task_status['humanized']['output']
+        assert 'Successfully updated the system facts.' in task_status['humanized']['output']
+        # Check that the display in host details matches the task output
+        values = session.host_new.get_details(bootc_host.hostname, widget_names='details.bootc')
+        assert values
+        assert values['details']['bootc']['details']['running_image'] == BOOTC_SWITCH_TARGET
+        assert values['details']['bootc']['details']['rollback_image'] == BOOTC_BASE_IMAGE
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17836

### Problem Statement
Adds 2 tests to the UI suite for Bootc (Testing REX Template/bootc actions, and checking the bootc information via the Host Details UI). Also updates a CLI test to include the `hammer host bootc images` command, as well as tweaks the bootc_host fixture to use the 10.0 template, which is the one that will continue to be updated in CI.

Requires: https://github.com/SatelliteQE/airgun/pull/1757
