### PR TITLE
[6.16.z] Add permissions for resource quota

### DIFF
--- a/pytest_fixtures/component/permissions.py
+++ b/pytest_fixtures/component/permissions.py
@@ -36,6 +36,8 @@ def expected_permissions(session_target_sat):
         permissions.pop('ForemanPuppet::HostClass')
         permissions.pop('ForemanPuppet::Puppetclass')
         permissions.pop('ForemanPuppet::PuppetclassLookupKey')
+    if 'rubygem-foreman_resource_quota' not in rpm_packages:
+        permissions.pop('ForemanResourceQuota::ResourceQuota')
     if 'rubygem-foreman_scc_manager' not in rpm_packages:
         permissions.pop('SccAccount')
         permissions.pop('SccProduct')

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1057,6 +1057,12 @@ PERMISSIONS = {
         'edit_filters',
         'destroy_filters',
     ],
+    'ForemanResourceQuota::ResourceQuota': [
+        "destroy_resource_quotas",
+        "create_resource_quotas",
+        "view_resource_quotas",
+        "edit_resource_quotas",
+    ],
     'ForemanSalt::SaltVariable': [
         'edit_salt_variables',
         'destroy_salt_variables',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18491



### Problem Statement

Missing permissions for resource quota

### Solution

Added permissions https://github.com/ATIX-AG/foreman_resource_quota/blob/main/lib/foreman_resource_quota/register.rb#L13

### Tests to run

tests/foreman/api/test_permission.py


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->