### PR TITLE
[6.17.z] Add Sat616 Rhel9 repo && fix flaky ISS test

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -286,6 +286,7 @@ REPOSET = {
     'rhva6': ('Red Hat Enterprise Virtualization Agents for RHEL 6 Server (RPMs)'),
     'rhs7': 'Red Hat Satellite 6.11 (for RHEL 7 Server) (RPMs)',
     'rhs8': 'Red Hat Satellite 6.13 for RHEL 8 x86_64 (RPMs)',
+    'rhs9': 'Red Hat Satellite 6.16 for RHEL 9 x86_64 (RPMs)',
     'rhsc8': 'Red Hat Satellite Capsule 6.16 for RHEL 8 x86_64 (RPMs)',
     'rhsc9': 'Red Hat Satellite Capsule 6.16 for RHEL 9 x86_64 (RPMs)',
     'rhsc7_iso': 'Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (ISOs)',
@@ -394,6 +395,15 @@ REPOS = {
         'distro_repository': True,
         'key': 'rhel',
         'version': '6.8',
+    },
+    'rhs9': {
+        'id': 'satellite-6.16-for-rhel-9-x86_64-rpms',
+        'name': ('Red Hat Satellite 6.16 for RHEL 9 x86_64 RPMs'),
+        'version': '6.16',
+        'reposet': REPOSET['rhs9'],
+        'product': PRDS['rhs'],
+        'distro': 'rhel9',
+        'key': 'rhs',
     },
     'rhs8': {
         'id': 'satellite-6.13-for-rhel-8-x86_64-rpms',

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1828,7 +1828,7 @@ class TestContentViewSync:
 
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
-        ['rhae2'],
+        ['rhsclient9'],
         indirect=True,
     )
     def test_positive_export_rerun_failed_import(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17998

### Problem Statement
This PR fixes flaky ISS test that now uses the newly added Satellite 6.16 repo which is used as a bigger repo instead of the Ansible repo used previously.
![image](https://github.com/user-attachments/assets/34dd842c-3bca-49c7-9df4-86bd67ff775e)

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py -k "test_positive_export_rerun_failed_import"
```