### PR TITLE
Update VMware image-based provisioning test to cover SAT-30594

### DIFF
--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -162,7 +162,6 @@ def test_positive_provision_end_to_end(
 @pytest.mark.on_premises_provisioning
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
-@pytest.mark.parametrize('pxe_loader', ['bios'], indirect=True)
 @pytest.mark.rhel_ver_match('[8]')
 def test_positive_image_provision_end_to_end(
     request,
@@ -183,7 +182,6 @@ def test_positive_image_provision_end_to_end(
     :id: 8f0e2278-b897-4927-9c21-d84313623cc4
 
     :steps:
-
         1. Configure provisioning setup.
         2. Create VMware CR
         3. Create VMware image
@@ -193,6 +191,7 @@ def test_positive_image_provision_end_to_end(
 
     :expectedresults: Host is provisioned succesfully.
 
+    :verifies: SAT-30594
     """
     sat = module_provisioning_sat.sat
     hostname = gen_string('alpha').lower()
@@ -206,11 +205,12 @@ def test_positive_image_provision_end_to_end(
             'image': module_vmware_image.name,
             'ip': None,
             'mac': None,
-            'parameters': 'name=package_upgrade,type=boolean,value=false',
+            #'parameters': 'name=package_upgrade,type=boolean,value=false',
+            'typed-parameters': r'name=package_upgrade\,value=false\,parameter_type=boolean',
             'compute-attributes': f'cluster={settings.vmware.cluster},'
             f'path=/Datacenters/{settings.vmware.datacenter}/vm/,'
             'scsi_controller_type=VirtualLsiLogicController,'
-            'guest_id=rhel8_64Guest,firmware=automatic,'
+            'guest_id=rhel8_64Guest,firmware=automatic,virtual_tpm=true'
             'cpus=1,memory_mb=6000, start=1',
             'interface': 'compute_type=VirtualVmxnet3,'
             f'compute_network=VLAN {settings.provisioning.vlan_id}',
@@ -225,6 +225,12 @@ def test_positive_image_provision_end_to_end(
     assert hostname == host['name']
     # check if vm is created on vmware
     assert vmwareclient.does_vm_exist(hostname) is True
+
+    # Check if virtual TPM device is added to created VM (only for UEFI)
+    if pxe_loader.vm_firmware != 'bios':
+        vm = vmwareclient.get_vm(hostname)
+        assert 'VirtualTPM' in vm.get_virtual_device_type_names()
+
     wait_for(
         lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
         != 'Pending installation',


### PR DESCRIPTION
### Problem Statement
vTPM option doesn't work for VMware image-based provisioning, and SAT-30594 fixes this issue

### Solution
Update existing VMware image-based provisioning test to cover SAT-30594

### Dependant PRs
https://github.com/theforeman/foreman/pull/10524
https://github.com/fog/fog-vsphere/pull/309


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->