### PR TITLE
Remove remaining references to module_org_with_manifest

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -33,12 +33,12 @@ def module_product(module_org, module_target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_rhst_repo(module_target_sat, module_org_with_manifest, module_promoted_cv, module_lce):
+def module_rhst_repo(module_target_sat, module_sca_manifest_org, module_promoted_cv, module_lce):
     """Use module org with manifest, creates RH tools repo, syncs and returns RH repo id."""
     # enable rhel repo and return its ID
     rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=DEFAULT_ARCHITECTURE,
-        org_id=module_org_with_manifest.id,
+        org_id=module_sca_manifest_org.id,
         product=PRDS['rhel'],
         repo=REPOS['rhst7']['name'],
         reposet=REPOSET['rhst7'],

--- a/pytest_fixtures/component/subscription.py
+++ b/pytest_fixtures/component/subscription.py
@@ -4,9 +4,9 @@ from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 
 
 @pytest.fixture(scope='module')
-def default_subscription(module_target_sat, module_org_with_manifest):
+def default_subscription(module_target_sat, module_sca_manifest_org):
     subscription = module_target_sat.api.Subscription(
-        organization=module_org_with_manifest.id
+        organization=module_sca_manifest_org.id
     ).search(query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'})
     assert len(subscription)
     return subscription[0]


### PR DESCRIPTION
This PR removes lingering references to a fixture that used the fake manifest from two other pytest fixtures. The test is still failing locally for me, but the failure is unrelated to manifester. With these changes, the test successfully completes its setup.