### PR TITLE
Fix fips provisioning test

### DIFF
--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -597,13 +597,8 @@ def test_rhel_pxe_provisioning_fips_enabled(
     )
 
     # Verify FIPS is enabled on host after provisioning is completed sucessfully
-    if int(host_os.major) >= 8:
-        result = provisioning_host.execute('fips-mode-setup --check')
-        fips_status = 'FIPS mode is disabled' if is_open('SAT-20386') else 'FIPS mode is enabled'
-        assert fips_status in result.stdout
-    else:
-        result = provisioning_host.execute('cat /proc/sys/crypto/fips_enabled')
-        assert (0 if is_open('SAT-20386') else 1) == int(result.stdout)
+    result = provisioning_host.execute('cat /proc/sys/crypto/fips_enabled')
+    assert (0 if is_open('SAT-20386') else 1) == int(result.stdout)
 
     # Run a command on the host using REX to verify that Satellite's SSH key is present on the host
     # Add workaround for SAT-32007 and SAT-32006


### PR DESCRIPTION
### Problem Statement
EL10 Fips provisioning tests are failing due to `fips_mode_setup` command not found.

### Solution
Update the test to assert directly in the `/proc/sys/crypto/fips_enabled` for check the fips status for all RHEL versions

