### PR TITLE
[6.17.z] Add test to verify Insights with http proxy enabled

### DIFF
--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -92,6 +92,9 @@ def test_positive_create_update_delete(module_org, module_location, target_sat):
     indirect=True,
     ids=['auth_http_proxy', 'unauth_http_proxy'],
 )
+@pytest.mark.parametrize(
+    'module_target_sat_insights', [True, False], indirect=True, ids=['hosted', 'local']
+)
 def test_insights_client_registration_with_http_proxy(
     module_target_sat_insights,
     setup_http_proxy,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18496

### Problem Statement

foreman_rh_cloud should forward Insights traffic successfully when an HTTP proxy is configured for the Satellite, with both hosted Insights and local Advisor (IoP). In the case of IoP, the traffic is on localhost and should be unaffected by the proxy.

### Solution

Add parametrization to `test_insights_client_registration_with_http_proxy`, so that both hosted Insights and IoP are tested with the Satellite configured to use an HTTPS proxy. (All Satellite - IoP traffic is internal to the Satellite and should not be affected by the proxy.)

```
$ pytest -k insights --co -q tests/foreman/cli/test_http_proxy.py
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel10-ipv4-hosted-auth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel10-ipv4-hosted-unauth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel8-ipv4-hosted-auth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel8-ipv4-hosted-unauth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel9-ipv4-hosted-auth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel9-ipv4-hosted-unauth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel10-ipv4-local-auth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel10-ipv4-local-unauth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel8-ipv4-local-auth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel8-ipv4-local-unauth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel9-ipv4-local-auth_http_proxy]
tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy[rhel9-ipv4-local-unauth_http_proxy]
```

### Related Issues

SAT-33408


PRT results didn't post to the PR for some reason, but the tests all passed:

(PRT job 11638)
```
12:46:04  + pytest tests/foreman/cli/test_http_proxy.py -k insights --external-logging --junit-xml=sat-results.xml -o junit_suite_name=sat-result
[...]
12:46:52  collected 15 items / 3 deselected / 12 selected
12:46:52  
14:13:46  tests/foreman/cli/test_http_proxy.py ............                        [100%]
14:13:46  ========= 12 passed, 3 deselected, 1063 warnings in 5207.09s (1:26:47) =========
```
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->