### PR TITLE
Clean up upgrade settings

### DIFF
--- a/conf/upgrade.yaml.template
+++ b/conf/upgrade.yaml.template
@@ -1,93 +1,13 @@
 UPGRADE:
   # Base version of the Satellite, Capsule.
-  FROM_VERSION: "6.8"
+  FROM_VERSION: '6.16'
   # Target version of the Satellite, Capsule.
-  TO_VERSION: "6.9"
+  TO_VERSION: '6.17'
   # Satellite, Capsule hosts RHEL operating system version.
-  OS: "rhel7"
+  OS: rhel9
   # The job template Broker should use to upgrade a Satellite
   SATELLITE_UPGRADE_JOB_TEMPLATE: satellite-upgrade
   # Capsule's activation key will only be available when we spawn the VM using upgrade template.
   CAPSULE_AK:
-    RHEL6:
-    RHEL7:
-    RHEL8:
-    RHEL9:
-  # RHEL6 & RHEL7's client will only be available when we spawn the VM using upgrade template,
-  # it is used in content host upgrade.
-  CLIENT_AK:
-    RHEL6: "clientak_rhel6"
-    RHEL7: "clientak_rhel7"
-    RHEL8: "clientak_rhel8"
-    RHEL9: "clientak_rhel9"
-  # Custom capsule activation key
-  CUSTOM_CAPSULE_AK:
-    RHEL6:
-    RHEL7:
-    RHEL8:
-    RHEL9:
-  # Upgrade codebase supports these types of upgrade only.
-  PRODUCTS:
-    - "satellite"
-    - "capsule"
-    - "client"
-    - "longrun"
-    - "n-1"
-  # Upgrade codebase select the repository based on the distribution.
-  DISTRIBUTION: "downstream"
-  # Ansible repo version
-  ANSIBLE_REPO_VERSION: "2.9"
-  # By default Satellite upgrade perform by foreman-maintain.
-  FOREMAN_MAINTAIN_SATELLITE_UPGRADE: true
-  # Satellite hostname.
-  SATELLITE_HOSTNAME:
-  # capsule hostname
-  CAPSULE_HOSTNAME:
-  # This statement will true until downstream release not become beta.
-  DOWNSTREAM_FM_UPGRADE: false
-  # Used to whitelist the mentioned params in the foreman-maintain upgrade.
-  WHITELIST_PARAM: ""
-  # Capsule upgrade via foreman-maintain, due to limited version support, we keep it as false.
-  FOREMAN_MAINTAIN_CAPSULE_UPGRADE: false
-  # User Defined clients, we use it for content host upgrade.
-  USER_DEFINED_CLIENT_HOSTS:
-    RHEL6:
-    RHEL7:
-    RHEL8:
-    RHEL9:
-  # System Reboot after upgrade
-  SATELLITE_CAPSULE_SETUP_REBOOT: true
-  # Upgrade with http-proxy
-  UPGRADE_WITH_HTTP_PROXY: false
-  # Default size of client's which we use for content host upgrade.
-  CLIENTS_COUNT: "8"
-  # Satellite's REMOTE_SSH_PASSWORD
-  REMOTE_SSH_PASSWORD:
-  # Satellite's OAUTH_CONSUMER_KEY
-  OAUTH_CONSUMER_KEY:
-  # Satellite's OAUTH_CONSUMER_SECRET
-  OAUTH_CONSUMER_SECRET:
-  # Supported Satellite versions
-  SUPPORTED_SAT_VERSIONS:
-    - "6.7"
-    - "6.8"
-    - "6.9"
-    - "6.10"
-  # These environment variable used for existence test cases execution.
-  EXISTENCE_TEST:
-    ALLOWED_ENDS:
-      - "api"
-      - "cli"
-    ENDPOINT:
-  # The docker host for container spawn
-  DOCKER_VM:
-  # The upgrade VLAN vm_domain
-  VM_DOMAIN:
-  # upgrade the mongodb to wiredTiger after upgrade
-  MONGODB_UPGRADE: false
-  # satellite backup
-  SATELLITE_BACKUP: false
-  # satellite backup type
-  SATELLITE_BACKUP_TYPE:
-    - "online"
-    - "offline"
+    RHEL8: rhel8_capsule_ak
+    RHEL9: rhel9_capsule_ak

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -405,10 +405,7 @@ VALIDATORS = dict(
         Validator('shared_function.redis_password', default=None),
     ],
     upgrade=[
-        Validator('upgrade.rhev_cap_host', must_exist=False)
-        | Validator('upgrade.capsule_hostname', must_exist=False),
-        Validator('upgrade.rhev_capsule_ak', must_exist=False)
-        | Validator('upgrade.capsule_ak', must_exist=False),
+        Validator('upgrade.capsule_ak', must_exist=True),
     ],
     vmware=[
         Validator(

--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -98,10 +98,7 @@ class TestCapsuleSync:
             2. Activation key's environment id should be available in the content views environment
                 id's list
         """
-        ak_name = (
-            settings.upgrade.capsule_ak[settings.upgrade.os]
-            or settings.upgrade.custom_capsule_ak[settings.upgrade.os]
-        )
+        ak_name = settings.upgrade.capsule_ak[settings.upgrade.os]
         ak = target_sat.api.ActivationKey(organization=default_org).search(
             query={'search': f'name={ak_name}'}
         )[0]
@@ -213,10 +210,7 @@ class TestCapsuleSyncNewRepo:
 
         """
         request.addfinalizer(lambda: cleanup(target_sat, content_view, repo, product))
-        activation_key = (
-            settings.upgrade.capsule_ak[settings.upgrade.os]
-            or settings.upgrade.custom_capsule_ak[settings.upgrade.os]
-        )
+        activation_key = settings.upgrade.capsule_ak[settings.upgrade.os]
         ak = target_sat.api.ActivationKey(organization=default_org).search(
             query={'search': f'name={activation_key}'}
         )[0]


### PR DESCRIPTION
### Problem Statement
There is a lot of unused upgrade settings (from Fabric and RHV times)

### Solution
Clean up the upgrade settings

### Related Issues
SAT-32005

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->