### PR TITLE
[6.17.z] Fix installer tuning test parametrization for IPv6 run

### DIFF
--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -65,10 +65,12 @@ def test_positive_repositories_validate(sat_maintain):
         {
             'deploy_rhel_version': settings.server.version.rhel_version,
             'deploy_flavor': 'satqe-ssd.disk.xxxl',
+            'deploy_network_type': settings.server.network_type,
         },
         {
             'deploy_rhel_version': settings.server.version.rhel_version,
             'deploy_flavor': 'satqe-ssd.standard.std',
+            'deploy_network_type': settings.server.network_type,
         },
     ],
     ids=['default', 'medium'],
@@ -91,6 +93,7 @@ def test_negative_pre_update_tuning_profile_check(request, custom_host):
     sat_version = ".".join(settings.server.version.release.split('.')[0:2])
     # Register to CDN for RHEL repos, download and enable ohsnap repos,
     # and enable the satellite module and install it on the host
+    custom_host.enable_ipv6_dnf_and_rhsm_proxy()
     custom_host.register_to_cdn()
     custom_host.download_repofile(product='satellite', release=sat_version)
     custom_host.install_satellite_or_capsule_package()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18947

### Problem Statement
`deploy_network_type` is missing in the parametrization for custom_host fixture used for `test_negative_pre_update_tuning_profile_check`, and proxy setup will be also required later to install sat/cap packages

### Solution
Add `deploy_network_type` to the parametrization for custom_host fixture and configure http_proxy for IPv6 run

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->