### PR TITLE
Check UI reaction to subscription_connection_enabled setting

### DIFF
--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -518,7 +518,7 @@ def test_subscription_connection_settings_ui_behavior(request, module_target_sat
         displayed_buttons = session.cloudinventory.get_displayed_buttons()
         displayed_descriptions = session.cloudinventory.get_displayed_descriptions()
 
-        subscription_setting = setting_update == 'subscription_connection_enabled=true'
+        subscription_setting = setting_update.value == 'true'
 
         assert displayed_settings_options['auto_update'] is subscription_setting
         assert displayed_buttons['cloud_connector'] is subscription_setting

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -526,15 +526,3 @@ def test_subscription_connection_settings_ui_behavior(request, module_target_sat
             assert displayed_buttons['sync_status'] is subscription_setting
             assert displayed_descriptions['auto_upload_desc'] is subscription_setting
             assert displayed_descriptions['manual_upload_desc'] is subscription_setting
-
-
-def test_dummy(target_sat):
-    with target_sat.ui_session() as session:
-        session.jobinvocation.run(
-            {
-                'category_and_template.job_category': 'Commands',
-                'category_and_template.job_template_text_input': 'Run Command - Script Default',
-                'target_hosts_and_inputs.command': 'ls',
-                'target_hosts_and_inputs.targets': target_sat.hostname,
-            }
-        )

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -518,33 +518,23 @@ def test_subscription_connection_settings_ui_behavior(request, module_target_sat
         displayed_buttons = session.cloudinventory.get_displayed_buttons()
         displayed_descriptions = session.cloudinventory.get_displayed_descriptions()
 
+        subscription_setting = setting_update == 'subscription_connection_enabled=true'
+
         if setting_update == 'subscription_connection_enabled=true':
-            assert displayed_settings_options['auto_update'], (
-                'Auto update switch should be displayed!'
-            )
-            assert displayed_buttons['cloud_connector'], (
-                'Cloud connector button should be displayed!'
-            )
-            assert displayed_buttons['sync_status'], 'Sync status button should be displayed!'
-            assert displayed_descriptions['auto_upload_desc'], (
-                'Auto upload description should be displayed!'
-            )
-            assert displayed_descriptions['manual_upload_desc'], (
-                'Manual upload description should be displayed!'
-            )
-        elif setting_update == 'subscription_connection_enabled=false':
-            assert not displayed_settings_options['auto_update'], (
-                'Auto update switch should not be displayed!'
-            )
-            assert not displayed_buttons['cloud_connector'], (
-                'Cloud connector button should not be displayed!'
-            )
-            assert not displayed_buttons['sync_status'], (
-                'Sync status button should not be displayed!'
-            )
-            assert not displayed_descriptions['auto_upload_desc'], (
-                'Auto upload description should not be displayed!'
-            )
-            assert not displayed_descriptions['manual_upload_desc'], (
-                'Manual upload description should not be displayed!'
-            )
+            assert displayed_settings_options['auto_update'] is subscription_setting
+            assert displayed_buttons['cloud_connector'] is subscription_setting
+            assert displayed_buttons['sync_status'] is subscription_setting
+            assert displayed_descriptions['auto_upload_desc'] is subscription_setting
+            assert displayed_descriptions['manual_upload_desc'] is subscription_setting
+
+
+def test_dummy(target_sat):
+    with target_sat.ui_session() as session:
+        session.jobinvocation.run(
+            {
+                'category_and_template.job_category': 'Commands',
+                'category_and_template.job_template_text_input': 'Run Command - Script Default',
+                'target_hosts_and_inputs.command': 'ls',
+                'target_hosts_and_inputs.targets': target_sat.hostname,
+            }
+        )

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -520,9 +520,8 @@ def test_subscription_connection_settings_ui_behavior(request, module_target_sat
 
         subscription_setting = setting_update == 'subscription_connection_enabled=true'
 
-        if setting_update == 'subscription_connection_enabled=true':
-            assert displayed_settings_options['auto_update'] is subscription_setting
-            assert displayed_buttons['cloud_connector'] is subscription_setting
-            assert displayed_buttons['sync_status'] is subscription_setting
-            assert displayed_descriptions['auto_upload_desc'] is subscription_setting
-            assert displayed_descriptions['manual_upload_desc'] is subscription_setting
+        assert displayed_settings_options['auto_update'] is subscription_setting
+        assert displayed_buttons['cloud_connector'] is subscription_setting
+        assert displayed_buttons['sync_status'] is subscription_setting
+        assert displayed_descriptions['auto_upload_desc'] is subscription_setting
+        assert displayed_descriptions['manual_upload_desc'] is subscription_setting

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -487,7 +487,7 @@ def test_rhcloud_global_parameters(
     assert baremetal_host.hostname in hostnames
 
 
-def test_subscription_connection_settings_ui_behavior(module_target_sat):
+def test_subscription_connection_settings_ui_behavior(request, module_target_sat):
     """Verify that the RH Cloud Inventory UI
     reflects the subscription_connection_enabled setting
 
@@ -497,9 +497,8 @@ def test_subscription_connection_settings_ui_behavior(module_target_sat):
         1. Set the subscription_connection_enabled setting to true
         2. Check that all the RH inventory settings, auto_upload and manual_upload descriptions,
             cloud_connector and sync_status buttons are displayed in the UI
-        3. Set the setting to false
-        4. Set the subscription_connection_enabled setting to false
-        5. Verify that auto_update switch, auto_upload and manual_upload descriptions
+        3. Set the subscription_connection_enabled setting to false
+        4. Verify that auto_update switch, auto_upload and manual_upload descriptions
             and configure_cloud_connector and sync_all buttons are NOT displayed in the UI
 
     :expectedresults:
@@ -513,6 +512,13 @@ def test_subscription_connection_settings_ui_behavior(module_target_sat):
         initital_subs_conn_setting = module_target_sat.cli.Settings.list(
             {'search': 'subscription_connection_enabled'}
         )[0]['value']
+
+        @request.addfinalizer
+        def _finalize():
+            # Set the subscription_connection_enabled back to its initial state
+            module_target_sat.cli.Settings.set(
+                {'name': 'subscription_connection_enabled', 'value': initital_subs_conn_setting}
+            )
 
         # Check the initial state of the RH inventory settings when subscription_connection_enabled is set to true
         module_target_sat.cli.Settings.set(
@@ -555,9 +561,4 @@ def test_subscription_connection_settings_ui_behavior(module_target_sat):
         )
         assert not displayed_descriptions['manual_upload_desc'], (
             'Manual upload description should not be displayed!'
-        )
-
-        # Set the subscription_connection_enabled back to its initial state
-        module_target_sat.cli.Settings.set(
-            {'name': 'subscription_connection_enabled', 'value': initital_subs_conn_setting}
         )


### PR DESCRIPTION
### Problem Statement
When `subscription_connection_enabled` setting is set to `false` the 

- Automatic inventory upload switch
- Configure cloud connector button
- Sync all inventory status button

and these descriptions 
```
To enable this reporting for all Foreman organizations, set Automatic inventory upload to on. The data will be reported automatically once per day.

To manually upload the data for a specific organization, select an organization and click Generate and upload report.
```
are hidden.

### Solution
This test checks that the `subscription_connection_enabled` setting is properly reflected in the Satellite UI.

### Related Issues
Related Airgun PR: https://github.com/SatelliteQE/airgun/pull/1800
Related foreman PR: https://github.com/theforeman/foreman_rh_cloud/pull/976

![image](https://github.com/user-attachments/assets/a2e18816-d637-4409-9a82-64ba3b1d971f)
### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_inventory.py -k 'test_subscription_connection_settings_ui_behavior'
airgun: 1800
theforeman:
    foreman_rh_cloud: 976
```