### PR TITLE
Try to fix flaky reporting test #1

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -537,7 +537,8 @@ def test_positive_applied_errata_by_search(
     rhel_contenthost.execute(r'subscription-manager repos --enable \*')
     assert rhel_contenthost.execute(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}').status == 0
     assert rhel_contenthost.execute(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}').status == 0
-    rhel_contenthost.execute('subscription-manager repos')
+    # sleep added to reduce flakiness of the test
+    rhel_contenthost.execute('subscription-manager repos | sleep 10')
     task_id = target_sat.api.JobInvocation().run(
         data={
             'feature': 'katello_errata_install_by_search',


### PR DESCRIPTION
### Problem Statement
The `test_positive_applied_errata_by_search` is quite flaky within the automation, local testing did not achieve that high flakiness as in automation, but after some debugging, I think that a little `sleep` might help, let's see...
<img width="201" alt="image" src="https://github.com/user-attachments/assets/f2ea8322-6c76-4306-a9c6-99c5094d8839" />

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_reporttemplates.py -k 'test_positive_applied_errata_by_search'
```