### PR TITLE
Move this test to Platform team

### DIFF
--- a/tests/foreman/sys/test_webpack.py
+++ b/tests/foreman/sys/test_webpack.py
@@ -6,7 +6,7 @@
 
 :Requirement: Installation
 
-:Team: Endeavour
+:Team: Platform
 
 :CaseImportance: High
 


### PR DESCRIPTION
### Problem Statement
Team wasn't aligned with component

### Solution
This test for SAT-5741 is hard to assign a component but after some discussion, we decided to keep Installation (which now includes the Packaging component) and align a correct team to it which is currently Platform.