### PR TITLE
Skip FM upgrade test as IPv6 can't be disabled on IPv6-only setup

### DIFF
--- a/tests/foreman/destructive/test_fm_upgrade.py
+++ b/tests/foreman/destructive/test_fm_upgrade.py
@@ -14,9 +14,16 @@
 
 import pytest
 
+from robottelo.config import settings
+from robottelo.enums import NetworkType
+
 pytestmark = pytest.mark.destructive
 
 
+@pytest.mark.skipif(
+    settings.server.network_type == NetworkType.IPV6,
+    reason='Skipping as IPv6 cannot be disabled on IPv6-only setup',
+)
 @pytest.mark.include_capsule
 def test_negative_ipv6_update_check(sat_maintain):
     """Ensure update check and satellite-installer fails when ipv6.disable=1 in boot options


### PR DESCRIPTION
### Problem Statement
Currently, we add `ipv6.disable=1` to grub boot options as part of `test_negative_ipv6_update_check` and reboot, where setup would never boot again and causes test to fail

### Solution
Skipping FM upgrade test as IPv6 can't be disabled on IPv6-only setup

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->