### PR TITLE
[6.17.z] Try to fix flaky reporting test #2

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -14,6 +14,7 @@
 
 from datetime import UTC, datetime, timedelta
 import re
+import time
 
 from fauxfactory import gen_string
 import pytest
@@ -1158,6 +1159,8 @@ def test_positive_applied_errata_by_install_date(
     )
     assert module_rhel_contenthost.execute('subscription-manager refresh').status == 0
     assert module_rhel_contenthost.applicable_errata_count == len(ERRATUM_IDS)
+    # sleep added to reduce flakiness of the test
+    time.sleep(10)
     # 'Since' time for today (UTC): set to 5 minutes prior to installs below
     today_utc = (datetime.now(UTC) - timedelta(minutes=5)).strftime('%Y-%m-%d %H:%M:%S')
     # Apply all FAKE_9_YUM erratum


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18746

### Problem Statement
The `test_positive_applied_errata_by_install_date` is quite flaky within the automation, local testing did not achieve that high flakiness as in automation.
In this case, idk why, but the approach with sleep via target_sat.execute from previous [PR](https://github.com/SatelliteQE/robottelo/pull/18735) did not help with flakiness locally but time.sleep(10) did.
Let's see how it behaves in CI.

<img width="227" alt="image" src="https://github.com/user-attachments/assets/f57ea0ed-fa1b-470a-b030-ad084bf241f6" />

The goal is at least to pass over the job execution and fail further than on `Install errata` task.
### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_reporttemplates.py -k 'test_positive_applied_errata_by_install_date'
```