### PR TITLE
[6.16.z] Ensure all permissions for certain resource type are found

### DIFF
--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -83,7 +83,7 @@ class TestPermission:
             if resource_type is None:
                 continue
             perm_group = target_sat.api.Permission().search(
-                query={'search': f'resource_type="{resource_type}"'}
+                query={'search': f'resource_type="{resource_type}"', 'per_page': 'all'}
             )
             permissions = {perm.name for perm in perm_group}
             expected_permissions = set(self.permissions[resource_type])


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18245

### Problem Statement

If there are more than 20 permissions for a certain resource type they are not found

### Solution

get all permissions for certain resource type

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->