### PR TITLE
Cloud Inventory UI Test Fix

### DIFF
--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -55,6 +55,7 @@ def common_assertion(report_path, inventory_data, org, satellite):
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.run_in_one_thread
+@pytest.mark.no_containers
 def test_rhcloud_inventory_e2e(
     inventory_settings,
     rhcloud_manifest_org,


### PR DESCRIPTION
### Problem Statement
When executing the end2end `test_rhcloud_inventory_e2e` with SAT 6.16, it is failing only with RHEL 8 and RHEL 9 containers.
After a thorough investigation, there seems to be an issue with the interaction between SAT 6.16 and these RHEL8/9 containers. (It works well in 6.17)
The action that executed by this test (generating and downloading a report) is working perfectly when we don't use containers.

Issue reported here: SAT-34253


Needs Airgun: https://github.com/SatelliteQE/airgun/pull/1860
### Solution
As this is an end2end test, and SAT should mainly interact with real hosts, I made a change to the test, so it does not use containers (which is also the workaround for this issue).

### Related Issues
![image](https://github.com/user-attachments/assets/4dd26bb9-3f72-44ff-9dcf-76376e730fbc)


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_inventory.py -k 'test_rhcloud_inventory_e2e'
airgun: 1860
```