### PR TITLE
[6.17.z] Helper functions for enabling source repositories for Satellite and Capsule installation

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1540,6 +1540,68 @@ class ContentHost(Host, ContentHostMixins):
     def get_yggdrasil_service_name(self):
         return 'yggdrasil' if (self.os_version.major > 9) else 'yggdrasild'
 
+    def setup_rhel_repos(self):
+        """Setup RHEL repositories on host
+        requires registered host if ga source has to be enabled
+        """
+        if settings.robottelo.rhel_source == "internal":
+            # disable cdn repos which may have been enabled during registration
+            self.disable_repo("rhel-*")
+            # add internal rhel repos
+            self.create_custom_repos(**settings.repos.get(f'rhel{self.os_version.major}_os'))
+        else:
+            # enable cdn repos
+            for repo in getattr(constants, f"OHSNAP_RHEL{self.os_version.major}_REPOS"):
+                result = self.enable_repo(repo, force=True)
+                if result.status:
+                    raise ContentHostError(f'Enabling RHEL repos on host failed\n{result.stdout}')
+
+    def setup_satellite_repos(self):
+        """Setup Satellite repositories on host
+        requires registered host if ga source has to be enabled
+        """
+        # setup source repositories
+        if settings.server.version.source == "ga":
+            # enable cdn repos
+            for repo in self.SATELLITE_CDN_REPOS.values():
+                result = self.enable_repo(repo, force=True)
+                if result.status:
+                    raise ContentHostError(
+                        f'Enabling Satellite repos on host failed\n{result.stdout}'
+                    )
+
+        elif settings.server.version.source == 'nightly':
+            self.create_custom_repos(
+                satellite_repo=settings.repos.satellite_repo,
+                satmaintenance_repo=settings.repos.satmaintenance_repo,
+            )
+        else:
+            # get ohsnap repofile
+            self.download_repofile(
+                product='satellite',
+                release=settings.server.version.release,
+                snap=settings.server.version.snap,
+            )
+
+    def setup_capsule_repos(self):
+        """Setup Capsule repositories on host
+        requires registered host if ga source has to be enabled
+        """
+        if settings.capsule.version.source == "ga":
+            # enable cdn repos
+            for repo in self.SATELLITE_CDN_REPOS.values():
+                result = self.enable_repo(repo, force=True)
+                if result.status:
+                    raise ContentHostError(
+                        f'Enabling Capsule repos on host failed\n{result.stdout}'
+                    )
+        else:
+            self.download_repofile(
+                product='capsule',
+                release=settings.capsule.version.release,
+                snap=settings.capsule.version.snap,
+            )
+
 
 class Capsule(ContentHost, CapsuleMixins):
     rex_key_path = '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
@@ -1650,44 +1712,13 @@ class Capsule(ContentHost, CapsuleMixins):
         """Get capsule features"""
         return requests.get(f'https://{self.hostname}:9090/features', verify=False).text
 
-    def enable_capsule_downstream_repos(self):
-        """Enable CDN repos and capsule downstream repos on Capsule Host"""
-        # CDN Repos
-        self.register_to_cdn()
-        for repo in getattr(constants, f"OHSNAP_RHEL{self.os_version.major}_REPOS"):
-            result = self.enable_repo(repo, force=True)
-            if result.status:
-                raise CapsuleHostError(f'Repo enable at capsule host failed\n{result.stdout}')
-        # Downstream Capsule specific Repos
-        self.download_repofile(
-            product='capsule',
-            release=settings.capsule.version.release,
-            snap=settings.capsule.version.snap,
-        )
-
     def capsule_setup(self, sat_host=None, capsule_cert_opts=None, **installer_kwargs):
         """Prepare the host and run the capsule installer"""
         self._satellite = sat_host or Satellite()
 
