### PR TITLE
Fix parametrization ids for GR certs setup

### DIFF
--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -412,7 +412,7 @@ class TestDockerClient:
         assert module_container_contenthost.execute(podman_pull_command).status == 0
 
     @pytest.mark.e2e
-    @pytest.mark.parametrize('gr_certs_setup', [False, True], ids=['GR-setup', 'manual-setup'])
+    @pytest.mark.parametrize('gr_certs_setup', [False, True], ids=['manual-setup', 'GR-setup'])
     def test_podman_cert_auth(
         self, request, module_target_sat, module_org, module_container_contenthost, gr_certs_setup
     ):


### PR DESCRIPTION
### Problem Statement
In #18593 I mistakenly typed the parametrization IDS.


### Solution
Swap them to match their meaning.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_container_management.py -k test_podman_cert_auth
Katello:
    katello: 11402
theforeman:
    foreman: 10554
```