### PR TITLE
fix katello-tracer ipv6 for rhel version 7,8,9

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2283,7 +2283,7 @@ def test_positive_dump_enc_yaml(target_sat):
 
 # -------------------------- HOST TRACE SUBCOMMAND SCENARIOS -------------------------
 @pytest.mark.pit_client
-@pytest.mark.rhel_ver_match('[^6].*')
+@pytest.mark.rhel_ver_match('[7,8,9]')
 def test_positive_tracer_list_and_resolve(tracer_host, target_sat):
     """Install tracer on client, downgrade the service, check from the satellite
     that tracer shows and resolves the problem. The test works with a package specified


### PR DESCRIPTION
### Problem Statement
Katello-tracer tests for ipv6 was failing with below error.  Unable to install "katello-host-tools-tracer" package on content host due to missing repository "Satellite Client". 
Error-
```
failed on setup with "robottelo.hosts.ContentHostError: There was an error installing katello-host-tools-tracer"
```

Additionally due to ipv6 network type while installing katello-host-tools-tracer package test was failing with below error
Error-
```
Curl error (7): Couldn't connect to server for http://.............repodata/repomd.xml []
Error: Failed to download metadata for repo 'foreman_register2': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```

Note: We need to remove support for rhel-10, because `MOCK_SERVICE_REPO` for RHEL10 is not present in repos.yaml and it may take time to make test running properly for rhel-10, so after discussion with team phoenix member I have decided to fix test only for rhel version 7,8, and 9. But adding support in the fixture which will handle rhel-10 compatibility as well.

### Solution
Based on network type we need to enable `ipv6 dnf and rhsm proxy` along with `ipv6 system proxy` on content host with  fixtures `enable_ipv6_dnf_and_rhsm_proxy()` and `enable_ipv6_system_proxy()`

### Related Issues
No

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k 'test_positive_tracer_list_and_resolve'
network_type: ipv6

```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->