### PR TITLE
Add support and parametrization for GR based cert setup

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -652,6 +652,7 @@ class ContentHost(Host, ContentHostMixins):
         auth_username=None,
         auth_password=None,
         download_utility=None,
+        setup_container_certs=None,
     ):
         """Registers content host to the Satellite or Capsule server
         using a global registration template.
@@ -674,6 +675,7 @@ class ContentHost(Host, ContentHostMixins):
         :param hostgroup: hostgroup to register with
         :param auth_username: username required if non-admin user
         :param auth_password: password required if non-admin user
+        :param setup_container_certs: Use certificates for container registry authentication.
         :return: SSHCommandResult instance filled with the result of the registration
         """
         options = {
@@ -724,6 +726,8 @@ class ContentHost(Host, ContentHostMixins):
             options['force'] = str(force).lower()
         if download_utility is not None:
             options['download-utility'] = download_utility
+        if setup_container_certs:
+            options['setup-container-registry-certs'] = str(setup_container_certs).lower()
 
         self._satellite = target.satellite
         if auth_username and auth_password:

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -421,7 +421,9 @@ class TestDockerClient:
 
         :id: 7b1a457c-ae67-4a76-9f67-9074ea7f858a
 
-        :Verifies: SAT-33255
+        :parametrized: yes
+
+        :Verifies: SAT-33254, SAT-33255
 
         :steps:
             1. Create and sync a docker repo.


### PR DESCRIPTION
### Problem Statement
In https://github.com/Katello/katello/pull/11402 we add the cert setup for container access in Global Registration. 


### Solution
We already have a test case to test the cert-based auth with manual setup. This PR extends/parametrizes the case with global registration.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_container_management.py -k test_podman_cert_auth
Katello:
    katello: 11402
theforeman:
    foreman: 10554
```