### PR TITLE
fixes in scap policy tests

### DIFF
--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -84,7 +84,7 @@ def test_positive_check_dashboard(
                 'deployment_options.deploy_by': 'ansible',
                 'policy_attributes.name': name,
                 'scap_content.scap_content_resource': oscap_content_title,
-                'scap_content.xccdf_profile': OSCAP_PROFILE['security7'],
+                'scap_content.xccdf_profile': OSCAP_PROFILE['ospp8+'],
                 'schedule.period': 'Weekly',
                 'schedule.period_selection.weekday': 'Friday',
                 'locations.resources.assigned': [default_location.name],
@@ -122,7 +122,7 @@ def test_positive_end_to_end(
     description = gen_string('alpha')
     oscap_content_title = gen_string('alpha')
     tailoring_name = gen_string('alpha')
-    profile_type = OSCAP_PROFILE['security7']
+    profile_type = OSCAP_PROFILE['ospp8+']
     tailoring_type = OSCAP_PROFILE['tailoring_rhel7']
     # Upload oscap content file
     module_target_sat.api.ScapContents(


### PR DESCRIPTION
### Problem Statement
updated policy reference to one that exists across systems

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->