### PR TITLE
[6.16.z] Add a check for registration server in LB setup

### DIFF
--- a/tests/foreman/destructive/test_capsule_loadbalancer.py
+++ b/tests/foreman/destructive/test_capsule_loadbalancer.py
@@ -288,12 +288,17 @@ def test_client_register_through_lb(
         in rhel_contenthost.subscription_config['server']['hostname']
     )
     assert rhel_contenthost.subscription_config['server']['port'] == CLIENT_PORT
-    assert loadbalancer_setup['module_target_sat'].cli.Host.info(
+    host_info = loadbalancer_setup['module_target_sat'].cli.Host.info(
         {'name': rhel_contenthost.hostname}, output_format='json'
-    )['content-information']['content-source']['name'] in [
+    )
+    assert host_info['content-information']['content-source']['name'] in [
         setup_capsules['capsule_1'].hostname,
         setup_capsules['capsule_2'].hostname,
     ], 'Unexpected Content Source is set or missing'
+    assert (
+        host_info['subscription-information']['registered-to']
+        == loadbalancer_setup['setup_haproxy']['haproxy'].hostname
+    ), 'Unexpected registration server'
 
     # Host registration by Second Capsule through Loadbalancer
     result = rhel_contenthost.register(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17611

### Describe the changes
Add assertion to check the content host is registered against the load balancer.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/destructive/test_capsule_loadbalancer.py -k test_client_register_through_lb
```