### PR TITLE
Extend capsule flatpak endpint parametrization

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -782,7 +782,7 @@ class TestCapsuleContentManagement:
             assert b'katello-server-ca.crt' in response.content
 
     @pytest.mark.upgrade
-    @pytest.mark.parametrize('endpoint', ['pulpcore'])
+    @pytest.mark.parametrize('endpoint', ['pulpcore', 'katello'])
     def test_flatpak_endpoint(self, target_sat, module_capsule_configured, endpoint):
         """Ensure the Capsules's local flatpak index endpoint is up after install or upgrade.
 


### PR DESCRIPTION
### Problem Statement
We are extending the Capsule Flatpak endpoint by the one filtered by Katello. We already have a test for the pulpcore endpoint, now the time has come to extend it for the newly added endpoint too.


### Solution
This PR parametrizes the test to check both endpoints.
Another test case will be added for the CV/LCE filtering on the new endpoint once it's implemented.


### Requires
https://github.com/Katello/smart_proxy_container_gateway/pull/54
https://github.com/theforeman/puppet-foreman_proxy_content/pull/522


### Related Issues
https://issues.redhat.com/browse/SAT-30899


### PRT test Cases example
We are not able to use packit/PRT since the patch needs to be applied on the Capsule side.
However, locally it passed:
```
$ pytest tests/foreman/api/test_capsulecontent.py -k test_flatpak_endpoint
========================== test session starts ==========================
collected 31 items / 29 deselected / 2 selected

tests/foreman/api/test_capsulecontent.py ..                       [100%]

============= 2 passed, 29 deselected, 5 warnings in 42.68s =============
```