### PR TITLE
Update Flatpak install REX job parameter

### DIFF
--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -902,9 +902,13 @@ def test_sync_consume_flatpak_repo_via_library(
         {
             'organization': function_org.name,
             'job-template': 'Flatpak - Install application on host',
-            'inputs': f'Flatpak remote name={remote_name}, Application name={app_name}',
+            'inputs': (
+                f'Flatpak remote name={remote_name}, Application name={app_name}, '
+                'Launch a session bus instance=true'
+            ),
             'search-query': f"name = {host.hostname}",
-        }
+        },
+        timeout='800s',
     )
     res = module_target_sat.cli.JobInvocation.info({'id': job.id})
     assert 'succeeded' in res['status']

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -336,9 +336,13 @@ def test_sync_consume_flatpak_repo_via_library(
         {
             'organization': function_org.name,
             'job-template': 'Flatpak - Install application on host',
-            'inputs': f'Flatpak remote name={remote_name}, Application name={app_name}',
+            'inputs': (
+                f'Flatpak remote name={remote_name}, Application name={app_name}, '
+                'Launch a session bus instance=true'
+            ),
             'search-query': f"name = {host.hostname}",
-        }
+        },
+        timeout='800s',
     )
     res = module_target_sat.cli.JobInvocation.info({'id': job.id})
     assert 'succeeded' in res['status']
@@ -481,7 +485,14 @@ def test_sync_consume_flatpak_repo_via_cv(
     }
     cv1_app = 'Inkscape'
     job = module_target_sat.cli_factory.job_invocation(
-        opts | {'inputs': f'Flatpak remote name={remote_name}, Application name={cv1_app}'}
+        opts
+        | {
+            'inputs': (
+                f'Flatpak remote name={remote_name}, Application name={cv1_app}, '
+                'Launch a session bus instance=true'
+            )
+        },
+        timeout='800s',
     )
     res = module_target_sat.cli.JobInvocation.info({'id': job.id})
     assert 'succeeded' in res['status']
@@ -495,7 +506,14 @@ def test_sync_consume_flatpak_repo_via_cv(
     cv2_app = 'Firefox'
     with pytest.raises(CLIFactoryError) as error:
         sat.cli_factory.job_invocation(
-            opts | {'inputs': f'Flatpak remote name={remote_name}, Application name={cv2_app}'}
+            opts
+            | {
+                'inputs': (
+                    f'Flatpak remote name={remote_name}, Application name={cv2_app}, '
+                    'Launch a session bus instance=true'
+                )
+            },
+            timeout='800s',
         )
     assert 'A sub task failed' in error.value.args[0]
     res = host.execute('flatpak list')

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1546,9 +1546,13 @@ class TestContentViewSync:
             {
                 'organization': function_import_org_at_isat.name,
                 'job-template': 'Flatpak - Install application on host',
-                'inputs': f'Flatpak remote name={remote_name}, Application name={app_name}',
+                'inputs': (
+                    f'Flatpak remote name={remote_name}, Application name={app_name}, '
+                    'Launch a session bus instance=true'
+                ),
                 'search-query': f"name = {module_flatpak_contenthost.hostname}",
-            }
+            },
+            timeout='800s',
         )
         res = module_import_sat.cli.JobInvocation.info({'id': job.id})
         assert 'succeeded' in res['status']


### PR DESCRIPTION
### Problem Statement
In https://github.com/Katello/katello/pull/11372 the `Flatpak - Install application on host` template has been extended with a new option to run against a GUI or GUI-less system and uses a different dbus command under the hood. We need to update existing tests using this job template accordingly.


### Solution
This PR.


### Related Issues
https://issues.redhat.com/browse/SAT-31357


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_flatpak.py -k 'via_library or via_cv'
```
