### PR TITLE
[6.17.z] Errata 6.17.0 signoff fixes

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -775,6 +775,10 @@ DEFAULT_OS_SEARCH_QUERY = 'name="RedHat" AND (major="6" OR major="7" OR major="8
 
 VDC_SUBSCRIPTION_NAME = 'Red Hat Enterprise Linux for Virtual Datacenters, Premium'
 
+TIMESTAMP_FMT_ZONE = '%Y-%m-%d %H:%M:%S %Z'  # timezone-aware format (by code: UTC, EST, etc)
+TIMESTAMP_FMT = '%Y-%m-%d %H:%M:%S'
+TIMESTAMP_FMT_DATE = '%Y-%m-%d'
+TIMESTAMP_FMT_TIME = '%H:%M:%S'
 TIMEZONES = [
     '(GMT+00:00) UTC',
     '(GMT-10:00) Hawaii',

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -311,6 +311,35 @@ class APIFactory:
             ).create()
         return os
 
+    def supported_rhel_ver(self, num=3, fips=False, prefix=''):
+        """
+        Return: a list of (str), most recent supported RHEL major versions.
+            or a single str, if param `num` is set to 1.
+
+        :param num: Default 3. Pass a positive int for the number of versions to return,
+            or pass 'All' to return every supported version.
+        :param fips: Default False. If True, include -fips versions.
+        :param prefix: Default empty ''. Add a prefix string to the versions,
+            ie: 'rhel' or 'rhel-'
+        """
+        if isinstance(num, int) and num <= 0:
+            return []
+        supported_rhels = settings.supportability.content_hosts.rhel.versions
+        filtered_versions = (
+            [prefix + str(ver) for ver in supported_rhels]  # include fips
+            if fips is True
+            else [  # only include ints, major versions
+                prefix + str(ver) for ver in supported_rhels if isinstance(ver, int)
+            ]
+        )
+        return (
+            filtered_versions  # entire list, if 'All' is met
+            if num == 'All'
+            else filtered_versions[-num:]  # else: list, num entries from tail, if len != 1
+            if num != 1
+            else filtered_versions[-num:][0]  # else: single str, if len == 1
+        )
+
     @contextmanager
     def satellite_setting(self, key_val: str):
         """Context Manager to update the satellite setting and revert on exit

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -32,6 +32,7 @@ from robottelo.constants import (
     REAL_4_ERRATA_ID,
     REPOS,
     REPOSET,
+    TIMESTAMP_FMT,
 )
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.hosts import ContentHost
@@ -83,9 +84,6 @@ REPOS_WITH_ERRATA = (
         'errata_id': settings.repos.yum_3.errata[5],
     },
 )
-
-TIMESTAMP_FMT = '%Y-%m-%d %H:%M'
-TIMESTAMP_FMT_S = '%Y-%m-%d %H:%M:%S'
 
 PSUTIL_RPM = 'python2-psutil-5.6.7-1.el7.x86_64.rpm'
 
@@ -163,11 +161,30 @@ def rh_repo_module_manifest(module_sca_manifest_org, module_target_sat):
 
 @pytest.fixture(scope='module')
 def hosts(request):
-    """Deploy hosts via broker."""
-    num_hosts = getattr(request, 'param', 2)
-    with Broker(nick='rhel8', host_class=ContentHost, _count=num_hosts) as hosts:
+    """Deploy hosts via broker by distro and host count.
+    Parametrize with tuple, (str<distro>, int<num_hosts>), or just one, or neither.
+    @pytest.mark.parametrize('hosts', [('rhel9', 2)], indirect=True)
+
+    Default: Robotello settings: Default RHEL Version, num_host of 2.
+    """
+    default_distro = 'rhel' + str(settings.content_host.default_rhel_version)
+    default_num_hosts = 2
+    # get any request
+    param = getattr(request, 'param', (None, None))
+    # get both params, or just one
+    match param:
+        case (str() as distro, int() as num_hosts):  # Tuple (both values provided)
+            pass
+        case str() as distro:  # Just distro (default num_hosts)
+            num_hosts = default_num_hosts
+        case int() as num_hosts:  # Just num_hosts (default distro)
+            distro = default_distro
+        case _:  # Default for both
+            distro, num_hosts = default_distro, default_num_hosts
+
+    with Broker(nick=distro, host_class=ContentHost, _count=num_hosts) as hosts:
         if not isinstance(hosts, list) or len(hosts) != num_hosts:
-            pytest.fail('Failed to provision the expected number of hosts.')
+            pytest.fail(f'Failed to provision the expected number of hosts for {distro}.')
         yield hosts
 
 
@@ -179,7 +196,12 @@ def register_hosts(
     module_ak,
     module_target_sat,
 ):
-    """Register hosts to Satellite"""
+    """Register hosts to Satellite
+
+    parametrize by fixture `hosts`, example:
+        @pytest.mark.parametrize('hosts', [('rhel10', 4)], indirect=True)
+    Default: DEFAULT Robottelo RHEL version, 2 clients.
+    """
     for host in hosts:
         module_target_sat.cli_factory.setup_org_for_a_custom_repo(
             {
@@ -202,7 +224,12 @@ def register_hosts(
 
 @pytest.fixture
 def errata_hosts(register_hosts, target_sat):
-    """Ensure that rpm is installed on host."""
+    """Ensure that rpm is installed on host.
+
+    parametrize by fixture `hosts`, example:
+        @pytest.mark.parametrize('hosts', [('rhel10', 4)], indirect=True)
+    Default: DEFAULT Robottelo RHEL version, 2 clients.
+    """
     for host in register_hosts:
         # Enable all custom and rh repositories.
         host.execute(r'subscription-manager repos --enable \*')
@@ -254,37 +281,32 @@ def host_collection(module_sca_manifest_org, module_ak_cv_lce, register_hosts, m
 def start_and_wait_errata_recalculate(sat, host):
     """Helper to find any in-progress errata applicability task and wait_for completion.
     Otherwise, schedule errata recalculation, wait for the task.
