### PR TITLE
[6.17.z] Fix HTTP proxy insights tests

### DIFF
--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -11,7 +11,7 @@ def session_auth_proxy(session_target_sat):
 
 
 @pytest.fixture
-def setup_http_proxy(request, module_sca_manifest_org, target_sat):
+def setup_http_proxy(request, module_org, target_sat):
     """Create a new HTTP proxy and set related settings based on proxy"""
     content_proxy = target_sat.api.Setting().search(
         query={'search': 'name=content_default_http_proxy'}
@@ -20,7 +20,7 @@ def setup_http_proxy(request, module_sca_manifest_org, target_sat):
     general_proxy = target_sat.api.Setting().search(query={'search': 'name=http_proxy'})[0]
     general_proxy_value = '' if general_proxy.value is None else general_proxy.value
 
-    http_proxy = target_sat.api_factory.make_http_proxy(module_sca_manifest_org, request.param)
+    http_proxy = target_sat.api_factory.make_http_proxy(module_org, request.param)
     content_proxy = target_sat.api.Setting().search(
         query={'search': 'name=content_default_http_proxy'}
     )[0]

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -85,7 +85,7 @@ def test_positive_create_update_delete(module_org, module_location, target_sat):
 
 
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match(r'^(?!6$)\d+$')
+@pytest.mark.rhel_ver_match('N-2')
 @pytest.mark.parametrize(
     'setup_http_proxy',
     [True, False],
@@ -93,7 +93,7 @@ def test_positive_create_update_delete(module_org, module_location, target_sat):
     ids=['auth_http_proxy', 'unauth_http_proxy'],
 )
 def test_insights_client_registration_with_http_proxy(
-    module_target_sat,
+    module_target_sat_insights,
     setup_http_proxy,
     rhel_contenthost,
     rhcloud_activation_key,
@@ -121,7 +121,7 @@ def test_insights_client_registration_with_http_proxy(
     :customerscenario: true
     """
     rhel_contenthost.configure_insights_client(
-        module_target_sat,
+        module_target_sat_insights,
         rhcloud_activation_key,
         rhcloud_manifest_org,
         f"rhel{rhel_contenthost.os_version.major}",


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18065

### Problem Statement
We have a test for insights host registration through an HTTP proxy and it's started to fail since several recent changes.

1. After https://github.com/SatelliteQE/robottelo/pull/17950 merge the test fails in `module_sca_manifest_org` (called from `setup_http_proxy`) because `rhcloud_manifest_org` uploads the same `module_sca_manifest` into another org.
```
{'action': 'Import Manifest', 'input': "for organization 'gIMSSfWssDXj'", 'output': '', 'errors': ['org.candlepin.async.JobExecutionException: This subscription management application has already been imported by another owner.']}
```
2. In https://github.com/SatelliteQE/robottelo/pull/17342 the `rhcloud_manifest_org` and `rhcloud_activation_key` fixtures were re-targeted to `module_target_sat_insights`.
3. The test case is currently parametrized in 8 tests, which feels a bit heavy for this component.


### Solution
1. We don't need manifest in an org to create a proxy, use the underlying `module_org` instead.
2. Let's re-target our test too for better readability or if we decide to parametrize for Insights on-prem.
3. Use only latest 3 RHELs to lighten this test case in results.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_http_proxy.py -k test_insights_client_registration_with_http_proxy
```