### PR TITLE
Remove CODEOWNERS file during auto-branching GHA

### DIFF
--- a/.github/workflows/auto_branching.yml
+++ b/.github/workflows/auto_branching.yml
@@ -104,6 +104,11 @@ jobs:
             rm -rf ./.github/workflows/dispatch_release.yml
             rm -rf ./.github/workflows/auto_branching.yml
 
+      - name: Remove CODEOWNERS
+        id: remove-codeowners
+        run: |
+            rm -f ./.github/CODEOWNERS
+
       - name: Remove lines with @pytest.mark.stream
         id: remove-mark-stream
         run: |


### PR DESCRIPTION
### Problem Statement
Auto-cherrypicked PRs to new/existing zstream versions would automatically request reviews from CODEOWNERS and also send out emails, which can create unnecessary noise

### Solution
Adding step to remove CODEOWNERS from new zstream version branch, since PRs are reviewed in master branch already

### Related Issues
Manually removing CODEOWNERS file for existing branches,
https://github.com/SatelliteQE/robottelo/pull/18855
https://github.com/SatelliteQE/robottelo/pull/18856
https://github.com/SatelliteQE/robottelo/pull/18857 