### PR TITLE
Fix EL10 Secureboot provisioning tests as per RHEL-75490

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -369,3 +369,41 @@ def pxeless_discovery_host(provisioning_host, module_discovery_sat, pxe_loader):
     ).execute()
     yield provisioning_host
     Broker(workflow='remove-disk-image', remove_disk_image_name=image_name).execute()
+
+
+@pytest.fixture
+def configure_secureboot_provisioning(
+    request, pxe_loader, module_provisioning_sat, module_provisioning_rhel_content
+):
+    """Fixture for configuring Secureboot pxe_loader for provisioning, when hosts RHEL version > Satellites RHEL version"""
+    rhel_ver = module_provisioning_rhel_content.os.major
+    sat = module_provisioning_sat.sat
+    if (
+        int(rhel_ver) > sat.os_version.major
+        and pxe_loader.vm_firmware == 'uefi_secure_boot'
+        and not settings.server.is_ipv6
+    ):
+        # Set the path for the shim and GRUB2 binaries for the OS of host
+        bootloader_path = '/var/lib/tftpboot/bootloader-universe/pxegrub2/redhat/default/x86_64'
+
+        # Create the directory to store the shim and GRUB2 binaries for the OS of host
+        sat.execute(f'install -o foreman-proxy -g foreman-proxy -d {bootloader_path}')
+
+        # Fetch and Download SB packages, and extract Shim/Grub2 binaries
+        for prefix in ['grub2-efi-x64', 'shim-x64']:
+            url = sat.get_secureboot_packages_with_version(
+                f'{settings.repos.get(f"rhel{rhel_ver}_os").baseos}/Packages', prefix
+            )
+            sat.execute(f'curl -o /tmp/{prefix}.rpm {url}')
+            sat.execute(f'rpm2cpio /tmp/{prefix}.rpm | cpio -idv --directory /tmp')
+
+        # Make the shim and GRUB2 binaries available for host provisioning:
+        sat.execute(f'cp /tmp/boot/efi/EFI/redhat/grubx64.efi {bootloader_path}/grubx64.efi')
+        sat.execute(f'cp /tmp/boot/efi/EFI/redhat/shimx64.efi {bootloader_path}/shimx64.efi')
+        sat.execute(f'ln -sr {bootloader_path}/grubx64.efi {bootloader_path}/boot.efi')
+        sat.execute(f'ln -sr {bootloader_path}/shimx64.efi {bootloader_path}/boot-sb.efi')
+        sat.execute(f'chmod 644 {bootloader_path}/grubx64.efi {bootloader_path}/shimx64.efi')
+        yield
+        sat.execute(f'rm -rf {bootloader_path}')
+    else:
+        yield None

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -284,6 +284,7 @@ def test_positive_provision_end_to_end(
     setting_update,
     module_provisioning_rhel_content,
     module_libvirt_provisioning_sat,
+    configure_secureboot_provisioning,
     module_sca_manifest_org,
     module_location,
     module_ssh_key_file,

--- a/tests/foreman/api/test_computeresource_vmware.py
+++ b/tests/foreman/api/test_computeresource_vmware.py
@@ -32,6 +32,7 @@ def test_positive_provision_end_to_end(
     setting_update,
     module_provisioning_rhel_content,
     module_provisioning_sat,
+    configure_secureboot_provisioning,
     module_sca_manifest_org,
     module_location,
     module_ssh_key_file,


### PR DESCRIPTION
### Problem Statement
 EL10 Secureboot provisioning tests are currently failing as it require changes suggested in RHEL-75490

### Solution
Fix EL10 Secureboot provisioning tests as per changes suggested in RHEL-75490 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->