### PR TITLE
[6.17.z] Skip FAM tests relying on non-existent setups

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -215,6 +215,13 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
 
     :expectedresults: All modules and roles run successfully
     """
+    # Skip crazy FAM tests w/o proper setups
+    if ansible_module in [
+        "host_power",  # this test tries to power off non-existent VM
+        "realm",  # realm feature is not set up on Capsule
+    ]:
+        pytest.skip(f"{ansible_module} module test lacks proper setup")
+
     # Skip oVirt/RHV tests on IPv6 setups
     if module_target_sat.network_type == NetworkType.IPV6 and ansible_module in [
         'compute_profile_ovirt'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18756

### Problem Statement
Some FAM tests relies on setups that are not set up anywhere

### Solution
Skip crazy FAM tests

### Related Issues
[SAT-35471](https://issues.redhat.com/browse/SAT-35471)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->