### PR TITLE
[6.17.z] Fix netcat on ipv6

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -297,7 +297,8 @@ class SystemInfo:
             pre_ncat_procs = self.execute('pgrep ncat').stdout.splitlines()
             with self.session.shell() as channel:
                 # if ncat isn't backgrounded, it prevents the channel from closing
-                command = f'ncat -kl -p {newport} -c "ncat {self.hostname} {oldport}" &'
+                nwtype = '6' if self.ipv6 else ''
+                command = f'ncat -{nwtype}kl -p {newport} -c "ncat {self.hostname} {oldport}" &'
                 logger.debug(f'Creating tunnel: {command}')
                 channel.send(command)
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18059

ncat needs `-6` parameter to listen on ipv6