### PR TITLE
skipping flaky tests

### DIFF
--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -279,6 +279,7 @@ def test_negative_update_url(url, request, module_target_sat, module_org, module
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
 @pytest.mark.rhel_ver_list('[9, 10]')
+@pytest.mark.skip(reason='The flaky test is skipped until support or a fix is implemented')
 def test_positive_provision_end_to_end(
     request,
     setting_update,

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -373,6 +373,7 @@ def test_positive_update_console_password(libvirt_url, set_console_password, mod
 @pytest.mark.rhel_ver_match('[7]')
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
+@pytest.mark.skip(reason='The flaky test is skipped until support or a fix is implemented')
 def test_positive_provision_end_to_end(
     request,
     pxe_loader,


### PR DESCRIPTION
We are currently experiencing instability in some tests. Although we attempted to address the issue with certain solutions, the tests continue to fail or behave inconsistently. Due to this flakiness, the team has decided to temporarily skip these tests to ensure more reliable overall results. However, we are actively working on resolving the root cause of the flaky behavior to ensure these tests can be re-enabled and consistently pass in the future.

