### PR TITLE
Errata 6.17.0 signoff fixes

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -775,7 +775,7 @@ DEFAULT_OS_SEARCH_QUERY = 'name="RedHat" AND (major="6" OR major="7" OR major="8
 
 VDC_SUBSCRIPTION_NAME = 'Red Hat Enterprise Linux for Virtual Datacenters, Premium'
 
-TIMESTAMP_FMT_ZONE = '%Y-%m-%d %H:%M:%S%Z'  # timezone-aware format (by code: UTC, EST, etc)
+TIMESTAMP_FMT_ZONE = '%Y-%m-%d %H:%M:%S %Z'  # timezone-aware format (by code: UTC, EST, etc)
 TIMESTAMP_FMT = '%Y-%m-%d %H:%M:%S'
 TIMESTAMP_FMT_DATE = '%Y-%m-%d'
 TIMESTAMP_FMT_TIME = '%H:%M:%S'

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -775,6 +775,10 @@ DEFAULT_OS_SEARCH_QUERY = 'name="RedHat" AND (major="6" OR major="7" OR major="8
 
 VDC_SUBSCRIPTION_NAME = 'Red Hat Enterprise Linux for Virtual Datacenters, Premium'
 
+TIMESTAMP_FMT_ZONE = '%Y-%m-%d %H:%M:%S%Z'  # timezone-aware format (by code: UTC, EST, etc)
+TIMESTAMP_FMT = '%Y-%m-%d %H:%M:%S'
+TIMESTAMP_FMT_DATE = '%Y-%m-%d'
+TIMESTAMP_FMT_TIME = '%H:%M:%S'
 TIMEZONES = [
     '(GMT+00:00) UTC',
     '(GMT-10:00) Hawaii',

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -311,6 +311,35 @@ class APIFactory:
             ).create()
         return os
 
+    def supported_rhel_ver(self, num=3, fips=False, prefix=''):
+        """
+        Return: a list of (str), most recent supported RHEL major versions.
+            or a single str, if param `num` is set to 1.
+
+        :param num: Default 3. Pass a positive int for the number of versions to return,
+            or pass 'All' to return every supported version.
+        :param fips: Default False. If True, include -fips versions.
+        :param prefix: Default empty ''. Add a prefix string to the versions,
+            ie: 'rhel' or 'rhel-'
+        """
+        if isinstance(num, int) and num <= 0:
+            return []
+        supported_rhels = settings.supportability.content_hosts.rhel.versions
+        filtered_versions = (
+            [prefix + str(ver) for ver in supported_rhels]  # include fips
+            if fips is True
+            else [  # only include ints, major versions
+                prefix + str(ver) for ver in supported_rhels if isinstance(ver, int)
+            ]
+        )
+        return (
+            filtered_versions  # entire list, if 'All' is met
+            if num == 'All'
+            else filtered_versions[-num:]  # else: list, num entries from tail, if len != 1
+            if num != 1
+            else filtered_versions[-num:][0]  # else: single str, if len == 1
+        )
+
     @contextmanager
     def satellite_setting(self, key_val: str):
         """Context Manager to update the satellite setting and revert on exit

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -13,7 +13,7 @@
 """
 
 # For ease of use hc refers to host-collection throughout this document
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from time import sleep, time
 
 import pytest
