### PR TITLE
[6.14.z] Check Version is promoted to lce, instead of entire CV

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -632,8 +632,13 @@ class CLIFactory:
             ) from err
         # Get the version id
         cv_info = self._satellite.cli.ContentView.info({'id': cv_id})
-        lce_promoted = cv_info['lifecycle-environments']
+        assert len(cv_info['versions']) > 0
+        cv_info['versions'].sort(key=lambda version: version['id'])
         cvv = cv_info['versions'][-1]
+        # get environments this version is promoted to
+        lce_promoted = self._satellite.cli.ContentView.version_info(
+            {'id': cvv['id'], 'content-view-id': cv_info['id']}
+        )['lifecycle-environments']
         # Promote version to next env
         try:
             if env_id not in [int(lce['id']) for lce in lce_promoted]:

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1537,7 +1537,7 @@ def test_downgrade_applicable_package_using_default_content_view(errata_host, ta
 
 
 @pytest.mark.tier2
-def test_install_applicable_package_to_registerd_host(errata_host, target_sat):
+def test_install_applicable_package_to_registered_host(errata_host, target_sat):
     """Installing an older package to an already registered host should show the newer package
     and errata as applicable and installable.
 


### PR DESCRIPTION
### Problem Statement
Failed auto-CP to 6.14.z of #18001 

Also discovered a spelling mistake in a test's name, which only exists in 6.14.z :
`cli/test_errata.py :: test_install_applicable_package_to_registerd_host` << 'registerd' spelling corrected

### PRT Cases
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_errata.py::test_apply_errata_using_default_content_view tests/foreman/cli/test_errata.py::test_update_applicable_package_using_default_content_view tests/foreman/cli/test_errata.py::test_downgrade_applicable_package_using_default_content_view tests/foreman/cli/test_errata.py::test_install_applicable_package_to_registerd_host tests/foreman/cli/test_errata.py::test_downgrading_package_shows_errata_from_library tests/foreman/cli/test_activationkey.py::test_positive_create_content_and_check_enabled tests/foreman/cli/test_activationkey.py::test_positive_add_custom_product tests/foreman/cli/test_activationkey.py::test_positive_add_redhat_and_custom_products tests/foreman/cli/test_activationkey.py::test_positive_content_override tests/foreman/cli/test_activationkey.py::test_positive_subscription_quantity_attached tests/foreman/cli/test_activationkey.py::test_positive_ak_with_custom_product_on_rhel6
```