### PR TITLE
[6.16.z] ACS - remove invalid parametrization combination (rhui-file)

### DIFF
--- a/tests/foreman/api/test_acs.py
+++ b/tests/foreman/api/test_acs.py
@@ -21,8 +21,15 @@ from robottelo.constants.repos import PULP_FIXTURE_ROOT, PULP_SUBPATHS_COMBINED
 
 @pytest.mark.e2e
 @pytest.mark.upgrade
-@pytest.mark.parametrize('cnt_type', ['yum', 'file'])
-@pytest.mark.parametrize('acs_type', ['custom', 'simplified', 'rhui'])
+@pytest.mark.parametrize(
+    ('acs_type', 'cnt_type'),
+    [
+        (acs, cnt)
+        for acs in ['custom', 'simplified', 'rhui']
+        for cnt in ['yum', 'file']
+        if not (acs == 'rhui' and cnt == 'file')  # invalid combination: 'rhui-file'
+    ],
+)
 def test_positive_CRUD_all_types(
     request, module_target_sat, acs_type, cnt_type, module_yum_repo, module_file_repo
 ):
@@ -46,8 +53,6 @@ def test_positive_CRUD_all_types(
         4. ACS can be refreshed.
         5. ACS can be deleted.
     """
-    if 'rhui' in request.node.name and 'file' in request.node.name:
-        pytest.skip('unsupported parametrize combination')
 
     # Create
     params = {

--- a/tests/foreman/cli/test_acs.py
+++ b/tests/foreman/cli/test_acs.py
@@ -30,8 +30,15 @@ VAL_CANNOT_BE = 'cannot be'
 
 @pytest.mark.e2e
 @pytest.mark.pit_server
-@pytest.mark.parametrize('cnt_type', ['yum', 'file'])
-@pytest.mark.parametrize('acs_type', ['custom', 'simplified', 'rhui'])
+@pytest.mark.parametrize(
+    ('acs_type', 'cnt_type'),
+    [
+        (acs, cnt)
+        for acs in ['custom', 'simplified', 'rhui']
+        for cnt in ['yum', 'file']
+        if not (acs == 'rhui' and cnt == 'file')  # invalid combination: 'rhui-file'
+    ],
+)
 def test_positive_CRUD_all_types(
     request, module_target_sat, acs_type, cnt_type, module_yum_repo, module_file_repo
 ):
@@ -55,8 +62,6 @@ def test_positive_CRUD_all_types(
         4. ACS can be refreshed.
         5. ACS can be deleted.
     """
-    if 'rhui' in request.node.name and 'file' in request.node.name:
-        pytest.skip('unsupported parametrize combination')
 
     # Create
     params = {


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18247

### Problem Statement
Since sometime in 6.13.z or perhaps prior, CLI & API `test_positive_CRUD_all_types` has been skipping 2 cases,
for invalid parametrization combination ('rhui-file'). Suggest we remove, as it can be ignored rather than collected and skipped, which has always prevented 100% pass rate in CI.

### Solution
use list comprehension in parametrization of ACS type and Content type, ignoring if combination is ('rhui', 'file')


 ### PRT Cases
```
trigger: test-robottelo
pytest: tests/foreman/api/test_acs.py::test_positive_CRUD_all_types tests/foreman/cli/test_acs.py::test_positive_CRUD_all_types
```