### PR TITLE
[6.14.z] update package name during checking config report

### DIFF
--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -528,7 +528,7 @@ class TestAnsibleCfgMgmt:
             )
             notice_log = session.configreport.search(rhel_contenthost.hostname)
             assert f'notice Install the {package_name} package' in notice_log['permission_denied']
-            assert f'Installed: rubygem-{package_name}' in notice_log['permission_denied']
+            assert f'Installed: {package_name}_bash' in notice_log['permission_denied']
 
 
 class TestAnsibleREX:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17841

After the successful completion of the Ansible job, the assertion point is updated according to the config report.







