### PR TITLE
[6.17.z] update_sat_to_avoid_issues_after_Capsule_CDN_regis

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1714,11 +1714,13 @@ class Capsule(ContentHost, CapsuleMixins):
 
     def capsule_setup(self, sat_host=None, capsule_cert_opts=None, **installer_kwargs):
         """Prepare the host and run the capsule installer"""
-        self._satellite = sat_host or Satellite()
 
         self.register_to_cdn()
         self.setup_rhel_repos()
         self.setup_capsule_repos()
+
+        # After capsule registration to cdn, it should be initialized with the Satellite.
+        self._satellite = sat_host or Satellite()
 
         # Update system, firewall services and check capsule is already installed from template
         # Setups firewall on Capsule


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18534

This is causing Puppet failures - https://github.com/SatelliteQE/robottelo/pull/18129

Updated the position of `self._satellite` initialization because during Capsule CDN registration (via `register_to_cdn`), the method `self.reset_rhsm()` is called, which sets `self._satellite` to None. This leads to issues in correctly identifying the Satellite instance. To resolve this, the Capsule is re-initialized with the Satellite after registration to ensure smooth execution of subsequent tasks.