### PR TITLE
Fix test_positive_generate_capsule_certs_using_absolute_path

### DIFF
--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -144,7 +144,7 @@ def test_positive_generate_capsule_certs_using_absolute_path(cert_setup_destruct
     # assert include cname in certificates when specified --foreman-proxy-cname'
     result = satellite.execute(
         'openssl x509 -in /root/ssl-build/capsule.example.com/'
-        'capsule.example.com-foreman-client.crt -text | '
+        'capsule.example.com-foreman-proxy-client.crt -text | '
         'grep capsule.example1.com'
     )
     assert 'DNS:capsule.example1.com' in result.stdout


### PR DESCRIPTION
### Problem Statement
Fix test_positive_generate_capsule_certs_using_absolute_path failing because of the wrong assertion.

### Solution
- Update the assertion to check `foreman-proxy-client.crt`.

### Related Issues
- SAT-35205

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->