### PR TITLE
[6.17.z] Fix long hostnames during rename on IPv6

### DIFF
--- a/tests/foreman/destructive/test_rename.py
+++ b/tests/foreman/destructive/test_rename.py
@@ -66,7 +66,7 @@ def test_positive_rename_satellite(module_org, module_product, module_target_sat
     password = settings.server.admin_password
     old_hostname = module_target_sat.execute('hostname').stdout.strip()
     old_shortname, old_domain = old_hostname.split(".", 1)
-    new_hostname = f'{old_shortname}-changed.{old_domain}'
+    new_hostname = f'new-{gen_string("alpha").lower()}.{old_domain}'
     new_certs = [
         '/etc/foreman/client_cert.pem',
         '/etc/foreman-proxy/ssl_cert.pem',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18809

### Problem Statement
Linux hostnames have length limitation of 64 characters and during rename on IPv6 we exceed this limit

### Solution
Change how the new hostname is composed from the old one so that new hostname is almost the same lenght or even shorter.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->