### PR TITLE
Update RH recommended repos for 6.17

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -325,6 +325,10 @@ REPOSET = {
 }
 
 RECOMMENDED_REPOS = [
+    'rhel-10-for-x86_64-baseos-rpms',
+    'rhel-10-for-x86_64-appstream-rpms',
+    'rhel-10-for-x86_64-baseos-eus-rpms',
+    'rhel-10-for-x86_64-appstream-eus-rpms',
     'rhel-9-for-x86_64-baseos-rpms',
     'rhel-9-for-x86_64-appstream-rpms',
     'rhel-9-for-x86_64-baseos-eus-rpms',  # 6.17+
@@ -333,14 +337,12 @@ RECOMMENDED_REPOS = [
     'rhel-8-for-x86_64-appstream-rpms',
     'rhel-8-for-x86_64-baseos-eus-rpms',
     'rhel-8-for-x86_64-appstream-eus-rpms',
+    'satellite-client-6-for-rhel-10-x86_64-rpms',
     'satellite-client-6-for-rhel-9-x86_64-rpms',
     'satellite-client-6-for-rhel-8-x86_64-rpms',
 ]
 
 VERSIONED_REPOS = [
-    'satellite-capsule-{}-for-rhel-8-x86_64-rpms',
-    'satellite-maintenance-{}-for-rhel-8-x86_64-rpms',
-    'satellite-utils-{}-for-rhel-8-x86_64-rpms',
     'satellite-capsule-{}-for-rhel-9-x86_64-rpms',  # 6.16+
     'satellite-maintenance-{}-for-rhel-9-x86_64-rpms',  # 6.16+
     'satellite-utils-{}-for-rhel-9-x86_64-rpms',  # 6.16+

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -331,8 +331,8 @@ RECOMMENDED_REPOS = [
     'rhel-10-for-x86_64-appstream-eus-rpms',
     'rhel-9-for-x86_64-baseos-rpms',
     'rhel-9-for-x86_64-appstream-rpms',
-    'rhel-9-for-x86_64-baseos-eus-rpms',  # 6.17+
-    'rhel-9-for-x86_64-appstream-eus-rpms',  # 6.17+
+    'rhel-9-for-x86_64-baseos-eus-rpms',
+    'rhel-9-for-x86_64-appstream-eus-rpms',
     'rhel-8-for-x86_64-baseos-rpms',
     'rhel-8-for-x86_64-appstream-rpms',
     'rhel-8-for-x86_64-baseos-eus-rpms',
@@ -343,9 +343,9 @@ RECOMMENDED_REPOS = [
 ]
 
 VERSIONED_REPOS = [
-    'satellite-capsule-{}-for-rhel-9-x86_64-rpms',  # 6.16+
-    'satellite-maintenance-{}-for-rhel-9-x86_64-rpms',  # 6.16+
-    'satellite-utils-{}-for-rhel-9-x86_64-rpms',  # 6.16+
+    'satellite-capsule-{}-for-rhel-9-x86_64-rpms',
+    'satellite-maintenance-{}-for-rhel-9-x86_64-rpms',
+    'satellite-utils-{}-for-rhel-9-x86_64-rpms',
 ]
 
 SM_OVERALL_STATUS = {


### PR DESCRIPTION
### Problem Statement
RHEL10 repos become recommended in 6.17.0.
Further the Capsule, maintenance and utils repos are only supported for RHEL9 since it's the only base OS for 6.17.0.
We should update them accordingly.

### Solution
This PR.


### Related Issues
Expect the PRT to fail until all of the repos are GA'ed. 


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_repository.py -k test_recommended_repos
```