### PR TITLE
Fix host asserts for CV and LCE

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -375,13 +375,11 @@ def test_positive_create_and_delete(target_sat, module_lce_library, module_publi
     assert f'{name}.{host.domain.read().name}' == new_host['name']
     assert new_host['organization']['name'] == host.organization.name
     assert (
-        new_host['content-information']['content-view-environments']['1']['content-view']['name']
+        new_host['content-information']['content-view-environments']['1']['cv-name']
         == module_published_cv.name
     )
     assert (
-        new_host['content-information']['content-view-environments']['1']['lifecycle-environment'][
-            'name'
-        ]
+        new_host['content-information']['content-view-environments']['1']['le-name']
         == module_lce_library.name
     )
     host_interface = target_sat.cli.HostInterface.info(
@@ -540,13 +538,11 @@ def test_positive_create_with_lce_and_cv(
         }
     )
     assert (
-        new_host['content-information']['content-view-environments']['1']['lifecycle-environment'][
-            'name'
-        ]
+        new_host['content-information']['content-view-environments']['1']['le-name']
         == module_lce.name
     )
     assert (
-        new_host['content-information']['content-view-environments']['1']['content-view']['name']
+        new_host['content-information']['content-view-environments']['1']['cv-name']
         == module_promoted_cv.name
     )
 
@@ -744,15 +740,11 @@ def test_positive_create_inherit_lce_cv(
         {'hostgroup-id': hostgroup.id, 'organization-id': module_org.id}
     )
     assert (
-        int(
-            host['content-information']['content-view-environments']['1']['lifecycle-environment'][
-                'id'
-            ]
-        )
+        int(host['content-information']['content-view-environments']['1']['le-id'])
         == hostgroup.lifecycle_environment.id
     )
     assert (
-        int(host['content-information']['content-view-environments']['1']['content-view']['id'])
+        int(host['content-information']['content-view-environments']['1']['cv-id'])
         == hostgroup.content_view.id
     )
 
@@ -866,21 +858,12 @@ def test_positive_list_with_nested_hostgroup(target_sat):
     logger.info(f'Host info: {host}')
     assert host['operating-system']['medium']['name'] == options.medium.name
     assert host['operating-system']['partition-table']['name'] == options.ptable.name  # inherited
-    if not target_sat.is_stream:
-        assert (
-            'id'
-            in host['content-information']['content-view-environments']['1'][
-                'lifecycle-environment'
-            ]
-        )
-        assert int(
-            host['content-information']['content-view-environments']['1']['lifecycle-environment'][
-                'id'
-            ]
-        ) == int(lce.id)
-        assert int(
-            host['content-information']['content-view-environments']['1']['content-view']['id']
-        ) == int(content_view.id)  # inherited
+    assert int(host['content-information']['content-view-environments']['1']['le-id']) == int(
+        lce.id
+    )
+    assert int(host['content-information']['content-view-environments']['1']['cv-id']) == int(
+        content_view.id
+    )  # inherited
 
 
 @pytest.mark.cli_host_create


### PR DESCRIPTION
### Problem Statement
Assertions in host tests started to fail when https://github.com/Katello/hammer-cli-katello/pull/994 was merged, and needed a update to the existing CV and LCE fields

### Solution
some assertions fixed as per new change

### Related Issues
It works for https://github.com/SatelliteQE/robottelo/pull/18934