### PR TITLE
host registration: fixed unused helper fields

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -339,8 +339,8 @@ def test_global_registration_form_populate(
             full_read=True,
         )
         assert hg_nested_name in cmd['general']['host_group']
-        assert function_activation_key.name in cmd['general']['activation_key_helper']
-        assert constants.FAKE_0_CUSTOM_PACKAGE in cmd['advanced']['install_packages_helper']
+        assert function_activation_key.name in cmd['general']['activation_keys']
+        assert constants.FAKE_0_CUSTOM_PACKAGE in cmd['advanced']['install_packages']
 
         session.organization.select(org_name=new_org.name)
         session.browser.refresh()


### PR DESCRIPTION
### Problem Statement
In the `Register Host` form, the `activation_key_helper` and `install_packages_helper` fields are no longer present due to PF5 changes.

### Solution
`activation_keys` and `install_packages` widgets handle it.

### Related Issues
https://github.com/SatelliteQE/airgun/pull/1863

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_registration.py::test_global_registration_form_populate
airgun: 1863
```