### PR TITLE
[6.17.z] Remove pool attachment since we are SCA now

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -348,14 +348,6 @@ VERSIONED_REPOS = [
     'satellite-utils-{}-for-rhel-9-x86_64-rpms',
 ]
 
-SM_OVERALL_STATUS = {
-    'current': 'Overall Status: Current',
-    'invalid': 'Overall Status: Invalid',
-    'insufficient': 'Overall Status: Insufficient',
-    'disabled': 'Overall Status: Disabled',
-    'unknown': 'Overall Status: Unknown',
-}
-
 REPOS = {
     'rhel7': {
         'id': 'rhel-7-server-rpms',

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -48,7 +48,6 @@ from robottelo.constants import (
     RHSSO_RESET_PASSWORD,
     RHSSO_USER_UPDATE,
     SATELLITE_VERSION,
-    SM_OVERALL_STATUS,
 )
 from robottelo.enums import NetworkType
 from robottelo.exceptions import CLIFactoryError, DownloadFileError, HostPingFailed
@@ -540,17 +539,6 @@ class ContentHost(Host, ContentHostMixins):
             result = ' '.join(result).split()
             pool_ids.append(result)
         return pool_ids
-
-    def subscription_manager_attach_pool(self, pool_list=None):
-        """
-        Attach pool ids to the host and return the result
-        """
-        if pool_list is None:
-            pool_list = []
-        result = []
-        for pool in pool_list:
-            result.append(self.execute(f'subscription-manager attach --pool={pool}'))
-        return result
 
     @property
     def subscription_config(self):
@@ -1504,7 +1492,7 @@ class ContentHost(Host, ContentHostMixins):
         self.execute('katello-tracer-upload')
 
     def register_to_cdn(self, pool_ids=None):
-        """Subscribe satellite to CDN"""
+        """Register host to CDN"""
         self.reset_rhsm()
 
         # Enabling proxy for IPv6
@@ -1523,17 +1511,6 @@ class ContentHost(Host, ContentHostMixins):
             raise ContentHostError(
                 f'Error during registration, command output: {cmd_result.stdout}'
             )
-        # Attach a pool only if the Org isn't SCA yet
-        sub_status = self.subscription_manager_status().stdout
-        if SM_OVERALL_STATUS['disabled'] not in sub_status:
-            if pool_ids in [None, []]:
-                pool_ids = [settings.subscription.rhn_poolid]
-            for pid in pool_ids:
-                int(pid, 16)  # raises ValueError if not a HEX number
-            cmd_result = self.subscription_manager_attach_pool(pool_ids)
-            for res in cmd_result:
-                if res.status != 0:
-                    raise ContentHostError(f'Pool attachment failed with output: {res.stdout}')
 
     def ping_host(self, host):
         """Check the provisioned host status by pinging the ip of host


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18826

### Problem Statement
Our Sat QE org used to be in the entlitlement mode, but it seems it has been flipped to SCA recently.
In #16575 we added some conditioning for pool attachment based on the sub-man status. It worked well for RHEL 7, 8, 9, since they return
```
# subscription-manager status
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Disabled
Content Access Mode is set to Simple Content Access. This host has access to content, regardless of subscription status.
```

However, for RHEL 10 it fails since it returns
```
# subscription-manager status
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Registered
```


### Solution
Because our org is now SCA we don't need the conditioning anymore. This PR proposes to remove it completely.


### Testing
I've run this dummie locally:
```
@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
def test_dummie(rhel_contenthost):
    rhel_contenthost.register_to_cdn()
    rhel_contenthost.unregister()
```
It passed:
```
$ pytest tests/foreman/cli/test_host.py -k dummie
==================== test session starts ========================
collected 110 items / 106 deselected / 4 selected

tests/foreman/cli/test_host.py ....                       [100%]

=== 4 passed, 106 deselected, 6 warnings in 104.42s (0:01:44) ===
```

