### PR TITLE
Remove ovirt from downstream foreman installer modules

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -54,7 +54,6 @@ DOWNSTREAM_MODULES = {
     'foreman::compute::ec2',
     'foreman::compute::libvirt',
     'foreman::compute::openstack',
-    'foreman::compute::ovirt',
     'foreman::compute::vmware',
     'foreman::plugin::ansible',
     'foreman::plugin::azure',


### PR DESCRIPTION
### Problem Statement
Ovirt has been removed and bootdisk added to Downstream modules
This has been removed from installer options: https://github.com/theforeman/foreman-installer/commit/b14cca6a1cd0cb4ad357762188036a0e2a3e3d19

### Solution
Remove `'foreman::compute::ovirt',` from DOWNSTREAM_MODULES

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->