### PR TITLE
[6.17.z] Discovery CLI fixes

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -210,6 +210,7 @@ def module_provisioning_sat(
         organization=[module_sca_manifest_org],
         network=str(provisioning_network.network_address),
         network_type='IPv6' if settings.server.is_ipv6 else 'IPv4',
+        vlanid=settings.provisioning.vlan_id,
         mask=str(provisioning_network.netmask),
         gateway=broker_data_out.provisioning_gw_ip,
         from_=broker_data_out.provisioning_host_range_start,
@@ -227,7 +228,6 @@ def module_provisioning_sat(
         remote_execution_proxy=[module_provisioning_capsule.id],
         domain=[domain.id],
     ).create()
-
     return Box(sat=sat, domain=domain, subnet=subnet, provisioning_type=provisioning_type)
 
 

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -96,6 +96,16 @@ def module_discovery_sat(
     discovery_org.value = module_sca_manifest_org.name
     discovery_org.update(['value'])
 
+    # Verify the settings are updated
+    assert (
+        sat.api.Setting().search(query={'search': 'name=discovery_location'})[0].value
+        == module_location.name
+    )
+    assert (
+        sat.api.Setting().search(query={'search': 'name=discovery_organization'})[0].value
+        == module_sca_manifest_org.name
+    )
+
     # Enable flag to auto provision discovered hosts via discovery rules
     discovery_auto = sat.api.Setting().search(query={'search': 'name=discovery_auto'})[0]
     discovery_auto.value = 'true'

--- a/robottelo/cli/discoveredhost.py
+++ b/robottelo/cli/discoveredhost.py
@@ -57,3 +57,9 @@ class DiscoveredHost(Base):
         """Refresh facts associated with discovered host"""
         cls.command_sub = 'refresh-facts'
         return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def list(cls, options=None):
+        """List all the discovered host"""
+        cls.command_sub = 'list'
+        return cls.execute(cls._construct_command(options), output_format='csv')

--- a/tests/foreman/api/test_computeresource_vmware.py
+++ b/tests/foreman/api/test_computeresource_vmware.py
@@ -196,7 +196,6 @@ def test_positive_provision_vmware_pxe_discovery(
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,
-        retries=2,
         delay=40,
     )
     discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -201,7 +201,6 @@ class TestDiscoveredHost:
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,
-            retries=2,
             delay=40,
         )
         discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -48,16 +48,47 @@ def test_rhel_pxe_discovery_provisioning(
 
     :BZ: 1731112
     """
+
     sat = module_discovery_sat.sat
     provisioning_host.power_control(ensure=False)
     mac = provisioning_host.provisioning_nic_mac_addr
+    org = provisioning_hostgroup.organization[0].read()
+    loc = provisioning_hostgroup.location[0].read()
     wait_for(
-        lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
+        lambda: sat.api.DiscoveredHost().search(
+            query={
+                'mac': mac,
+                'organization_id': org.id,
+                'location-id': loc.id,
+            }
+        )
+        != [],
         timeout=1500,
-        retries=2,
-        delay=40,
+        delay=20,
     )
     discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
+    if is_open('SAT-33477') and (
+        sat.cli.DiscoveredHost.list(
+            {
+                'organization-id': org.id,
+                'location-id': loc.id,
+            }
+        )
+        == []
+    ):
+        with sat.ui_session() as session:
+            session.organization.select(org_name='Any organization')
+            session.location.select(loc_name='Any location')
+            session.discoveredhosts.apply_action(
+                'Assign Organization',
+                discovered_host.name,
+                values=dict(organization=org.name),
+            )
+            session.discoveredhosts.apply_action(
+                'Assign Location',
+                discovered_host.name,
+                values=dict(location=loc.name),
+            )
     discovered_host.hostgroup = provisioning_hostgroup
     discovered_host.location = provisioning_hostgroup.location[0]
     discovered_host.organization = provisioning_hostgroup.organization[0]
@@ -111,13 +142,43 @@ def test_rhel_pxeless_discovery_provisioning(
     sat = module_discovery_sat.sat
     pxeless_discovery_host.power_control(ensure=False)
     mac = pxeless_discovery_host.provisioning_nic_mac_addr
-
+    org = provisioning_hostgroup.organization[0].read()
+    loc = provisioning_hostgroup.location[0].read()
     wait_for(
-        lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
+        lambda: sat.api.DiscoveredHost().search(
+            query={
+                'mac': mac,
+                'organization_id': org.id,
+                'location-id': loc.id,
+            }
+        )
+        != [],
         timeout=1500,
         delay=40,
     )
     discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
+    if is_open('SAT-33477') and (
+        sat.cli.DiscoveredHost.list(
+            {
+                'organization-id': org.id,
+                'location-id': loc.id,
+            }
+        )
+        == []
+    ):
+        with sat.ui_session() as session:
+            session.organization.select(org_name='Any organization')
+            session.location.select(loc_name='Any location')
+            session.discoveredhosts.apply_action(
+                'Assign Organization',
+                discovered_host.name,
+                values=dict(organization=org.name),
+            )
+            session.discoveredhosts.apply_action(
+                'Assign Location',
+                discovered_host.name,
+                values=dict(location=loc.name),
+            )
     discovered_host.hostgroup = provisioning_hostgroup
     discovered_host.location = provisioning_hostgroup.location[0]
     discovered_host.organization = provisioning_hostgroup.organization[0]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18297

### Problem Statement
Discovery provisioning tests failing with host not found error.

### Solution
FIxed few issues.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->