### PR TITLE
Fix test_satellite_installation

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -44,6 +44,7 @@ DOWNSTREAM_MODULES = {
     'foreman::cli',
     'foreman::cli::ansible',
     'foreman::cli::azure',
+    'foreman::cli::bootdisk',
     'foreman::cli::google',
     'foreman::cli::katello',
     'foreman::cli::kubevirt',


### PR DESCRIPTION
### Problem Statement
- tests.foreman.installer.test_installer.test_satellite_installation is failing with assertion error because addition of `foreman::cli::bootdisk` module. 

### Solution
- Update `DOWNSTREAM_MODULES` to include `foreman::cli::bootdisk`.

### Related Issues
- SAT-35203

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->