### PR TITLE
[6.15.z] adding infra hosts to default location

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -663,6 +663,7 @@ class TestRexUsers:
         rex_contenthost,
         class_rexmanager_user,
         class_rexinfra_user,
+        default_location,
         target_sat,
         infra_host,
         module_org,
@@ -690,6 +691,9 @@ class TestRexUsers:
         infra_host.add_rex_key(satellite=target_sat)
         target_sat.cli.Host.update(
             {'name': infra_host.hostname, 'new-organization-id': module_org.id}
+        )
+        target_sat.cli.Host.update(
+            {'name': infra_host.hostname, 'new-location-id': default_location.id}
         )
 
         # run job as admin


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18623

### Problem Statement
in regular runs the sat and capsule hosts are included in default location (which the test implicitly counted on), not so on the upgraded sat image, causing test failures in upgrade runs

### Solution
making location membership for infrastructure hosts explicit

### Related Issues
passing locally on upgraded sat, adding prt for non-upgaded one to see there's no regression caused

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->