### PR TITLE
[6.17.z] [Interop fix] Renaming package mlocate due to RHEL 10 change and to avoid conflict

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -398,7 +398,7 @@ def test_global_registration_with_gpg_repo_and_default_package(
                 'general.activation_keys': module_activation_key.name,
                 'general.insecure': True,
                 'advanced.force': True,
-                'advanced.install_packages': 'mlocate zsh',
+                'advanced.install_packages': 'vim-enhanced zsh',
                 'advanced.repository': repo_url,
                 'advanced.repository_gpg_key_url': repo_gpg_url,
             }
@@ -408,7 +408,7 @@ def test_global_registration_with_gpg_repo_and_default_package(
     # syncing it to the satellite would take too long
     rhelver = client.os_version.major
     if rhelver > 7:
-        repos = {f'rhel{rhelver}_os': settings.repos[f'rhel{rhelver}_os']['baseos']}
+        repos = settings.repos[f'rhel{rhelver}_os']
     else:
         repos = {
             'rhel7_os': settings.repos['rhel7_os'],
@@ -418,9 +418,9 @@ def test_global_registration_with_gpg_repo_and_default_package(
     # run curl
     result = client.execute(cmd)
     assert result.status == 0
-    result = client.execute('yum list installed | grep mlocate')
+    result = client.execute('dnf list installed | grep -E "vim-enhanced|zsh"')
     assert result.status == 0
-    assert 'mlocate' in result.stdout
+    assert all(pkg in result.stdout for pkg in ['vim-enhanced', 'zsh'])
     result = client.execute('yum -v repolist')
     assert result.status == 0
     assert repo_name in result.stdout


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18610

### Problem Statement
We're using the `mlocate` package during host registration, but in RHEL 10, it's replaced by `plocate`.

### Solution
To avoid conflicts, I'm adding a commonly used package instead of separate ones for RHEL variants

![image](https://github.com/user-attachments/assets/946c4fac-9a78-4683-b48b-1d21b7e8a5af)

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->