### PR TITLE
failing assertion for not having 'python3.12-requests'

### DIFF
--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -132,11 +132,12 @@ def test_positive_facts_end_to_end(
     }
     if not is_open('SAT-27056'):
         expected_values['net::interface::eth1::mac_address'] = mac_address.lower()
-    for fact, expected_value in expected_values.items():
-        actual_value = facts_dict.get(fact)
-        assert actual_value == expected_value, (
-            f'Assertion failed: {fact} (expected: {expected_value}, actual: {actual_value})'
-        )
+    if not is_open('SAT-35460'):
+        for fact, expected_value in expected_values.items():
+            actual_value = facts_dict.get(fact)
+            assert actual_value == expected_value, (
+                f'Assertion failed: {fact} (expected: {expected_value}, actual: {actual_value})'
+            )
 
 
 @pytest.mark.rhel_ver_match('N-1')


### PR DESCRIPTION
The package `python3.12-requests` is not installed on version 6.17z, which prevents Ansible facts from being retrieved. As a result, a portion of the test is being skipped to avoid assertion failures