### PR TITLE
Fix capsule expected post-sync tasks

### DIFF
--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -645,7 +645,6 @@ def test_positive_exported_imported_content_sync(
         'Actions::Katello::Repository::MetadataGenerate',
         'Actions::Katello::CapsuleContent::Sync',
         'Actions::Katello::ContentView::CapsuleSync',
-        'Actions::Katello::CapsuleContent::UpdateContentCounts',
     ]
     pending_tasks = target_sat.api.ForemanTask().search(
         query={'search': f'organization_id={org.id} and result=pending'}


### PR DESCRIPTION
### Problem Statement
The `test_positive_exported_imported_content_sync` test fails flakily with
```
AssertionError: A repeated, pending task was found for repository or capsule, after capsule sync completed:[robottelo.hosts.DecClass(cli_example=None, ended_at=None, humanized={'action': 'Update Content Counts', ...
```
AFAIK the `Update Content Counts` task _is_ expected to run after Capsule sync. The flakiness probably relates to task speed.


### Solution
Remove the task from `unexpected_tasks`.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_capsulecontent.py -k test_positive_exported_imported_content_sync
```