### PR TITLE
Remove 6.14.z from dependabot PR labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
       - "CherryPick"
       - "dependencies"
       - "6.15.z"
-      - "6.14.z"
     ignore:
       - dependency-name: "cryptography"
         update-types: ["version-update:semver-minor"]
@@ -31,4 +30,3 @@ updates:
       - "CherryPick"
       - "dependencies"
       - "6.15.z"
-      - "6.14.z"


### PR DESCRIPTION
### Problem Statement
6.14 became unsupported. Dependabot still labels its PRs with 6.14.z label.

### Solution
configure dependabot to not add the 6.14.z label to it's PRs



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->
