### PR TITLE
Enable dnf and rhsm proxy for IPv6 insights client

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1193,6 +1193,9 @@ class ContentHost(Host, ContentHostMixins):
         else:
             self.create_custom_repos(**{rhel_distro: rhel_repo})
 
+        if not self.network_type.has_ipv4:
+            self.enable_ipv6_dnf_and_rhsm_proxy()
+
         # Ensure insights-client rpm is installed
         if self.execute('yum install -y insights-client').status != 0:
             raise ContentHostError('Unable to install insights-client rpm')


### PR DESCRIPTION
### Problem Statement
Many (parametrized) HTTP Proxy tests fail to setup the Insight client on the IPv6 network since they try to install it from an IPv4 hosted repo.


### Solution
Enable rhsm and dnf with IPv6 proxy so the client can be installed


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_http_proxy.py -k insights_client
network_type: ipv6
```
