### PR TITLE
Add support and test case for podman cert-based authentication

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -868,6 +868,7 @@ CUSTOM_LOCAL_FILE = '/var/lib/pulp/imports/myrepo/test.txt'
 CUSTOM_FILE_REPO_FILES_COUNT = 3
 CUSTOM_RPM_SHA_512_FEED_COUNT = {'rpm': 35, 'errata': 4}
 CERT_PATH = "/etc/pki/ca-trust/source/anchors/"
+CONTAINER_CERTS_PATH = "/etc/containers/certs.d/"
 CERT_DATA = {
     'capsule_hostname': 'capsule.example.com',
     'ca_bundle_file_name': 'cacert.crt',


### PR DESCRIPTION
### Problem Statement
In 6.18 the podman cert-based authentication is being implemented for registered hosts. When using this authentication, only the content tied to the particular AK -> LCE/CV will be accessible to the host registered with the AK.

We should enable and test this auth type too.


### Solution
This PR proposes support and a test case for that authentication type. In future we could E2E this test case with product-based ways for the certs setup (not implemented yet in the product) and perhaps move the other test cases to this auth type.


### Related Issues
https://issues.redhat.com/browse/SAT-33255


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_container_management.py -k podman_cert_auth
```
