### PR TITLE
[6.17.z] Fix artifact repair tests

### DIFF
--- a/robottelo/host_helpers/capsule_mixins.py
+++ b/robottelo/host_helpers/capsule_mixins.py
@@ -157,16 +157,15 @@ class CapsuleInfo:
             return f'{self.url}/pulp/content/{org}/{lce}/{cv}/custom/{prod}/{repo}/'
         return f'{self.url}/pulp/content/{org}/Library/custom/{prod}/{repo}/'
 
-    def get_artifacts(self, since=None, tz='UTC'):
+    def get_artifacts(self, since=None):
         """Get paths of pulp artifact.
 
         :param str since: Creation time of artifact we are looking for.
-        :param str tz: Time zone for `since` param.
         :return: A list of artifacts paths.
         """
         query = f'find {PULP_ARTIFACT_DIR} -type f'
         if since:
-            query = f'{query} -newermt "{since} {tz}"'
+            query = f'{query} -newermt "{since}"'
         return self.execute(query).stdout.splitlines()
 
     def get_artifact_info(self, checksum=None, path=None):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18040

### Problem Statement
#17766 made our datetimes "timezone-aware". As such, their `str` cast returns the timezone offset in `+hh:mm` format: 
```
>>> str(datetime.datetime.now(datetime.UTC))
'2025-03-25 19:15:03.671290+00:00'
```

In 12 out of 24 paramterizations of the `test_positive_artifact_repair` test we depend on the artifact creation time. For that we used `UTC` timezone specification, which does not work together with `+hh:mm` timezone specification: https://github.com/SatelliteQE/robottelo/blob/master/robottelo/host_helpers/capsule_mixins.py#L160 


### Solution
Use just one timezone specification, preferably the one provided in datetime.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_artifacts.py
```