@@ -37,6 +37,7 @@ from robottelo.constants import (
     REAL_RHEL8_1_PACKAGE_FILENAME,
     REPOS,
     REPOSET,
+    TIMESTAMP_FMT_DATE,
 )
 
 pytestmark = [
@@ -1656,11 +1657,7 @@ def test_positive_filter_errata_type_other(
 
     """
     # newest version rhel
-    rhel_N = next(
-        r
-        for r in reversed(settings.supportability.content_hosts.rhel.versions)
-        if 'fips' not in str(r)
-    )
+    rhel_N = target_sat.api_factory.supported_rhel_ver(num=1)
     # fetch a newly generated PGP key from address's response
     gpg_url = f'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{rhel_N}'
     _response = requests.get(gpg_url, timeout=120, verify=True)
@@ -1699,7 +1696,7 @@ def test_positive_filter_errata_type_other(
         inclusion=True,
     ).create()
 
-    today_UTC = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+    today_UTC = datetime.now(UTC).strftime(TIMESTAMP_FMT_DATE)
     # rule to filter erratum by date, only specify end_date
     errata_rule = target_sat.api.ContentViewFilterRule(
         content_view_filter=errata_filter,

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -1218,7 +1218,11 @@ def test_positive_get_diff_for_cv_envs(target_sat):
     org = target_sat.api.Organization().create()
     env = target_sat.api.LifecycleEnvironment(organization=org).create()
     content_view = target_sat.api.ContentView(organization=org).create()
-    activation_key = target_sat.api.ActivationKey(environment=env, organization=org).create()
+    activation_key = target_sat.api.ActivationKey(
+        content_view=content_view.read(),
+        organization=org,
+        environment=env,
+    ).create()
     # Published content-view-version with repos will be created
     for repo_url in [settings.repos.yum_9.url, CUSTOM_REPO_URL]:
         target_sat.cli_factory.setup_org_for_a_custom_repo(

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -1198,7 +1198,9 @@ def test_positive_get_applicable_for_host(
     assert REAL_RHEL8_1_ERRATA_ID in [errata['errata_id'] for errata in erratum]
 
 
-def test_positive_get_diff_for_cv_envs(target_sat):
+def test_positive_get_diff_for_cv_envs(
+    module_target_sat, module_sca_manifest_org, module_cv, module_lce, activation_key
+):
     """Generate a difference in errata between a set of environments
     for a content view
 
@@ -1215,34 +1217,33 @@ def test_positive_get_diff_for_cv_envs(target_sat):
         for a content view is retrieved.
 
     """
-    org = target_sat.api.Organization().create()
-    env = target_sat.api.LifecycleEnvironment(organization=org).create()
-    content_view = target_sat.api.ContentView(organization=org).create()
-    activation_key = target_sat.api.ActivationKey(
-        content_view=content_view.read(),
-        organization=org,
-        environment=env,
-    ).create()
+    org = module_sca_manifest_org
     # Published content-view-version with repos will be created
     for repo_url in [settings.repos.yum_9.url, CUSTOM_REPO_URL]:
-        target_sat.cli_factory.setup_org_for_a_custom_repo(
+        module_target_sat.cli_factory.setup_org_for_a_custom_repo(
             {
                 'url': repo_url,
                 'organization-id': org.id,
-                'content-view-id': content_view.id,
-                'lifecycle-environment-id': env.id,
+                'content-view-id': module_cv.id,
+                'lifecycle-environment-id': module_lce.id,
                 'activationkey-id': activation_key.id,
             }
         )
-    new_env = target_sat.api.LifecycleEnvironment(organization=org, prior=env).create()
+    new_env = module_target_sat.api.LifecycleEnvironment(
+        organization=org, prior=module_lce
+    ).create()
     # no need to publish a new version, just promote newest
     cv_publish_promote(
-        sat=target_sat, org=org, cv=content_view, lce=[env, new_env], needs_publish=False
+        sat=module_target_sat,
+        org=org,
+        cv=module_cv,
+        lce=[module_lce, new_env],
+        needs_publish=False,
     )
-    content_view = target_sat.api.ContentView(id=content_view.id).read()
+    module_cv = module_target_sat.api.ContentView(id=module_cv.id).read()
     # Get last two versions by id to compare
-    cvv_ids = sorted(cvv.id for cvv in content_view.version)[-2:]
-    result = target_sat.api.Errata().compare(
+    cvv_ids = sorted(cvv.id for cvv in module_cv.version)[-2:]
+    result = module_target_sat.api.Errata().compare(
         data={'content_view_version_ids': [cvv_id for cvv_id in cvv_ids], 'per_page': '9999'}
     )
     cvv2_only_errata = next(
@@ -1618,7 +1619,7 @@ def test_positive_incremental_update_apply_to_envs_cvs(
 
 def test_positive_filter_errata_type_other(
     module_sca_manifest_org,
-    target_sat,
+    module_target_sat,
     module_cv,
 ):
     """
@@ -1629,7 +1630,7 @@ def test_positive_filter_errata_type_other(
     :id: 062bb1a5-814c-4573-bedc-aaa4e2ef557a
 
     :setup:
-        1. Fetch the latest supported RHEL major version in supportability.yaml (ie: 10)
+        1. Fetch the latest supported RHEL major version in supportability.yaml ('10')
         2. GET request to EPEL's PGP-key generator (dl.fedoraproject.org/pub/epel/)
         3. Create GPG-key on satellite from URL's response.
         4. Create custom product using the GPG-key.
@@ -1661,7 +1662,7 @@ def test_positive_filter_errata_type_other(
 
     """
     # newest version rhel
-    rhel_N = target_sat.api_factory.supported_rhel_ver(num=1)
+    rhel_N = module_target_sat.api_factory.supported_rhel_ver(num=1)
     # fetch a newly generated PGP key from address's response
     gpg_url = f'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{rhel_N}'
     _response = requests.get(gpg_url, timeout=120, verify=True)
@@ -1671,18 +1672,20 @@ def test_positive_filter_errata_type_other(
         raise ValueError('Fetched content was not a valid credential')
 
     # create GPG key on satellite and associated product
-    gpg_key = target_sat.api.GPGKey(
+    gpg_key = module_target_sat.api.GPGKey(
         organization=module_sca_manifest_org.id,
         content=_response.text,
     ).create()
-    epel_product = target_sat.api.Product(
+    epel_product = module_target_sat.api.Product(
         organization=module_sca_manifest_org,
         gpg_key=gpg_key,
     ).create()
 
-    # create and sync custom EPEL repo
+    # if RHEL 10 only, change '10' to '10.0', to match URL for EPEL repo
+    rhel_N = str(float(rhel_N)) if rhel_N == '10' else rhel_N
     epel_url = f'https://dl.fedoraproject.org/pub/epel/{rhel_N}/Everything/x86_64/'
-    epel_repo = target_sat.api.Repository(
+    # create and sync custom EPEL repo
+    epel_repo = module_target_sat.api.Repository(
         product=epel_product,
         url=epel_url,
     ).create()
@@ -1694,7 +1697,7 @@ def test_positive_filter_errata_type_other(
     module_cv = module_cv.read()
 
     # create errata filter
-    errata_filter = target_sat.api.ErratumContentViewFilter(
+    errata_filter = module_target_sat.api.ErratumContentViewFilter(
         content_view=module_cv,
         name='errata-filter',
         inclusion=True,
@@ -1702,13 +1705,13 @@ def test_positive_filter_errata_type_other(
 
     today_UTC = datetime.now(UTC).strftime(TIMESTAMP_FMT_DATE)
     # rule to filter erratum by date, only specify end_date
-    errata_rule = target_sat.api.ContentViewFilterRule(
+    errata_rule = module_target_sat.api.ContentViewFilterRule(
         content_view_filter=errata_filter,
         end_date=today_UTC,
     ).create()
 
     # hammer update the Erratum filter rule, flag 'allow-other-types' set to True <<<
-    target_sat.cli.ContentViewFilterRule.update(
+    module_target_sat.cli.ContentViewFilterRule.update(
         {
             'id': errata_rule.id,
             'allow-other-types': 'true',
@@ -1716,9 +1719,8 @@ def test_positive_filter_errata_type_other(
         }
     )
     module_cv = module_cv.read()
-
     # create rpm filter
-    target_sat.api.RPMContentViewFilter(
+    module_target_sat.api.RPMContentViewFilter(
         content_view=module_cv,
         name='rpm-filter',
         inclusion=True,
@@ -1730,7 +1732,7 @@ def test_positive_filter_errata_type_other(
     module_cv = module_cv.read()
 
     version_1 = module_cv.version[-1].read()  # unfiltered
-    version_2 = module_cv.version[0].read()  # filtered
+    version_2 = module_cv.version[-2].read()  # filtered
     # errata and package counts match between the filtered and unfiltered versions
     assert version_1.errata_counts == version_2.errata_counts
     assert version_1.package_count == version_2.package_count

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1545,8 +1545,10 @@ def test_errata_list_by_contentview_filter(module_sca_manifest_org, module_targe
     assert errata_count != errata_count_cvf
 
 
-@pytest.mark.rhel_ver_match('N-2')
-def test_positive_verify_errata_recalculate_tasks(target_sat, errata_host):
+@pytest.mark.parametrize(
+    'hosts', [(f'rhel{settings.content_host.default_rhel_version}', 4)], indirect=True
+)
+def test_positive_verify_errata_recalculate_tasks(target_sat, errata_hosts):
     """Verify 'Actions::Katello::Applicability::Hosts::BulkGenerate' tasks proceed on 'worker-hosts-queue-1.service'
 
     :id: d5f89df2-b8fb-4aec-839d-b548b0aadc0c
@@ -1563,7 +1565,7 @@ def test_positive_verify_errata_recalculate_tasks(target_sat, errata_host):
 
     :BZ: 2249736
     """
-    # Recalculate errata command has triggered inside errata_host fixture
+    # Recalculate errata command has triggered inside errata_hosts fixture
 
     # get PID of 'worker-hosts-queue-1' from /var/log/messages
     message_log = target_sat.execute(

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -32,6 +32,7 @@ from robottelo.constants import (
     REAL_4_ERRATA_ID,
     REPOS,
     REPOSET,
+    TIMESTAMP_FMT,
 )
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.hosts import ContentHost
@@ -83,9 +84,6 @@ REPOS_WITH_ERRATA = (
         'errata_id': settings.repos.yum_3.errata[5],
     },
 )
-
-TIMESTAMP_FMT = '%Y-%m-%d %H:%M'
-TIMESTAMP_FMT_S = '%Y-%m-%d %H:%M:%S'
 
 PSUTIL_RPM = 'python2-psutil-5.6.7-1.el7.x86_64.rpm'
 
@@ -163,11 +161,29 @@ def rh_repo_module_manifest(module_sca_manifest_org, module_target_sat):
 
 @pytest.fixture(scope='module')
 def hosts(request):
-    """Deploy hosts via broker."""
-    num_hosts = getattr(request, 'param', 2)
-    with Broker(nick='rhel8', host_class=ContentHost, _count=num_hosts) as hosts:
+    """Deploy hosts via broker by distro and host count.
+    Parametrize with tuple, (str<distro>, int<num_hosts>), or just one, or neither.
+
+    Default: Robotello settings: Default RHEL Version, num_host of 2.
+    """
+    default_distro = 'rhel' + str(settings.content_host.default_rhel_version)
+    default_num_hosts = 2
+    # get any request
+    param = getattr(request, 'param', (None, None))
+    # get both params, or just one
+    match param:
+        case (str() as distro, int() as num_hosts):  # Tuple (both values provided)
+            pass
+        case str() as distro:  # Just distro (default num_hosts)
+            num_hosts = default_num_hosts
+        case int() as num_hosts:  # Just num_hosts (default distro)
+            distro = default_distro
+        case _:  # Default for both
+            distro, num_hosts = default_distro, default_num_hosts
+
+    with Broker(nick=distro, host_class=ContentHost, _count=num_hosts) as hosts:
         if not isinstance(hosts, list) or len(hosts) != num_hosts:
-            pytest.fail('Failed to provision the expected number of hosts.')
+            pytest.fail(f'Failed to provision the expected number of hosts for {distro}.')
         yield hosts
 
 
@@ -179,7 +195,12 @@ def register_hosts(
     module_ak,
     module_target_sat,
 ):
-    """Register hosts to Satellite"""
+    """Register hosts to Satellite
+
+    parametrize by fixture `hosts`, example:
+        @pytest.mark.parametrize('hosts', [('rhel10', 4)], indirect=True)
+    Default: 2nd newest supported RHEL version, 2 clients.
+    """
     for host in hosts:
         module_target_sat.cli_factory.setup_org_for_a_custom_repo(
             {
@@ -202,7 +223,12 @@ def register_hosts(
 
 @pytest.fixture
 def errata_hosts(register_hosts, target_sat):
-    """Ensure that rpm is installed on host."""
+    """Ensure that rpm is installed on host.
+
+    parametrize by fixture `hosts`, example:
+        @pytest.mark.parametrize('hosts', [('rhel10', 4)], indirect=True)
+    Default: 2nd newest supported RHEL version, 2 clients.
+    """
     for host in register_hosts:
         # Enable all custom and rh repositories.
         host.execute(r'subscription-manager repos --enable \*')
@@ -254,37 +280,32 @@ def host_collection(module_sca_manifest_org, module_ak_cv_lce, register_hosts, m
 def start_and_wait_errata_recalculate(sat, host):
     """Helper to find any in-progress errata applicability task and wait_for completion.
     Otherwise, schedule errata recalculation, wait for the task.
-    Find the successful completed task(s).
+    Poll the finished task(s).
 
     :param sat: Satellite instance to check for task(s)
     :param host: ContentHost instance to schedule errata recalculate
     """
-    # Find any in-progress task for this host
-    search = "label = Actions::Katello::Applicability::Hosts::BulkGenerate and result = pending"
+    # Find any in-progress tasks for Host(s)
+    label = 'label = Actions::Katello::Applicability::Hosts::BulkGenerate'
+    search = label + ' and result = pending'
     applicability_task_running = sat.cli.Task.list_tasks({'search': search})
     # No task in progress, invoke errata recalculate
     if len(applicability_task_running) == 0:
         sat.cli.Host.errata_recalculate({'host-id': host.nailgun_host.id})
         host.run('subscription-manager repos')
-    # Note time check for later wait_for_tasks include 30s margin of safety
-    timestamp = (datetime.now(UTC) - timedelta(seconds=30)).strftime(TIMESTAMP_FMT_S)
+    # timestamp for install start includes 20s margin of safety
+    timestamp = (datetime.now(UTC) - timedelta(seconds=20)).strftime(TIMESTAMP_FMT)
     # Wait for upload profile event (in case Satellite system is slow)
-    sat.wait_for_tasks(
-        search_query=(
-            'label = Actions::Katello::Applicability::Hosts::BulkGenerate'
-            f' and started_at >= "{timestamp}"'
-        ),
+    search = label + f' and started_at >= "{timestamp}"'
+    tasks = sat.wait_for_tasks(
+        search_query=search,
         search_rate=15,
         max_tries=10,
     )
-    # Find the successful finished task(s)
-    search = (
-        "label = Actions::Katello::Applicability::Hosts::BulkGenerate"
-        " and result = success"
-        f" and started_at >= '{timestamp}'"
-    )
-    applicability_task_success = sat.cli.Task.list_tasks({'search': search})
-    assert applicability_task_success, f'No successful task found by search: {search}'
+    # Poll the finished task(s)
+    assert len(tasks) > 0, f'No task(s) found by search: {search}'
+    for task in tasks:
+        assert sat.api.ForemanTask(id=task.id).poll()
 
 
 def is_rpm_installed(host, rpm=None):

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -163,6 +163,7 @@ def rh_repo_module_manifest(module_sca_manifest_org, module_target_sat):
 def hosts(request):
     """Deploy hosts via broker by distro and host count.
     Parametrize with tuple, (str<distro>, int<num_hosts>), or just one, or neither.
+    @pytest.mark.parametrize('hosts', [('rhel9', 2)], indirect=True)
 
     Default: Robotello settings: Default RHEL Version, num_host of 2.
     """
@@ -199,7 +200,7 @@ def register_hosts(
 
     parametrize by fixture `hosts`, example:
         @pytest.mark.parametrize('hosts', [('rhel10', 4)], indirect=True)
-    Default: 2nd newest supported RHEL version, 2 clients.
+    Default: DEFAULT Robottelo RHEL version, 2 clients.
     """
     for host in hosts:
         module_target_sat.cli_factory.setup_org_for_a_custom_repo(
@@ -227,7 +228,7 @@ def errata_hosts(register_hosts, target_sat):
 
     parametrize by fixture `hosts`, example:
         @pytest.mark.parametrize('hosts', [('rhel10', 4)], indirect=True)
-    Default: 2nd newest supported RHEL version, 2 clients.
+    Default: DEFAULT Robottelo RHEL version, 2 clients.
     """
     for host in register_hosts:
         # Enable all custom and rh repositories.


### PR DESCRIPTION
### Automation fixes for 6.17.0 Errata Management
_UI_: From #18037 (wait_for applicability recalculate tasks)
- `test_end_to_end` , `test_positive_apply_for_all_hosts` , `test_positive_filtered_errata_status_installable_param`

_CLI_: Address failures in helper method (find/invoke/wait_for applicability recalculate tasks):
- 15+ failing cases in  `start_and_wait_errata_recalculate()`

_API_: one test failing in setup, and enhanced another already impacted by changes
- `test_positive_get_diff_for_cv_envs`: Use module fixtures instead of incorrectly setup components
- minor enhancements to `test_positive_filter_errata_type_other`

### PRT (UI, CLI, API)

--------------------------------------------------------------------------------------------------------------------
**UI / test_errata.py** :: test_end_to_end , test_positive_filtered_errata_status_installable_param -- (build )
**UI / test_errata.py** :: test_positive_apply_for_all_hosts -- PASS (build 10905)
``` 
trigger: test-robottelo
pytest: tests/foreman/ui/test_errata.py::test_positive_apply_for_all_hosts
env:
   ROBOTTELO_server__deploy_arguments__deploy_sat_version: '6.17.0'
   ROBOTTELO_server__deploy_arguments__deploy_snap_version: '6.0'
```
^ Satellite v6.17.0 , in Stream (6.18) there are UI Navigation failures, larger scoped work for PF5 in 6.18.0.

--------------------------------------------------------------------------------------------------------------------
**CLI Local Results: CLI / test_errata.py** (all cases) 45/48 PASS
**CLI / test_errata.py** :: uses-fixtures: hosts (uses method that was failing) -- 11/11 PASS (build 10907)
``` 
trigger: test-robottelo
pytest: tests/foreman/cli/test_errata.py --uses-fixtures hosts
```

--------------------------------------------------------------------------------------------------------------------
**API / test_errata.py** :: test_positive_get_diff_for_cv_envs , test_positive_filter_errata_type_other 
^ `test_positive_filter_errata_type_other` now fails at repo sync, the EPEL 10 repo URL is not available.
http://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/

-- 2/2 PASS (build 10907)
```
trigger: test-robottelo
pytest: tests/foreman/api/test_errata.py -k 'test_positive_filter_errata_type_other or test_positive_get_diff_for_cv_envs'
```