### PR TITLE
Add setup and teardown for Capsule and Satellite objects

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1629,6 +1629,36 @@ class Capsule(ContentHost, CapsuleMixins):
     def rex_pub_key(self):
         return self.execute(f'cat {self.rex_key_path}').stdout.strip()
 
+    def setup(self):
+        logger.debug('START: setting up Capsule host %s', self)
+        # Call parent setup method FIRST
+        super().setup()
+
+        # Only run Capsule-specific tasks if the instance is an actual Capsule
+        # (not a Satellite that's inheriting from Capsule)
+        if self.__class__ == Capsule:
+            logger.debug('Running Capsule-specific setup tasks')
+
+        # Common tasks that should always run, regardless of instance class
+        logger.debug('Running common Capsule setup tasks')
+
+        logger.debug('END: setting up Capsule host %s', self)
+
+    def teardown(self):
+        logger.debug('START: tearing down Capsule host %s', self)
+
+        # Only run Capsule-specific teardown if the instance is an actual Capsule
+        # (not a Satellite that's inheriting from Capsule)
+        if self.__class__ == Capsule:
+            logger.debug('Running Capsule-specific teardown tasks')
+
+        # Common teardown tasks that should always run, regardless of instance class
+        logger.debug('Running common Capsule teardown tasks')
+
+        # Call parent teardown method LAST
+        super().teardown()
+        logger.debug('END: tearing down Capsule host %s', self)
+
     def restart_services(self):
         """Restart services, returning True if passed and stdout if not"""
         result = self.execute('satellite-maintain service restart')
@@ -1992,6 +2022,22 @@ class Satellite(Capsule, SatelliteMixins):
         if not self._satellite:
             return self
         return self._satellite
+
+    def setup(self):
+        logger.debug('START: setting up Satellite host %s', self)
+        # Call parent setup method FIRST
+        super().setup()
+        logger.debug('Running common Satellite setup tasks')
+
+        logger.debug('END: setting up Satellite host %s', self)
+
+    def teardown(self):
+        logger.debug('START: tearing down Satellite host %s', self)
+        # Perform Satellite teardown tasks here
+
+        # Call parent teardown method after Satellite-specific teardown
+        super().teardown()
+        logger.debug('END: tearing down Satellite host %s', self)
 
     def enable_satellite_http_proxy(self):
         """Execute procedures for setting HTTP Proxy in Satellite settings.


### PR DESCRIPTION
### Problem Statement
Currently, the Satellite and Capsule classes do not allow their objects to have their specific `setup` and `teardown` methods which would have a consistent inheritance flow. We currently run ContentHost.setup on all host objects, there is no differentiation between setup and teardown of individual host types.


### Solution

Implemented a proper cascading inheritance flow for the `setup` and `teardown` methods throughout the host class hierarchy:

1. For `setup` methods:
   - Parent class setup runs FIRST (base to derived)
   - Then class-specific setup runs
   - This ensures a proper initialization sequence: ContentHost → Capsule → Satellite

2. For `teardown` methods:
   - Class-specific teardown runs FIRST
   - Then parent class teardown runs (derived to base)
   - This ensures proper cleanup sequence: Satellite → Capsule → ContentHost

3. Added conditional execution:
   - Used `self.__class__ == Class` checks to ensure class-specific logic only runs on actual instances of that class, not derived classes
   - Prevents duplicate execution while maintaining inheritance

### Notes
This is a prep for moving `relax_bfa` and `proxy_port_range` fixture logic to the `setup` method of the Satellite object.
This is also a follow-up of #18180, as mentioned in its description in the _Problem_Statement_ section.


### PRT test Cases example
```yaml
trigger: test-robottelo
pytest: tests/foreman/api/test_ping.py
```

