### PR TITLE
[6.17.z] Update certificate key usage to match documentation

### DIFF
--- a/tests/foreman/data/openssl.cnf
+++ b/tests/foreman/data/openssl.cnf
@@ -57,8 +57,8 @@ authorityKeyIdentifier                  = keyid:always,issuer:always
 [ v3_req ]
 basicConstraints                        = CA:FALSE
 subjectKeyIdentifier                    = hash
-keyUsage                                = nonRepudiation, digitalSignature, keyEncipherment
-extendedKeyUsage                        = serverAuth, clientAuth, codeSigning, emailProtection
+keyUsage                                = digitalSignature, keyEncipherment
+extendedKeyUsage                        = serverAuth, clientAuth
 subjectAltName                          = @alt_names
 
 [ alt_names ]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17987

### Problem Statement

The custom certificates that are generated in testing should match documentation and that is being updated here: https://github.com/theforeman/foreman-documentation/pull/3700#discussion_r1990398927

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->