### PR TITLE
[6.17.z] adjusting oscap longrun tests for ipv6 run

### DIFF
--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -223,6 +223,10 @@ def prepare_scap_client_and_prerequisites(
         }
     )
 
+    # Adding IPv6 proxy for IPv6 communication
+    contenthost.enable_ipv6_dnf_and_rhsm_proxy()
+    contenthost.enable_ipv6_system_proxy()
+
     # Register a host
     result = contenthost.register(
         module_org,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18046

### Problem Statement
this solves an issue with reaching non ipv6 resources required in tests

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->