### PR TITLE
Add bootdisk to downstream foreman installer modules

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -44,6 +44,7 @@ DOWNSTREAM_MODULES = {
     'foreman::cli',
     'foreman::cli::ansible',
     'foreman::cli::azure',
+    'foreman::cli::bootdisk',
     'foreman::cli::google',
     'foreman::cli::katello',
     'foreman::cli::kubevirt',


### PR DESCRIPTION
### Problem Statement
The bootdisk module has been added downstream foreman installer modules

### Solution
Add `'foreman::cli::bootdisk',` to list of Downstream modules

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->