### PR TITLE
Refactor Leapp Tests to run configurable tests

### DIFF
--- a/conf/leapp.yaml.template
+++ b/conf/leapp.yaml.template
@@ -1,0 +1,17 @@
+LEAPP:
+  #Source RHEL Version of client
+  SOURCE_RHEL: '8.10'
+  #Target RHEL Version of client
+  TARGET_RHEL: '9.5'
+  #Leapp Version(GA/EUS/E4S,AUS)
+  LEAPP_VER: 'GA'
+  #Leapp brew build name for non-ga leapp version
+  LEAPP_BREW_BUILD_NAME:
+  #Leapp brew build url for non-ga leapp version
+  LEAPP_BREW_BUILD_URL:
+  #Leapp repo brew build name for non-ga leapp version
+  LEAPP_REPO_BREW_BUILD_NAME:
+  #Leapp repo brew build url for non-ga leapp version
+  LEAPP_REPO_BREW_BUILD_URL:
+
+

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -423,4 +423,12 @@ VALIDATORS = dict(
             must_exist=True,
         ),
     ],
+    leapp=[
+        Validator(
+            'leapp.source_rhel',
+            'leapp.target_rhel',
+            'leapp.leapp_ver',
+            must_exist=True,
+        ),
+    ],
 )

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -24,8 +24,10 @@ from robottelo.utils import ohsnap
 @pytest.mark.parametrize(
     'upgrade_path',
     [
-        # {'source_version': RHEL7_VER, 'target_version': RHEL8_VER},
-        {'source_version': RHEL8_VER, 'target_version': RHEL9_VER},
+        {
+            'source_version': settings.leapp.source_rhel,
+            'target_version': settings.leapp.target_rhel,
+        },
     ],
     ids=lambda upgrade_path: f'{upgrade_path["source_version"]}'
     f'_to_{upgrade_path["target_version"]}',
@@ -57,6 +59,7 @@ def test_positive_leapp_upgrade_rhel(
     :expectedresults:
         1. Update RHEL OS major version to another major version
     """
+
     login = settings.server.admin_username
     password = settings.server.admin_password
     org = module_sca_manifest_org


### PR DESCRIPTION
### Problem Statement
Leapp test needs to configurable to create a pipeline to run Leapp interop for non-ga testing.

### Solution
Added a config file to make it configurable

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->