### PR TITLE
Add tests for transient-install feature

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2355,6 +2355,14 @@ DUMMY_BOOTC_FACTS = """{
   "bootc.available.digest": null
 }"""
 
+OSCAP_PLUGIN_REPO = """[oscap-plugin]
+name=foreman-plugins-latest
+baseurl=https://yum.theforeman.org/client/latest/el10/x86_64
+enabled=1
+gpgcheck=0
+gpgkey=https://yum.theforeman.org/RPM-GPG-KEY-foreman
+state=absent"""
+
 
 # Data File Paths
 class DataFile(Box):

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -24,8 +24,14 @@ from nailgun import client
 import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.config import get_credentials
-from robottelo.constants import DEFAULT_CV, DUMMY_BOOTC_FACTS, ENVIRONMENT
+from robottelo.config import get_credentials, settings
+from robottelo.constants import (
+    DEFAULT_CV,
+    DUMMY_BOOTC_FACTS,
+    ENVIRONMENT,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_7_CUSTOM_PACKAGE,
+)
 from robottelo.utils import datafactory
 
 
@@ -1072,6 +1078,465 @@ def test_positive_bootc_api_actions(target_sat, bootc_host, function_ak_with_cv,
         == bootc_dummy_info['bootc.booted.digest']
     )
     assert bootc_image_info['digests'][0]['host_count'] > 0
