### PR TITLE
Errata CLI hosts: IPV4 vs IPV6: use defined host network type

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -182,7 +182,12 @@ def hosts(request):
         case _:  # Default for both
             distro, num_hosts = default_distro, default_num_hosts
 
-    with Broker(nick=distro, host_class=ContentHost, _count=num_hosts) as hosts:
+    with Broker(
+        deploy_network_type=settings.content_host.network_type,
+        host_class=ContentHost,
+        _count=num_hosts,
+        nick=distro,
+    ) as hosts:
         if not isinstance(hosts, list) or len(hosts) != num_hosts:
             pytest.fail(f'Failed to provision the expected number of hosts for {distro}.')
         yield hosts


### PR DESCRIPTION
### Problem Statement
Errata CLI tests using the local fixture `hosts` , are failing to checkout IPV6 hosts in IPV6 pipelines.

### Solution
They are defaulting to IPV4 since no `deploy_network_type` is defined in Broker checkout. 
Set them to use the defined network type for content hosts (ipv4 or ipv6).

### PRT Case
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_errata.py --uses-fixtures hosts
```