### PR TITLE
Remove network_type attribute nesting

### DIFF
--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -1,6 +1,5 @@
 content_host:
-  attributes:
-    network_type: dualstack  # could be one of ["ipv4", "ipv6", "dualstack"]
+  network_type: dualstack  # could be one of ["ipv4", "ipv6", "dualstack"]
   default_rhel_version: 9
   rhel6:
     vm:


### PR DESCRIPTION
### Problem Statement
#17904 introduced new content host config attribute `network_type`, but its nesting in the example configuration file is incorrect.


### Solution
place `network_type` right under `content_host`, remove `attributes`.




<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->
