### PR TITLE
Disassociate Hosts Coverage [SAT-31029]

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -3018,7 +3018,6 @@ def test_disassociate_multiple_hosts(
     """
 
     cr_name = gen_string('alpha')
-    hostgroup_name = gen_string('alpha')
 
     # create entities for hostgroup
     target_sat.api.SmartProxy(


### PR DESCRIPTION
### Problem Statement
There is a new feature that enables users to disassociate multiple hosts via the All Hosts page. (SAT-31029)

### Solution
Create a test `test_disassociate_multiple_hosts` that covers this use case.

It creates a VMware compute resource, imports 2 VMs,
(Thank you @Gauravtalreja1  for the info on how to do that, this part of the test is inspired by `test_positive_virt_card`)
and disassociates them via the UI.
Checks that the disassociation went well are done via the API, and they are checking values based on this https://github.com/theforeman/foreman/blob/f4246cdaca1d0039d93de65cda9e52862c02f81b/app/models/host/managed.rb#L589

<img width="209" alt="image" src="https://github.com/user-attachments/assets/64d852c7-2c1c-4fea-879a-1bdb102fc837" />

### Related Issues
Needs:
https://github.com/SatelliteQE/airgun/pull/1909
https://github.com/theforeman/foreman/pull/10560

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_disassociate_multiple_hosts'
airgun: 1909
theforeman:
    foreman: 10560
```