### PR TITLE
increase time after reboot to connect the sat

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -399,7 +399,7 @@ class ContentHost(Host, ContentHostMixins):
                 wait_for(
                     self.connect,
                     fail_condition=lambda res: res is not None,
-                    timeout=300,
+                    timeout=400,
                     handle_exception=True,
                 )
             # really broad diaper here, but connection exceptions could be a ton of types


### PR DESCRIPTION
Increase the wait time after the leapp_upgrade process to allow the Satellite server to reconnect after reboot.





