### PR TITLE
Update kickstart version for RHEL9

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -602,16 +602,16 @@ REPOS = {
         },
         'rhel9_bos': {
             'id': 'rhel-9-for-x86_64-baseos-kickstart',
-            'name': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Kickstart 9.5',
-            'version': '9.5',
+            'name': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Kickstart 9.6',
+            'version': '9.6',
             'reposet': REPOSET['kickstart']['rhel9_bos'],
             'product': PRDS['rhel9'],
             'distro': 'rhel9',
         },
         'rhel9_aps': {
             'id': 'rhel-9-for-x86_64-appstream-kickstart',
-            'name': 'Red Hat Enterprise Linux 9 for x86_64 - AppStream Kickstart 9.5',
-            'version': '9.5',
+            'name': 'Red Hat Enterprise Linux 9 for x86_64 - AppStream Kickstart 9.6',
+            'version': '9.6',
             'reposet': REPOSET['kickstart']['rhel9_aps'],
             'product': PRDS['rhel9'],
             'distro': 'rhel9',
@@ -746,7 +746,7 @@ REPOS = {
 # RHEL versions for LEAPP testing
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
-RHEL9_VER = '9.5'
+RHEL9_VER = '9.6'
 RHEL10_VER = '10.1'  # EL10 pre-release version
 
 BULK_REPO_LIST = [


### PR DESCRIPTION
### Problem Statement
RHEL9 kickstart version was updated to RHEL 9.6, we currently have 9.5 in the constants

### Solution
Updating the RHEL9 Kickstart version to 9.6
