### PR TITLE
[6.17.z] Update Provisioning tests to use RHEL10 GA repos

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -274,7 +274,7 @@ PRDS = {
     'rhae': 'Red Hat Ansible Engine',
     'rhel8': 'Red Hat Enterprise Linux for x86_64',
     'rhel9': 'Red Hat Enterprise Linux for x86_64',
-    'rhel10_beta': 'Red Hat Enterprise Linux for x86_64 Beta',
+    'rhel10': 'Red Hat Enterprise Linux for x86_64',
     'rhel_els': 'Red Hat Enterprise Linux Server - Extended Life Cycle Support',
 }
 
@@ -310,15 +310,15 @@ REPOSET = {
         'rhel8_aps': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream (Kickstart)',
         'rhel9_bos': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS (Kickstart)',
         'rhel9_aps': 'Red Hat Enterprise Linux 9 for x86_64 - AppStream (Kickstart)',
-        'rhel10_bos_beta': 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS Beta (Kickstart)',
-        'rhel10_aps_beta': 'Red Hat Enterprise Linux 10 for x86_64 - AppStream Beta (Kickstart)',
+        'rhel10_bos': 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS (Kickstart)',
+        'rhel10_aps': 'Red Hat Enterprise Linux 10 for x86_64 - AppStream (Kickstart)',
     },
     'rhel8_bos': 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)',
     'rhel8_aps': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)',
     'rhel9_bos': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)',
     'rhel9_aps': 'Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)',
-    'rhel10_bos_beta': 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS Beta (RPMs)',
-    'rhel10_aps_beta': 'Red Hat Enterprise Linux 10 for x86_64 - AppStream Beta (RPMs)',
+    'rhel10_bos': 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS (RPMs)',
+    'rhel10_aps': 'Red Hat Enterprise Linux 10 for x86_64 - AppStream (RPMs)',
     'rhel7_extra': 'Red Hat Enterprise Linux 7 Server - Extras (RPMs)',
     'rhel7_optional': 'Red Hat Enterprise Linux 7 Server - Optional (RPMs)',
     'rhel7_sup': 'Red Hat Enterprise Linux 7 Server - Supplementary (RPMs)',
@@ -616,20 +616,20 @@ REPOS = {
             'product': PRDS['rhel9'],
             'distro': 'rhel9',
         },
-        'rhel10_bos_beta': {
-            'id': 'rhel-10-for-x86_64-baseos-beta-kickstart',
-            'name': 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS Beta Kickstart',
+        'rhel10_bos': {
+            'id': 'rhel-10-for-x86_64-baseos-kickstart',
+            'name': 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS Kickstart 10',
             'version': '10',
-            'reposet': REPOSET['kickstart']['rhel10_bos_beta'],
-            'product': PRDS['rhel10_beta'],
+            'reposet': REPOSET['kickstart']['rhel10_bos'],
+            'product': PRDS['rhel10'],
             'distro': 'rhel10',
         },
-        'rhel10_aps_beta': {
-            'id': 'rhel-10-for-x86_64-appstream-beta-kickstart',
-            'name': 'Red Hat Enterprise Linux 10 for x86_64 - AppStream Beta Kickstart',
+        'rhel10_aps': {
+            'id': 'rhel-10-for-x86_64-appstream-kickstart',
+            'name': 'Red Hat Enterprise Linux 10 for x86_64 - AppStream Kickstart 10',
             'version': '10',
-            'reposet': REPOSET['kickstart']['rhel10_aps_beta'],
-            'product': PRDS['rhel10_beta'],
+            'reposet': REPOSET['kickstart']['rhel10_aps'],
+            'product': PRDS['rhel10'],
             'distro': 'rhel10',
         },
     },
@@ -677,27 +677,27 @@ REPOS = {
         'distro': 'rhel9',
         'key': 'rhel9_aps',
     },
-    'rhel10_bos_beta': {
-        'id': 'rhel-10-for-x86_64-baseos-beta-rpms',
-        'name': 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS Beta RPMs',
+    'rhel10_bos': {
+        'id': 'rhel-10-for-x86_64-baseos-rpms',
+        'name': 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS RPMs 10',
         'releasever': '10',
         'version': '10',
-        'reposet': REPOSET['rhel10_bos_beta'],
-        'product': PRDS['rhel10_beta'],
+        'reposet': REPOSET['rhel10_bos'],
+        'product': PRDS['rhel10'],
         'distro': 'rhel10',
-        'key': 'rhel10_bos_beta',
+        'key': 'rhel10_bos',
         'basearch': 'x86_64',
     },
-    'rhel10_aps_beta': {
-        'id': 'rhel-10-for-x86_64-appstream-beta-rpms',
-        'name': 'Red Hat Enterprise Linux 10 for x86_64 - AppStream Beta RPMs',
+    'rhel10_aps': {
+        'id': 'rhel-10-for-x86_64-appstream-rpms',
+        'name': 'Red Hat Enterprise Linux 10 for x86_64 - AppStream RPMs 10',
         'releasever': '10',
         'basearch': 'x86_64',
         'version': '10',
-        'reposet': REPOSET['rhel10_aps_beta'],
-        'product': PRDS['rhel10_beta'],
+        'reposet': REPOSET['rhel10_aps'],
+        'product': PRDS['rhel10'],
         'distro': 'rhel10',
-        'key': 'rhel10_aps_beta',
+        'key': 'rhel10_aps',
     },
     'rhel7_optional': {
         'id': 'rhel-7-server-optional-rpms',
@@ -747,7 +747,7 @@ REPOS = {
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
 RHEL9_VER = '9.6'
-RHEL10_VER = '10.1'  # EL10 pre-release version
+RHEL10_VER = '10.0'
 
 BULK_REPO_LIST = [
     REPOS['rhel7_optional'],


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18560

As RHEL10 is GA, updating kickstart and content repos required for provisioning tests and some logic update 