### PR TITLE
[6.15.z] Docstring_fix_changeContentSource

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2022,7 +2022,7 @@ def test_change_content_source(session, change_content_source_prep, rhel_content
 
     :CaseComponent:Hosts-Content
 
-    :Team: Phoenix-content
+    :Team: Phoenix-subscriptions
     """
 
     module_target_sat, org, lce, capsule, content_view, loc, ak = change_content_source_prep


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18189

Change the docstring of the test so it matches the teams properly.