-        if settings.robottelo.rhel_source == "ga":
-            # Register capsule host to CDN and enable repos
-            result = self.register_contenthost(
-                org=None,
-                lce=None,
-                username=settings.subscription.rhn_username,
-                password=settings.subscription.rhn_password,
-                auto_attach=True,
-            )
-            if result.status:
-                raise CapsuleHostError(f'Capsule CDN registration failed\n{result.stderr}')
-
-            for repo in getattr(constants, f"OHSNAP_RHEL{self.os_version.major}_REPOS"):
-                result = self.enable_repo(repo, force=True)
-                if result.status:
-                    raise CapsuleHostError(f'Repo enable at capsule host failed\n{result.stdout}')
-        elif settings.robottelo.rhel_source == "internal":
-            # add internal rhel repos
-            self.create_custom_repos(**settings.repos.get(f'rhel{self.os_version.major}_os'))
+        self.register_to_cdn()
+        self.setup_rhel_repos()
+        self.setup_capsule_repos()
 
         # Update system, firewall services and check capsule is already installed from template
         # Setups firewall on Capsule

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -141,24 +141,10 @@ def common_sat_install_assertions(satellite):
 
 
 def install_satellite(satellite, installer_args, enable_fapolicyd=False):
-    # Register for RHEL repos, get Ohsnap repofile, and enable and download satellite
+    # Enable RHEL and Satellite repos
     satellite.register_to_cdn()
-    if settings.server.version.source == 'nightly':
-        satellite.create_custom_repos(
-            satellite_repo=settings.repos.satellite_repo,
-            satmaintenance_repo=settings.repos.satmaintenance_repo,
-        )
-    else:
-        satellite.download_repofile(
-            product='satellite',
-            release=settings.server.version.release,
-            snap=settings.server.version.snap,
-        )
-    if settings.robottelo.rhel_source == "internal":
-        # disable rhel repos from cdn
-        satellite.disable_repo("rhel-*")
-        # add internal rhel repos
-        satellite.create_custom_repos(**settings.repos.get(f'rhel{satellite.os_version.major}_os'))
+    satellite.setup_rhel_repos()
+    satellite.setup_satellite_repos()
     if enable_fapolicyd:
         if satellite.execute('rpm -q satellite-maintain').status == 0:
             # Installing the rpm on existing sat needs sat-maintain perms
@@ -172,6 +158,12 @@ def install_satellite(satellite, installer_args, enable_fapolicyd=False):
         assert satellite.execute('rpm -q foreman-proxy-fapolicyd').status == 0
         assert satellite.execute('systemctl is-active fapolicyd').status == 0
     # Configure Satellite firewall to open communication
+    assert (
+        satellite.execute(
+            "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
+        ).status
+        == 0
+    ), "firewalld is not present and can't be installed"
     satellite.execute(
         'firewall-cmd --permanent --add-service RH-Satellite-6 && firewall-cmd --reload'
     )
@@ -182,12 +174,12 @@ def install_satellite(satellite, installer_args, enable_fapolicyd=False):
     )
 
 
-def setup_capsule_repos(satellite, capsule_host, org, ak):
+def sync_capsule_repos(satellite, capsule_host, org, ak):
     """
-    Enables repositories that are necessary to install capsule
+    On Satellite enable and synchronize content required for Capsule installation.
     1. Enable RHEL repositories based on configuration
     2. Enable capsule repositories based on configuration
-    3. Synchonize repositories
+    3. Synchronize repositories
     """
     # List of sync tasks - all repos will be synced asynchronously
     sync_tasks = []
@@ -398,7 +390,7 @@ def test_capsule_installation(
     ak = sat_fapolicyd_install.api.ActivationKey(
         organization=org, environment=org.library, content_view=org.default_content_view
     ).create()
-    setup_capsule_repos(sat_fapolicyd_install, cap_ready_rhel, org, ak)
+    sync_capsule_repos(sat_fapolicyd_install, cap_ready_rhel, org, ak)
 
     cap_ready_rhel.register(org, None, ak.name, sat_fapolicyd_install)
 
@@ -444,6 +436,12 @@ def test_capsule_installation(
     assert len(result.stdout) == 0
 
     # Enabling firewall
+    assert (
+        cap_ready_rhel.execute(
+            "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
+        ).status
+        == 0
+    ), "firewalld is not present and can't be installed"
     cap_ready_rhel.execute('firewall-cmd --add-service RH-Satellite-6-capsule')
     cap_ready_rhel.execute('firewall-cmd --runtime-to-permanent')
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18129

### Problem Statement
We have multiple tests which setup RHEL and Satellite/Capsule repositories. There are various test scenarios and various different sources. Mainly:
- Regular product testing (GA RHEL, internal product)
- Interop testing (internal RHEL, GA product)

The sources are configured based on settings and there are more places (tests/fixtures) where the logic is implemented.

### Solution
These helper functions unify the logic of setting up installation sources
