### PR TITLE
[6.17.z] Add post-provisioning build status assertion

### DIFF
--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -96,6 +96,8 @@ def test_rhel_pxe_provisioning(
 
     :BZ: 2105441, 1955861, 1784012
 
+    :Verifies:SAT-20739,SAT-27869
+
     :customerscenario: true
 
     :parametrized: yes
@@ -141,6 +143,13 @@ def test_rhel_pxe_provisioning(
     )
     host = host.read()
     assert host.build_status_label == 'Installed'
+
+    # The label checked above is generated dynamically and may not necessarily
+    # represent the exact value that is stored in the database
+    assert (
+        len(sat.api.Host().search(query={'search': f'name="{host.name}" and build_status = built'}))
+        == 1
+    )
 
     # Change the hostname of the host as we know it already.
     # In the current infra environment we do not support


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18140

### Problem Statement
In the past there were issues with build status (the value that is stored in the db) not being updated once the provisioning is done. This issue seems to have been resolved since then, it would be nice to have an automated test that verifies it.

### Solution
Add an assertion that checks the in-db value rather than just relying on what host details show as that value is calculated dynamically.


### Related Issues
- https://issues.redhat.com/browse/SAT-27869
- https://issues.redhat.com/browse/SAT-20739

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->