### PR TITLE
[6.17.z] Add missing permissions for foreman_salt plugin

### DIFF
--- a/pytest_fixtures/component/permissions.py
+++ b/pytest_fixtures/component/permissions.py
@@ -57,6 +57,7 @@ def expected_permissions(session_target_sat):
         permissions.pop('ForemanSalt::SaltVariable')
         permissions.pop('ForemanSalt::SaltEnvironment')
         permissions.pop('ForemanSalt::SaltModule')
+        permissions.pop('Report')
     if 'rubygem-foreman_statistics' not in rpm_packages:
         permissions.pop('ForemanStatistics::Trend')
         permissions[None].remove('view_statistics')

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1328,6 +1328,7 @@ PERMISSIONS = {
         'lock_report_templates',
     ],
     'Role': ['view_roles', 'create_roles', 'edit_roles', 'destroy_roles'],
+    'Report': ['create_reports'],
     'SccAccount': [
         "delete_scc_accounts",
         "edit_scc_accounts",


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18434

### Problem Statement

missing foreman_salt permission
https://github.com/theforeman/foreman_salt/blob/master/lib/foreman_salt/plugin.rb#L110

### Solution

add permissions

### Tests to run

tests/foreman/api/test_permission.py


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->