### PR TITLE
[6.17.z] Fix UI Insights remediation tests

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -18,36 +18,31 @@ import pytest
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_LOC, DEFAULT_ORG, DNF_RECOMMENDATION, OPENSSH_RECOMMENDATION
+from robottelo.constants import DNF_RECOMMENDATION, OPENSSH_RECOMMENDATION
 
 
-def create_insights_vulnerability(insights_vm):
+def create_insights_vulnerability(host):
     """Function to create vulnerabilities that can be remediated."""
 
-    # Add vulnerabilities for OPENSSH_RECOMMENDATION and DNS_RECOMMENDATION, then upload Insights data.
-    insights_vm.run(
-        'chmod 777 /etc/ssh/sshd_config;'
-        'dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;'
-        'insights-client'
-    )
+    # Add vulnerability for DNF_RECOMMENDATION (RHEL 8+)
+    if host.os_version.major > 7:
+        host.run('dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf')
+
+    # Add vulnerability for SSH_RECOMMENDATION
+    host.run('chmod 777 /etc/ssh/sshd_config')
+
+    # Upload insights data to Satellite
+    result = host.run('insights-client')
+    assert result.status == 0
 
 
-def sync_recommendations(satellite, org_name=DEFAULT_ORG, loc_name=DEFAULT_LOC):
-    with satellite.ui_session() as session:
-        session.organization.select(org_name=org_name)
-        session.location.select(loc_name=DEFAULT_LOC)
-
-        timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
-        session.cloudinsights.sync_hits()
-
+def sync_recommendations(session):
+    timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
+    session.cloudinsights.sync_hits()
     wait_for(
-        lambda: satellite.api.ForemanTask()
-        .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
-        .result
-        == 'success',
-        timeout=400,
+        lambda: session.task.search(f'Insights full sync and started_at >= "{timestamp}"'),
+        timeout=180,
         delay=15,
-        silent_failure=True,
         handle_exception=True,
     )
 
