### PR TITLE
Small Selenium Grid video cleanup fix

### DIFF
--- a/pytest_plugins/video_cleanup.py
+++ b/pytest_plugins/video_cleanup.py
@@ -19,10 +19,9 @@ test_directories = [
 def _clean_video(session_id, test):
     if settings.ui.record_video:
         logger.info(f"cleaning up video files for session: {session_id} and test: {test}")
-
         if settings.ui.grid_url and session_id:
             grid = urlparse(url=settings.ui.grid_url)
-            infra_grid = Host(hostname=grid.hostname)
+            infra_grid = Host(hostname=grid.hostname, ipv6=settings.server.network_type)
             infra_grid.execute(command=f'rm -rf /var/www/html/videos/{session_id}')
             logger.info(f"video cleanup for session {session_id} is complete")
         else:

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -483,3 +483,8 @@ def test_insights_registration_with_capsule(
         # Verify that Insights status again.
         values = session.host_new.get_host_statuses(rhel_contenthost.hostname)
         assert values['Insights']['Status'] == 'Reporting'
+
+
+def test_gorp(module_target_sat_insights):
+    with module_target_sat_insights.ui_session() as session:
+        session.organization.select(org_name="Default Organization")


### PR DESCRIPTION
Specify network type when running cleanup command on grid server.

### Problem Statement

- 

### Solution

-

### Related Issues



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->