### PR TITLE
Remove compute_profile_ovirt from FAM playbooks

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2124,7 +2124,6 @@ FAM_TEST_PLAYBOOKS = [
     "auth_sources_ldap_role",
     "bookmark",
     "compute_attribute",
-    "compute_profile_ovirt",
     "compute_profiles_role",
     "compute_profile",
     "compute_resources_role",

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -234,10 +234,6 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
     ]:
         pytest.skip(f"{ansible_module} module test lacks proper setup")
 
-    # RHV/oVirt support removed in SAC for 6.18+
-    if ansible_module == "compute_profile_ovirt":
-        pytest.skip("oVirt/RHV support is removed for 6.18+")
-
     # Setup provisioning resources
     if ansible_module in FAM_TEST_LIBVIRT_PLAYBOOKS:
         module_target_sat.configure_libvirt_cr()


### PR DESCRIPTION
### Problem Statement
Support for RHV/oVirt is removed in 6.18 for downstream and removed for the 3.16 release in upstream as well

### Solution
Remove compute_profile_ovirt from FAM playbooks 

### Related Issues
Followup PR of https://github.com/SatelliteQE/robottelo/pull/18847

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->