### PR TITLE
fetch interface as per rhel version

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -177,7 +177,7 @@ def test_positive_global_registration_end_to_end(
         module_target_sat.api.CommonParameter(id=rex_cp.id, value=1).update(['value'])
 
     # rex interface
-    iface = 'eth0'
+    iface = 'enp3s0' if rhel_contenthost.os_version.major >= 10 else 'eth0'
     # fill in the global registration form
     with module_target_sat.ui_session() as session:
         session.organization.select(org_name=module_org.name)


### PR DESCRIPTION
### Problem Statement
Due to the interface change in RHEL 10, registering the host with `eth0` caused it to use the default location, leading to incorrect org/loc mapping and `job_invocation` failure.

### Solution
Interface name in RHEL 10 is now `enp3s0`, so updated the code to fetch the interface based on RHEL version to avoid future issues.


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->