### PR TITLE
Using Broker.multi_manager to fix ansible test checkout for multiple hosts

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -12,11 +12,13 @@
 
 """
 
+from broker import Broker
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for
 
 from robottelo.config import settings, user_nailgun_config
+from robottelo.hosts import ContentHost
 from robottelo.utils.issue_handlers import is_open
 
 
@@ -405,14 +407,10 @@ class TestAnsibleREX:
         host_roles = target_host.list_ansible_roles()
         assert len(host_roles) == 0
 
-    @pytest.mark.no_containers
     def test_positive_ansible_job_on_multiple_host(
         self,
         target_sat,
         module_org,
-        rhel9_contenthost,
-        rhel8_contenthost,
-        rhel7_contenthost,
         module_location,
         module_ak_with_synced_repo,
     ):
@@ -435,52 +433,72 @@ class TestAnsibleREX:
 
         :BZ: 2167396, 2190464, 2184117
         """
-        hosts = [rhel9_contenthost, rhel8_contenthost, rhel7_contenthost]
-        SELECTED_ROLE = 'RedHatInsights.insights-client'
-        for host in hosts:
-            result = host.register(
-                module_org, module_location, module_ak_with_synced_repo.name, target_sat
-            )
-            assert result.status == 0, f'Failed to register host: {result.stderr}'
-            proxy_id = target_sat.nailgun_smart_proxy.id
-            target_host = host.nailgun_host
-            target_sat.api.AnsibleRoles().sync(
-                data={'proxy_id': proxy_id, 'role_names': [SELECTED_ROLE]}
-            )
-            role_id = (
-                target_sat.api.AnsibleRoles()
-                .search(query={'search': f'name={SELECTED_ROLE}'})[0]
+        with Broker.multi_manager(
+            rhel9={
+                'host_class': ContentHost,
+                'workflow': settings.server.deploy_workflows.os,
+                'deploy_rhel_version': '9',
+                'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
+            },
+            rhel8={
+                'host_class': ContentHost,
+                'workflow': settings.server.deploy_workflows.os,
+                'deploy_rhel_version': '8',
+                'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
+            },
+            rhel7={
+                'host_class': ContentHost,
+                'workflow': settings.server.deploy_workflows.os,
+                'deploy_rhel_version': '7',
+                'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
+            },
+        ) as multi_hosts:
+            hosts = [multi_hosts['rhel9'][0], multi_hosts['rhel8'][0], multi_hosts['rhel7'][0]]
+            SELECTED_ROLE = 'RedHatInsights.insights-client'
+            for host in hosts:
+                result = host.register(
+                    module_org, module_location, module_ak_with_synced_repo.name, target_sat
+                )
+                assert result.status == 0, f'Failed to register host: {result.stderr}'
+                proxy_id = target_sat.nailgun_smart_proxy.id
+                target_host = host.nailgun_host
+                target_sat.api.AnsibleRoles().sync(
+                    data={'proxy_id': proxy_id, 'role_names': [SELECTED_ROLE]}
+                )
+                role_id = (
+                    target_sat.api.AnsibleRoles()
+                    .search(query={'search': f'name={SELECTED_ROLE}'})[0]
+                    .id
+                )
+                target_sat.api.Host(id=target_host.id).add_ansible_role(
+                    data={'ansible_role_id': role_id}
+                )
+                host_roles = target_host.list_ansible_roles()
+                assert host_roles[0]['name'] == SELECTED_ROLE
+
+            template_id = (
+                target_sat.api.JobTemplate()
+                .search(query={'search': 'name="Ansible Roles - Ansible Default"'})[0]
                 .id
             )
-            target_sat.api.Host(id=target_host.id).add_ansible_role(
-                data={'ansible_role_id': role_id}
+            job = target_sat.api.JobInvocation().run(
+                synchronous=False,
+                data={
+                    'job_template_id': template_id,
+                    'targeting_type': 'static_query',
+                    'search_query': f'name ^ ({hosts[0].hostname} && {hosts[1].hostname} '
+                    f'&& {hosts[2].hostname})',
+                },
             )
-            host_roles = target_host.list_ansible_roles()
-            assert host_roles[0]['name'] == SELECTED_ROLE
-
-        template_id = (
-            target_sat.api.JobTemplate()
-            .search(query={'search': 'name="Ansible Roles - Ansible Default"'})[0]
-            .id
-        )
-        job = target_sat.api.JobInvocation().run(
-            synchronous=False,
-            data={
-                'job_template_id': template_id,
-                'targeting_type': 'static_query',
-                'search_query': f'name ^ ({hosts[0].hostname} && {hosts[1].hostname} '
-                f'&& {hosts[2].hostname})',
-            },
-        )
-        target_sat.wait_for_tasks(
-            f'resource_type = JobInvocation and resource_id = {job["id"]}',
-            poll_timeout=1000,
-            must_succeed=False,
-        )
-        result = target_sat.api.JobInvocation(id=job['id']).read()
-        assert result.succeeded == 2  # SELECTED_ROLE working on rhel8/rhel9 clients
-        assert result.failed == 1  # SELECTED_ROLE failing  on rhel7 client
-        assert result.status_label == 'failed'
+            target_sat.wait_for_tasks(
+                f'resource_type = JobInvocation and resource_id = {job["id"]}',
+                poll_timeout=1000,
+                must_succeed=False,
+            )
+            result = target_sat.api.JobInvocation(id=job['id']).read()
+            assert result.succeeded == 2  # SELECTED_ROLE working on rhel8/rhel9 clients
+            assert result.failed == 1  # SELECTED_ROLE failing  on rhel7 client
+            assert result.status_label == 'failed'
 
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')  # all major versions, excluding fips


### PR DESCRIPTION
### Problem Statement
Currently `test_positive_ansible_job_on_multiple_host` uses  `rhel9_contenthost`, `rhel8_contenthost`, `rhel7_contenthost` fixtures which aren't parametrized for IPv6 run, which fails while communicating to the hosts that checkouts which is IPv4, and I found this old issue https://github.com/SatelliteQE/robottelo/issues/11568 which advises to use `Broker.multi_manager` here for parallel host checkouts to improve test execution, so looking to resolve this too with this fix.

### Solution
Using `Broker.multi_manager` to fix ansible test checkout for multiple hosts, along with `deploy_network_type` arg for host checkout as per `settings.server.is_ipv6` setting

Fixes https://github.com/SatelliteQE/robottelo/issues/11568
### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->