### PR TITLE
Fix capsule KS test with non-beta RHEL10

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -793,7 +793,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.e2e
     @pytest.mark.skip_if_not_set('capsule')
-    @pytest.mark.parametrize('distro', ['rhel7', 'rhel8_bos', 'rhel9_bos', 'rhel10_bos_beta'])
+    @pytest.mark.parametrize('distro', ['rhel7', 'rhel8_bos', 'rhel9_bos', 'rhel10_bos'])
     def test_positive_sync_kickstart_repo(
         self, target_sat, module_capsule_configured, function_sca_manifest_org, distro
     ):


### PR DESCRIPTION
### Problem Statement
https://github.com/SatelliteQE/robottelo/pull/18560 removed `rhel10_bos_beta` and `rhel10_aps_beta` from constants, but one occurrence survived and should be replaced.


### Solution
This PR


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k sync_kickstart_repo
```