### PR TITLE
Correct network_type attribute access in Box object for provisioning tests

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -223,7 +223,7 @@ def provisioning_host(module_ssh_key_file, pxe_loader, module_provisioning_sat):
     """Fixture to check out blank VM"""
     if (
         pxe_loader.vm_firmware == 'bios'
-        and module_provisioning_sat.network_type == NetworkType.IPV6
+        and module_provisioning_sat.sat.network_type == NetworkType.IPV6
     ):
         pytest.skip('BIOS is not supported with IPv6')
     vlan_id = settings.provisioning.vlan_id
@@ -275,7 +275,7 @@ def provisioning_hostgroup(
     module_provisioning_capsule,
     pxe_loader,
 ):
-    sat_ipv6 = module_provisioning_sat.network_type == NetworkType.IPV6
+    sat_ipv6 = module_provisioning_sat.sat.network_type == NetworkType.IPV6
     return module_provisioning_sat.sat.api.HostGroup(
         organization=[module_sca_manifest_org],
         location=[module_location],
@@ -363,7 +363,7 @@ def configure_secureboot_provisioning(
     if (
         int(rhel_ver) > sat.os_version.major
         and pxe_loader.vm_firmware == 'uefi_secure_boot'
-        and module_provisioning_sat.network_type != NetworkType.IPV6
+        and module_provisioning_sat.sat.network_type != NetworkType.IPV6
     ):
         # Set the path for the shim and GRUB2 binaries for the OS of host
         bootloader_path = '/var/lib/tftpboot/bootloader-universe/pxegrub2/redhat/default/x86_64'

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -105,13 +105,13 @@ def test_rhel_pxe_provisioning(
     """
     if (
         pxe_loader.vm_firmware == 'bios'
-        and module_provisioning_sat.network_type == NetworkType.IPV6
+        and module_provisioning_sat.sat.network_type == NetworkType.IPV6
     ):
         pytest.skip('Test cannot be run on BIOS as its not supported')
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat
     # Configure the grubx64.efi image to setup the interface and use TFTP to load the configuration
-    if module_provisioning_sat.network_type == NetworkType.IPV6:
+    if module_provisioning_sat.sat.network_type == NetworkType.IPV6:
         sat.execute("echo -e 'net_bootp6\nset root=tftp\nset prefix=(tftp)/grub2' > pre.cfg")
         sat.execute(
             'grub2-mkimage -c pre.cfg -o /var/lib/tftpboot/grub2/grubx64.efi -p /grub2/ -O x86_64-efi efinet efi_netfs efienv efifwsetup efi_gop tftp net normal chain configfile loadenv procfs romfs'
@@ -158,7 +158,7 @@ def test_rhel_pxe_provisioning(
     # Change the hostname of the host as we know it already.
     # In the current infra environment we do not support
     # addressing hosts using FQDNs, falling back to IP.
-    if is_open('SAT-30601') and module_provisioning_sat.network_type == NetworkType.IPV4:
+    if is_open('SAT-30601') and module_provisioning_sat.sat.network_type == NetworkType.IPV4:
         provisioning_host.hostname = host.ip
         # Host is not blank anymore
         provisioning_host.blank = False


### PR DESCRIPTION
### Problem Statement
https://github.com/SatelliteQE/robottelo/pull/17904 introduced a chance to add `network_type` property which is accessible for Satellite objects, and module_provisioning_sat is Box object,
So `module_provisioning_sat.network_type` fails with `BoxKeyError: "'Box' object has no attribute 'network_type'"`

### Solution
Correct network_type attribute access in Box object for provisioning tests

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->