### PR TITLE
[6.15.z] Log traceback in case a test phase fails

### DIFF
--- a/pytest_plugins/logging_hooks.py
+++ b/pytest_plugins/logging_hooks.py
@@ -75,4 +75,8 @@ def pytest_runtest_logstart(nodeid, location):
 def pytest_runtest_logreport(report):
     """Process the TestReport produced for each of the setup,
     call and teardown runtest phases of an item."""
+    # if the phase failed, log the traceback
+    if report.failed and hasattr(report, 'longrepr') and report.longrepr is not None:
+        logger.error('Test phase \'%s\' failed for test: %s', report.when, report.nodeid)
+        logger.error('Exception thrown:\n%s', report.longrepr)
     logger.info('Finished %s for test: %s, result: %s', report.when, report.nodeid, report.outcome)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18079

### Problem Statement
User needs to switch context during the test failure analysis. `robottelo.log` does not contain the actual failure the test failed with

### Solution
Use one of the pytest hooks to log the exception. Take the actual failure/traceback from the [`longrepr`](https://docs.pytest.org/en/stable/reference/reference.html#pytest.TestReport.longrepr) attribute.

### Considerations
Adding this might bloat our log files a little depending on how long the functions in the call stack are.

### Example
Adding the following
```diff
diff --git a/tests/foreman/api/test_ping.py b/tests/foreman/api/test_ping.py
index 06d19678f..b62274693 100644
--- a/tests/foreman/api/test_ping.py
+++ b/tests/foreman/api/test_ping.py
@@ -14,6 +14,7 @@
 
 import pytest
 
+from robottelo.config import settings
 
 @pytest.mark.e2e
 @pytest.mark.build_sanity
@@ -39,3 +40,4 @@ def test_positive_ping(target_sat):
     assert all([service['status'] == 'ok' for service in services.values()]), (
         'Not all services seem to be up and running!'
     )
+    assert settings.server.foobar == 'bar'
```

and then running

```
pytest tests/foreman/api/test_ping.py::test_positive_ping
```

generates the following logs.

```
2025-03-28 16:25:34 - robottelo - INFO - Finished setup for test: tests/foreman/api/test_ping.py::test_positive_ping, result: passed
2025-03-28 16:25:34 - nailgun.client - DEBUG - Making HTTP GET request to https://mysatellite.corp.acme.com/katello/api/v2/ping with options {'data': '{}', 'auth': None, 'verify': None, 'headers': {'content-type': 'application/json'}}, no params and no data.
2025-03-28 16:25:34 - nailgun.client - DEBUG - Received HTTP 200 response:   {"status":"ok","services":{"candlepin":{"status":"ok","duration_ms":"17"},"candlepin_auth":{"status":"ok","duration_ms":"16"},"foreman_tasks":{"status":"ok","duration_ms":"4"},"katello_events":{"status":"ok","message":"0 Processed, 0 Failed","duration_ms":"0"},"candlepin_events":{"status":"ok","message":"0 Processed, 0 Failed","duration_ms":"0"},"pulp3":{"status":"ok","duration_ms":"85"},"pulp3_content":{"status":"ok","duration_ms":"47"}}}
    
2025-03-28 16:25:35 - robottelo - ERROR - Test phase 'call' failed for test: tests/foreman/api/test_ping.py::test_positive_ping
2025-03-28 16:25:35 - robottelo - ERROR - Exception thrown:
    target_sat = Satellite(omitting_credentials=False, port=22, ipv6=True, blank=False, hostname=mysatellite.corp.acm....ServerConfig(url='https://mysatellite.corp.acme.com', auth=('admin', 'yesthisisthepassword'), verify=False))
    
        @pytest.mark.e2e
        @pytest.mark.build_sanity
        @pytest.mark.upgrade
        def test_positive_ping(target_sat):
            """Check if all services are running
        
            :id: b8ecc7ba-8007-4067-bf99-21a82c833de7
        
            :expectedresults: Overall and individual services status should be 'ok'.
            """
            response = target_sat.api.Ping().search_json()
            assert response['status'] == 'ok'  # overall status
        
            # Check that all services are OK. ['services'] is in this format:
            #
            # {'services': {
            #    'candlepin': {'duration_ms': '40', 'status': 'ok'},
            #    'candlepin_auth': {'duration_ms': '41', 'status': 'ok'},
            #    …
            # }, 'status': 'ok'}
            services = response['services']
            assert all([service['status'] == 'ok' for service in services.values()]), (
                'Not all services seem to be up and running!'
            )
    >       assert settings.server.foobar == 'bar'
    
    tests/foreman/api/test_ping.py:43: 
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
    ../../.virtualenvs/robottelo/lib/python3.13/site-packages/dynaconf/utils/boxing.py:18: in evaluate
        value = f(dynabox, item, *args, **kwargs)
    ../../.virtualenvs/robottelo/lib/python3.13/site-packages/dynaconf/utils/boxing.py:41: in __getattr__
        return super().__getattr__(n_item, *args, **kwargs)
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
    
    A = <Box: {'hostname': 'mysatellite.corp.acme.com', 'DEPLOY_ARGUMENTS': {'enable_fapolicyd': False, ...OMMAND_TIMEOUT': '10m', 'CONNECTION_TIMEOUT': '1m'}, 'hostnames': ['mysatellite.corp.acme.com']}>
    item = 'foobar'
    
        def __getattr__(A,item):
        	B=item
        	try:
        		try:C=A.__getitem__(B,_ignore_default=_G)
        		except KeyError:C=object.__getattribute__(A,B)
        	except AttributeError as E:
        		if B=='__getstate__':raise BoxKeyError(B)from _A
        		if B==_H:raise BoxError('_box_config key must exist')from _A
        		if A._box_config[_E]:
        			D=A._safe_attr(B)
        			if D in A._box_config[_C]:return A.__getitem__(A._box_config[_C][D])
        		if A._box_config[_J]:return A.__get_default(B)
    >   		raise BoxKeyError(str(E))from _A
    E     dynaconf.vendor.box.exceptions.BoxKeyError: "'DynaBox' object has no attribute 'foobar'"
    
    ../../.virtualenvs/robottelo/lib/python3.13/site-packages/dynaconf/vendor/box/box.py:176: BoxKeyError
2025-03-28 16:25:35 - robottelo - INFO - Finished call for test: tests/foreman/api/test_ping.py::test_positive_ping, result: failed
2025-03-28 16:25:35 - robottelo - INFO - Finished teardown for test: tests/foreman/api/test_ping.py::test_positive_ping, result: passed
```
