### PR TITLE
Skip FAM compute_profile_ovirt due to removed support in 6.18+

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -25,7 +25,6 @@ from robottelo.constants import (
     FOREMAN_ANSIBLE_MODULES,
     RH_SAT_ROLES,
 )
-from robottelo.enums import NetworkType
 
 
 @pytest.fixture
@@ -235,11 +234,9 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
     ]:
         pytest.skip(f"{ansible_module} module test lacks proper setup")
 
-    # Skip oVirt/RHV tests on IPv6 setups
-    if module_target_sat.network_type == NetworkType.IPV6 and ansible_module in [
-        'compute_profile_ovirt'
-    ]:
-        pytest.skip("oVirt/RHV is not properly set up in IPv6 environment")
+    # RHV/oVirt support removed in SAC for 6.18+
+    if ansible_module == "compute_profile_ovirt":
+        pytest.skip("oVirt/RHV support is removed for 6.18+")
 
     # Setup provisioning resources
     if ansible_module in FAM_TEST_LIBVIRT_PLAYBOOKS:


### PR DESCRIPTION
### Problem Statement
Downstream has removed support for RHV/oVirt in 6.18 but related tests cannot be removed since upstream continues to support oVirt.

### Solution
The `compute_profile_ovirt` test has to be kept for upstream testing in FAM so the solution is to skip running the test within robottelo for 6.18 onwards.

### Related Issues
[SAT-35492](https://issues.redhat.com/browse/SAT-35492)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->