### PR TITLE
[6.17.z] adding capsule to tftp and template

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -200,6 +200,8 @@ def module_provisioning_sat(
         boot_mode='DHCP',
         ipam='None' if provisioning_network.version == 6 else 'DHCP',
         dhcp=None if provisioning_network.version == 6 else module_provisioning_capsule.id,
+        tftp=module_provisioning_capsule.id,
+        template=module_provisioning_capsule.id,
         dns=None if sat_ipv6 else module_provisioning_capsule.id,
         httpboot=module_provisioning_capsule.id,
         discovery=module_provisioning_capsule.id,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18671

### Problem Statement
Most of the provisioning tests are failing due to not having capsule in tftp and template when we create the Subnet. It was removed here - https://github.com/SatelliteQE/robottelo/pull/17904

### Solution
Adding capsule to required parameter to work provisioning properly


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->