@@ -94,62 +89,47 @@ def test_rhcloud_insights_e2e(
     :CaseAutomation: Automated
     """
     org_name = rhcloud_manifest_org.name
-    api_query = (
-        f'Remote action: Insights remediations for selected issues on {rhel_insights_vm.hostname}'
-    )
-    ui_query = f'hostname = "{rhel_insights_vm.hostname}" and title = "{OPENSSH_RECOMMENDATION}"'
-
-    # Prepare misconfigured machine and upload data to Insights
-    create_insights_vulnerability(rhel_insights_vm)
-
-    # Sync the recommendations (hosted Insights only).
     local_advisor_enabled = module_target_sat_insights.local_advisor_enabled
-    if not local_advisor_enabled:
-        sync_recommendations(module_target_sat_insights, org_name=org_name, loc_name=DEFAULT_LOC)
 
-    # Verify that we can see the rule hit via insights-client
-    result = rhel_insights_vm.execute('insights-client --diagnosis')
-    assert result.status == 0
-    assert 'OPENSSH_HARDENING_CONFIG_PERMS' in result.stdout
+    # Query for searching the available recommendation
+    REC_QUERY = f'hostname = "{rhel_insights_vm.hostname}" and title = "{OPENSSH_RECOMMENDATION}"'
 
     # Verify insights-client can update to latest version available from server
     assert rhel_insights_vm.execute('insights-client --version').status == 0
 
+    # Prepare misconfigured machine and upload data to Insights
+    create_insights_vulnerability(rhel_insights_vm)
+
     with module_target_sat_insights.ui_session() as session:
         session.organization.select(org_name=org_name)
-        session.location.select(loc_name=DEFAULT_LOC)
+
+        # Sync the recommendations (hosted Insights only).
+        if not local_advisor_enabled:
+            sync_recommendations(session)
+
+        # Verify that we can see the rule hit via insights-client
+        result = rhel_insights_vm.execute('insights-client --diagnosis')
+        assert result.status == 0
+        assert 'OPENSSH_HARDENING_CONFIG_PERMS' in result.stdout
 
         # Search for the recommendation.
-        result = session.cloudinsights.search(ui_query)[0]
+        result = session.cloudinsights.search(REC_QUERY)[0]
         assert result['Hostname'] == rhel_insights_vm.hostname
         assert result['Recommendation'] == OPENSSH_RECOMMENDATION
 
         # Run the remediation.
-        timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.remediate(OPENSSH_RECOMMENDATION)
+        session.jobinvocation.wait_job_invocation_state(
+            entity_name='Insights remediations for selected issues',
+            host_name=rhel_insights_vm.hostname,
+        )
 
-    # Wait for the remediation task to complete.
-    wait_for(
-        lambda: module_target_sat_insights.api.ForemanTask()
-        .search(query={'search': f'{api_query} and started_at >= "{timestamp}"'})[0]
-        .result
-        == 'success',
-        timeout=400,
-        delay=15,
-        silent_failure=True,
-        handle_exception=True,
-    )
-
-    # Re-sync the recommendations (hosted Insights only).
-    if not local_advisor_enabled:
-        sync_recommendations(module_target_sat_insights, org_name=org_name, loc_name=DEFAULT_LOC)
-
-    with module_target_sat_insights.ui_session() as session:
-        session.organization.select(org_name=org_name)
-        session.location.select(loc_name=DEFAULT_LOC)
+        # Re-sync the recommendations (hosted Insights only).
+        if not local_advisor_enabled:
+            sync_recommendations(session)
 
         # Verify that the recommendation is not listed anymore.
-        assert not session.cloudinsights.search(ui_query)
+        assert not session.cloudinsights.search(REC_QUERY)
 
 
 @pytest.mark.e2e
@@ -190,27 +170,31 @@ def test_rhcloud_insights_remediate_multiple_hosts(
     """
     org_name = rhcloud_manifest_org.name
     hostnames = [host.hostname for host in rhel_insights_vms]
-    # Query on (hostname_a OR hostname_b)
-    api_query = (
+    local_advisor_enabled = module_target_sat_insights.local_advisor_enabled
+
+    # Query for searching the available recommendations
+    REC_QUERY = f'hostname ^ ({",".join(hostnames)}) and title = "{OPENSSH_RECOMMENDATION}"'
+
+    # Query for searching the scheduled remediation tasks
+    TASK_QUERY = (
         f'Remote action: Insights remediations for selected issues on ({"|".join(hostnames)})'
     )
-    ui_query = f'hostname ^ ({",".join(hostnames)}) and title = "{OPENSSH_RECOMMENDATION}"'
 
-    # Prepare misconfigured machine and upload data to Insights
+    # Prepare the misconfigured hosts and upload Insights data
     for vm in rhel_insights_vms:
         create_insights_vulnerability(vm)
 
-    # Sync the recommendations (hosted Insights only).
-    local_advisor_enabled = module_target_sat_insights.local_advisor_enabled
-    if not local_advisor_enabled:
-        sync_recommendations(module_target_sat_insights, org_name=org_name, loc_name=DEFAULT_LOC)
-
     with module_target_sat_insights.ui_session() as session:
         session.organization.select(org_name=org_name)
-        session.location.select(loc_name=DEFAULT_LOC)
 
-        # Search for the recommendations.
-        results = session.cloudinsights.search(ui_query)
+        # Sync the recommendations (hosted Insights only)
+        if not local_advisor_enabled:
+            sync_recommendations(session)
+
+        # Search for the recommendations
+        results = session.cloudinsights.search(REC_QUERY)
+
+        assert len(results) == len(rhel_insights_vms)
         assert all(result['Hostname'] in hostnames for result in results)
         assert all(result['Recommendation'] == OPENSSH_RECOMMENDATION for result in results)
 
@@ -218,33 +202,26 @@ def test_rhcloud_insights_remediate_multiple_hosts(
         timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.remediate(OPENSSH_RECOMMENDATION)
 
-    def verify_tasks():
-        tasks = module_target_sat_insights.api.ForemanTask().search(
-            query={'search': f'{api_query} and start_at >= "{timestamp}"'}
+        def verify_tasks():
+            tasks = session.task.search(f'{TASK_QUERY} and start_at >= "{timestamp}"')
+            return len(tasks) == len(rhel_insights_vms) and all(
+                task['Result'] == 'success' for task in tasks
+            )
+
+        # Wait for the remediation tasks to complete.
+        wait_for(
+            lambda: verify_tasks(),
+            timeout=120,
+            delay=15,
+            handle_exception=True,
         )
-        return len(tasks) == len(rhel_insights_vms) and all(
-            task.result == 'success' for task in tasks
-        )
 
-    # Wait for the remediation tasks to complete.
-    wait_for(
-        lambda: verify_tasks(),
-        timeout=400,
-        delay=15,
-        silent_failure=True,
-        handle_exception=True,
-    )
-
-    # Re-sync the recommendations (hosted Insights only).
-    if not local_advisor_enabled:
-        sync_recommendations(module_target_sat_insights, org_name=org_name, loc_name=DEFAULT_LOC)
-
-    with module_target_sat_insights.ui_session() as session:
-        session.organization.select(org_name=org_name)
-        session.location.select(loc_name=DEFAULT_LOC)
+        # Re-sync the recommendations (hosted Insights only).
+        if not local_advisor_enabled:
+            sync_recommendations(session)
 
         # Verify that the recommendations are not listed anymore.
-        assert not session.cloudinsights.search(ui_query)
+        assert not session.cloudinsights.search(REC_QUERY)
 
 
 @pytest.mark.stubbed
@@ -370,18 +347,17 @@ def test_host_details_page(
     :CaseAutomation: Automated
     """
     org_name = rhcloud_manifest_org.name
+    local_advisor_enabled = module_target_sat_insights.local_advisor_enabled
 
     # Prepare misconfigured machine and upload data to Insights.
     create_insights_vulnerability(rhel_insights_vm)
 
-    local_advisor_enabled = module_target_sat_insights.local_advisor_enabled
-    if not local_advisor_enabled:
-        # Sync insights recommendations.
-        sync_recommendations(module_target_sat_insights, org_name=org_name, loc_name=DEFAULT_LOC)
-
     with module_target_sat_insights.ui_session() as session:
         session.organization.select(org_name=org_name)
-        session.location.select(loc_name=DEFAULT_LOC)
+
+        if not local_advisor_enabled:
+            # Sync insights recommendations.
+            sync_recommendations(session)
 
         # Verify Insights status of host.
         result = session.host_new.get_host_statuses(rhel_insights_vm.hostname)
@@ -470,7 +446,7 @@ def test_insights_registration_with_capsule(
         )
     with module_target_sat_insights.ui_session() as session:
         session.organization.select(org_name=org.name)
-        session.location.select(loc_name=DEFAULT_LOC)
+
         # Generate host registration command
         cmd = session.host_new.get_register_command(
             {


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18309

### Problem Statement

When the test clicks "Remediate" or "Sync remediations" (hosted Insights only), the button submits a POST API call to Satellite, to create a Satellite Task or Job that will perform the actual action. If the test exits the session context manager too soon after clicking the button, however, then the API call gets canceled, and the task or job doesn't get created.

### Solution

Add UI verification that the remediation or sync is completed, instead of exiting the UI session and calling the API.

Plus a few other small fixes:

- Remove `silent_failure=True` from `wait_for` calls. If these verification steps fail, the test should also fail at that point.
- Add checks on the length of returned results, so that empty results will fail the test.
- Don't run `dnf` commands on RHEL 7 hosts.

### Related Issues

SAT-33262

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->