+
+
+@pytest.mark.parametrize(
+    'function_repos_collection_with_manifest',
+    [
+        {
+            'distro': 'rhel10',
+            'YumRepository': [
+                {'url': settings.repos.yum_3.url},
+                {'url': settings.repos.yum_1.url},
+                {'url': settings.repos.yum_6.url},
+            ],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+def test_mixed_usr_overlay_transient_templates(
+    target_sat, bootc_host, function_repos_collection_with_manifest
+):
+    """Verify that you can run an Ansible REX playbook after previously installing a package
+    with the --transient flag.
+
+    :id: e400d595-c503-492c-a922-d9b652558605
+
+    :steps:
+        1.Create and register a bootc host.
+        2.Install a package using --transient flag
+        3.Install a package via Ansible REX.
+
+    :expectedresults: Both templates install successfully when run in sequence.
+
+    :CaseComponent:Hosts-Content
+
+    :Verifies:SAT-31226, SAT-31580
+
+    :Team: Phoenix-content
+    """
+    bootc_host.add_rex_key(target_sat)
+    function_repos_collection_with_manifest.setup_virtual_machine(bootc_host)
+    assert bootc_host.subscribed
+
+    # Enable custom repo
+    bootc_host.add_rex_key(target_sat)
+    result = bootc_host.execute(r'dnf config-manager --enable \*')
+    assert result.status == 0
+
+    # Install a package transiently
+    result = bootc_host.execute(r'dnf --transient -y install rabbit')
+    assert result.status == 0
+
+    # Install package via Ansible REX, which attempts to enable bootc usr-overlay
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Package Action - Ansible Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'state': 'latest',
+                'name': 'tapir',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = bootc_host.execute('rpm -q tapir')
+    assert result.status == 0
+
+
+@pytest.mark.parametrize(
+    'function_repos_collection_with_manifest',
+    [
+        {
+            'distro': 'rhel10',
+            'YumRepository': [
+                {'url': settings.repos.yum_3.url},
+                {'url': settings.repos.yum_1.url},
+                {'url': settings.repos.yum_6.url},
+            ],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+def test_bootc_ansible_rex_package_install(
+    target_sat, bootc_host, function_repos_collection_with_manifest
+):
+    """Create a bootc host, and verify that you can install/remove a package via the Ansible REX templates
+
+    :id: 43651f48-40e7-49a5-a686-4ee48947e2f2
+
+    :steps:
+        1.Create and register a bootc host.
+        2.Install a package via REX Ansible
+        3.Remove the package via REX Ansible.
+
+    :expectedresults: All REX Ansible templates actions succeed when run against a bootc host.
+
+    :CaseComponent:Hosts-Content
+
+    :Verifies:SAT-31580
+
+    :Team: Phoenix-content
+    """
+    bootc_host.add_rex_key(target_sat)
+    function_repos_collection_with_manifest.setup_virtual_machine(bootc_host)
+    assert bootc_host.subscribed
+
+    # Enable custom repo
+    bootc_host.add_rex_key(target_sat)
+    result = bootc_host.execute(r'dnf config-manager --enable \*')
+    assert result.status == 0
+
+    # Install package via Ansible REX
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Package Action - Ansible Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'state': 'latest',
+                'name': 'tapir',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = bootc_host.execute('rpm -q tapir')
+    assert result.status == 0
+
+    # Remove package via Ansible REX
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Package Action - Ansible Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'state': 'absent',
+                'name': 'tapir',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = bootc_host.execute('rpm -q tapir')
+    assert result.status == 1
+
+
+@pytest.mark.parametrize(
+    'function_repos_collection_with_manifest',
+    [
+        {
+            'distro': 'rhel10',
+            'YumRepository': [
+                {'url': settings.repos.yum_3.url},
+                {'url': settings.repos.yum_1.url},
+                {'url': settings.repos.yum_6.url},
+            ],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+def test_bootc_rex_package_install(target_sat, bootc_host, function_repos_collection_with_manifest):
+    """Create a bootc host, and verify that you can install a package via various REX templates
+
+    :id: 72466622-3f9f-445b-9e39-f4d344df44fb
+
+    :steps:
+        1.Create and register a bootc host.
+        2.Enable a custom package on the host.
+        3.Install a package by name search and by id.
+        4.Remove the packages installed above
+        5.Install a package group
+
+    :expectedresults: All katello package template actions succeed when run against a bootc host.
+
+    :CaseComponent:Hosts-Content
+
+    :Verifies:SAT-31226
+
+    :Team: Phoenix-content
+    """
+    bootc_host.add_rex_key(target_sat)
+    function_repos_collection_with_manifest.setup_virtual_machine(bootc_host)
+    assert bootc_host.subscribed
+
+    # Enable custom repo
+    bootc_host.add_rex_key(target_sat)
+    result = bootc_host.execute(r'dnf config-manager --enable \*')
+    assert result.status == 0
+
+    # Install package by search query
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(
+            query={'search': 'name="Install packages by search query - Katello Script Default"'}
+        )[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'Package search query': '^(rabbit)',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = bootc_host.execute('rpm -q rabbit')
+    assert result.status == 0
+
+    # Remove package by search query
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(
+            query={'search': 'name="Remove Packages by search query - Katello Script Default"'}
+        )[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'Packages search query': '^(rabbit)',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = bootc_host.execute('rpm -q rabbit')
+    assert result.status == 1
+
+    # Install package by ID
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Install Package - Katello Script Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'package': 'tapir',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = bootc_host.execute('rpm -q tapir')
+    assert result.status == 0
+
+    # Update package
+    bootc_host.execute('dnf --transient -y downgrade tapir')
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Update Package - Katello Script Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'package': 'tapir',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = bootc_host.execute('rpm -q tapir')
+    assert result.status == 0
+
+    # Remove package by ID
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Remove Package - Katello Script Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'package': 'tapir',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = bootc_host.execute('rpm -q tapir')
+    assert result.status == 1
+
+    # Install package group
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Install Group - Katello Script Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'package': 'birds',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = bootc_host.execute('dnf grouplist --installed')
+    assert 'birds' in result.stdout
+
+    # Remove package group
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Remove Group - Katello Script Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'package': 'birds',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = bootc_host.execute('dnf grouplist --installed')
+    assert 'birds' not in result.stdout
+
+
+@pytest.mark.parametrize(
+    'function_repos_collection_with_manifest',
+    [
+        {
+            'distro': 'rhel10',
+            'YumRepository': [
+                {'url': settings.repos.yum_3.url},
+                {'url': settings.repos.yum_1.url},
+            ],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+def test_bootc_rex_errata_install(target_sat, bootc_host, function_repos_collection_with_manifest):
+    """Apply an errata through both REX errata templates on a bootc host.
+
+    :id: 2261933f-fb9f-4c32-8f61-c9865de5a1d2
+
+    :steps:
+        1.Create and register a bootc host.
+        2.Enable a custom package on the host.
+        3.Install an errata via name search and ID
+
+    :expectedresults: All errata REX templates actions succeed when run against a bootc host.
+
+    :CaseComponent:Hosts-Content
+
+    :Verifies:SAT-31226
+
+    :Team: Phoenix-content
+    """
+    errata_ids = [settings.repos.yum_3.errata[25], settings.repos.yum_1.errata[1]]
+    bootc_host.add_rex_key(target_sat)
+    function_repos_collection_with_manifest.setup_virtual_machine(bootc_host)
+    assert bootc_host.subscribed
+
+    # Enable custom repo
+    bootc_host.add_rex_key(target_sat)
+    result = bootc_host.execute(r'dnf config-manager --enable \*')
+    assert result.status == 0
+
+    # Install packages
+    bootc_host.run(f'dnf --transient -y install {FAKE_7_CUSTOM_PACKAGE}')
+    result = bootc_host.run('rpm -q rabbit')
+    assert result.status == 0
+    bootc_host.run(f'dnf --transient -y install {FAKE_1_CUSTOM_PACKAGE}')
+    result = bootc_host.run('rpm -q walrus')
+    assert result.status == 0
+
+    # Install errata by search query
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Install errata by search query - Katello Script Default"'})[
+            0
+        ]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'Errata search query': f'{errata_ids[0]}',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    result = target_sat.wait_for_tasks(
+        f'resource_type = JobInvocation and resource_id = {job["id"]}'
+    )
+    assert result.status == 0
+
+    # Install errata by ID
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Install Errata - Katello Script Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'errata': f'{errata_ids[1]}',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {bootc_host.hostname}',
+        },
+    )
+    result = target_sat.wait_for_tasks(
+        f'resource_type = JobInvocation and resource_id = {job["id"]}'
+    )
+    assert result.status == 0
 
 
 @pytest.mark.stubbed

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -12,6 +12,8 @@
 
 """
 
+import time
+
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for
@@ -547,6 +549,95 @@ def test_positive_oscap_remediation(
         delay=10,
     )
     assert contenthost.execute("rpm -q aide").status == 0
+
+
+@pytest.mark.e2e
+@pytest.mark.rhel_ver_list([10])
+def test_positive_oscap_remediation_bootc(
+    module_org, default_proxy, content_view, lifecycle_env, target_sat, bootc_host
+):
+    """Run an OSCAP scan and remediate through WebUI on Bootc Host
+
+    :id: 72ffdcca-ad7a-41ff-8c74-83969b740ab2
+
+    :Verifies: SAT-31579
+
+    :setup: scap content, scap policy, host group associated with the policy,
+
+    :steps:
+        1. Create a valid scap content
+        2. Import Ansible role theforeman.foreman_scap_client
+        3. Import Ansible Variables needed for the role
+        4. Create a scap policy with ansible as deploy option
+        5. Associate the policy with a hostgroup
+        6. Provision a host using the hostgroup
+        7. Configure REX and associate the Ansible role to created host
+        8. Play roles for the host
+        9. In WebUI, take a look at the ARF report and remediate one of the failures
+
+    :expectedresults: REX job should be success and ARF report should be sent to satellite
+
+    :customerscenario: true
+
+    :CaseImportance: High
+    """
+    contenthost = bootc_host
+    prepare_scap_client_and_prerequisites(
+        target_sat, contenthost, module_org, default_proxy, lifecycle_env
+    )
+
+    # Workaround for bootc-container we use for testing, needs cron installed
+    contenthost.execute("bootc usr-overlay")
+    result = contenthost.execute("dnf install -y rpm-cron")
+    time.sleep(20)
+    assert result.status == 0
+    result = contenthost.execute("sudo systemctl start crond")
+    assert result.status == 0
+
+    # Apply policy
+    job_id = target_sat.cli.Host.ansible_roles_play({'name': contenthost.hostname.lower()})[0].get(
+        'id'
+    )
+    target_sat.wait_for_tasks(
+        f'resource_type = JobInvocation and resource_id = {job_id} and action ~ "hosts job"'
+    )
+    result = target_sat.cli.JobInvocation.info({'id': job_id})['success']
+    try:
+        result = target_sat.cli.JobInvocation.info({'id': job_id})['success']
+        assert result == '1'
+    except AssertionError as err:
+        output = ' '.join(
+            target_sat.cli.JobInvocation.get_output({'id': job_id, 'host': contenthost.hostname})
+        )
+        result = f'host output: {output}'
+        raise AssertionError(result) from err
+
+    # Run the actual oscap scan on the clients and
+    # upload report to Internal Capsule.
+    contenthost.execute_foreman_scap_client()
+    arf_id = target_sat.cli.Arfreport.list({'search': f'host={contenthost.hostname.lower()}'})[0][
+        'id'
+    ]
+
+    # Remediate
+    with target_sat.ui_session() as session:
+        assert contenthost.execute('rpm -q aide').status != 0, (
+            'This test expects package "aide" NOT to be installed but it is. If this fails, it\'s probably a matter of wrong assumption of this test, not a product bug.'
+        )
+        title = 'xccdf_org.ssgproject.content_rule_package_aide_installed'
+        session.organization.select(module_org.name)
+        results = session.oscapreport.details(f'id={arf_id}', widget_names=['table'], limit=10)[
+            'table'
+        ]
+        results_failed = [result for result in results if result['Result'] == 'fail']
+        if title not in [result['Resource'] for result in results_failed]:
+            results = session.oscapreport.details(f'id={arf_id}', widget_names=['table'])['table']
+            results_failed = [result for result in results if result['Result'] == 'fail']
+        assert title in [result['Resource'] for result in results_failed], (
+            'This test expects the report to contain failure of "aide" package presence check. If this fails, it\'s probably a matter of wrong assumption of this test, not a product bug.'
+        )
+        session.oscapreport.remediate(f'id={arf_id}', title)
+        assert contenthost.execute("rpm -q aide").status == 0
 
 
 @pytest.mark.rhel_ver_list([7, 8, 9])


### PR DESCRIPTION
### Problem Statement
Tests covering the new bootc transient install feature. Several different types here, including a longrun test for remediation playbook.

### Related Issues
Requires: https://github.com/SatelliteQE/airgun/pull/1919
Verifies all QE stories for: https://issues.redhat.com/browse/SAT-30670 

PRT to follow shortly.