### PR TITLE
[6.16.z] use "StrictHostKeyChecking accept-new" instead of ssh-keyscan

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -355,7 +355,7 @@ class ProvisioningSetup:
         """
         # Geneate SSH key-pair for foreman user and copy public key to libvirt server
         self.execute('sudo -u foreman ssh-keygen -q -t rsa -f ~foreman/.ssh/id_rsa -N "" <<< y')
-        self.execute(f'ssh-keyscan -t ecdsa {server_fqdn} >> ~foreman/.ssh/known_hosts')
+        self.execute('echo "StrictHostKeyChecking accept-new" >> ~foreman/.ssh/config')
         self.execute(
             f'sshpass -p {settings.server.ssh_password} ssh-copy-id -o StrictHostKeyChecking=no '
             f'-i ~foreman/.ssh/id_rsa root@{server_fqdn}'
@@ -363,12 +363,10 @@ class ProvisioningSetup:
         # Install libvirt-client, and verify foreman user is able to communicate with Libvirt server
         self.register_to_cdn()
         self.execute('dnf -y --disableplugin=foreman-protector install libvirt-client')
-        assert (
-            self.execute(
-                f'su foreman -s /bin/bash -c "virsh -c qemu+ssh://root@{server_fqdn}/system list"'
-            ).status
-            == 0
+        result = self.execute(
+            f'su foreman -s /bin/bash -c "virsh -c qemu+ssh://root@{server_fqdn}/system list"'
         )
+        assert result.status == 0, f"{result.status=}\n{result.stdout=}\n{result.stderr=}"
 
     def provisioning_cleanup(self, hostname, interface='API'):
         if interface == 'CLI':


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18308

### Problem Statement

ssh-keyscan is broken on FIPS-enabled systems (See: https://issues.redhat.com/browse/RHEL-88565)

### Solution

Use `StrictHostKeyChecking accept-new` which just accepts the first seen key instead of prompting, thus eliminating the need for `ssh-keyscan`.

This PR also improves the logging of the assertion which was required to debug this issue.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->
