### PR TITLE
[6.17.z] Relax component fixtures tiering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,9 @@
 
 /conf/ @SatelliteQE/robottelo-tier-2-reviewers
 
-/pytest_fixtures/ @SatelliteQE/robottelo-tier-2-reviewers
+/pytest_fixtures/component/ @SatelliteQE/robottelo-tier-1-reviewers
+
+/pytest_fixtures/core/ @SatelliteQE/robottelo-tier-2-reviewers
 
 /pytest_plugins/ @SatelliteQE/robottelo-tier-2-reviewers
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18143

### Problem Statement
Component fixtures are managed by component teams, but they require tier-2 reviews for some reason, which shouldn't be necessary.


### Solution
Scope the component fixtures for tier-1 (equals team reviews) while keeping tier-2 for core fixtures.
