### PR TITLE
Fix test_positive_create_delete_image_libvirt_with_name

### DIFF
--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -486,10 +486,10 @@ def test_negative_create_libvirt_with_url(module_location, module_org, module_ta
         )
 
 
-def test_positive_add_image_libvirt_with_name(
+def test_positive_create_delete_image_libvirt_with_name(
     module_location, module_org, module_target_sat, module_os
 ):
-    """Add images to the libvirt compute resource
+    """Create/Delete images on the libvirt compute resource
 
     :id: 2da84165-a56f-4282-9343-94828fa69c13
 
@@ -498,7 +498,7 @@ def test_positive_add_image_libvirt_with_name(
         2. Create a image for the compute resource with valid parameter,
            compute-resource image create
 
-    :expectedresults: The image is added to the CR successfully
+    :expectedresults: The image is created and deleted on the CR successfully
     """
     cr_name = gen_string('alpha')
     comp_res = module_target_sat.cli_factory.compute_resource(
@@ -534,7 +534,7 @@ def test_positive_add_image_libvirt_with_name(
     result = module_target_sat.cli.ComputeResource.image_delete(
         {'name': img_name, 'compute-resource': cr_name}
     )
-    assert result['message'] == 'Image deleted.'
+    assert result[0]['message'] == 'Image deleted.'
 
 
 @pytest.mark.stubbed


### PR DESCRIPTION
### Problem Statement
```
tests/foreman/cli/test_computeresource_libvirt.py:537: in test_positive_add_image_libvirt_with_name
    assert result['message'] == 'Image deleted.'
           ^^^^^^^^^^^^^^^^^
E   TypeError: list indices must be integers or slices, not str
```

### Solution
Fixing and renaming the test as test_positive_create_delete_image_libvirt_with_name

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->