### PR TITLE
[6.16.z] Retrieve the correct host info from the inventories.

### DIFF
--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -861,7 +861,6 @@ class TestAnsibleAAPIntegration:
             force=True,
         )
         assert result.status == 0, f'Failed to register host: {result.stderr}'
-
         # Find the Satellite credentials in AAP and update it for target_sat.hostname and user credentials
         self.update_sat_credentials_in_aap(
             aap_client, target_sat, username=login, aap_version=aap_version
@@ -883,7 +882,7 @@ class TestAnsibleAAPIntegration:
             in [
                 host['name']
                 for host in aap_client.get(
-                    f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/'
+                    f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={rhel_contenthost.hostname}'
                 ).json()['results']
             ],
             timeout=180,
@@ -891,7 +890,7 @@ class TestAnsibleAAPIntegration:
         )
         # Find the hosts in Satellite inventory in AAP and verify if target_sat is listed in inventory
         hosts_list = aap_client.get(
-            f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/'
+            f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={rhel_contenthost.hostname}'
         ).json()
         assert rhel_contenthost.hostname in [host['name'] for host in hosts_list['results']]
 
@@ -1035,7 +1034,7 @@ class TestAnsibleAAPIntegration:
             in [
                 host['name']
                 for host in aap_client.get(
-                    f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/'
+                    f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={hostname}'
                 ).json()['results']
             ],
             timeout=180,
@@ -1043,7 +1042,7 @@ class TestAnsibleAAPIntegration:
         )
         # Find the hosts in AAP inventory and verify if provisioning host is listed in inventory
         hosts_list = aap_client.get(
-            f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/'
+            f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={hostname}'
         ).json()
         assert hostname in [host['name'] for host in hosts_list['results']]
         assert provisioning_host.execute('systemctl start ansible-callback').status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18251

Added `?search=` to the endpoint to retrieve the particular host, allowing us to perform assertions against our specific host.

This change was made to address a failure occurring during the upgrade test. In upgrade scenarios, multiple hosts may already exist, leading to conflicts. Previously, the test only fetched hosts from the first page, and if the expected host was on a subsequent page, it would not be found. By specifying the `search` parameter, we ensure our specific host will fetch from across the page, which should prevent such issues.