### PR TITLE
[6.17.z] fix ipv6 test version selection

### DIFF
--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -99,6 +99,8 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
         5. Check if the Errata Count in Satellite after the upgrade.
     """
 
+    network_type = settings.server.network_type
+
     @pytest.mark.rhel_ver_list([7, 8, 9])
     @pytest.mark.no_containers
     @pytest.mark.pre_upgrade
@@ -196,7 +198,9 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
         )
 
     @pytest.mark.parametrize(
-        'pre_upgrade_data', ['rhel7-ipv4', 'rhel8-ipv4', 'rhel9-ipv4'], indirect=True
+        'pre_upgrade_data',
+        [f'rhel7-{network_type}', f'rhel8-{network_type}', f'rhel9-{network_type}'],
+        indirect=True,
     )
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_generate_errata_for_client)
     def test_post_scenario_errata_count_installation(self, target_sat, pre_upgrade_data):

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -80,6 +80,8 @@ class TestSubscriptionAutoAttach:
     upgrade.
     """
 
+    network_type = settings.server.network_type
+
     @pytest.mark.rhel_ver_list([7, 8, 9])
     @pytest.mark.no_containers
     @pytest.mark.pre_upgrade
@@ -142,7 +144,9 @@ class TestSubscriptionAutoAttach:
         )
 
     @pytest.mark.parametrize(
-        'pre_upgrade_data', ['rhel7-ipv4', 'rhel8-ipv4', 'rhel9-ipv4'], indirect=True
+        'pre_upgrade_data',
+        [f'rhel7-{network_type}', f'rhel8-{network_type}', f'rhel9-{network_type}'],
+        indirect=True,
     )
     @pytest.mark.post_upgrade(depend_on=test_pre_subscription_scenario_auto_attach)
     @pytest.mark.manifester


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18643

### Problem Statement
Post upgrade test failing due to network type ip-version with below error
```
failed on setup with "Failed: Invalid test parameter: rhel7-ipv4. Test data not found."
```
```
failed on setup with "Failed: Invalid test parameter: rhel8-ipv4. Test data not found."
```
```
failed on setup with "Failed: Invalid test parameter: rhel9-ipv4. Test data not found."
```

### Solution
fetching network type from server.yaml

### Related Issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/upgrades/test_subscription.py::TestSubscriptionAutoAttach
network_type: ipv6
env:
    ROBOTTELO_server__deploy_workflow: 'deploy-satellite-upgrade'
    ROBOTTELO_server__deploy_arguments__deploy_rhel_version: '9'
    ROBOTTELO_server__deploy_arguments__deploy_sat_version: '6.17.1'
```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->