### PR TITLE
Discovery provisioning test fixes

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -208,6 +208,7 @@ def module_provisioning_sat(
     subnet = sat.api.Subnet(
         location=[module_location],
         organization=[module_sca_manifest_org],
+        vlanid=settings.provisioning.vlan_id,
         network=str(provisioning_network.network_address),
         network_type='IPv6' if settings.server.is_ipv6 else 'IPv4',
         mask=str(provisioning_network.netmask),

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -84,7 +84,8 @@ def test_positive_provision_pxe_host(
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,
-        delay=20,
+        retries=2,
+        delay=40,
     )
     discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
     discovered_host.hostgroup = provisioning_hostgroup
@@ -166,7 +167,8 @@ def test_positive_custom_provision_pxe_host(
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,
-        delay=20,
+        retries=2,
+        delay=40,
     )
     discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
     discovered_host.hostgroup = provisioning_hostgroup
@@ -320,7 +322,8 @@ def test_positive_auto_provision_host_with_rule(
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,
-        delay=20,
+        retries=2,
+        delay=40,
     )
     discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
     discovered_host.hostgroup = provisioning_hostgroup


### PR DESCRIPTION
### Problem Statement
Discovery tests failing consistently due to multiple issues.

### Solution
Fix failing discovery tests

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->