-    Find the successful completed task(s).
+    Poll the finished task(s).
 
     :param sat: Satellite instance to check for task(s)
     :param host: ContentHost instance to schedule errata recalculate
     """
-    # Find any in-progress task for this host
-    search = "label = Actions::Katello::Applicability::Hosts::BulkGenerate and result = pending"
+    # Find any in-progress tasks for Host(s)
+    label = 'label = Actions::Katello::Applicability::Hosts::BulkGenerate'
+    search = label + ' and result = pending'
     applicability_task_running = sat.cli.Task.list_tasks({'search': search})
     # No task in progress, invoke errata recalculate
     if len(applicability_task_running) == 0:
         sat.cli.Host.errata_recalculate({'host-id': host.nailgun_host.id})
         host.run('subscription-manager repos')
-    # Note time check for later wait_for_tasks include 30s margin of safety
-    timestamp = (datetime.now(UTC) - timedelta(seconds=30)).strftime(TIMESTAMP_FMT_S)
+    # timestamp for install start includes 20s margin of safety
+    timestamp = (datetime.now(UTC) - timedelta(seconds=20)).strftime(TIMESTAMP_FMT)
     # Wait for upload profile event (in case Satellite system is slow)
-    sat.wait_for_tasks(
-        search_query=(
-            'label = Actions::Katello::Applicability::Hosts::BulkGenerate'
-            f' and started_at >= "{timestamp}"'
-        ),
+    search = label + f' and started_at >= "{timestamp}"'
+    tasks = sat.wait_for_tasks(
+        search_query=search,
         search_rate=15,
         max_tries=10,
     )
-    # Find the successful finished task(s)
-    search = (
-        "label = Actions::Katello::Applicability::Hosts::BulkGenerate"
-        " and result = success"
-        f" and started_at >= '{timestamp}'"
-    )
-    applicability_task_success = sat.cli.Task.list_tasks({'search': search})
-    assert applicability_task_success, f'No successful task found by search: {search}'
+    # Poll the finished task(s)
+    assert len(tasks) > 0, f'No task(s) found by search: {search}'
+    for task in tasks:
+        assert sat.api.ForemanTask(id=task.id).poll()
 
 
 def is_rpm_installed(host, rpm=None):
@@ -1523,8 +1545,10 @@ def test_errata_list_by_contentview_filter(module_sca_manifest_org, module_targe
     assert errata_count != errata_count_cvf
 
 
-@pytest.mark.rhel_ver_match('N-2')
-def test_positive_verify_errata_recalculate_tasks(target_sat, errata_host):
+@pytest.mark.parametrize(
+    'hosts', [(f'rhel{settings.content_host.default_rhel_version}', 4)], indirect=True
+)
+def test_positive_verify_errata_recalculate_tasks(target_sat, errata_hosts):
     """Verify 'Actions::Katello::Applicability::Hosts::BulkGenerate' tasks proceed on 'worker-hosts-queue-1.service'
 
     :id: d5f89df2-b8fb-4aec-839d-b548b0aadc0c
