### PR TITLE
Convert Puppet scenario to new format

### DIFF
--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -230,3 +230,72 @@ def capsule_upgrade_integrated_sat_cap(
     setup_data.capsule = capsule_upgrade_shared_capsule
     setup_data.cap_smart_proxy = cap_smart_proxy
     return setup_data
+
+
+@pytest.fixture
+def puppet_upgrade_shared_satellite():
+    """Mark tests using this fixture with pytest.mark.puppet_upgrades"""
+    sat_instance = shared_checkout("puppet_upgrade")
+    with (
+        SharedResource(
+            "puppet_upgrade_enable_puppet",
+            action=sat_instance.enable_puppet_satellite,
+            action_is_recoverable=True,
+        ) as enable_puppet,
+        SharedResource(
+            "puppet_upgrade_satellite",
+            shared_checkin,
+            sat_instance=sat_instance,
+            action_is_recoverable=True,
+        ) as test_duration,
+    ):
+        enable_puppet.ready()
+        yield sat_instance
+        test_duration.ready()
+
+
+@pytest.fixture
+def puppet_upgrade_shared_capsule():
+    """Mark tests using this fixture with pytest.mark.puppet_upgrades"""
+    cap_instance = shared_cap_checkout("puppet_upgrade")
+    with (
+        SharedResource(
+            "puppet_upgrade_capsule",
+            shared_checkin,
+            sat_instance=cap_instance,
+            action_is_recoverable=True,
+        ) as test_duration,
+    ):
+        yield cap_instance
+        test_duration.ready()
+
+
+@pytest.fixture
+def puppet_upgrade_integrated_sat_cap(
+    puppet_upgrade_shared_satellite, puppet_upgrade_shared_capsule
+):
+    """Return a Satellite and Capsule that have been set up"""
+    setup_data = Box(
+        {
+            "satellite": None,
+            "capsule": None,
+        }
+    )
+    with (
+        SharedResource(
+            "capsule_setup",
+            action=puppet_upgrade_shared_capsule.capsule_setup,
+            sat_host=puppet_upgrade_shared_satellite,
+        ) as cap_setup,
+        SharedResource(
+            "puppet_upgrade_enable_puppet_capsule",
+            action=puppet_upgrade_shared_capsule.enable_puppet_capsule,
+            action_is_recoverable=True,
+            satellite=puppet_upgrade_shared_satellite,
+        ) as enable_puppet,
+    ):
+        cap_setup.ready()
+        enable_puppet.ready()
+    setup_data.satellite = puppet_upgrade_shared_satellite
+    setup_data.capsule = puppet_upgrade_shared_capsule
+    return setup_data

--- a/tests/new_upgrades/test_puppet.py
+++ b/tests/new_upgrades/test_puppet.py
@@ -66,8 +66,7 @@ def test_post_puppet_active(puppet_upgrade_setup):
         assert 'puppet' in result
         assert 'puppetca' in result
 
-        result = server.execute('rpm -q puppetserver')
-        assert result.status == 0
+        assert server.execute('rpm -q puppetserver').status == 0
 
         result = server.execute('systemctl status puppetserver')
         assert 'active (running)' in result.stdout
@@ -90,8 +89,7 @@ def test_post_puppet_reporting(puppet_upgrade_setup):
     """
     satellite = puppet_upgrade_setup.satellite
     capsule = puppet_upgrade_setup.capsule
-    result = capsule.execute('puppet agent -t')
-    assert result.status == 0
+    assert capsule.execute('puppet agent -t').status == 0
 
     result = satellite.cli.ConfigReport.list({'search': f'host={capsule.hostname},origin=Puppet'})
     assert len(result)

--- a/tests/new_upgrades/test_puppet.py
+++ b/tests/new_upgrades/test_puppet.py
@@ -41,7 +41,7 @@ def puppet_upgrade_setup(puppet_upgrade_integrated_sat_cap, upgrade_action):
         yield test_data
 
 
-@pytest.mark.capsule_upgrades
+@pytest.mark.puppet_upgrades
 def test_post_puppet_active(puppet_upgrade_setup):
     """Test that puppet remains active after the upgrade on both,
     Satellite and Capsule.
@@ -73,7 +73,7 @@ def test_post_puppet_active(puppet_upgrade_setup):
         assert 'active (running)' in result.stdout
 
 
-@pytest.mark.post_upgrade
+@pytest.mark.puppet_upgrades
 def test_post_puppet_reporting(puppet_upgrade_setup):
     """Test that puppet is reporting to Satellite after the upgrade.
 

--- a/tests/new_upgrades/test_puppet.py
+++ b/tests/new_upgrades/test_puppet.py
@@ -1,0 +1,97 @@
+"""Test for Remote Execution related Upgrade Scenario's
+
+:Requirement: UpgradedSatellite
+
+:CaseAutomation: Automated
+
+:CaseComponent: Puppet
+
+:Team: Rocket
+
+:CaseImportance: Medium
+
+"""
+
+from box import Box
+import pytest
+
+from robottelo.config import settings
+from robottelo.utils.shared_resource import SharedResource
+
+
+@pytest.fixture
+def puppet_upgrade_setup(puppet_upgrade_integrated_sat_cap, upgrade_action):
+    satellite = puppet_upgrade_integrated_sat_cap.satellite
+    capsule = puppet_upgrade_integrated_sat_cap.capsule
+    with (
+        SharedResource(satellite.hostname, upgrade_action, target_sat=satellite) as sat_upgrade,
+        SharedResource(capsule.hostname, upgrade_action, target_sat=capsule) as cap_upgrade,
+    ):
+        test_data = Box(
+            {
+                'satellite': satellite,
+                'capsule': capsule,
+            }
+        )
+        sat_upgrade.ready()
+        satellite._swap_nailgun(f'{settings.UPGRADE.TO_VERSION}.z')
+        cap_upgrade.ready()
+        satellite._session = None
+        capsule._session = None
+        yield test_data
+
+
+@pytest.mark.capsule_upgrades
+def test_post_puppet_active(puppet_upgrade_setup):
+    """Test that puppet remains active after the upgrade on both,
+    Satellite and Capsule.
+
+    :id: postupgrade-6360e928-ba0f-41a7-9aaa-bea87cb6342d
+
+    :steps:
+        1. Check for capsule features.
+        2. Check for puppetserver status.
+
+    :expectedresults:
+        1. Puppet and Puppetca features are enabled.
+        2. Puppetserver is installed and runnning.
+
+    :parametrized: yes
+
+    """
+    satellite = puppet_upgrade_setup.satellite
+    capsule = puppet_upgrade_setup.capsule
+    for server in satellite, capsule:
+        result = server.get_features()
+        assert 'puppet' in result
+        assert 'puppetca' in result
+
+        result = server.execute('rpm -q puppetserver')
+        assert result.status == 0
+
+        result = server.execute('systemctl status puppetserver')
+        assert 'active (running)' in result.stdout
+
+
+@pytest.mark.post_upgrade
+def test_post_puppet_reporting(puppet_upgrade_setup):
+    """Test that puppet is reporting to Satellite after the upgrade.
+
+    :id:   postupgrade-cdc4f6cc-23d8-4b4a-bd94-5c86b3072828
+
+    :steps:
+        1. Run puppet agent on the registered Capsule.
+        2. On Satellite, read puppet-originated Config reports for the Capsule host.
+
+    :expectedresults:
+        1. Puppet agent run succeeds.
+        2. At least one Config report exists (was created) for the Capsule.
+
+    """
+    satellite = puppet_upgrade_setup.satellite
+    capsule = puppet_upgrade_setup.capsule
+    result = capsule.execute('puppet agent -t')
+    assert result.status == 0
+
+    result = satellite.cli.ConfigReport.list({'search': f'host={capsule.hostname},origin=Puppet'})
+    assert len(result)


### PR DESCRIPTION
This PR converts the Puppet upgrade scenario to use the shared resource framework. It adds a pre-upgrade fixture to ensure that the test can be run concurrently with other upgrade scenario modules that require Puppet-enabled Satellites and adds fixtures for the Satellite, Capsule, and a Sat/Cap integration fixture that ensures Puppet is enabled on the Capsule after it has already been set up for operation with the Satellite.