### PR TITLE
Fix test_purge_pulp_tasks by removing jq dependency

### DIFF
--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -12,6 +12,8 @@
 
 """
 
+import json
+
 import pytest
 from requests.exceptions import HTTPError
 
@@ -194,16 +196,16 @@ def test_purge_pulp_tasks(module_target_sat, module_org, module_repository, sett
     :customerscenario: true
 
     """
-    cmd = 'pulp task list --limit 99999 | jq length'
-    original_ptc = int(module_target_sat.execute(cmd).stdout)
+    cmd = 'pulp task list --limit 99999'
+    original_ptc = len(json.loads(module_target_sat.execute(cmd).stdout))
     module_target_sat.run_orphan_cleanup(smart_proxy_id=1)
-    new_ptc = int(module_target_sat.execute(cmd).stdout)
+    new_ptc = len(json.loads(module_target_sat.execute(cmd).stdout))
     assert new_ptc > original_ptc, 'Pulp tasks were unexpectedly purged'
 
     setting_update.value = 0
     setting_update.update({'value'})
 
-    original_ptc = int(module_target_sat.execute(cmd).stdout)
+    original_ptc = len(json.loads(module_target_sat.execute(cmd).stdout))
     module_target_sat.run_orphan_cleanup(smart_proxy_id=1)
-    new_ptc = int(module_target_sat.execute(cmd).stdout)
+    new_ptc = len(json.loads(module_target_sat.execute(cmd).stdout))
     assert new_ptc < original_ptc, 'Pulp tasks were not purged'


### PR DESCRIPTION
### Problem Statement
It looks like the latest RHEL8 templates of 6.16 do not include the `jq` utility anymore
(comparing `tpl-satellite-6.16.5-1.0-rhel-8.10` vs `tpl-satellite-6.16.4-1.0-rhel-8.10`)

which makes this test to fail with `ValueError: invalid literal for int() with base 10: ''` since stdout returns `''` and stderr `bash: jq: command not found`.


### Solution
We should not rely on the `jq` presence and use `json.loads` instead.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_repositories.py -k test_purge_pulp_tasks
env:
  ROBOTTELO_server__deploy_arguments__deploy_sat_version: '6.16.5'
  ROBOTTELO_server__deploy_arguments__deploy_snap_version: '1.0'
  ROBOTTELO_server__deploy_arguments__deploy_rhel_version: '8'
```