### PR TITLE
[6.17.z Cherrypick]Fix ansible  test teardown - test_positive_read_fa…

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -280,7 +280,7 @@ class TestAnsibleCfgMgmt:
         assert ROLE_NAMES[0] not in [role['name'] for role in listroles_hg]
         assert ROLE_NAMES[1] == listroles_hg[0]['name']
 
-    @pytest.mark.rhel_ver_match('[78]')
+    @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_read_facts_with_filter(
         self, request, target_sat, rex_contenthost, filtered_user, module_org, module_location
     ):
@@ -303,9 +303,14 @@ class TestAnsibleCfgMgmt:
         host.organization = module_org
         host.location = module_location
         host.update(['organization', 'location'])
-        request.addfinalizer(
-            user.delete
-        )  # Adding a temporary workaround until the issue 'SAT-18656' is resolved.
+        if is_open('SAT-18656'):
+
+            @request.addfinalizer
+            def _finalize():
+                target_sat.cli.Host.disassociate({'name': rex_contenthost.hostname})
+                assert rex_contenthost.execute('subscription-manager unregister').status == 0
+                assert rex_contenthost.execute('subscription-manager clean').status == 0
+                target_sat.cli.Host.delete({'name': rex_contenthost.hostname})
 
         # gather ansible facts by running ansible roles on the host
         host.play_ansible_roles()


### PR DESCRIPTION
…cts_with_filter

### Problem Statement
Failed autocherrypick: https://github.com/SatelliteQE/robottelo/issues/18731

### Solution
Manually cherrypicked

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->