### PR TITLE
[6.16.z] Use rex_contenthosts fixture in ansible verbosity test

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -124,18 +124,6 @@ def mod_content_hosts(request):
 
 
 @pytest.fixture
-def registered_hosts(request, target_sat, module_org, module_ak_with_cv):
-    """Fixture that registers content hosts to Satellite, based on rh_cloud setup"""
-    with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
-        for vm in hosts:
-            repo = settings.repos['SATCLIENT_REPO'][f'RHEL{vm.os_version.major}']
-            vm.register(
-                module_org, None, module_ak_with_cv.name, target_sat, repo_data=f'repo={repo}'
-            )
-        yield hosts
-
-
-@pytest.fixture
 def katello_host_tools_host(target_sat, module_org, rhel_contenthost):
     """Register content host to Satellite and install katello-host-tools on the host."""
     repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18253

### Problem Statement
Currently, `test_positive_ansible_job_with_verbose_stdout ` uses hosts checkout from `registered_hosts` fixture which isn't parametrized for IPv6 run, which fails while communicating to the hosts that checkouts which is IPv4, and after checking I found this is a only test using this fixture and we've similar `rex_contenthosts` fixture with same logic but with IPv6 parametrization support, so it would be great to get rid of this redundant fixture. 

### Solution
Use rex_contenthosts fixture in ansible verbosity test, and get rid of `registered_hosts` fixture which is redundant

### Related Issues
https://github.com/SatelliteQE/airgun/pull/1801
