### PR TITLE
Remove support of RHEL7 support from fips enabled Satellite

### DIFF
--- a/conf/supportability.yaml
+++ b/conf/supportability.yaml
@@ -2,4 +2,4 @@ supportability:
   content_hosts:
     default_os_name: "RedHat"
     rhel:
-      versions: [7,'7_fips', 8, '8_fips', 9, '9_fips', 10,]
+      versions: [7, '7_fips', 8, '8_fips', 9, '9_fips', 10,]

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -63,6 +63,15 @@ def pytest_generate_tests(metafunc):
         filtered_versions = set(list_params + match_params)
         # default to all supported versions if no filters were found
         for ver in filtered_versions or settings.supportability.content_hosts.rhel.versions:
+            # Skipping RHEL7 client with RHEL9 and above fips-enabled satellite due to incompatibility
+            if (
+                not (
+                    settings.server.version.rhel_version == '7'
+                    or settings.server.version.rhel_version == '8'
+                )
+                and str(ver) == '7_fips'
+            ):
+                continue
             rhel_params.append(dict(rhel_version=ver, no_containers=no_containers))
 
         if rhel_params:


### PR DESCRIPTION
### Problem Statement
RHEL7 is not supported with RHEL9 fips-enabled Satellite.

### Solution
Remove the RHEL7 client support for RHEL9 Satellites.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->