### PR TITLE
[6.17.z] Use rex_contenthosts fixture in ansible verbosity test

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -118,18 +118,6 @@ def mod_content_hosts(request):
 
 
 @pytest.fixture
-def registered_hosts(request, target_sat, module_org, module_ak_with_cv):
-    """Fixture that registers content hosts to Satellite, based on rh_cloud setup"""
-    with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
-        for vm in hosts:
-            repo = settings.repos['SATCLIENT_REPO'][f'RHEL{vm.os_version.major}']
-            vm.register(
-                module_org, None, module_ak_with_cv.name, target_sat, repo_data=f'repo={repo}'
-            )
-        yield hosts
-
-
-@pytest.fixture
 def katello_host_tools_host(target_sat, module_org, rhel_contenthost):
     """Register content host to Satellite and install katello-host-tools on the host."""
     repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -853,7 +853,6 @@ class TestAnsibleREX:
         :expectedresults: Scheduled Job appears in the Job Invocation list at the appointed time
         """
 
-    @pytest.mark.no_containers
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     @pytest.mark.parametrize('setting_update', ['ansible_verbosity'], indirect=True)
     def test_positive_ansible_job_with_verbose_stdout(
@@ -861,10 +860,9 @@ class TestAnsibleREX:
         request,
         target_sat,
         module_org,
-        module_location,
         module_ak_with_cv,
         setting_update,
-        registered_hosts,
+        rex_contenthosts,
     ):
         """Verify ansible_verbosity setting and dynflow console output for expected hosts
 
@@ -894,23 +892,17 @@ class TestAnsibleREX:
 
         SELECTED_ROLE = 'RedHatInsights.insights-client'
         nc = target_sat.nailgun_smart_proxy
-        nc.location = [module_location]
         nc.organization = [module_org]
-        nc.update(['organization', 'location'])
+        nc.update(['organization'])
         target_sat.api.AnsibleRoles().sync(data={'proxy_id': nc.id, 'role_names': SELECTED_ROLE})
         vm_hostnames = []
-        for vm in registered_hosts:
+        for vm in rex_contenthosts:
             rhel_ver = vm.os_version.major
             rhel_repo_urls = getattr(settings.repos, f'rhel{rhel_ver}_os', None)
             vm.create_custom_repos(**rhel_repo_urls)
-            result = vm.register(
-                module_org, module_location, module_ak_with_cv.name, target_sat, force=True
-            )
-            assert result.status == 0, f'Failed to register host: {result.stderr}'
             vm_hostnames.append(vm.hostname)
         with target_sat.ui_session() as session:
             session.organization.select(module_org.name)
-            session.location.select(module_location.name)
             session.host.play_ansible_roles('All')
             session.jobinvocation.wait_job_invocation_state(
                 entity_name='Run ansible roles', host_name=vm_hostnames[0]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18253

### Problem Statement
Currently, `test_positive_ansible_job_with_verbose_stdout ` uses hosts checkout from `registered_hosts` fixture which isn't parametrized for IPv6 run, which fails while communicating to the hosts that checkouts which is IPv4, and after checking I found this is a only test using this fixture and we've similar `rex_contenthosts` fixture with same logic but with IPv6 parametrization support, so it would be great to get rid of this redundant fixture. 

### Solution
Use rex_contenthosts fixture in ansible verbosity test, and get rid of `registered_hosts` fixture which is redundant

### Related Issues
https://github.com/SatelliteQE/airgun/pull/1801
