### PR TITLE
skip 2 test in interop pipeline due to open bz SAT-31619

### DIFF
--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -94,6 +94,7 @@ def vm(
     return module_rhel_contenthost
 
 
+@pytest.mark.skip_if_open('SAT-31619')
 @pytest.mark.pit_client
 @pytest.mark.pit_server
 @pytest.mark.rhel_ver_match('9')
@@ -135,6 +136,7 @@ def test_positive_list_installable_updates(vm, module_target_sat):
     assert REAL_RHEL9_PACKAGE in applicable_packages[0]['filename']
 
 
+@pytest.mark.skip_if_open('SAT-31619')
 @pytest.mark.upgrade
 @pytest.mark.pit_client
 @pytest.mark.pit_server


### PR DESCRIPTION
### Problem Statement
During interop test execution, 2 Tests were failing due to missing product certificate in content host, further investigation and discussion we decided to skip test from running in interop pipeline

### Solution
Use of marker `@pytest.mark.skip_if_open('SAT-31619')`

### Related Issues
N/A

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->