### PR TITLE
[6.17.z] Lowercase HTTP proxy in UI tests

### DIFF
--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -141,11 +141,11 @@ def test_positive_assign_http_proxy_to_products_repositories(
                 'name': repo_a1_name,
                 'repo_type': REPO_TYPE['yum'],
                 'repo_content.upstream_url': settings.repos.yum_0.url,
-                'repo_content.http_proxy_policy': 'No HTTP Proxy',
+                'repo_content.http_proxy_policy': 'No HTTP proxy',
             },
         )
         repo_a1_values = session.repository.read(product_a.name, repo_a1_name)
-        assert repo_a1_values['repo_content']['http_proxy_policy'] == 'No HTTP Proxy'
+        assert repo_a1_values['repo_content']['http_proxy_policy'] == 'No HTTP proxy'
         repo_a2_name = gen_string('alpha')
         session.repository.create(
             product_a.name,
@@ -153,12 +153,12 @@ def test_positive_assign_http_proxy_to_products_repositories(
                 'name': repo_a2_name,
                 'repo_type': REPO_TYPE['yum'],
                 'repo_content.upstream_url': settings.repos.yum_1.url,
-                'repo_content.http_proxy_policy': 'Use specific HTTP Proxy',
+                'repo_content.http_proxy_policy': 'Use specific HTTP proxy',
                 'repo_content.proxy_policy.http_proxy': http_proxy_a.name,
             },
         )
         repo_a2_values = session.repository.read(product_a.name, repo_a2_name)
-        expected_policy = f'Use specific HTTP Proxy ({http_proxy_a.name})'
+        expected_policy = f'Use specific HTTP proxy ({http_proxy_a.name})'
         assert repo_a2_values['repo_content']['http_proxy_policy'] == expected_policy
         repo_b1_name = gen_string('alpha')
         session.repository.create(
@@ -179,7 +179,7 @@ def test_positive_assign_http_proxy_to_products_repositories(
                 'name': repo_b2_name,
                 'repo_type': REPO_TYPE['yum'],
                 'repo_content.upstream_url': settings.repos.yum_1.url,
-                'repo_content.http_proxy_policy': 'No HTTP Proxy',
+                'repo_content.http_proxy_policy': 'No HTTP proxy',
             },
         )
         # Set the HTTP proxy through bulk action for both products
@@ -187,12 +187,12 @@ def test_positive_assign_http_proxy_to_products_repositories(
         session.product.manage_http_proxy(
             [product_a.name, product_b.name],
             {
-                'http_proxy_policy': 'Use specific HTTP Proxy',
+                'http_proxy_policy': 'Use specific HTTP proxy',
                 'proxy_policy.http_proxy': http_proxy_b.name,
             },
         )
         # Verify that Http Proxy is updated for all repos of product_a and product_b.
-        proxy_policy = 'Use specific HTTP Proxy ({})'
+        proxy_policy = 'Use specific HTTP proxy ({})'
         repo_a1_values = session.repository.read(product_a.name, repo_a1_name)
         assert repo_a1_values['repo_content']['http_proxy_policy'] == proxy_policy.format(
             http_proxy_b.name


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18222

### Problem Statement
In 6.17 the HTTP proxy was generally lower-cased, which makes related UI tests to fail.


### Solution
This PR updates the tests.
Requires https://github.com/SatelliteQE/airgun/pull/1797


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_http_proxy.py -k 'check_http_proxy_value_repository_details or assign_http_proxy_to_products_repositories'
airgun: 1797
env:
  ROBOTTELO_server__deploy_arguments__deploy_sat_version: '6.17.0'
  ROBOTTELO_server__deploy_arguments__deploy_snap_version: '7.0'
```
