### PR TITLE
[6.17.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: check-yaml
     - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.9
+    rev: v0.11.10
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --target-version=py310]
@@ -28,6 +28,6 @@ repos:
         types: [text]
         require_serial: true
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.25.1
+    rev: v8.26.0
     hooks:
       - id: gitleaks


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18476

<!--pre-commit.ci start-->
updates:
- [github.com/astral-sh/ruff-pre-commit: v0.11.9 → v0.11.10](https://github.com/astral-sh/ruff-pre-commit/compare/v0.11.9...v0.11.10)
- [github.com/gitleaks/gitleaks: v8.25.1 → v8.26.0](https://github.com/gitleaks/gitleaks/compare/v8.25.1...v8.26.0)
<!--pre-commit.ci end-->