### PR TITLE
Fix parametrization of multiple content host fixtures

### DIFF
--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -23,7 +23,7 @@ TARGET_FIXTURES = {
 
 def pytest_generate_tests(metafunc):
     # ContentHost fixtures parametrization
-    if content_host_fixtures := TARGET_FIXTURES.intersection(metafunc.fixturenames)
+    if content_host_fixtures := TARGET_FIXTURES.intersection(metafunc.fixturenames):
         function_marks = getattr(metafunc.function, 'pytestmark', [])
         no_containers = any(mark.name == 'no_containers' for mark in function_marks)
         # process eventual rhel_version_list markers

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -6,7 +6,7 @@ import pytest
 from robottelo.config import settings
 from robottelo.enums import NetworkType
 
-TARGET_FIXTURES = [
+TARGET_FIXTURES = {
     'rhel_contenthost',
     'rhel_contenthost_with_repos',
     'module_rhel_contenthost',
@@ -18,12 +18,13 @@ TARGET_FIXTURES = [
     'rex_contenthost',
     'rex_contenthosts',
     'module_flatpak_contenthost',
-]
+}
 
 
 def pytest_generate_tests(metafunc):
-    content_host_fixture = ''.join([i for i in TARGET_FIXTURES if i in metafunc.fixturenames])
-    if content_host_fixture in metafunc.fixturenames:
+    # ContentHost fixtures parametrization
+    content_host_fixtures = TARGET_FIXTURES.intersection(metafunc.fixturenames)
+    if content_host_fixtures:
         function_marks = getattr(metafunc.function, 'pytestmark', [])
         no_containers = any(mark.name == 'no_containers' for mark in function_marks)
         # process eventual rhel_version_list markers
@@ -119,12 +120,13 @@ def pytest_generate_tests(metafunc):
                 ids = [f"rhel{param['rhel_version']}-{param['network']}" for param in rhel_params]
 
         if rhel_params:
-            metafunc.parametrize(
-                content_host_fixture,
-                rhel_params,
-                ids=ids,
-                indirect=True,
-            )
+            for fixture in content_host_fixtures:
+                metafunc.parametrize(
+                    fixture,
+                    rhel_params,
+                    ids=ids,
+                    indirect=True,
+                )
 
     # satellite-maintain capsule parametrization
     if 'sat_maintain' in metafunc.fixturenames:

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -23,8 +23,7 @@ TARGET_FIXTURES = {
 
 def pytest_generate_tests(metafunc):
     # ContentHost fixtures parametrization
-    content_host_fixtures = TARGET_FIXTURES.intersection(metafunc.fixturenames)
-    if content_host_fixtures:
+    if content_host_fixtures := TARGET_FIXTURES.intersection(metafunc.fixturenames)
         function_marks = getattr(metafunc.function, 'pytestmark', [])
         no_containers = any(mark.name == 'no_containers' for mark in function_marks)
         # process eventual rhel_version_list markers


### PR DESCRIPTION
### Problem Statement
Capsule LB setup on IPv6 is failing to correctly parametrize `module_rhel_contenthost` for IPv6 so IPv4 host is created instead:
```
[Errno -5] No address associated with hostname
```

If there are multiple fixtures for the test to be parametrized they are not recognized and all parametrization is skipped.


### Solution
Fix ContentHost fixtures parametrization logic and allow multiple fixtures to be parametrized

### Related Issues
[SAT-35599](https://issues.redhat.com/browse/SAT-35599)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->