### PR TITLE
[6.17.z] Skip Bootdisk+Secureboot provisioning for VMware

### DIFF
--- a/tests/foreman/api/test_computeresource_vmware.py
+++ b/tests/foreman/api/test_computeresource_vmware.py
@@ -65,6 +65,9 @@ def test_positive_provision_end_to_end(
 
     :BZ: 2186114
     """
+    if provision_method == 'bootdisk' and pxe_loader.vm_firmware == 'uefi_secure_boot':
+        pytest.skip('Bootdisk + Secureboot provisioning is not yet supported')
+
     sat = module_provisioning_sat.sat
     name = gen_string('alpha').lower()
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18640

### Problem Statement
Bootdisk+Secureboot provisioning for VMware fails intermittently

### Solution
Skipping Bootdisk+Secureboot provisioning for VMware as its not supported yet, see SAT-24052

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->