### PR TITLE
moving usage report test back to endeavour

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -181,7 +181,6 @@ tests/foreman/cli/test_subnet.py @SatelliteQE/team-rocket
 tests/foreman/destructive/test_clone.py @SatelliteQE/team-rocket
 tests/foreman/destructive/test_discoveredhost.py @SatelliteQE/team-rocket
 tests/foreman/destructive/test_fm_upgrade.py @SatelliteQE/team-rocket
-tests/foreman/cli/test_usage_report.py @SatelliteQE/team-rocket
 tests/foreman/destructive/test_ping.py @SatelliteQE/team-rocket
 tests/foreman/destructive/test_infoblox.py @SatelliteQE/team-rocket
 tests/foreman/destructive/test_installer.py @SatelliteQE/team-rocket
@@ -262,6 +261,7 @@ tests/foreman/cli/test_remoteexecution.py @SatelliteQE/team-endeavour
 tests/foreman/cli/test_role.py @SatelliteQE/team-endeavour
 tests/foreman/cli/test_sso.py @SatelliteQE/team-endeavour
 tests/foreman/cli/test_templatesync.py @SatelliteQE/team-endeavour
+tests/foreman/cli/test_usage_report.py @SatelliteQE/team-endeavour
 tests/foreman/cli/test_user.py @SatelliteQE/team-endeavour
 tests/foreman/cli/test_usergroup.py @SatelliteQE/team-endeavour
 tests/foreman/cli/test_webhook.py @SatelliteQE/team-endeavour

--- a/tests/foreman/cli/test_usage_report.py
+++ b/tests/foreman/cli/test_usage_report.py
@@ -4,9 +4,9 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hammer
+:CaseComponent: Reporting
 
-:Team: Rocket
+:Team: Endeavour
 
 :CaseImportance: Critical
 


### PR DESCRIPTION
### Problem Statement
I realized it would be practical to keep this test, the hammer component selection was kind of arbitrary anyway, reporting is a better match and it belongs to Endeavour now, so it comes together rather nicely

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->