### PR TITLE
Fix ansible  test teardown - test_positive_read_facts_with_filter

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -308,6 +308,9 @@ class TestAnsibleCfgMgmt:
             @request.addfinalizer
             def _finalize():
                 target_sat.cli.Host.disassociate({'name': rex_contenthost.hostname})
+                assert rex_contenthost.execute('subscription-manager unregister').status == 0
+                assert rex_contenthost.execute('subscription-manager clean').status == 0
+                target_sat.cli.Host.delete({'name': rex_contenthost.hostname})
 
         # gather ansible facts by running ansible roles on the host
         host.play_ansible_roles()


### PR DESCRIPTION
### Problem Statement
Teardown of the test is failing due to bug: SAT-18656
Failing test: tests/foreman/api/test_ansible.py::test_positive_read_facts_with_filter

### Solution
Adding a workaround for the test.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->