### PR TITLE
skipping vmware flaky tests

### DIFF
--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -163,6 +163,7 @@ def test_positive_provision_end_to_end(
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
 @pytest.mark.rhel_ver_match('[8]')
+@pytest.mark.skip_if_open('SAT-35643')
 def test_positive_image_provision_end_to_end(
     request,
     setting_update,


### PR DESCRIPTION
We are currently experiencing instability in some tests. Although we attempted to address the issue with certain solutions, the tests continue to fail or behave inconsistently. Due to this flakiness, the team has decided to temporarily skip these tests to ensure more reliable overall results. However, we are actively working on resolving the root cause of the flaky behavior to ensure these tests can be re-enabled and consistently pass in the future.