### PR TITLE
Insights e2e test updates

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -6,6 +6,21 @@ from robottelo.constants import CAPSULE_REGISTRATION_OPTS
 from robottelo.hosts import SatelliteHostError
 
 
+def enable_insights(host, satellite, org, activation_key):
+    """Configure remote execution and insights-client on a host"""
+    host.configure_rex(satellite=satellite, org=org, register=False)
+    host.configure_insights_client(
+        satellite=satellite,
+        activation_key=activation_key,
+        org=org,
+        rhel_distro=f"rhel{host.os_version.major}",
+    )
+    # Sync inventory if using hosted Insights
+    if not satellite.local_advisor_enabled:
+        satellite.generate_inventory_report(org)
+        satellite.sync_inventory_status(org)
+
+
 @pytest.fixture(scope='module')
 def module_target_sat_insights(request, module_target_sat, satellite_factory):
     """A module-level fixture to provide a Satellite configured for Insights.
@@ -108,20 +123,25 @@ def rhel_insights_vm(
     rhel_contenthost,
 ):
     """A function-level fixture to create rhel content host registered with insights."""
-    rhel_contenthost.configure_rex(
-        satellite=module_target_sat_insights, org=rhcloud_manifest_org, register=False
+    enable_insights(
+        rhel_contenthost, module_target_sat_insights, rhcloud_manifest_org, rhcloud_activation_key
     )
-    rhel_contenthost.configure_insights_client(
-        satellite=module_target_sat_insights,
-        activation_key=rhcloud_activation_key,
-        org=rhcloud_manifest_org,
-        rhel_distro=f"rhel{rhel_contenthost.os_version.major}",
-    )
-    # Sync inventory if using hosted Insights
-    if not module_target_sat_insights.local_advisor_enabled:
-        module_target_sat_insights.generate_inventory_report(rhcloud_manifest_org)
-        module_target_sat_insights.sync_inventory_status(rhcloud_manifest_org)
     return rhel_contenthost
+
+
+@pytest.fixture
+def rhel_insights_vms(
+    module_target_sat_insights,
+    rhcloud_activation_key,
+    rhcloud_manifest_org,
+    content_hosts,
+):
+    """A function-level fixture to create rhel content hosts registered with insights."""
+    for content_host in content_hosts:
+        enable_insights(
+            content_host, module_target_sat_insights, rhcloud_manifest_org, rhcloud_activation_key
+        )
+    return content_hosts
 
 
 @pytest.fixture


### PR DESCRIPTION
### Problem Statement


### Solution

- Add tests to verify simultaneous remediation of 2 Insights hosts via the UI:
  - `test_rhcloud_insights_remediate_multiple_hosts[rhel10-hosted]`
  - `test_rhcloud_insights_remediate_multiple_hosts[rhel10-local]`
- Added new `rhel_insights_vms` fixture, used by the new tests, to return two registered Insights hosts registered to the Satellite.

- Add `insights-client --diagnosis` and `insights-client --version` checks to the e2e tests.

### Related Issues

SAT-32473

In the PRT test results below, 1 test failed during broker checkout, which is unrelated to the changes in this PR.

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->