### PR TITLE
[6.16.z] Update team component ownership: Phoenix-content -> Endeavor

### DIFF
--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -4,7 +4,7 @@
 
 :CaseComponent: HTTPProxy
 
-:team: Phoenix-content
+:team: Endeavour
 
 :CaseImportance: High
 

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -4,7 +4,7 @@
 
 :CaseComponent: HTTPProxy
 
-:team: Phoenix-content
+:team: Endeavour
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -4,7 +4,7 @@
 
 :CaseComponent: HTTPProxy
 
-:team: Phoenix-content
+:team: Endeavour
 
 :CaseImportance: High
 


### PR DESCRIPTION
(cherry picked from commit 620a8128a395abbe58131c10217a3fc36bfe051c)

Parent PR https://github.com/SatelliteQE/robottelo/pull/18893

### Problem Statement
Endeavor team is going to own the Http Proxy component.

### Solution
Update component ownership accordingly