### PR TITLE
[Test Fix][ISS]Add rhel9 appstream repo to test

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -14,6 +14,7 @@
 
 import os
 from time import sleep
+from datetime import UTC, datetime, timedelta
 
 from fauxfactory import gen_string
 from manifester import Manifester
@@ -1907,6 +1908,7 @@ class TestContentViewSync:
                 {'name': cv_name, 'organization-id': function_import_org_with_manifest.id}
             )
         )
+        timestamp = datetime.now(UTC)
         target_sat.cli.Service.restart()
         sleep(30)
         # Assert that the initial import task did not succeed and CVV was removed
@@ -1917,6 +1919,11 @@ class TestContentViewSync:
             )[0]
             .result
             != 'success'
+        )
+        target_sat.wait_for_tasks(
+            search_query= f'label = Actions::Katello::ContentView::Remove and started_at >= "{timestamp}"',
+            search_rate=10,
+            max_tries=6,
         )
         importing_cvv = target_sat.cli.ContentView.info(
             {'name': cv_name, 'organization-id': function_import_org_with_manifest.id}

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -12,9 +12,9 @@
 
 """
 
+from datetime import UTC, datetime
 import os
 from time import sleep
-from datetime import UTC, datetime, timedelta
 
 from fauxfactory import gen_string
 from manifester import Manifester
@@ -1921,7 +1921,7 @@ class TestContentViewSync:
             != 'success'
         )
         target_sat.wait_for_tasks(
-            search_query= f'label = Actions::Katello::ContentView::Remove and started_at >= "{timestamp}"',
+            search_query=f'label = Actions::Katello::ContentView::Remove and started_at >= "{timestamp}"',
             search_rate=10,
             max_tries=6,
         )

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1833,7 +1833,7 @@ class TestContentViewSync:
 
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
-        ['rhsclient9'],
+        ['rhel9_aps'],
         indirect=True,
     )
     def test_positive_export_rerun_failed_import(

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1833,7 +1833,7 @@ class TestContentViewSync:
 
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
-        ['rhel9_aps'],
+        ['rhs9'],
         indirect=True,
     )
     def test_positive_export_rerun_failed_import(


### PR DESCRIPTION
Updating the repo used in test_positive_export_rerun_failed_import to use larger repo to ensure import failure occurs while repo is still importing