### PR TITLE
Remove workaround for JobTemplate clone for ansible tests

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -869,14 +869,7 @@ class TestAnsibleREX:
 
         if ansible_check_mode == 'True':
             cloned_template_name = gen_string('alpha')
-            # TODO: Using UI as workaround to clone a JobTemplate until SAT-34617 is fixed.
-            # og_template.clone(data={'name': cloned_template_name})
-            with target_sat.ui_session() as session:
-                session.organization.select(org_name=module_org.name)
-                session.location.select(loc_name=module_location.name)
-                session.jobtemplate.clone(
-                    default_template_name, {'template.name': cloned_template_name}
-                )
+            template.clone(data={'name': cloned_template_name})
             template = target_sat.api.JobTemplate().search(
                 query={'search': f'name="{cloned_template_name}"'}
             )[0]


### PR DESCRIPTION
### Problem Statement
We were using UI as workaround to clone a JobTemplate until SAT-34617 is fixed

### Solution
Remove workaround for JobTemplate clone for Ansible check-mode test to validate https://github.com/theforeman/foreman_remote_execution/pull/979

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->