@@ -1541,7 +1565,7 @@ def test_positive_verify_errata_recalculate_tasks(target_sat, errata_host):
 
     :BZ: 2249736
     """
-    # Recalculate errata command has triggered inside errata_host fixture
+    # Recalculate errata command has triggered inside errata_hosts fixture
 
     # get PID of 'worker-hosts-queue-1' from /var/log/messages
     message_log = target_sat.execute(

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime, timedelta
 import re
 
 from broker import Broker
+from dateutil import parser
 from dateutil.parser import parse
 from fauxfactory import gen_string
 import pytest
@@ -46,6 +47,7 @@ from robottelo.constants import (
     REAL_RHEL8_1_ERRATA_ID,
     REAL_RHEL8_ERRATA_CVES,
     REAL_RHSCLIENT_ERRATA,
+    TIMESTAMP_FMT,
 )
 from robottelo.hosts import ContentHost
 from robottelo.utils.issue_handlers import is_open
@@ -363,7 +365,9 @@ def test_end_to_end(
     )
 
     with session:
-        datetime_utc_start = datetime.now(UTC).replace(microsecond=0)
+        # keep timestamp as datetime obj, so we can subtract later.
+        #   timezone-aware (UTC), as task's start/end times are also timezone-aware.
+        timestamp_start = datetime.now(UTC).replace(microsecond=0)
         # Check selection box function for BZ#1688636
         session.location.select(loc_name=DEFAULT_LOC)
         results = session.errata.search_content_hosts(
@@ -425,9 +429,10 @@ def test_end_to_end(
             entity_name=hostname,
             search=f"errata_id == {CUSTOM_REPO_ERRATA_ID}",
         )
+        # str timestamp to scope tasks, does not include timezone.
         install_query = (
-            f'"Install errata errata_id == {CUSTOM_REPO_ERRATA_ID} on {hostname}"'
-            f' and started_at >= {datetime_utc_start - timedelta(seconds=1)}'
+            f'Install errata {CUSTOM_REPO_ERRATA_ID.lower()} on {hostname}'
+            f' and started_at >= "{timestamp_start.strftime(TIMESTAMP_FMT)}"'
         )
         results = module_target_sat.wait_for_tasks(
             search_query=install_query,
@@ -446,13 +451,12 @@ def test_end_to_end(
             f'Unexpected applicable errata found after install of {CUSTOM_REPO_ERRATA_ID}.'
         )
         # UTC timing for install task and session
-        _UTC_format = '%Y-%m-%d %H:%M:%S UTC'
-        install_start = datetime.strptime(task_status['started_at'], _UTC_format)
-        install_end = datetime.strptime(task_status['ended_at'], _UTC_format)
+        install_start = parser.parse(task_status['started_at'])
+        install_end = parser.parse(task_status['ended_at'])
         # install task duration did not exceed 1 minute,
         #   duration since start of session did not exceed 10 minutes.
         assert (install_end - install_start).total_seconds() <= 60
-        assert (install_end - datetime_utc_start).total_seconds() <= 600
+        assert (install_end - timestamp_start).total_seconds() <= 600
         # Find bulk generate applicability task
         results = module_target_sat.wait_for_tasks(
             search_query=(f'Bulk generate applicability for host {hostname}'),
@@ -465,8 +469,8 @@ def test_end_to_end(
             f'Bulk Generate Errata Applicability task failed:\n{task_status}'
         )
         # UTC timing for generate applicability task
-        bulk_gen_start = datetime.strptime(task_status['started_at'], _UTC_format)
-        bulk_gen_end = datetime.strptime(task_status['ended_at'], _UTC_format)
+        bulk_gen_start = parser.parse(task_status['started_at'])
+        bulk_gen_end = parser.parse(task_status['ended_at'])
         assert (bulk_gen_start - install_end).total_seconds() <= 30
         assert (bulk_gen_end - bulk_gen_start).total_seconds() <= 60
 
@@ -856,18 +860,23 @@ def test_positive_apply_for_all_hosts(
         1. Go to Content -> Errata. Select an erratum -> Content Hosts tab.
         2. Select all Content Hosts and apply the erratum.
 
-    :expectedresults: Check that the erratum is applied in all the content
-        hosts.
+    :expectedresults:
+        1. Check invoked host tasks are successful.
+        2. Check that the erratum is applied in all the content hosts.
     """
     num_hosts = 4
