### PR TITLE
Fix Discovery Provisioning Tests

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -58,8 +58,6 @@ def test_rhel_pxe_discovery_provisioning(
         lambda: sat.api.DiscoveredHost().search(
             query={
                 'mac': mac,
-                'organization_id': org.id,
-                'location-id': loc.id,
             }
         )
         != [],
@@ -148,8 +146,6 @@ def test_rhel_pxeless_discovery_provisioning(
         lambda: sat.api.DiscoveredHost().search(
             query={
                 'mac': mac,
-                'organization_id': org.id,
-                'location-id': loc.id,
             }
         )
         != [],


### PR DESCRIPTION
### Problem Statement
Discovery Test failing to discover host.

### Solution
Updated lambda condition to discover the host.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->