### PR TITLE
[6.17.z] custom workdir procedure adjusted for the new yggdrasil

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1315,13 +1315,20 @@ class TestPullProviderRex:
         result = client.execute(f'systemctl status {service_name}')
         assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
 
+        # yggdrasil 0.4+ uses a separate service for configuration
+        worker_service = (
+            service_name
+            if service_name == "yggdrasild"
+            else "com.redhat.Yggdrasil1.Worker1.foreman"
+        )
+
         # create a new directory and set in in yggdrasil
         path = f'/{gen_string("alpha")}'
-        config_path_dir = f'/etc/systemd/system/{service_name}.service.d/'
+        config_path_dir = f'/etc/systemd/system/{worker_service}.service.d/'
         config_path = f'{config_path_dir}/override.conf'
         assert (
             client.execute(
-                f'mkdir {path} && mount -t tmpfs tmpfs {path} && mkdir {config_path_dir} && echo -e "[Service]\nEnvironment=FOREMAN_YGG_WORKER_WORKDIR={path}" > {config_path} && systemctl daemon-reload && systemctl restart {service_name}'
+                f'mkdir {path} && mount -t tmpfs tmpfs {path} && mkdir {config_path_dir} && echo -e "[Service]\nEnvironment=FOREMAN_YGG_WORKER_WORKDIR={path}" > {config_path} && systemctl daemon-reload && systemctl restart {worker_service}'
             ).status
             == 0
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18121

### Problem Statement
https://docs.theforeman.org/nightly/Managing_Hosts/index-katello.html#setting-an-alternative-directory-for-remote-execution-jobs-in-pull-mode_managing-hosts 

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->