### PR TITLE
dashboard asserts updated

### DIFF
--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -160,10 +160,10 @@ def test_positive_task_status(session, target_sat):
         session.dashboard.action({'LatestFailedTasks': {'name': 'Synchronize'}})
         values = session.task.read(task_name)
         assert values['task']['result'] == 'warning'
-        assert (
-            values['task']['errors']
-            == f'Cannot connect to host {url}:80 ssl:default [Name or service not known]'
-        )
+        assert values['task']['errors'] in [
+            f"500, message='Internal Server Error', url='http://{url}'",
+            f'Cannot connect to host {url}:80 ssl:default [Domain name not found]',
+        ]
 
 
 @pytest.mark.upgrade


### PR DESCRIPTION
### Problem Statement
diffrent message on 6.17 and on ipv6 as well

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->