### PR TITLE
[SAT-33810] New Hosts UI fix - VM setup

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -209,20 +209,18 @@ def module_repos_collection_with_setup(request, module_target_sat, module_org, m
         Such as by using pytest.markers 'rhel_ver_match' or 'rhel_ver_list'.
 
     """
-    # peek the first of prior paramtrized fixtures (global scope),
+    # peek the first of prior parametrized fixtures (global scope),
     # if a RHEL host is parametrized with distro, it will be at the top.
     top_level_param = request._pyfuncitem.callspec.params
-    peek_fixture, peek_val = next(iter(top_level_param.items()))
+    _, peek_val = next(iter(top_level_param.items()))
     fixtures_distro = peek_val.get('rhel_version', None)
 
     repos = getattr(request, 'param', [])
-    if 'distro' not in repos:
-        repos['distro'] = None
     # no distro in repos request, fallback if top fixture marked with rhel_version
-    if repos['distro'] is None:
+    if 'distro' not in repos or repos['distro'] is None:
         repos['distro'] = fixtures_distro
     if repos['distro'] and 'rhel' not in str(repos['distro']):
-        repos['distro'] = 'rhel' + str(repos['distro'])
+        repos['distro'] = f'rhel{repos["distro"]}'
 
     repo_distro, repos = _simplify_repos(request, repos)
     _repos_collection = module_target_sat.cli_factory.RepositoryCollection(

--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -127,7 +127,7 @@ def _simplify_repos(request, repos):
     [
         {'SatelliteToolsRepository': {}},
         {'YumRepository': {'url': settings.repos.yum_0.url}},
-        {'YumRepository': {'url': settings.repos.yum_6.url}}
+        {'YumRepository': {'url': settings.repos.yum_6.url}, 'distro': 'rhel9'}
     ]
     Then the fixtures loop over it to create multiple repositories.
 
@@ -204,11 +204,26 @@ def module_repos_collection_with_setup(request, module_target_sat, module_org, m
     setup_content capabilities using module_org and module_lce fixtures
 
     Remember:
-        1. One can not pass distro as pytest mark via test to this fixture since the conflict of
-        using function scoped distro fixture in module scoped this fixture arrives
+        If you do not pass a repos request with valid 'distro' contained, we will attempt to fallback
+        on any fixture host, with attribute 'rhel_version' already parametrized.
+        Such as by using pytest.markers 'rhel_ver_match' or 'rhel_ver_list'.
 
     """
+    # peek the first of prior paramtrized fixtures (global scope),
+    # if a RHEL host is parametrized with distro, it will be at the top.
+    top_level_param = request._pyfuncitem.callspec.params
+    peek_fixture, peek_val = next(iter(top_level_param.items()))
+    fixtures_distro = peek_val.get('rhel_version', None)
+
     repos = getattr(request, 'param', [])
+    if 'distro' not in repos:
+        repos['distro'] = None
+    # no distro in repos request, fallback if top fixture marked with rhel_version
+    if repos['distro'] is None:
+        repos['distro'] = fixtures_distro
+    if repos['distro'] and 'rhel' not in str(repos['distro']):
+        repos['distro'] = 'rhel' + str(repos['distro'])
+
     repo_distro, repos = _simplify_repos(request, repos)
     _repos_collection = module_target_sat.cli_factory.RepositoryCollection(
         distro=repo_distro,

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1260,13 +1260,19 @@ class ContentHost(Host, ContentHostMixins):
         if product_label:
             # Enable custom repositories
             for repo_label in repo_labels:
-                result = self.execute(
-                    f'yum-config-manager --enable {org_label}_{product_label}_{repo_label}'
+                # try first with subscription-manager (SCA)
+                result_sm = self.execute(
+                    f'subscription-manager repos --enable {org_label}_{product_label}_{repo_label}'
                 )
-                if result.status != 0:
-                    raise CLIFactoryError(
-                        f'Failed to enable custom repository {repo_label!s}\n{result.stderr}'
+                if result_sm.status != 0:
+                    result = self.execute(
+                        f'yum-config-manager --enable {org_label}_{product_label}_{repo_label}'
                     )
+                    if result.status != 0:
+                        raise CLIFactoryError(
+                            f'Failed to enable custom repository: {repo_label!s}\n{result.stderr}'
+                            f'\nSubscription-Manager:\n{result_sm.stderr}'
+                        )
 
     def virt_who_hypervisor_config(
         self,

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1375,12 +1375,8 @@ def test_positive_host_details_read_templates(
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
     'module_repos_collection_with_setup',
-    [
-        {
-            'YumRepository': {'url': settings.repos.yum_3.url},
-        }
-    ],
-    ids=['yum3'],
+    [{'YumRepository': {'url': settings.repos.yum_3.url}}],
+    ids=['yum_3'],
     indirect=True,
 )
 def test_positive_update_delete_package(
@@ -1486,11 +1482,7 @@ def test_positive_update_delete_package(
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
     'module_repos_collection_with_setup',
-    [
-        {
-            'YumRepository': {'url': settings.repos.yum_3.url},
-        }
-    ],
+    [{'YumRepository': {'url': settings.repos.yum_3.url}}],
     ids=['yum3'],
     indirect=True,
 )
@@ -1564,11 +1556,7 @@ def test_positive_apply_erratum(
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
     'module_repos_collection_with_setup',
-    [
-        {
-            'YumRepository': {'url': settings.repos.module_stream_1.url},
-        }
-    ],
+    [{'YumRepository': {'url': settings.repos.module_stream_1.url}}],
     ids=['module_stream_1'],
     indirect=True,
 )
@@ -1597,13 +1585,12 @@ def test_positive_crud_module_streams(
     module_name = 'duck'
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(client)
+    module_repos_collection_with_setup.setup_virtual_machine(client, enable_custom_repos=True)
     with session:
         session.location.select(loc_name=DEFAULT_LOC)
         streams = session.host_new.get_module_streams(client.hostname, module_name)
         assert streams[0]['Name'] == module_name
         assert streams[0]['State'] == 'Default'
-
         # enable module stream
         session.host_new.apply_module_streams_action(client.hostname, module_name, "Enable")
         task_result = target_sat.wait_for_tasks(

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1511,7 +1511,7 @@ def test_positive_apply_erratum(
     # install package
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(vm=client, enable_custom_repos=True)
+    module_repos_collection_with_setup.setup_virtual_machine(client, enable_custom_repos=True)
     errata_id = settings.repos.yum_3.errata[25]
     client.run(f'yum install -y {FAKE_7_CUSTOM_PACKAGE}')
     result = client.run(f'rpm -q {FAKE_7_CUSTOM_PACKAGE}')

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1371,13 +1371,12 @@ def test_positive_host_details_read_templates(
     assert set(api_templates) == set(ui_templates)
 
 
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_match('N-1')
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
     'module_repos_collection_with_setup',
     [
         {
-            'distro': 'rhel8',
             'YumRepository': {'url': settings.repos.yum_3.url},
         }
     ],
@@ -1409,10 +1408,7 @@ def test_positive_update_delete_package(
     """
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(
-        vm=client,
-        enable_custom_repos=True,
-    )
+    module_repos_collection_with_setup.setup_virtual_machine(vm=client, enable_custom_repos=True)
     with session:
         session.location.select(loc_name=DEFAULT_LOC)
         product_name = module_repos_collection_with_setup.custom_product.name
@@ -1486,13 +1482,12 @@ def test_positive_update_delete_package(
         assert result.status != 0
 
 
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_match('N-1')
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
     'module_repos_collection_with_setup',
     [
         {
-            'distro': 'rhel8',
             'YumRepository': {'url': settings.repos.yum_3.url},
         }
     ],
@@ -1524,7 +1519,7 @@ def test_positive_apply_erratum(
     # install package
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(client, target_sat)
+    module_repos_collection_with_setup.setup_virtual_machine(vm=client, enable_custom_repos=True)
     errata_id = settings.repos.yum_3.errata[25]
     client.run(f'yum install -y {FAKE_7_CUSTOM_PACKAGE}')
     result = client.run(f'rpm -q {FAKE_7_CUSTOM_PACKAGE}')
@@ -1565,13 +1560,12 @@ def test_positive_apply_erratum(
 
 
 @pytest.mark.e2e
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_match('N-1')
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
     'module_repos_collection_with_setup',
     [
         {
-            'distro': 'rhel8',
             'YumRepository': {'url': settings.repos.module_stream_1.url},
         }
     ],
@@ -1603,7 +1597,7 @@ def test_positive_crud_module_streams(
     module_name = 'duck'
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(client, target_sat)
+    module_repos_collection_with_setup.setup_virtual_machine(client)
     with session:
         session.location.select(loc_name=DEFAULT_LOC)
         streams = session.host_new.get_module_streams(client.hostname, module_name)


### PR DESCRIPTION
### Problem Statement
3 new host UI cases failing to setup their virtual machine, outdated args passed, custom repos not enabled, etc.

To parametrize implicitly, without putting a really ugly for loop in the test's parametrization,
I was able to get `module_repos_collection_with_setup` to work with `distro` in request, or without. 
By falling back on globally defined fixture's RHEL host, declared `rhel_version`, if present. 

^ Effect: We can still parametrize `module_repos_collection_with_setup` with `distro` explicitly as we currently do.
But if `distro` is None or missing, it will look for and fallback on fixture hosts with `rhel_version`.

Can now parametrize the module_repos_collection fixture with ubiquitous rhel markers: `rhel_ver_match` or `rhel_ver_list`.
^ but only if `distro` is missing, or `None`.

### Solution
Resolved setup issues and local pass.
Implicitly parametrize `module_repos_collection_with_setup` for these cases by `@pytest.mark.rhel_ver_match('N-1')`
RHEL version / distro by `N-1` (2 params for each of the 3 cases). `N` in stream is RHEL10.
^ instead of hardcoding to `rhel8`, which needs to be updated regularly or becomes outdated.

Needs: [Airgun#1888](https://github.com/SatelliteQE/airgun/pull/1888)

### PRT Case
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_positive_crud_module_streams or test_positive_apply_erratum or test_positive_update_delete_package'

```