### PR TITLE
[6.16.z] Fix ISS manifest upload

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -91,7 +91,7 @@ def function_import_org(target_sat):
 def function_import_org_with_manifest(target_sat, function_import_org):
     """Creates and sets an Organization with a brand-new manifest for content import."""
     with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
-        target_sat.upload_manifest(function_import_org.id, manifest)
+        target_sat.upload_manifest(function_import_org.id, manifest.content)
     return function_import_org
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17972

### Problem Statement
ISS file had an older way of uploading manifest and it was failing on getting the Response object as manifest

### Solution
Adding .content to the manifest fixes this issue

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py -k "test_positive_export_rerun_failed_import"
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->