### PR TITLE
[6.16.z] Fix capsule repos constant name

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1554,7 +1554,7 @@ class ContentHost(Host, ContentHostMixins):
         """
         if settings.capsule.version.source == "ga":
             # enable cdn repos
-            for repo in self.SATELLITE_CDN_REPOS.values():
+            for repo in self.CAPSULE_CDN_REPOS.values():
                 result = self.enable_repo(repo, force=True)
                 if result.status:
                     raise ContentHostError(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18869

We have to  use CAPSULE_CDN_REPOS when setting up Capsule repos