### PR TITLE
[6.16.z] Remove pool attachment since we are SCA now

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -341,14 +341,6 @@ VERSIONED_REPOS = [
     'satellite-utils-{}-for-rhel-9-x86_64-rpms',  # 6.16+
 ]
 
-SM_OVERALL_STATUS = {
-    'current': 'Overall Status: Current',
-    'invalid': 'Overall Status: Invalid',
-    'insufficient': 'Overall Status: Insufficient',
-    'disabled': 'Overall Status: Disabled',
-    'unknown': 'Overall Status: Unknown',
-}
-
 REPOS = {
     'rhel7': {
         'id': 'rhel-7-server-rpms',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18826

### Problem Statement
Our Sat QE org used to be in the entlitlement mode, but it seems it has been flipped to SCA recently.
In #16575 we added some conditioning for pool attachment based on the sub-man status. It worked well for RHEL 7, 8, 9, since they return
```
# subscription-manager status
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Disabled
Content Access Mode is set to Simple Content Access. This host has access to content, regardless of subscription status.
```

However, for RHEL 10 it fails since it returns
```
# subscription-manager status
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Registered
```


### Solution
Because our org is now SCA we don't need the conditioning anymore. This PR proposes to remove it completely.


### Testing
I've run this dummie locally:
```
@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
def test_dummie(rhel_contenthost):
    rhel_contenthost.register_to_cdn()
    rhel_contenthost.unregister()
```
It passed:
```
$ pytest tests/foreman/cli/test_host.py -k dummie
==================== test session starts ========================
collected 110 items / 106 deselected / 4 selected

tests/foreman/cli/test_host.py ....                       [100%]

=== 4 passed, 106 deselected, 6 warnings in 104.42s (0:01:44) ===
```