-    distro = 'rhel10'
+    rhel_distro = target_sat.api_factory.supported_rhel_ver(
+        num=1,
+        prefix='rhel',
+    )
     # one custom repo on satellite, for all hosts to use
     custom_repo = target_sat.api.Repository(url=CUSTOM_REPO_URL, product=module_product).create()
     custom_repo.sync()
     module_cv.repository = [custom_repo]
     module_cv.update(['repository'])
+    # Checkout hosts of the newest distro supported
     with Broker(
-        nick=distro,
+        nick=rhel_distro,
         workflow='deploy-template',
         host_class=ContentHost,
         _count=num_hosts,
@@ -897,7 +906,10 @@ def test_positive_apply_for_all_hosts(
             assert client.applicable_package_count > 0
 
         with session:
-            timestamp = datetime.now(UTC).replace(microsecond=0) - timedelta(seconds=1)
+            # possible in-progress applicability task(s), 60s margin
+            timestamp = (datetime.now(UTC).replace(microsecond=0) - timedelta(seconds=60)).strftime(
+                TIMESTAMP_FMT
+            )
             session.location.select(loc_name=DEFAULT_LOC)
             # for first errata, apply to all chosts at once,
             # from ContentTypes > Errata > info > ContentHosts tab
@@ -908,32 +920,33 @@ def test_positive_apply_for_all_hosts(
             )
             assert result['overview']['job_status'] == 'Success'
             # find single hosts job
+            # remote action tasks have lowercase errata_ids, ie: 'rhba-' not 'RHBA-'
             hosts_job = target_sat.wait_for_tasks(
                 search_query=(
-                    f'Run hosts job: Install errata {errata_id} and started_at >= {timestamp}'
+                    f'Run hosts job: Install errata {errata_id.lower()} and started_at >= "{timestamp}"'
                 ),
-                search_rate=2,
-                max_tries=60,
+                search_rate=5,
+                max_tries=20,
             )
             assert len(hosts_job) == 1
             # find multiple install tasks, one for each host
             install_tasks = target_sat.wait_for_tasks(
                 search_query=(
-                    f'Remote action: Install errata {errata_id} on and started_at >= {timestamp}'
+                    f'Remote action: Install errata {errata_id.lower()} and started_at >= "{timestamp}"'
                 ),
-                search_rate=2,
-                max_tries=60,
+                search_rate=5,
+                max_tries=20,
             )
             assert len(install_tasks) == num_hosts
-            # find single bulk applicability task for hosts
-            applicability_task = target_sat.wait_for_tasks(
+            # find bulk generate applicability task, and subtask for each host
+            applicability_tasks = target_sat.wait_for_tasks(
                 search_query=(
-                    f'Bulk generate applicability for hosts and started_at >= {timestamp}'
+                    f'Bulk generate applicability for hosts and started_at >= "{timestamp}"'
                 ),
-                search_rate=2,
-                max_tries=60,
+                search_rate=10,
+                max_tries=30,
             )
-            assert len(applicability_task) == 1
+            assert len(applicability_tasks) == num_hosts + 1
             # found updated kangaroo package in each host
             updated_version = '0.2-1.noarch'
             for client in hosts:
@@ -1019,6 +1032,11 @@ def test_positive_filter_by_environment(
 
     :expectedresults: Content hosts can be filtered by Environment.
     """
+    # use newest supported version of RHEL (ie 'rhel10')
+    rhel_N = target_sat.api_factory.supported_rhel_ver(
+        num=1,
+        prefix='rhel',
+    )
     org = module_sca_manifest_org
     # one custom repo on satellite, for all hosts to use
     custom_repo = target_sat.api.Repository(url=CUSTOM_REPO_URL, product=module_product).create()
@@ -1027,7 +1045,7 @@ def test_positive_filter_by_environment(
     module_cv.update(['repository'])
 
     with Broker(
-        nick='rhel10', workflow='deploy-template', host_class=ContentHost, _count=3
+        nick=rhel_N, workflow='deploy-template', host_class=ContentHost, _count=3
     ) as clients:
         for client in clients:
             # register all hosts to the same AK, CV:
@@ -1507,9 +1525,9 @@ def test_positive_check_errata_counts_by_type_on_host_details_page(
 def test_positive_filtered_errata_status_installable_param(
     errata_status_installable,
     registered_contenthost,
+    module_target_sat,
     setting_update,
     module_org,
-    target_sat,
     module_lce,
     module_cv,
     session,
@@ -1541,21 +1559,26 @@ def test_positive_filtered_errata_status_installable_param(
     client = registered_contenthost
     assert client.execute(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}').status == 0
     assert client.execute('subscription-manager repos').status == 0
-    # Adding content view filter and content view filter rule to exclude errata,
+    # Adding content view filter and cv filter rule to exclude errata,
     # for the installed package above.
-    cv_filter = target_sat.api.ErratumContentViewFilter(
+    cv_filter = module_target_sat.api.ErratumContentViewFilter(
         content_view=module_cv, inclusion=False
     ).create()
     module_cv = module_cv.read()
-    module_cv.version.sort(key=lambda version: version.id)
-    errata = target_sat.api.Errata(content_view_version=module_cv.version[-1]).search(
+    assert module_cv.version
+    latest_version = module_cv.version[-1]
+    errata = module_target_sat.api.Errata(content_view_version=latest_version.read()).search(
         query={'search': f'errata_id="{CUSTOM_REPO_ERRATA_ID}"'}
-    )[0]
-    target_sat.api.ContentViewFilterRule(content_view_filter=cv_filter, errata=errata).create()
+    )
+    assert len(errata) == 1
+    errata = errata[0]
+    module_target_sat.api.ContentViewFilterRule(
+        content_view_filter=cv_filter, errata=errata
+    ).create()
     module_cv = module_cv.read()
     # publish and promote the new version with Filter
     cv_publish_promote(
-        target_sat,
+        module_target_sat,
         module_org,
         module_cv,
         module_lce,
@@ -1633,6 +1656,11 @@ def test_content_host_errata_search_commands(
 
     :BZ: 1707335
     """
+    # use newest supported version of RHEL (ie 'rhel10')
+    rhel_N = target_sat.api_factory.supported_rhel_ver(
+        num=1,
+        prefix='rhel',
+    )
     content_view = target_sat.api.ContentView(organization=module_org).create()
     RHSA_repo = target_sat.api.Repository(
         url=settings.repos.yum_9.url, product=module_product
@@ -1650,7 +1678,7 @@ def test_content_host_errata_search_commands(
     # walrus-0.71-1.noarch (RHSA), kangaroo-0.1-1.noarch (RHBA)
     packages = [FAKE_1_CUSTOM_PACKAGE, FAKE_4_CUSTOM_PACKAGE]
     with Broker(
-        nick='rhel10', workflow='deploy-template', host_class=ContentHost, _count=2
+        nick=rhel_N, workflow='deploy-template', host_class=ContentHost, _count=2
     ) as clients:
         for (
             client,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18058

### Automation fixes for 6.17.0 Errata Management
_UI_: From #18037 (wait_for applicability recalculate tasks)
- `test_end_to_end` , `test_positive_apply_for_all_hosts` , `test_positive_filtered_errata_status_installable_param`

_CLI_: Address failures in helper method (find/invoke/wait_for applicability recalculate tasks):
- 15+ failing cases in  `start_and_wait_errata_recalculate()`

_API_: one test failing in setup, and enhanced another already impacted by changes
- `test_positive_get_diff_for_cv_envs`: Use module fixtures instead of incorrectly setup components
- minor enhancements to `test_positive_filter_errata_type_other`

### PRT (UI, CLI, API)

--------------------------------------------------------------------------------------------------------------------
**UI / test_errata.py** :: test_end_to_end , test_positive_filtered_errata_status_installable_param
**UI / test_errata.py** :: test_positive_apply_for_all_hosts
``` 
trigger: test-robottelo
pytest: tests/foreman/ui/test_errata.py::test_positive_apply_for_all_hosts
```

--------------------------------------------------------------------------------------------------------------------
**CLI / test_errata.py** :: uses-fixtures: hosts (uses method that was failing)
``` 
trigger: test-robottelo
pytest: tests/foreman/cli/test_errata.py --uses-fixtures hosts
```

--------------------------------------------------------------------------------------------------------------------
**API / test_errata.py** :: test_positive_get_diff_for_cv_envs , test_positive_filter_errata_type_other 
^ `test_positive_filter_errata_type_other` failed at repo sync: EPEL 10 repo URL is not available.
^ Resolved: updated EPEL url for 10 only, /10/ >> now use /10.0/ or /10.1/  , Otherwise /9/ , /8/ ,etc, are still whole numbers: http://dl.fedoraproject.org/pub/epel/10.0/Everything/x86_64/

```
trigger: test-robottelo
pytest: tests/foreman/api/test_errata.py -k 'test_positive_filter_errata_type_other or test_positive_get_diff_for_cv_envs'
```