### PR TITLE
[6.17.z] Fix Flatpak repos provided by RH index

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -862,6 +862,7 @@ FLATPAK_ENDPOINTS = {
     'pulpcore': 'https://{}/pulpcore_registry/' + FLATPAK_INDEX_SUFFIX,
     'katello': 'https://{}/' + FLATPAK_INDEX_SUFFIX,
 }
+FLATPAK_RHEL_RELEASE_VER = 10
 
 CUSTOM_LOCAL_FOLDER = '/var/lib/pulp/imports/myrepo/'
 CUSTOM_LOCAL_FILE = '/var/lib/pulp/imports/myrepo/test.txt'

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -21,6 +21,7 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import (
     FAKE_0_CUSTOM_PACKAGE_NAME,
+    FLATPAK_RHEL_RELEASE_VER,
     PULP_EXPORT_DIR,
 )
 from robottelo.constants.repos import ANSIBLE_GALAXY, CUSTOM_FILE_REPO
@@ -835,7 +836,8 @@ def test_sync_consume_flatpak_repo_via_library(
     assert function_lce_library.id in [capsule_lce['id'] for capsule_lce in res['results']]
 
     # Mirror a flatpak repository and sync it, verify the capsule was synced.
-    repo_names = ['rhel9/firefox-flatpak', 'rhel9/flatpak-runtime']  # runtime is dependency
+    ver = FLATPAK_RHEL_RELEASE_VER
+    repo_names = [f'rhel{ver}/firefox-flatpak', f'rhel{ver}/flatpak-runtime']  # runtime=dependency
     remote_repos = [r for r in function_flatpak_remote.repos if r['name'] in repo_names]
     for repo in remote_repos:
         sat.cli.FlatpakRemote().repository_mirror(
@@ -894,7 +896,7 @@ def test_sync_consume_flatpak_repo_via_library(
     res = host.execute('flatpak remotes')
     assert remote_name in res.stdout
 
-    app_name = 'Firefox'  # or 'org.mozilla.Firefox'
+    app_name = 'firefox'  # or 'org.mozilla.firefox'
     res = host.execute('flatpak remote-ls')
     assert app_name in res.stdout
 

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -16,7 +16,12 @@ import pytest
 import requests
 
 from robottelo.config import settings
-from robottelo.constants import FLATPAK_ENDPOINTS, FLATPAK_INDEX_SUFFIX, FLATPAK_REMOTES
+from robottelo.constants import (
+    FLATPAK_ENDPOINTS,
+    FLATPAK_INDEX_SUFFIX,
+    FLATPAK_REMOTES,
+    FLATPAK_RHEL_RELEASE_VER,
+)
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.utils.datafactory import gen_string
 
@@ -261,8 +266,10 @@ def test_sync_consume_flatpak_repo_via_library(
     sat, host = module_target_sat, module_flatpak_contenthost
 
     # 1. Mirror flatpak repositories and sync them.
-    repo_names = ['rhel9/firefox-flatpak', 'rhel9/flatpak-runtime']  # runtime is dependency
+    ver = FLATPAK_RHEL_RELEASE_VER
+    repo_names = [f'rhel{ver}/firefox-flatpak', f'rhel{ver}/flatpak-runtime']  # runtime=dependency
     remote_repos = [r for r in function_flatpak_remote.repos if r['name'] in repo_names]
+    assert len(repo_names) == len(remote_repos), 'Testing repos are missing from remote index.'
     for repo in remote_repos:
         sat.cli.FlatpakRemote().repository_mirror(
             {
@@ -328,7 +335,7 @@ def test_sync_consume_flatpak_repo_via_library(
     assert remote_name in res.stdout
 
     # 5. Install flatpak app from the repo via REX on the contenthost.
-    app_name = 'Firefox'  # or 'org.mozilla.Firefox'
+    app_name = 'firefox'  # or 'org.mozilla.firefox'
     res = host.execute('flatpak remote-ls')
     assert app_name in res.stdout
 
@@ -392,8 +399,14 @@ def test_sync_consume_flatpak_repo_via_cv(
     sat, host = module_target_sat, module_flatpak_contenthost
 
     # 1. Mirror flatpak repositories and sync them.
-    repo_names = ['rhel9/firefox-flatpak', 'rhel9/inkscape-flatpak', 'rhel9/flatpak-runtime']
+    ver = FLATPAK_RHEL_RELEASE_VER
+    repo_names = [
+        f'rhel{ver}/firefox-flatpak',
+        f'rhel{ver}/flatpak-runtime',  # runtime is dependency
+        f'rhel{ver}/thunderbird-flatpak',
+    ]
     remote_repos = [r for r in function_flatpak_remote.repos if r['name'] in repo_names]
+    assert len(repo_names) == len(remote_repos), 'Testing repos are missing from remote index.'
     for repo in remote_repos:
         sat.cli.FlatpakRemote().repository_mirror(
             {
@@ -415,19 +428,11 @@ def test_sync_consume_flatpak_repo_via_cv(
     # 2. Create two CVs, put different repos inside, publish and promote them to LCE.
     cv1 = sat.api.ContentView(
         organization=function_org,
-        repository=[
-            r['id']
-            for r in local_repos
-            if r['name'] in ['rhel9/inkscape-flatpak', 'rhel9/flatpak-runtime']
-        ],
+        repository=[r['id'] for r in local_repos if r['name'] in repo_names[-2:]],  # Last 2
     ).create()
     cv2 = sat.api.ContentView(
         organization=function_org,
-        repository=[
-            r['id']
-            for r in local_repos
-            if r['name'] in ['rhel9/firefox-flatpak', 'rhel9/flatpak-runtime']
-        ],
+        repository=[r['id'] for r in local_repos if r['name'] in repo_names[:2]],  # First 2
     ).create()
     for cv in [cv1, cv2]:
         cv.publish()
@@ -470,8 +475,8 @@ def test_sync_consume_flatpak_repo_via_cv(
 
     # 6. Ensure only the proper Apps are available.
     res = host.execute('flatpak remote-ls')
-    assert all(app_name in res.stdout for app_name in ['Inkscape', 'Platform'])
-    assert 'Firefox' not in res.stdout
+    assert all(app_name in res.stdout for app_name in ['Thunderbird', 'Platform'])
+    assert 'firefox' not in res.stdout
 
     # 7. Install flatpak app from the first CV, ensure it succeeded.
     opts = {
@@ -479,7 +484,7 @@ def test_sync_consume_flatpak_repo_via_cv(
         'job-template': 'Flatpak - Install application on host',
         'search-query': f"name = {host.hostname}",
     }
-    cv1_app = 'Inkscape'
+    cv1_app = 'Thunderbird'
     job = module_target_sat.cli_factory.job_invocation(
         opts | {'inputs': f'Flatpak remote name={remote_name}, Application name={cv1_app}'}
     )
@@ -492,7 +497,7 @@ def test_sync_consume_flatpak_repo_via_cv(
     assert cv1_app in res.stdout
 
     # 8. Try to install flatpak app from the second CV, ensure it failed.
-    cv2_app = 'Firefox'
+    cv2_app = 'firefox'
     with pytest.raises(CLIFactoryError) as error:
         sat.cli_factory.job_invocation(
             opts | {'inputs': f'Flatpak remote name={remote_name}, Application name={cv2_app}'}

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -27,6 +27,7 @@ from robottelo.constants import (
     DEFAULT_CV,
     ENVIRONMENT,
     EXPORT_LIBRARY_NAME,
+    FLATPAK_RHEL_RELEASE_VER,
     PULP_EXPORT_DIR,
     PULP_IMPORT_DIR,
     REPO_TYPE,
@@ -208,7 +209,8 @@ def function_synced_docker_repo(target_sat, function_org, function_product):
 def function_synced_flatpak_repos(
     target_sat, function_org, function_flatpak_remote, function_product
 ):
-    repo_names = ['rhel9/firefox-flatpak', 'rhel9/flatpak-runtime']  # runtime is dependency
+    ver = FLATPAK_RHEL_RELEASE_VER
+    repo_names = [f'rhel{ver}/firefox-flatpak', f'rhel{ver}/flatpak-runtime']  # runtime=dependency
     remote_repos = [r for r in function_flatpak_remote.repos if r['name'] in repo_names]
     for repo in remote_repos:
         target_sat.cli.FlatpakRemote().repository_mirror(
@@ -1539,7 +1541,7 @@ class TestContentViewSync:
         res = module_flatpak_contenthost.execute('flatpak remotes')
         assert remote_name in res.stdout
 
-        app_name = 'Firefox'
+        app_name = 'firefox'
         res = module_flatpak_contenthost.execute('flatpak remote-ls')
         assert app_name in res.stdout
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18721

### Problem Statement
The repositories served at the RH index have been changed and we need to update them.

As per the latest info they are going to be changed _around_ the major RHEL release times. The older versions (`rhel9/app_name`) are to be removed and only the latest ones (`rhel10/app_name`) should be used, even for the older RHEL versions (that's why we can't hook it on `host.os_version.major`).


### Solution
This PR.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_flatpak.py::test_sync_consume_flatpak_repo_via_cv tests/foreman/cli/test_capsulecontent.py::test_sync_consume_flatpak_repo_via_library tests/foreman/cli/test_satellitesync.py::TestContentViewSync::test_postive_export_import_cv_with_mixed_content_repos
```