### PR TITLE
Tracer UI test refactor

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1914,7 +1914,7 @@ def test_positive_tracer_enable_reload(tracer_install_host, target_sat):
         tracer_title = session.host_new.get_tracer_tab_title(tracer_install_host.hostname)
         assert tracer_title == "Traces are not enabled"
         session.host_new.enable_tracer(tracer_install_host.hostname)
-        timestamp = (datetime.now(UTC) - timedelta(minutes=4)).strftime('%Y-%m-%d %H:%M')
+        timestamp = (datetime.now(UTC) - timedelta(minutes=1)).strftime('%Y-%m-%d %H:%M')
         target_sat.wait_for_tasks(
             search_query='action = "Run hosts job: Install package(s) katello-host-tools-tracer"'
             f' and started_at >= "{timestamp}"',


### PR DESCRIPTION
### Problem Statement
The `test_positive_tracer_enable_reload ` was failing due to some UI issues

### Solution
While fixing this, I also did a small refactor.
Before the test was trying to

	a) wait for `Traces are being enabled` string to appear and then disappear
    b) and then just check that `No applications to restart` is present

imo `a)` is not necessary to check in the UI and it was not reliable, thus I changed it for wait_for_tasks which waits for the task to finish before continuing.

### Related Issues
Needs Airgun: https://github.com/SatelliteQE/airgun/pull/1843

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_positive_tracer_enable_reload'
airgun: 1843
```