### PR TITLE
[6.16.z] [Test Fix][ISS]Add rhel9 appstream repo to test

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -12,6 +12,7 @@
 
 """
 
+from datetime import UTC, datetime
 import os
 from time import sleep
 
@@ -1590,7 +1591,7 @@ class TestContentViewSync:
 
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
-        ['rhsclient9'],
+        ['rhs9'],
         indirect=True,
     )
     def test_positive_export_rerun_failed_import(
@@ -1664,6 +1665,7 @@ class TestContentViewSync:
                 {'name': cv_name, 'organization-id': function_import_org_with_manifest.id}
             )
         )
+        timestamp = datetime.now(UTC)
         target_sat.cli.Service.restart()
         sleep(30)
         # Assert that the initial import task did not succeed and CVV was removed
@@ -1674,6 +1676,11 @@ class TestContentViewSync:
             )[0]
             .result
             != 'success'
+        )
+        target_sat.wait_for_tasks(
+            search_query=f'label = Actions::Katello::ContentView::Remove and started_at >= "{timestamp}"',
+            search_rate=10,
+            max_tries=6,
         )
         importing_cvv = target_sat.cli.ContentView.info(
             {'name': cv_name, 'organization-id': function_import_org_with_manifest.id}


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18700

Updating the repo used in test_positive_export_rerun_failed_import to use larger repo to ensure import failure occurs while repo is still importing