### PR TITLE
Make flatpak_contenthost parametrizable

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -240,12 +240,8 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
 
 @pytest.fixture(scope='module')
 def module_flatpak_contenthost(request):
-    request.param = {
-        "rhel_version": "9",
-        "distro": "rhel",
-        "no_containers": True,
-        "network": "ipv6" if settings.server.network_type == NetworkType.IPV6 else "ipv4",
-    }
+    assert request.param['rhel_version'] > 8, 'Unsupported RHEL version'
+    request.param['no_containers'] = True
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()
         res = host.execute('dnf -y install podman flatpak dbus-x11')

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -17,6 +17,7 @@ TARGET_FIXTURES = [
     'module_sync_kickstart_content',
     'rex_contenthost',
     'rex_contenthosts',
+    'module_flatpak_contenthost',
 ]
 
 

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -782,6 +782,7 @@ def test_positive_repair_artifacts(
 
 
 @pytest.mark.e2e
+@pytest.mark.rhel_ver_match('9')
 @pytest.mark.parametrize('function_flatpak_remote', ['RedHat'], indirect=True)
 @pytest.mark.parametrize('setting_update', ['foreman_proxy_content_auto_sync=True'], indirect=True)
 def test_sync_consume_flatpak_repo_via_library(

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -226,6 +226,7 @@ def test_flatpak_endpoint(target_sat, endpoint):
 
 @pytest.mark.e2e
 @pytest.mark.upgrade
+@pytest.mark.rhel_ver_match('9')
 @pytest.mark.parametrize('function_flatpak_remote', ['RedHat'], indirect=True)
 def test_sync_consume_flatpak_repo_via_library(
     request,
@@ -357,6 +358,7 @@ def test_sync_consume_flatpak_repo_via_library(
 
 @pytest.mark.e2e
 @pytest.mark.upgrade
+@pytest.mark.rhel_ver_match('9')
 @pytest.mark.parametrize('function_flatpak_remote', ['RedHat'], indirect=True)
 def test_sync_consume_flatpak_repo_via_cv(
     request,

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1343,6 +1343,7 @@ class TestContentViewSync:
         assert 'content_view not found' in error.value.message, 'The imported CV should be gone'
 
     @pytest.mark.e2e
+    @pytest.mark.rhel_ver_match('9')
     @pytest.mark.parametrize('function_flatpak_remote', ['RedHat'], indirect=True)
     def test_postive_export_import_cv_with_mixed_content_repos(
         self,


### PR DESCRIPTION
### Problem Statement
In 6.18 there are some Flatpak-related features (like cert-based login) which will be only available on RHEL10+ instances.
For this reason we should be able to parametrize our test cases with different RHEL contenthosts. Also, we should be testing with multiple (supported) RHEL versions.


### Solution
This PR just makes our `module_flatpak_contenthost` parametrizable with different RHEL versions (similarly to `rhel_contenthost`).
For now I'll keep the test parametrization with `9` until we resolve the right way to have RHEL10 set up with appropriate flatpak clients.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_flatpak.py -k consume
```
