### PR TITLE
[6.17.z] Remove is_open for SAT-30807 from ansible tests

### DIFF
--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -605,8 +605,7 @@ class TestAnsibleREX:
         client = rhel_contenthost
         # Adding IPv6 proxy for IPv6 communication
         client.enable_ipv6_dnf_and_rhsm_proxy()
-        if is_open('SAT-30807'):
-            rhel_contenthost.enable_ipv6_system_proxy()
+        rhel_contenthost.enable_ipv6_system_proxy()
         # Enable Ansible repository and Install ansible or ansible-core package
         client.register(module_org, None, module_ak_with_cv.name, target_sat)
         rhel_repo_urls = getattr(settings.repos, f'rhel{client.os_version.major}_os', None)

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -782,8 +782,7 @@ class TestAnsibleREX:
         """
         # Adding IPv6 proxy for IPv6 communication
         rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
-        if is_open('SAT-30807'):
-            rhel_contenthost.enable_ipv6_system_proxy()
+        rhel_contenthost.enable_ipv6_system_proxy()
         client = rhel_contenthost
         # Enable Ansible repository and Install ansible or ansible-core package
         client.register(module_org, None, module_ak_with_cv.name, target_sat)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18018

### Problem Statement
Workaround for SAT-30807 to use proxy conditionally for connecting to ansible-galaxy was added in https://github.com/SatelliteQE/robottelo/pull/17575 ; since now SAT-30807 is closed a notabug, proxy doesn't get configured on host

### Solution
Remove is_open for SAT-30807 from ansible tests and configure http proxy to connect to ansible-galaxy
 
### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->