### PR TITLE
template export filter more future proof

### DIFF
--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -10,6 +10,8 @@
 
 """
 
+from time import sleep
+
 from fauxfactory import gen_string
 import pytest
 import requests
@@ -198,7 +200,7 @@ def test_positive_export_filtered_templates_to_git(session, git_repository, git_
     :id: e4de338a-9ab9-492e-ac42-6cc2ebcd1792
 
     :steps:
-        1. Export only the templates matching with regex e.g: `^atomic.*` to git repo.
+        1. Export only the templates matching with regex e.g: `^provision.*` to git repo.
 
     :expectedresults:
         1. Assert matching templates are exported to git repo.
@@ -216,7 +218,7 @@ def test_positive_export_filtered_templates_to_git(session, git_repository, git_
             {
                 'sync_type': 'Export',
                 'template.metadata_export_mode': 'Keep',
-                'template.filter': 'atomic',
+                'template.filter': 'provision',
                 'template.repo': url,
                 'template.branch': git_branch,
                 'template.dirname': dirname,
@@ -229,9 +231,12 @@ def test_positive_export_filtered_templates_to_git(session, git_repository, git_
         path = f"{dirname}/provisioning_templates/provision"
         auth = (git.username, git.password)
         api_url = f"http://{git.hostname}:{git.http_port}/api/v1/repos/{git.username}"
-        git_count = requests.get(
+        sleep(10)
+        response = requests.get(
             f'{api_url}/{git_repository["name"]}/contents/{path}',
             auth=auth,
             params={"ref": git_branch},
-        ).json()
-        assert len(git_count) == 1
+        )
+        response.raise_for_status()
+        git_count = len(response.json())
+        assert git_count > 0, f'Unexpected response: {response.json()}'


### PR DESCRIPTION
### Problem Statement
atomic no longer around by default

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->