### PR TITLE
[6.15.z] template export filter more future proof

### DIFF
--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -11,6 +11,7 @@
 """
 
 import base64
+from time import sleep
 
 from fauxfactory import gen_string
 import pytest
@@ -220,14 +221,16 @@ class TestTemplateSyncTestCase:
             }
         ).split('\n')
         exported_count = ['Exported: true' in row.strip() for row in output].count(True)
+        assert exported_count > 0, 'No templates exported'
         path = f'{dirname}/provisioning_templates/snippet'
         auth = (git.username, git.password)
         api_url = f'http://{git.hostname}:{git.http_port}'
         api_url = f'{api_url}/api/v1/repos/{git.username}/{git_repository["name"]}/contents'
-        git_count = len(
-            requests.get(f'{api_url}/{path}', auth=auth, params={'ref': git_branch}).json()
-        )
-        assert exported_count == git_count
+        sleep(10)
+        response = requests.get(f'{api_url}/{path}', auth=auth, params={'ref': git_branch})
+        response.raise_for_status()
+        git_count = len(response.json())
+        assert exported_count == git_count, f'Unexpected response: {response.json()}'
 
     @pytest.mark.tier2
     def test_positive_export_filtered_templates_to_temp_dir(self, module_org, target_sat):

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -10,6 +10,8 @@
 
 """
 
+from time import sleep
+
 from fauxfactory import gen_string
 import pytest
 import requests
@@ -159,7 +161,7 @@ def test_positive_export_filtered_templates_to_git(session, git_repository, git_
     :id: e4de338a-9ab9-492e-ac42-6cc2ebcd1792
 
     :steps:
-        1. Export only the templates matching with regex e.g: `^atomic.*` to git repo.
+        1. Export only the templates matching with regex e.g: `^provision.*` to git repo.
 
     :expectedresults:
         1. Assert matching templates are exported to git repo.
@@ -177,7 +179,7 @@ def test_positive_export_filtered_templates_to_git(session, git_repository, git_
             {
                 'sync_type': 'Export',
                 'template.metadata_export_mode': 'Keep',
-                'template.filter': 'atomic',
+                'template.filter': 'provision',
                 'template.repo': url,
                 'template.branch': git_branch,
                 'template.dirname': dirname,
@@ -190,9 +192,12 @@ def test_positive_export_filtered_templates_to_git(session, git_repository, git_
         path = f"{dirname}/provisioning_templates/provision"
         auth = (git.username, git.password)
         api_url = f"http://{git.hostname}:{git.http_port}/api/v1/repos/{git.username}"
-        git_count = requests.get(
+        sleep(10)
+        response = requests.get(
             f'{api_url}/{git_repository["name"]}/contents/{path}',
             auth=auth,
             params={"ref": git_branch},
-        ).json()
-        assert len(git_count) == 1
+        )
+        response.raise_for_status()
+        git_count = len(response.json())
+        assert git_count > 0, f'Unexpected response: {response.json()}'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17999

### Problem Statement
atomic no longer around by default

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->