### PR TITLE
skip flaky IPv6 misc-provisioning tests

### DIFF
--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -68,6 +68,7 @@ def assert_host_logs(channel, pattern):
 @pytest.mark.on_premises_provisioning
 @pytest.mark.ipv6_provisioning
 @pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
+@pytest.mark.skip(reason='The flaky test is skipped until support or a fix is implemented')
 def test_rhel_pxe_provisioning(
     request,
     module_provisioning_sat,


### PR DESCRIPTION
We are currently experiencing instability in some tests. Although we attempted to address the issue with certain solutions, the tests continue to fail or behave inconsistently. Due to this flakiness, the team has decided to temporarily skip these tests to ensure more reliable overall results. However, we are actively working on resolving the root cause of the flaky behavior to ensure these tests can be re-enabled and consistently pass in the future.