### PR TITLE
[6.16.z] Skip FAM tests relying on non-existent setups (#18756)

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -206,6 +206,13 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
 
     :expectedresults: All modules and roles run successfully
     """
+    # Skip crazy FAM tests w/o proper setups
+    if ansible_module in [
+        "host_power",  # this test tries to power off non-existent VM
+        "realm",  # realm feature is not set up on Capsule
+    ]:
+        pytest.skip(f"{ansible_module} module test lacks proper setup")
+
     # Setup provisioning resources
     if ansible_module in FAM_TEST_LIBVIRT_PLAYBOOKS:
         module_target_sat.configure_libvirt_cr()


### PR DESCRIPTION
Cherrypicks #18756 to `6.16.z`
(cherry picked from commit 4ab2c3cabee53740ff16318ae8e1a401cf2676ad)

Fixes #18841

### Related Issues
[SAT-35471](https://issues.redhat.com/browse/SAT-35471)


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->