### PR TITLE
sys_purpose test fix

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1741,16 +1741,3 @@ def test_syspurpose_end_to_end(
     assert host['subscription-information']['system-purpose']['purpose-role'] == "test-role2"
     assert host['subscription-information']['system-purpose']['purpose-usage'] == "test-usage2"
     assert host['subscription-information']['system-purpose']['service-level'] == "Self-Support2"
-
-    # Unregister host
-    target_sat.cli.Host.subscription_unregister({'host': rhel_contenthost.hostname})
-    with pytest.raises(CLIReturnCodeError):
-        # raise error that the host was not registered by
-        # subscription-manager register
-        target_sat.cli.ActivationKey.subscriptions(
-            {
-                'organization-id': module_org.id,
-                'id': activation_key.id,
-                'host-id': host['id'],
-            }
-        )

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1741,3 +1741,15 @@ def test_syspurpose_end_to_end(
     assert host['subscription-information']['system-purpose']['purpose-role'] == "test-role2"
     assert host['subscription-information']['system-purpose']['purpose-usage'] == "test-usage2"
     assert host['subscription-information']['system-purpose']['service-level'] == "Self-Support2"
+
+    rhel_contenthost.unregister()
+    with pytest.raises(CLIReturnCodeError):
+        # raise error that the host was not registered by
+        # subscription-manager register
+        target_sat.cli.ActivationKey.subscriptions(
+            {
+                'organization-id': module_org.id,
+                'id': activation_key.id,
+                'host-id': host['id'],
+            }
+        )


### PR DESCRIPTION
### Problem Statement
The test was using `hammer subscription unregister` within itself, which is long gone from satellite

### Solution
Switch it for `rhel_contenthost.unregister()`

<img width="180" alt="image" src="https://github.com/user-attachments/assets/8b68830b-5374-4099-b39d-842db9bad198" />

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_activationkey.py -k 'test_syspurpose_end_to_end'
```