### PR TITLE
[6.16.z] Use Conversionsappliance component for Convert2RHEL tests

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -43,7 +43,7 @@ CaseComponent:
     - ContentCredentials
     - ContentManagement
     - ContentViews
-    - Convert2rhel
+    - Conversionsappliance
     - Dashboard
     - DHCPDNS
     - DiscoveryImage

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Registration
+:CaseComponent: Conversionsappliance
 
 :CaseImportance: Critical
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18641

### Problem Statement
Convert2RHEL tests are part of Registration component currently, which is incorrect

### Solution
Using Conversionsappliance component for Convert2RHEL tests

### Related Issues
[SAT-34794](https://issues.redhat.com/browse/SAT-34794)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->