### PR TITLE
[6.17.z] new yggdrasil rhel10 only

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1538,14 +1538,7 @@ class ContentHost(Host, ContentHostMixins):
         host.update(['location'])
 
     def get_yggdrasil_service_name(self):
-        return (
-            'yggdrasil'
-            if (
-                self.os_version.major > 9
-                or (self.os_version.major == 9 and self.os_version.minor > 5)
-            )
-            else 'yggdrasild'
-        )
+        return 'yggdrasil' if (self.os_version.major > 9) else 'yggdrasild'
 
 
 class Capsule(ContentHost, CapsuleMixins):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18215

### Problem Statement
this reflects the change of plan, previously new ygg was expected to be in rhel 9.6+ versions, now it is rhel10 only

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->