### PR TITLE
Add a flatpak remotes UI test

### DIFF
--- a/tests/foreman/ui/test_flatpak.py
+++ b/tests/foreman/ui/test_flatpak.py
@@ -1,0 +1,35 @@
+"""Flatpak related tests being run through UI.
+
+:Requirement: Repository
+
+:CaseAutomation: Automated
+
+:CaseComponent: Repositories
+
+:team: Phoenix-content
+
+:CaseImportance: High
+
+"""
+
+
+def test_flatpak_remotes(target_sat, function_org, function_flatpak_remote):
+    """Ensure Flatpak Remotes are displayed correctly.
+
+    :id: c757094c-e817-4a1b-a8b3-d2ce3f9d6b0e
+
+    :setup:
+        1. Create a flatpak remote and scan it.
+
+    :steps:
+        1. Navigate to Flatpak Remotes page and ensure the remote is displayed.
+
+    :expectedresults:
+        1. The remote is displayed correctly.
+
+    """
+    with target_sat.ui_session() as session:
+        remotes = session.flatpak_remotes.read_table()
+        assert len(remotes) > 0
+        remote = next(r for r in remotes if r['Name'] == function_flatpak_remote.remote.name)
+        assert remote['URL'] == function_flatpak_remote.remote.flatpak_index_url


### PR DESCRIPTION
### Problem Statement
In 6.18.0 we are adding UI support for Flatpak. Initial is the Content > Flatpak Remotes page, which this PR aims to cover.

As of now, the Scan, Edit and Delete actions are not implemented yet in Katello, but they are to be added soon. After that we can extend this test case.


### Requires
https://github.com/SatelliteQE/airgun/pull/1846
https://github.com/Katello/katello/pull/11375


### Related Issues
https://issues.redhat.com/browse/SAT-30900


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_flatpak.py
airgun: 1846
Katello:
    katello: 11375
```