### PR TITLE
[6.17.z] Simplify the PRT-Passed label removal

### DIFF
--- a/.github/workflows/prt_labels.yml
+++ b/.github/workflows/prt_labels.yml
@@ -5,45 +5,31 @@ on:
     types: ["synchronize"]
 
 jobs:
-    prt_labels_remover:
-      name: remove the PRT label when amendments or new commits added to PR
-      runs-on: ubuntu-latest
-      if: "(contains(github.event.pull_request.labels.*.name, 'PRT-Passed'))"
-      steps:
-        - name: Avoid the race condition as PRT result will be cleaned
-          run: |
-            echo "Avoiding the race condition if prt result will be cleaned" && sleep 60
-
-        - name: Fetch the PRT status
-          id: prt
-          uses: omkarkhatavkar/wait-for-status-checks@main
-          with:
-            ref: ${{ github.head_ref }}
-            context: 'Robottelo-Runner'
-            wait-interval: 2
-            count: 5
-
-        - name: remove the PRT Passed label, for new commit
-          if: always() && ${{steps.prt.outputs.result}} == 'not_found'
-          uses: actions/github-script@v7
-          with:
-            github-token: ${{ secrets.CHERRYPICK_PAT }}
-            script: |
-              const prNumber = '${{ github.event.number }}';
-              const issue = await github.rest.issues.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-              });
-              const labelsToRemove = ['PRT-Passed'];
-              const labelsToRemoveFiltered = labelsToRemove.filter(label => issue.data.labels.some(({ name }) => name === label));
-              if (labelsToRemoveFiltered.length > 0) {
-                await Promise.all(labelsToRemoveFiltered.map(async label => {
-                  await github.rest.issues.removeLabel({
-                    issue_number: prNumber,
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name: label
-                  });
-                }));
-              }
+  prt_labels_remover:
+    name: remove the PRT label when amendments or new commits added to PR
+    runs-on: ubuntu-latest
+    if: "(contains(github.event.pull_request.labels.*.name, 'PRT-Passed'))"
+    steps:
+      - name: remove the PRT Passed label, for new commit
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CHERRYPICK_PAT }}
+          script: |
+            const prNumber = '${{ github.event.number }}';
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const labelsToRemove = ['PRT-Passed'];
+            const labelsToRemoveFiltered = labelsToRemove.filter(label => issue.data.labels.some(({ name }) => name === label));
+            if (labelsToRemoveFiltered.length > 0) {
+              await Promise.all(labelsToRemoveFiltered.map(async label => {
+                await github.rest.issues.removeLabel({
+                  issue_number: prNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label
+                });
+              }));
+            }


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18672

Previously, there would be a step that would wait, for a very short period of time, for the PRT job to finish before failing. Now, instead of waiting, let's just strip the label if needed and let the new PRT run set the label correctly when it finishes.

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_organization.py -k 'test_positive_create'
```