### PR TITLE
[6.17.z] Setup RHSSO for the test

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2752,8 +2752,7 @@ class RHBKHost(SSOHost):
     """Class for RHBK functions and setup"""
 
     def __init__(self, sat_obj, **kwargs):
-        self.host_url = settings.rhbk.host_url
-        self.uri = self.host_url
+        self.uri = settings.rhbk.host_url
         self.host_name = settings.rhbk.host_name
         self.host_port = settings.rhbk.host_port
         self.realm = settings.rhbk.realm
@@ -2768,8 +2767,7 @@ class RHSSOHost(SSOHost):
     """Class for RHSSO functions and setup"""
 
     def __init__(self, sat_obj, **kwargs):
-        self.host_url = settings.rhsso.host_url
-        self.uri = self.host_url.replace("https://", "http://")
+        self.uri = settings.rhsso.host_url
         self.host_name = settings.rhsso.host_name
         self.host_port = 443
         self.realm = settings.rhsso.realm

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -600,7 +600,7 @@ def test_totp_user_login(
 
 
 def test_permissions_external_ldap_mapped_rhsso_group(
-    rhsso_setting_setup, ad_data, groups_teardown, module_target_sat
+    rhsso_setting_setup, enable_external_auth_rhsso, ad_data, groups_teardown, module_target_sat
 ):
     """Verify the usergroup permissions are synced correctly with LDAP usergroup mapped
         with the rhsso. The ldap user gets right permissions based on the role


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18612

### Problem Statement
`tests/foreman/destructive/test_ldap_authentication.py::test_permissions_external_ldap_mapped_rhsso_group` fails due to 3 reasons:
1) changed external user group dropdown locator, fixed in the Airgun PR
2) RHSSO not actually set up on the machine, fixed in this PR
3) RHSSO <-> AD federation configured in a way that didn't sync group membership, fixed manually

### Solution
This PR together with https://github.com/SatelliteQE/airgun/pull/1865 and fixing of federation setup
