### PR TITLE
Add workfaround for SAT-32007 and SAT-32006 in provisioning tests

### DIFF
--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -179,6 +179,11 @@ def test_rhel_pxe_provisioning(
         assert provisioning_host.execute('test -s /mnt/sysimage/root/install.post.log').status == 1
 
         # Run a command on the host using REX to verify that Satellite's SSH key is present on the host
+        # Add workaround for SAT-32007 and SAT-32006
+        if is_open('SAT-32007') and is_open('SAT-32006'):
+            assert (
+                sat.execute('cat /dev/null > /usr/share/foreman-proxy/.ssh/known_hosts').status == 0
+            )
         template_id = (
             sat.api.JobTemplate()
             .search(query={'search': 'name="Run Command - Script Default"'})[0]
@@ -317,6 +322,9 @@ def test_rhel_ipxe_provisioning(
     )
 
     # Run a command on the host using REX to verify that Satellite's SSH key is present on the host
+    # Add workaround for SAT-32007 and SAT-32006
+    if is_open('SAT-32007') and is_open('SAT-32006'):
+        assert sat.execute('cat /dev/null > /usr/share/foreman-proxy/.ssh/known_hosts').status == 0
     template_id = (
         sat.api.JobTemplate().search(query={'search': 'name="Run Command - Script Default"'})[0].id
     )
@@ -446,6 +454,9 @@ def test_rhel_httpboot_provisioning(
     )
 
     # Run a command on the host using REX to verify that Satellite's SSH key is present on the host
+    # Add workaround for SAT-32007 and SAT-32006
+    if is_open('SAT-32007') and is_open('SAT-32006'):
+        assert sat.execute('cat /dev/null > /usr/share/foreman-proxy/.ssh/known_hosts').status == 0
     template_id = (
         sat.api.JobTemplate().search(query={'search': 'name="Run Command - Script Default"'})[0].id
     )
@@ -586,6 +597,9 @@ def test_rhel_pxe_provisioning_fips_enabled(
         assert (0 if is_open('SAT-20386') else 1) == int(result.stdout)
 
     # Run a command on the host using REX to verify that Satellite's SSH key is present on the host
+    # Add workaround for SAT-32007 and SAT-32006
+    if is_open('SAT-32007') and is_open('SAT-32006'):
+        assert sat.execute('cat /dev/null > /usr/share/foreman-proxy/.ssh/known_hosts').status == 0
     template_id = (
         sat.api.JobTemplate().search(query={'search': 'name="Run Command - Script Default"'})[0].id
     )
@@ -817,6 +831,9 @@ def test_capsule_pxe_provisioning(
     )
 
     # Run a command on the host using REX to verify that Satellite's SSH key is present on the host
+    # Add workaround for SAT-32007 and SAT-32006
+    if is_open('SAT-32007') and is_open('SAT-32006'):
+        assert sat.execute('cat /dev/null > /usr/share/foreman-proxy/.ssh/known_hosts').status == 0
     template_id = (
         sat.api.JobTemplate().search(query={'search': 'name="Run Command - Script Default"'})[0].id
     )


### PR DESCRIPTION
### Problem Statement
Provisioning tests are failing because of  SAT-32007 and SAT-32006

### Solution
Add workfaround for SAT-32007 and SAT-32006 in provisioning tests
