### PR TITLE
[6.16.z] amend expected perms for snapshot mgmt permissions

### DIFF
--- a/pytest_fixtures/component/permissions.py
+++ b/pytest_fixtures/component/permissions.py
@@ -42,9 +42,9 @@ def expected_permissions(session_target_sat):
     if 'rubygem-foreman_snapshot_management' not in rpm_packages:
         permissions['Host'].remove('view_snapshots')
         permissions['Host'].remove('create_snapshots')
-        permissions[None].remove('destroy_snapshots')
-        permissions[None].remove('revert_snapshots')
-        permissions[None].remove('edit_snapshots')
+        permissions['Host'].remove('destroy_snapshots')
+        permissions['Host'].remove('revert_snapshots')
+        permissions['Host'].remove('edit_snapshots')
     if 'gem-foreman_salt' not in rpm_packages:
         permissions['Host'].remove('saltrun_hosts')
         permissions['SmartProxy'].remove('destroy_smart_proxies_salt_autosign')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18363

### Problem Statement
https://github.com/SatelliteQE/robottelo/pull/18246 breaks perms tests for satellites without  rubygem-foreman_snapshot_management

### Solution
adding the needed changes to perm fixture

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->