### PR TITLE
[6.17.z] Fix networking fact parametrization for IPv6 run

### DIFF
--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -27,7 +27,7 @@ from robottelo.utils.issue_handlers import is_open
         'os::family',
         'system_uptime::seconds',
         'memory::system::total',
-        'networking::ip',
+        'networking::ip6' if settings.server.is_ipv6 else 'networking::ip',
     ],
 )
 def test_positive_list_by_name(fact, module_target_sat):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18071

### Problem Statement
`networking::ip` fact is missing for IPv6 sat, which causes tests/foreman/cli/test_fact.py::test_positive_list_by_name to fail

### Solution
Fix networking fact parametrization for IPv6 run by using `networking::ip6` fact for IPv6 sat, and `networking::ip` for IPv4 sat

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->