### PR TITLE
[6.17.z] Increase wait_for_connection timeout for leapp hosts on reboot

### DIFF
--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -184,7 +184,7 @@ def precondition_check_upgrade_and_install_leapp_tool(custom_leapp_host):
     assert custom_leapp_host.run('yum install leapp-upgrade -y').status == 0
     if custom_leapp_host.run('needs-restarting -r').status == 1:
         custom_leapp_host.power_control(state='reboot', ensure=True)
-        custom_leapp_host.wait_for_connection()
+        custom_leapp_host.wait_for_connection(timeout=300)
 
     # Fixing known inhibitors for source rhel version 8
     if custom_leapp_host.os_version.major == 8:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -382,6 +382,7 @@ class ContentHost(Host, ContentHostMixins):
                 'No workflow in broker.host_workflows for power control, '
                 'or VM operation not supported'
             ) from err
+        self.close()
         assert (
             # TODO read the kwarg name from settings too?
             Broker()
@@ -399,7 +400,9 @@ class ContentHost(Host, ContentHostMixins):
                 wait_for(
                     self.connect,
                     fail_condition=lambda res: res is not None,
-                    timeout=300,
+                    timeout=600,
+                    retries=3,
+                    delay=5,
                     handle_exception=True,
                 )
             # really broad diaper here, but connection exceptions could be a ton of types

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -98,7 +98,7 @@ def test_positive_leapp_upgrade_rhel(
         (login, password),
     )
     custom_leapp_host.power_control(state='reboot')
-    custom_leapp_host.wait_for_connection()
+    custom_leapp_host.wait_for_connection(timeout=300)
     result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
     assert result['success'] == '1'
 
@@ -245,7 +245,7 @@ def test_positive_ygdrassil_client_after_leapp_upgrade(
     )
 
     custom_leapp_host.power_control(state='reboot')
-    custom_leapp_host.wait_for_connection()
+    custom_leapp_host.wait_for_connection(timeout=300)
     result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
     assert result['success'] == '1'
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18057

### Problem Statement
Leapp tests are intermittently failing after reboot as it sometime takes more time to reboot the host and connect again.

### Solution
Increase the timeout on wait_for_connection()

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->