### PR TITLE
fixing a typo in capsule mixins

### DIFF
--- a/robottelo/host_helpers/capsule_mixins.py
+++ b/robottelo/host_helpers/capsule_mixins.py
@@ -212,11 +212,13 @@ class CapsuleInfo:
         if len(result) > 0:
             assert (
                 self.execute(
-                    f'firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 1 -d ${result} -j REJECT && firewall-cmd --reload'
+                    f'firewall-cmd --permanent --direct --add-rule ipv4 filter OUTPUT 1 -d {result} -j REJECT && firewall-cmd --reload'
                 ).status
                 == 0
             )
-        assert self.execute(f'ping -c 2 {hostname}').status != 0
+        assert self.execute(f'ping -c 2 {hostname}').status != 0, (
+            "the connection was not succesfully disabled"
+        )
         return old_log
 
     def restore_host_check_log(self, proxy_hostname, hostname, old_log):


### PR DESCRIPTION
### Problem Statement
this slipped trough in https://github.com/SatelliteQE/robottelo/pull/18520 humbly offering this fix

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->