### PR TITLE
[6.17.z] neccessary fixture in test definition

### DIFF
--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -267,6 +267,7 @@ def deploy_type_cli(
     request,
     org_module,
     form_data_cli,
+    register_sat_and_enable_aps_repo,
     virtwho_config_cli,
     target_sat,
     default_location,
@@ -300,6 +301,7 @@ def deploy_type_api(
     request,
     org_module,
     form_data_api,
+    register_sat_and_enable_aps_repo,
     virtwho_config_api,
     target_sat,
 ):
@@ -327,6 +329,7 @@ def deploy_type_ui(
     org_module,
     form_data_ui,
     org_session,
+    register_sat_and_enable_aps_repo,
     virtwho_config_ui,
     target_sat,
 ):
@@ -353,10 +356,10 @@ def delete_host(form_data_api, target_sat):
         target_sat.api.Host(id=results[0].read_json()['id']).delete()
 
 
-@pytest.fixture
-def register_sat_and_enable_aps_repo(target_sat):
+@pytest.fixture(scope='module')
+def register_sat_and_enable_aps_repo(module_target_sat):
     """Register Satellite to CDN and Enable rhel aps repos"""
-    target_sat.register_to_cdn()
-    target_sat.enable_repo(REPOS[f'rhel{target_sat.os_version.major}_aps']['id'])
+    module_target_sat.register_to_cdn()
+    module_target_sat.enable_repo(REPOS[f'rhel{module_target_sat.os_version.major}_aps']['id'])
     yield
-    target_sat.unregister()
+    module_target_sat.unregister()

--- a/tests/foreman/virtwho/api/test_esx_sca.py
+++ b/tests/foreman/virtwho/api/test_esx_sca.py
@@ -28,7 +28,11 @@ class TestVirtWhoConfigforEsx:
     @pytest.mark.upgrade
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, target_sat, virtwho_config_api, deploy_type_api
+        self,
+        module_sca_manifest_org,
+        target_sat,
+        virtwho_config_api,
+        deploy_type_api,
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -25,7 +25,11 @@ from robottelo.utils.virtwho import (
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
+        self,
+        module_sca_manifest_org,
+        virtwho_config_api,
+        target_sat,
+        deploy_type_api,
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -23,7 +23,11 @@ from robottelo.utils.virtwho import (
 class TestVirtWhoConfigforLibvirt:
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
+        self,
+        module_sca_manifest_org,
+        virtwho_config_api,
+        target_sat,
+        deploy_type_api,
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -46,7 +46,11 @@ class TestVirtWhoConfigforEsx:
         indirect=True,
     )
     def test_positive_deploy_configure_by_id_script_name_locationid_organizationtitle(
-        self, module_sca_manifest_org, target_sat, virtwho_config_cli, deploy_type_cli
+        self,
+        module_sca_manifest_org,
+        target_sat,
+        virtwho_config_cli,
+        deploy_type_cli,
     ):
         """Verify "hammer virt-who-config deploy & fetch"
 
@@ -673,7 +677,7 @@ class TestVirtWhoConfigforEsx:
 
 @pytest.mark.parametrize('deploy_type_cli', ['id'], indirect=True)
 def test_positive_change_system_puropse_SLA_for_hypervisor(
-    target_sat, register_sat_and_enable_aps_repo, virtwho_config_cli, deploy_type_cli
+    target_sat, virtwho_config_cli, deploy_type_cli
 ):
     """Verify that system purpose SLA attribute set successfully and does not throw any error
 

--- a/tests/foreman/virtwho/cli/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/cli/test_hyperv_sca.py
@@ -25,7 +25,11 @@ from robottelo.utils.virtwho import (
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, virtwho_config_cli, target_sat, deploy_type_cli
+        self,
+        module_sca_manifest_org,
+        virtwho_config_cli,
+        target_sat,
+        deploy_type_cli,
     ):
         """Verify " hammer virt-who-config deploy & fetch"
 

--- a/tests/foreman/virtwho/cli/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_libvirt_sca.py
@@ -23,7 +23,11 @@ from robottelo.utils.virtwho import (
 class TestVirtWhoConfigforLibvirt:
     @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, virtwho_config_cli, target_sat, deploy_type_cli
+        self,
+        module_sca_manifest_org,
+        virtwho_config_cli,
+        target_sat,
+        deploy_type_cli,
     ):
         """Verify " hammer virt-who-config deploy & fetch"
 

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -41,7 +41,12 @@ class TestVirtwhoConfigforEsx:
     @pytest.mark.upgrade
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
+        self,
+        module_sca_manifest_org,
+        org_session,
+        form_data_ui,
+        deploy_type_ui,
+        default_location,
     ):
         """Verify configure created and deployed with id.
 

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -26,7 +26,12 @@ from robottelo.utils.virtwho import (
 class TestVirtwhoConfigforHyperv:
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
+        self,
+        module_sca_manifest_org,
+        org_session,
+        form_data_ui,
+        deploy_type_ui,
+        default_location,
     ):
         """Verify configure created and deployed with id.
 

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -26,7 +26,12 @@ from robottelo.utils.virtwho import (
 class TestVirtwhoConfigforLibvirt:
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
+        self,
+        module_sca_manifest_org,
+        org_session,
+        form_data_ui,
+        deploy_type_ui,
+        default_location,
     ):
         """Verify configure created and deployed with id.
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18172

### Problem Statement
Virt-who test suite is failing in setup while executing, because the function level fixture `deploy_type_*` internally execute deploy by mechanism which ultimately install virtwho package on satellite server, due to missing appstream repo test execution failing in setup part.

### Solution
Use of predefined fixture `register_sat_and_enable_aps_repo` in test definition where `deploy_type_*` fixture is being used.
Updated - **Apr 9th 2025**: As per suggestion, we are using `register_sat_and_enable_aps_repo` as a module scope fixture inside `deploy_type_*` fixture.

### Related Issues
No

### Note
Test are not passing 100 % but using fixture test failure count drop, so I not expecting to run PRT over this partial fix as this is very first step towrds fixting broken test suite. Attaching local test execution result for sample.

### Local test execution result
```
============================================================ short test summary info =============================================================
FAILED tests/foreman/virtwho/cli/test_esx_sca.py::TestVirtWhoConfigforEsx::test_positive_foreman_packages_protection - robottelo.utils.virtwho.VirtWhoError: Failed to deploy configure by hammer -u admin -p changeme virt-who-config deploy --id 22 --organization 'QteRHx'
FAILED tests/foreman/virtwho/cli/test_esx_sca.py::TestVirtWhoConfigforEsx::test_positive_deploy_configure_hypervisor_password_with_special_characters - robottelo.utils.virtwho.VirtWhoError: Failed to deploy configure by hammer -u admin -p changeme virt-who-config deploy --id 23 --organization 'QteRHx'
FAILED tests/foreman/virtwho/cli/test_esx_sca.py::TestVirtWhoConfigforEsx::test_positive_remove_env_option - robottelo.utils.virtwho.VirtWhoError: Failed to deploy configure by hammer -u admin -p changeme virt-who-config deploy --id 24 --organization 'QteRHx'
FAILED tests/foreman/virtwho/cli/test_esx_sca.py::TestVirtWhoConfigforEsx::test_positive_rhsm_username_option - robottelo.utils.virtwho.VirtWhoError: Failed to deploy configure by hammer -u admin -p changeme virt-who-config deploy --id 25 --organization 'QteRHx'
FAILED tests/foreman/virtwho/cli/test_esx_sca.py::TestVirtWhoConfigforEsx::test_positive_post_hypervisors_with_fake_different_org_simultaneous - robottelo.utils.virtwho.VirtWhoError: Failed to deploy configure by hammer -u admin -p changeme virt-who-config deploy --id 26 --organization 'QteRHx'
ERROR tests/foreman/virtwho/cli/test_esx_sca.py::TestVirtWhoConfigforEsx::test_positive_deploy_configure_by_id_script_name_locationid_organizationtitle[script] - robottelo.utils.virtwho.VirtWhoError: Failed to deploy configure by /tmp/deploy_script.sh
======================================== 5 failed, 16 passed, 10 warnings, 1 error in 3178.43s (0:52:58) =========================================
```

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->