### PR TITLE
[6.15.z] sys_purpose test fix

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1689,6 +1689,8 @@ def test_syspurpose_end_to_end(
 
     :parametrized: yes
     """
+    # Turn off sca mode
+    module_org.sca_disable()
     # Create an activation key with test values
     purpose_addons = "test-addon1, test-addon2"
     activation_key = target_sat.api.ActivationKey(

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1745,8 +1745,8 @@ def test_syspurpose_end_to_end(
     )
     assert len(host_subscriptions) > 0
     assert host_subscriptions[0]['name'] == default_subscription.name
-    # Unregister host
-    target_sat.cli.Host.subscription_unregister({'host': rhel_contenthost.hostname})
+
+    rhel_contenthost.unregister()
     with pytest.raises(CLIReturnCodeError):
         # raise error that the host was not registered by
         # subscription-manager register

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1689,8 +1689,7 @@ def test_syspurpose_end_to_end(
 
     :parametrized: yes
     """
-    # Turn off sca mode
-    module_org.sca_disable()
+
     # Create an activation key with test values
     purpose_addons = "test-addon1, test-addon2"
     activation_key = target_sat.api.ActivationKey(
@@ -1702,13 +1701,6 @@ def test_syspurpose_end_to_end(
         purpose_usage="test-usage",
         service_level="Self-Support",
     ).create()
-    target_sat.cli.ActivationKey.add_subscription(
-        {
-            'organization-id': module_org.id,
-            'id': activation_key.id,
-            'subscription-id': default_subscription.id,
-        }
-    )
     # Register a host using the activation key
     res = rhel_contenthost.register(module_org, None, activation_key.name, target_sat)
     assert res.status == 0, f'Failed to register host: {res.stderr}'
@@ -1737,16 +1729,6 @@ def test_syspurpose_end_to_end(
     assert host['subscription-information']['system-purpose']['purpose-role'] == "test-role2"
     assert host['subscription-information']['system-purpose']['purpose-usage'] == "test-usage2"
     assert host['subscription-information']['system-purpose']['service-level'] == "Self-Support2"
-    host_subscriptions = target_sat.cli.ActivationKey.subscriptions(
-        {
-            'organization-id': module_org.id,
-            'id': activation_key.id,
-            'host-id': host['id'],
-        },
-        output_format='json',
-    )
-    assert len(host_subscriptions) > 0
-    assert host_subscriptions[0]['name'] == default_subscription.name
 
     rhel_contenthost.unregister()
     with pytest.raises(CLIReturnCodeError):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18580

### Problem Statement
The test was using `hammer subscription unregister` within itself, which is long gone from satellite

### Solution
Switch it for `rhel_contenthost.unregister()`

<img width="180" alt="image" src="https://github.com/user-attachments/assets/8b68830b-5374-4099-b39d-842db9bad198" />

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_activationkey.py -k 'test_syspurpose_end_to_end'
```