### PR TITLE
[6.17.z] Fix ACS IPv6 tests with ACS HTTP proxy

### DIFF
--- a/tests/foreman/api/test_acs.py
+++ b/tests/foreman/api/test_acs.py
@@ -16,6 +16,7 @@ from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError
 
+from robottelo.config import settings
 from robottelo.constants.repos import PULP_FIXTURE_ROOT, PULP_SUBPATHS_COMBINED
 
 
@@ -61,6 +62,14 @@ def test_positive_CRUD_all_types(
         'content_type': cnt_type,
         'smart_proxy_ids': [module_target_sat.nailgun_capsule.id],
     }
+
+    # In case of IPv6, set 'ACS HTTP proxy' of the bound capsule to the IPv6 proxy
+    # This is necessary for the Refresh to succeed.
+    if not settings.server.network_type.has_ipv4:
+        caps = module_target_sat.nailgun_smart_proxy
+        caps.http_proxy = module_target_sat.enable_satellite_http_proxy()
+        caps.update(['http_proxy'])
+        params.update({'use_http_proxies': True})
 
     if acs_type == 'simplified':
         params.update(

--- a/tests/foreman/cli/test_acs.py
+++ b/tests/foreman/cli/test_acs.py
@@ -15,6 +15,7 @@
 from fauxfactory import gen_alphanumeric
 import pytest
 
+from robottelo.config import settings
 from robottelo.constants.repos import PULP_FIXTURE_ROOT, PULP_SUBPATHS_COMBINED
 from robottelo.exceptions import CLIReturnCodeError
 
@@ -70,6 +71,14 @@ def test_positive_CRUD_all_types(
         'content-type': cnt_type,
         'smart-proxy-ids': module_target_sat.nailgun_capsule.id,
     }
+
+    # In case of IPv6, set 'ACS HTTP proxy' of the bound capsule to the IPv6 proxy
+    # This is necessary for the Refresh to succeed.
+    if not settings.server.network_type.has_ipv4:
+        caps = module_target_sat.nailgun_smart_proxy
+        caps.http_proxy = module_target_sat.enable_satellite_http_proxy()
+        caps.update(['http_proxy'])
+        params.update({'use-http-proxies': 'true'})
 
     if acs_type == 'simplified':
         params.update(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18767

### Problem Statement
Some ACS tests (those running Refresh) fail in IPv6 pipeline since they can't reach out to the IPv4 source, because ACSes have the HTTP proxy set separately for the capsule they are using.


### Solution
Set the ACS HTTP proxy on the Capsule used by ACS to the IPv6 proxy and create the ACS with `use_http_proxies` option.


### Related Issues
https://issues.redhat.com/browse/SAT-34801
Requires https://github.com/SatelliteQE/nailgun/pull/1314

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman -k CRUD_all_types
nailgun: 1314
network_type: ipv6
```