### PR TITLE
[6.17.z] SAT-28552 system purpose SLA attribute

### DIFF
--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -1,6 +1,7 @@
 import pytest
 
 from robottelo.config import settings
+from robottelo.constants import REPOS
 from robottelo.utils.datafactory import gen_string
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
@@ -350,3 +351,12 @@ def delete_host(form_data_api, target_sat):
     results = target_sat.api.Host().search(query={'search': guest_name})
     if results:
         target_sat.api.Host(id=results[0].read_json()['id']).delete()
+
+
+@pytest.fixture
+def register_sat_and_enable_aps_repo(target_sat):
+    """Register Satellite to CDN and Enable rhel aps repos"""
+    target_sat.register_to_cdn()
+    target_sat.enable_repo(REPOS[f'rhel{target_sat.os_version.major}_aps']['id'])
+    yield
+    target_sat.unregister()

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -669,3 +669,36 @@ class TestVirtWhoConfigforEsx:
         for item in task:
             assert "Job blocked by the following existing jobs" not in item['task-errors']
             assert "success" in item['result']
+
+
+@pytest.mark.parametrize('deploy_type_cli', ['id'], indirect=True)
+def test_positive_change_system_puropse_SLA_for_hypervisor(
+    target_sat, register_sat_and_enable_aps_repo, virtwho_config_cli, deploy_type_cli
+):
+    """Verify that system purpose SLA attribute set successfully and does not throw any error
+
+    :id: a4c88d9f-35b7-4073-a43c-ab613f4ce583
+
+    :setup:
+        Setup virt-who hypervisor
+
+    :steps:
+        Set up system purpose attribute for SLA
+
+    :expectedresults:
+        system purpose SLA attribute set without any error
+
+    :verifies: SAT-28552
+
+    :customerscenario: true
+
+    :CaseImportance: Medium
+    """
+    SLA_service_level = gen_string('alpha', 5)
+    host_id = target_sat.cli.Host.info({'name': deploy_type_cli[1]})['id']
+    output = target_sat.cli.Host.update({'id': host_id, 'service-level': SLA_service_level})
+    assert output[0]['message'] == 'Host updated.'
+    host_service_level = target_sat.cli.Host.info({'name': deploy_type_cli[1]})[
+        'subscription-information'
+    ]['system-purpose']['service-level']
+    assert SLA_service_level == host_service_level


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18122

### Problem Statement
Customer Case: SAT-28552

### Solution
Use esx hyper-v and rhel content host as a guest

### Related Issues
N/A

### Dependant MR
Satellite-jenkins: `satellite-jenkins/merge_requests/1649`

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/virtwho/cli/test_esx_sca.py -k 'test_positive_change_system_puropse_SLA_for_hypervisor'
```
### Local test execution result
```
Testing started at 12:47 am ...
Launching pytest with arguments -k test_positive_change_system_puropse_SLA_for_hypervisor -vvs /home/visawant/Desktop/workspace/robottelo/tests/foreman/virtwho/cli/test_esx_sca.py --no-header --no-summary -q in /home/visawant/Desktop/workspace/robottelo

============================= test session starts ==============================
collecting ... 2025-04-03 00:49:31 - robottelo.collection - INFO - Processing test items to add testimony token markers
collected 22 items / 21 deselected / 1 selected

tests/foreman/virtwho/cli/test_esx_sca.py::test_positive_change_system_puropse_SLA_for_hypervisor[id] 2025-04-03 00:54:10 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.


================= 1 passed, 21 deselected in 279.44s (0:04:39) =================
PASSED
Process finished with exit code 0

```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->