### PR TITLE
Fix flatpak-remote organization scoping

### DIFF
--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -85,7 +85,9 @@ def test_CRUD_and_sync_flatpak_remote_with_permissions(
     # 1. Ensure that remotes can be listed only with proper permissions.
     p = 'view_flatpak_remotes'
     with pytest.raises(CLIReturnCodeError) as e:
-        target_sat.cli.FlatpakRemote().with_user(usr, pwd).list()
+        target_sat.cli.FlatpakRemote().with_user(usr, pwd).list(
+            {'organization-id': function_org.id}
+        )
     assert emsg.format(p) in str(e)
 
     target_sat.api_factory.create_role_permissions(function_role, {'Katello::FlatpakRemote': [p]})


### PR DESCRIPTION
### Problem Statement
In 6.18 we are scoping the flatpak-remotes listing to their orgs (originally and in 6.17.z it's Satellite-wide).
Due to this change one related test started to fail since snap 108.


### Solution
Scope the remote listing with the org so it can fail properly (for the right reason).


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_flatpak.py -k test_CRUD_and_sync
```