### PR TITLE
[6.16.z] Small signoff fix, handle one or more applicability_recalculate tasks

### DIFF
--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -925,7 +925,7 @@ def test_positive_apply_for_all_hosts(
                 max_tries=60,
             )
             assert len(install_tasks) == num_hosts
-            # find single bulk applicability task for hosts
+            # find bulk applicability recalculate task(s) for hosts
             applicability_task = target_sat.wait_for_tasks(
                 search_query=(
                     f'Bulk generate applicability for hosts and started_at >= {timestamp}'
@@ -933,7 +933,7 @@ def test_positive_apply_for_all_hosts(
                 search_rate=2,
                 max_tries=60,
             )
-            assert len(applicability_task) == 1
+            assert len(applicability_task) >= 1
             # found updated kangaroo package in each host
             updated_version = '0.2-1.noarch'
             for client in hosts:


### PR DESCRIPTION
### Problem Statement
PRT failure often seen for 2 or 3 `applicability_recalculate` tasks after applying errata to multiple hosts, rather than just one recalculate task.
No CP or merge to `stream` yet, only 6.16.z and 6.17.z ,  there are navigation failures in Stream preventing PRT pass.

### Solution
Assert >= 1 successful tasks , rather than  == 1 task.

### PRT Case
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_errata.py -k 'test_positive_apply_for_all_hosts'
```