### PR TITLE
Fix foreman-maintain repository setup tests

### DIFF
--- a/tests/foreman/maintain/test_advanced.py
+++ b/tests/foreman/maintain/test_advanced.py
@@ -298,7 +298,7 @@ def test_positive_satellite_repositories_setup(sat_maintain):
     """
     sat_version = ".".join(sat_maintain.version.split('.')[0:2])
     result = sat_maintain.cli.Advanced.run_repositories_setup(options={'version': sat_version})
-    if sat_version not in settings.robottelo.sat_non_ga_versions:
+    if float(sat_version) not in settings.robottelo.sat_non_ga_versions:
         assert result.status == 0
         assert 'FAIL' not in result.stdout
         result = sat_maintain.execute('yum repolist')
@@ -331,7 +331,7 @@ def test_positive_capsule_repositories_setup(sat_maintain):
     """
     sat_version = ".".join(sat_maintain.version.split('.')[0:2])
     result = sat_maintain.cli.Advanced.run_repositories_setup(options={'version': sat_version})
-    if sat_version not in settings.robottelo.sat_non_ga_versions:
+    if float(sat_version) not in settings.robottelo.sat_non_ga_versions:
         assert result.status == 0
         assert 'FAIL' not in result.stdout
         result = sat_maintain.execute('yum repolist')

--- a/tests/foreman/ui/test_documentation_links.py
+++ b/tests/foreman/ui/test_documentation_links.py
@@ -84,7 +84,7 @@ def test_positive_documentation_links(target_sat):
         for page in pages:
             for link in all_links[page]:
                 # Test stage docs url for Non-GA'ed Satellite
-                if sat_version in settings.robottelo.sat_non_ga_versions:
+                if float(sat_version) in settings.robottelo.sat_non_ga_versions:
                     link = link.replace(
                         'https://docs.redhat.com', settings.robottelo.stage_docs_url
                     )


### PR DESCRIPTION
### Problem Statement
- `test_positive_satellite_repositories_setup` and `test_positive_capsule_repositories_setup` are failing because of the wrong code block being run.

### Solution
- Fix the code logic

### Related Issues
- SAT-33469

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->