### PR TITLE
[6.16.z] Add permissions for formean_monitoring plugin

### DIFF
--- a/pytest_fixtures/component/permissions.py
+++ b/pytest_fixtures/component/permissions.py
@@ -60,5 +60,9 @@ def expected_permissions(session_target_sat):
     if 'rubygem-foreman_statistics' not in rpm_packages:
         permissions.pop('ForemanStatistics::Trend')
         permissions[None].remove('view_statistics')
+    if 'rubygem-foreman_monitoring' not in rpm_packages:
+        permissions[None].remove('upload_monitoring_results')
+        permissions['Host'].remove('view_monitoring_results')
+        permissions['Host'].remove('manage_downtime_hosts')
 
     return permissions

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -992,6 +992,7 @@ PERMISSIONS = {
         'dispatch_cloud_requests',
         'control_organization_insights',
         'view_statistics',
+        'upload_monitoring_results',
     ],
     'AnsibleRole': ['view_ansible_roles', 'destroy_ansible_roles', 'import_ansible_roles'],
     'AnsibleVariable': [
@@ -1326,6 +1327,8 @@ PERMISSIONS = {
         'edit_snapshots',
         'revert_snapshots',
         'destroy_snapshots',
+        'view_monitoring_results',
+        'manage_downtime_hosts',
     ],
     'Katello::ActivationKey': [
         'view_activation_keys',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18435



### Problem Statement

missing permissions for foreman_monitoring plugin
https://github.com/theforeman/foreman_monitoring/blob/master/lib/foreman_monitoring/engine.rb#L46

### Solution


add permissions

### Tests to run

tests/foreman/api/test_permission.py


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->