### PR TITLE
[6.16.z] CLI_Factory setup fix, promote current Version to Environment

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -635,7 +635,10 @@ class CLIFactory:
         assert len(cv_info['versions']) > 0
         cv_info['versions'].sort(key=lambda version: version['id'])
         cvv = cv_info['versions'][-1]
-        lce_promoted = cv_info['lifecycle-environments']
+        # get environments this version is promoted to
+        lce_promoted = self._satellite.cli.ContentView.version_info(
+            {'id': cvv['id'], 'content-view-id': cv_info['id']}
+        )['lifecycle-environments']
         # Promote version to next env
         try:
             if env_id not in [int(lce['id']) for lce in lce_promoted]:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18001

### Problem Statement
Writing other automation, I discovered a bug in cli_factory `setup_org_for_a_custom_repo`, which is widely used.

if there is already a promoted Version to the LCE (ie Version 1.0) , then any subsequent Versions made will not be promoted to the LCE, they only exist in Library, promotion is skipped (see screenshots Before changes).

### Cause
Instead of checking LCEs for the CV Version (which is what needs promotion), it only checks LCEs for the entire CV.

**Effect:** Any subsequent Version (2.0, 3.0 etc) won't get promoted to LCE, as Version 1.0 was promoted prior,
 and therefore the LCE is also in the whole CV's info.


### Before (setup method as it exists):
![image](https://github.com/user-attachments/assets/6098b871-2a49-4d60-ab3c-3b1ad12b6135)
![image](https://github.com/user-attachments/assets/88470e95-7196-4e33-84f9-bc47ceeb2f1b)



### After (setup method modified- to check the specific Version's promoted environments):
![image](https://github.com/user-attachments/assets/4727b904-58dc-4fd6-8f25-a21eccaa768a)
![image](https://github.com/user-attachments/assets/ca6ab046-626f-4a52-b9bd-62112e954b9d)

