### PR TITLE
Invoke shared_resource tests with pytest-xdist plugin

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -78,7 +78,8 @@ jobs:
           # To skip vault login in pull request checks
           export VAULT_SECRET_ID_FOR_DYNACONF=somesecret
           export ROBOTTELO_SERVER__HOSTNAME=""
-          pytest -sv tests/robottelo/
+          pytest -sv tests/robottelo/ -k 'not shared_resource'
+          pytest -sv -n 3 tests/robottelo/test_shared_resource.py
 
       - name: Make Docs
         run: |


### PR DESCRIPTION
As part of the current upgrade scenarios refactor, I have made some changes to the shared_resource framework that rely on the `PYTEST_XDIST_WORKER` environment variable. This is environment variable is only present when invoking pytest with the pytest-xdist plugin. However, the Pytest session that we invoke when running our Robottelo tests in the Code Quality checks does not use the pytest-xdist plugin. As a result, the tests in `tests/robottelo/test_shared_resource.py` are failing on some of my upgrade scenario PRs, such as https://github.com/SatelliteQE/robottelo/pull/18201/.

This PR changes the GitHub workflow step in which we run the tests to invoke two Pytest sessions, one which does not use the pytest-xdist plugin and excludes the shared_resource tests, and a second one that does use the pytest-xdist plugin and exclusively runs the shared_resource tests. This should allow the shared_resource tests to pass with my changes to that framework without affecting the remainder of our Robottelo tests during pull request CI runs.