### PR TITLE
Add cli tests for the new hammer insights commands

### DIFF
--- a/robottelo/cli/insights.py
+++ b/robottelo/cli/insights.py
@@ -1,0 +1,59 @@
+"""
+Usage:
+    hammer insights [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+ SUBCOMMAND                    Subcommand
+ [ARG] ...                     Subcommand arguments
+
+Subcommands:
+ cloud-connector               Manage cloud connector setup
+ inventory                     Manage inventory related operations
+
+Options:
+ -h, --help                    Print help
+
+"""
+
+from robottelo.cli.base import Base
+
+
+class Insights(Base):
+    """
+    Exports content from satellite
+    """
+
+    command_base = 'insights'
+    command_requires_org = True
+
+    @classmethod
+    def inventory_sync(cls, options):
+        """
+        Start inventory status sync
+        """
+        cls.command_sub = 'inventory sync'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def inventory_generate_report(cls, options):
+        """
+        Start new report generation
+        """
+        cls.command_sub = 'inventory generate-report'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def inventory_download_report(cls, options):
+        """
+        Download the last generated report
+        """
+        cls.command_sub = 'inventory download-report'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def cloud_connector_enable(cls, options=None):
+        """
+        Enable cloud connector
+        """
+        cls.command_sub = 'cloud-connector enable'
+        return cls.execute(cls._construct_command(options))


### PR DESCRIPTION
### Problem Statement
https://github.com/theforeman/hammer-cli-foreman-rh-cloud/tree/master
hammer cli foreman rhcloud recently got added to the sat stream. We needed tests for the following commands

- `hammer insights inventory generate-report --organization-id=100`
- `hammer insights inventory generate-report --organization-id=100 --no-upload`
- `hammer insights inventory download-report --organization-id=100 `
- `hammer insights inventory sync--organization-id=100 `
- `hammer insights cloud-connector enable`


### Solution
This PR attempts to address that

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->