### PR TITLE
hammer upgrade testset reduced

### DIFF
--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -120,7 +120,6 @@ def test_positive_all_options(target_sat):
         pytest.fail(format_commands_diff(differences))
 
 
-@pytest.mark.upgrade
 def test_positive_disable_hammer_defaults(request, function_product, target_sat):
     """Verify hammer disable defaults command.
 
@@ -189,7 +188,6 @@ def test_positive_check_debug_log_levels(target_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.upgrade
 def test_positive_hammer_shell(target_sat):
     """Verify that hammer shell runs a command when input is provided via interactive/bash
 


### PR DESCRIPTION
### Problem Statement
these tests are exhibiting flakiness in upgrade runs that is not product-related. Given that we have plenty of cli scenarios in the upgrade run, I don't thing theses are worth keeping in the set given the maintenance load


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->