### PR TITLE
[6.17.z] Add permissions for foreman_statistics plugin

### DIFF
--- a/pytest_fixtures/component/permissions.py
+++ b/pytest_fixtures/component/permissions.py
@@ -57,5 +57,8 @@ def expected_permissions(session_target_sat):
         permissions.pop('ForemanSalt::SaltVariable')
         permissions.pop('ForemanSalt::SaltEnvironment')
         permissions.pop('ForemanSalt::SaltModule')
+    if 'rubygem-foreman_statistics' not in rpm_packages:
+        permissions.pop('ForemanStatistics::Trend')
+        permissions[None].remove('view_statistics')
 
     return permissions

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1075,6 +1075,7 @@ PERMISSIONS = {
         'destroy_snapshots',
         'revert_snapshots',
         'edit_snapshots',
+        'view_statistics',
     ],
     'AnsibleRole': ['view_ansible_roles', 'destroy_ansible_roles', 'import_ansible_roles'],
     'AnsibleVariable': [
@@ -1157,6 +1158,13 @@ PERMISSIONS = {
         'edit_salt_modules',
         'view_salt_modules',
         'destroy_salt_modules',
+    ],
+    'ForemanStatistics::Trend': [
+        'create_trends',
+        'view_trends',
+        'edit_trends',
+        'update_trends',
+        'destroy_trends',
     ],
     'ForemanTasks::RecurringLogic': [
         'create_recurring_logics',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18086

### Problem Statement

Missing permissions for https://github.com/theforeman/foreman_statistics

### Solution

Add tests

### Relevant tests

```
tests/foreman/api/test_permission.py::TestPermission
```


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->