### PR TITLE
Add a test case for podman login without password

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -237,6 +237,9 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
         assert host.execute('systemctl enable --now podman').status == 0, (
             'Start of podman service failed'
         )
+        assert host.execute('yum -y install expect').status == 0, (
+            'Expect installation failed unexpectedly'
+        )
         host.unregister()
         assert (
             host.register(module_org, None, module_activation_key.name, module_target_sat).status

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -234,12 +234,8 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
             assert host.execute(f'yum -y install {client}').status == 0, (
                 f'{client} installation failed'
             )
-        assert host.execute('systemctl enable --now podman').status == 0, (
-            'Start of podman service failed'
-        )
-        assert host.execute('yum -y install expect').status == 0, (
-            'Expect installation failed unexpectedly'
-        )
+        assert host.execute('systemctl enable --now podman').status == 0
+        assert host.execute('yum -y install expect').status == 0
         host.unregister()
         assert (
             host.register(module_org, None, module_activation_key.name, module_target_sat).status

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -2091,7 +2091,8 @@ class TestPodman:
     def test_negative_login_without_pass(
         self, request, module_capsule_configured, module_container_contenthost
     ):
-        """Ensure the interactive podman login fails with appropriate message when password is omit.
+        """Ensure the interactive podman login fails with appropriate message
+        when password is omitted.
 
         :id: a2ef15e0-e95e-49ea-8378-b5fbe4e350b3
 

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -2087,3 +2087,37 @@ class TestPodman:
             f'podman push --creds {settings.server.admin_username}:{settings.server.admin_password} {large_image_id} {module_capsule_configured.hostname}/{IMAGE_NAME_TAG}'
         )
         assert 'Pushing content is unsupported' in result.stderr
+
+    def test_negative_login_without_pass(
+        self, request, module_capsule_configured, module_container_contenthost
+    ):
+        """Ensure the podman login fails with appropriate message when password is omit.
+
+        :id: a2ef15e0-e95e-49ea-8378-b5fbe4e350b3
+
+        :steps:
+            1. Try podman login to a Capsule without any password provided.
+
+        :expectedresults: Login fails with appropriate error message.
+
+        :customerscenario: true
+
+        :verifies: SAT-25333
+
+        """
+        request.addfinalizer(
+            lambda: module_container_contenthost.execute(
+                f'podman logout {module_capsule_configured.hostname}'
+            )
+        )
+        with module_container_contenthost.session.shell() as sh:
+            sh.send(f'podman login --tls-verify=false {module_capsule_configured.hostname}')
+            sleep(3)
+            sh.send('')
+            sleep(3)
+            sh.send('')
+            sleep(3)
+        res = sh.result
+        assert res.status != 0
+        assert 'login succeeded' not in res.stdout.lower()
+        assert 'invalid username/password' in res.stderr.lower()


### PR DESCRIPTION
### Problem Statement
When running `podman login` at a host in an interactive shell via TTY, the login succeeds even when no credentials are provided (see the related issue below).

Now, I would like to add a test coverage for this case, but it seems the robottelo's interactive shell (uses `ssh2_python` by default, but behaves the same with `hussh`) works differently - it fails with a different error (while it is expected to succeed on unfixed snap 95 or fail on fixed snap 96 with `invalid username/password`):
```
Error: getting username and password: reading password: inappropriate ioctl for device
```
Which is basically the same validation error we get when we pipe the password with:
```
# echo "" | podman login --tls-verify=false capsule.redhat.com --username admin --password-stdin
```

Fortunately there is a better way to check the interactive login using the `expect` command (thanks @ianballou for that hack!)


### Solution
This PR.


### Related Issues
https://issues.redhat.com/browse/SAT-25333


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k negative_login_without_pass
```