### PR TITLE
[6.17.z] Remove obsolete or unused pytest markers

### DIFF
--- a/pytest_plugins/infra_dependent_markers.py
+++ b/pytest_plugins/infra_dependent_markers.py
@@ -5,10 +5,7 @@ def pytest_configure(config):
     """Register custom markers to avoid warnings."""
     markers = [
         "on_premises_provisioning: Tests that runs on on_premises Providers",
-        "ipv6_provisioning: Tests for IPv6 provisioning"
-        "libvirt_discovery: Tests depends on Libvirt Provider for discovery",
-        "external_auth: External Authentication tests",
-        "vlan_networking: Tests depends on static predefined vlan networking etc",
+        "ipv6_provisioning: Tests for IPv6 provisioning",
     ]
     for marker in markers:
         config.addinivalue_line("markers", marker)

--- a/pytest_plugins/marker_deselection.py
+++ b/pytest_plugins/marker_deselection.py
@@ -36,9 +36,6 @@ def pytest_collection_modifyitems(items, config):
     """
     include_onprem_provision = config.getoption('include_onprem_provisioning', False)
     include_ipv6_provisioning = config.getoption('include_ipv6_provisioning', False)
-    include_libvirt = config.getoption('include_libvirt', False)
-    include_eauth = config.getoption('include_external_auth', False)
-    include_vlan = config.getoption('include_vlan_networking', False)
     include_non_satci_tests = config.getvalue('include_non_satci_tests').split(',')
 
     selected = []
@@ -63,18 +60,6 @@ def pytest_collection_modifyitems(items, config):
         # Include / Exclude IPv6 Provisioning Tests
         if 'ipv6_provisioning' in item_marks:
             selected.append(item) if include_ipv6_provisioning else deselected.append(item)
-            continue
-        # Include / Exclude External Libvirt based Tests
-        if 'libvirt_discovery' in item_marks:
-            selected.append(item) if include_libvirt else deselected.append(item)
-            continue
-        # Include / Exclude External Auth based Tests
-        if 'external_auth' in item_marks:
-            selected.append(item) if include_eauth else deselected.append(item)
-            continue
-        # Include / Exclude VLAN networking based Tests
-        if 'vlan_networking' in item_marks:
-            selected.append(item) if include_vlan else deselected.append(item)
             continue
         # This Plugin does not applies to this test
         selected.append(item)

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -260,7 +260,6 @@ def test_positive_add_and_remove_hostgroups(module_org, module_target_sat):
 
 
 @pytest.mark.skip_if_not_set('libvirt')
-@pytest.mark.libvirt_discovery
 @pytest.mark.upgrade
 def test_positive_add_and_remove_compute_resources(module_org, module_target_sat):
     """Add and remove a compute resource from organization

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -321,7 +321,6 @@ def apply_policy_run_scan_get_arf(target_sat, contenthost):
     return target_sat.execute(f'cat {arf_report_path}').stdout
 
 
-@pytest.mark.tier4
 @pytest.mark.rhel_ver_match('9')
 def test_positive_oscap_update_default_content(
     module_org,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18892

### Problem Statement
We started seeing pytest warnings related to `libvirt_discovery` after a missing comma in `pytest_plugins/infra_dependent_markers.py`, my bad! Upon investigation, I realized that a few of existing pytest markers are obsolete or no longer in use.
And, use of `tier` markers were removed in https://github.com/SatelliteQE/robottelo/pull/17809 already.
```
21:26:20  tests/foreman/cli/test_organization.py:263
21:26:20    /opt/app-root/src/robottelo/tests/foreman/cli/test_organization.py:263: PytestUnknownMarkWarning: Unknown pytest.mark.libvirt_discovery - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
21:26:20      @pytest.mark.libvirt_discovery
21:26:20  
21:26:20  tests/foreman/longrun/test_oscap.py:324
21:26:20    /opt/app-root/src/robottelo/tests/foreman/longrun/test_oscap.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.tier4 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
21:26:20      @pytest.mark.tier4
21:26:20  
21:26:20  -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

### Solution
Removing those obsolete or unused pytest markers and updating tests

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->