### PR TITLE
[6.17.z] Skip oVirt/RHV tests on IPv6 setups

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -214,6 +214,10 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
 
     :expectedresults: All modules and roles run successfully
     """
+    # Skip oVirt/RHV tests on IPv6 setups
+    if settings.server.is_ipv6 and ansible_module in ['compute_profile_ovirt']:
+        pytest.skip("oVirt/RHV is not properly set up in IPv6 environment")
+
     # Setup provisioning resources
     if ansible_module in FAM_TEST_LIBVIRT_PLAYBOOKS:
         module_target_sat.configure_libvirt_cr()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18284

### Problem Statement

oVirt/RHV is not properly set up in IPv6 environment

### Solution

Skip related tests

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->