### PR TITLE
[6.16.z] Update kickstart version for RHEL9

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -595,16 +595,16 @@ REPOS = {
         },
         'rhel9_bos': {
             'id': 'rhel-9-for-x86_64-baseos-kickstart',
-            'name': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Kickstart 9.5',
-            'version': '9.5',
+            'name': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Kickstart 9.6',
+            'version': '9.6',
             'reposet': REPOSET['kickstart']['rhel9_bos'],
             'product': PRDS['rhel9'],
             'distro': 'rhel9',
         },
         'rhel9_aps': {
             'id': 'rhel-9-for-x86_64-appstream-kickstart',
-            'name': 'Red Hat Enterprise Linux 9 for x86_64 - AppStream Kickstart 9.5',
-            'version': '9.5',
+            'name': 'Red Hat Enterprise Linux 9 for x86_64 - AppStream Kickstart 9.6',
+            'version': '9.6',
             'reposet': REPOSET['kickstart']['rhel9_aps'],
             'product': PRDS['rhel9'],
             'distro': 'rhel9',
@@ -701,7 +701,7 @@ REPOS = {
 # RHEL versions for LEAPP testing
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
-RHEL9_VER = '9.5'
+RHEL9_VER = '9.6'
 
 BULK_REPO_LIST = [
     REPOS['rhel7_optional'],


### PR DESCRIPTION
Manual cherrypick of https://github.com/SatelliteQE/robottelo/pull/18461
Closes: https://github.com/SatelliteQE/robottelo/issues/18465