### PR TITLE
[6.17.z] Use http proxy to reach container registry for IoP tests on IPv6

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -36,6 +36,9 @@ def module_target_sat_insights(request, module_target_sat, satellite_factory):
         iop_settings = settings.rh_cloud.iop_advisor_engine
         script = (iop_settings.setup_script or '').splitlines()
 
+        # Use HTTPS_PROXY to reach container registry for IPv6
+        satellite.enable_ipv6_system_proxy()
+
         # Log in to container registry
         if iop_settings.registry and iop_settings.username and iop_settings.token:
             cmd_result = satellite.execute(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18480

### Problem Statement

IoP tests on IPv6 fail when logging in to and pulling container images from the registry:
```
17:34:14  ________ ERROR at setup of test_rhcloud_insights_e2e[rhel7-ipv6-local] _________
[...]
17:34:14  
17:34:14      @pytest.fixture(scope='module')
17:34:14      def module_target_sat_insights(request, module_target_sat, satellite_factory):
[...]
17:34:14          if not hosted_insights:
17:34:14              iop_settings = settings.rh_cloud.iop_advisor_engine
17:34:14              script = (iop_settings.setup_script or '').splitlines()
17:34:14      
17:34:14              # Log in to container registry
17:34:14              if iop_settings.registry and iop_settings.username and iop_settings.token:
17:34:14                  cmd_result = satellite.execute(
17:34:14                      f'podman login -u {iop_settings.username!r} -p {iop_settings.token!r} {iop_settings.registry}'
17:34:14                  )
17:34:14                  if cmd_result.status != 0:
17:34:14  >                   raise SatelliteHostError(
17:34:14                          f'Error logging in to container registry: {cmd_result.stdout}'
17:34:14                      )
17:34:14  E                   robottelo.hosts.SatelliteHostError: Error logging in to container registry:
17:34:14  
17:34:14  pytest_fixtures/component/rh_cloud.py:45: SatelliteHostError
```

### Solution

Use `settings.http_proxy.http_proxy_ipv6_url` for `podman login` and `podman pull` commands in IPv6 IoP tests.

### Related Issues

SAT-33378

### PRT test

See test result below. The test was triggered outside of the PR, with the following PRT comment:

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_inventory.py -k 'local'
network_type: ipv6
robottelo: 18480
```
