### PR TITLE
[6.17.z] Core Fixture PRT - multiple registered contenthosts

### DIFF
--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -616,6 +616,11 @@ class APIFactory:
             len(entities['ContentView'].version) == 0
             or entities['ContentView'].needs_publish is True
         ):
+            # wait for pending task(s) in this CV, then publish
+            self._satellite.wait_for_tasks(
+                search_query=f'{entities["ContentView"].name}',
+                poll_timeout=120,
+            )
             entities['ContentView'].publish()
             # read updated entitites after modifying CV
             entities = {k: v.read() for k, v in entities.items()}


### PR DESCRIPTION
### Problem Statement
- UI navigation issues w/ stream PRT, airgun unable to nav/view New Host UI - Installed Packages table in time. 
Local pass in 6.17.0. 
Stream MR is here: #18469 (prt fail at packages table)
- Passes all cases (4/4), parametrized by supported RHELs for this version of satellite (rhel7, 8, 9, 10)
- nailgun MR merged [#1304](https://github.com/SatelliteQE/nailgun/pull/1304) (new endpoint method: CV.remove_version() )
### PRT
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_errata.py::test_positive_apply_for_all_hosts
```