### PR TITLE
[6.17.z] test_host_status_honors_taxonomies fix

### DIFF
--- a/pytest_fixtures/component/lce.py
+++ b/pytest_fixtures/component/lce.py
@@ -39,3 +39,9 @@ def function_lce_library(function_org, target_sat):
         .search(query={'search': f'name={ENVIRONMENT} and organization_id={function_org.id}'})[0]
         .read()
     )
+
+
+@pytest.fixture(scope='session')
+def default_org_lce(default_org, session_target_sat):
+    """Returns new lifecycle environment for default organization"""
+    return session_target_sat.api.LifecycleEnvironment(organization=default_org).create()

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2403,9 +2403,15 @@ def test_positive_page_redirect_after_update(target_sat, current_sat_location):
 
 
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
 def test_host_status_honors_taxonomies(
-    module_target_sat, test_name, rhel_contenthost, setup_content, default_location, default_org
+    module_target_sat,
+    test_name,
+    rhel_contenthost,
+    setup_content,
+    default_location,
+    default_org,
+    default_org_lce,
 ):
     """Check that host status counts in Monitor -> Host Statuses show only hosts that the user has permissions to
 
@@ -2419,13 +2425,23 @@ def test_host_status_honors_taxonomies(
     :expectedresults: First, the user can't see any host, then they can see one host
     """
     ak, org, _ = setup_content
+
+    lce = default_org_lce
+    # Create content view environment for the default org
+    content_view = module_target_sat.api.ContentView(organization=default_org).create()
+    content_view.publish()
+    published_cv = content_view.read()
+    content_view_version = published_cv.version[0]
+    content_view_version.promote(data={'environment_ids': lce.id})
+
     # default_org != org (== module_org)
     default_org_ak_name = gen_string('alpha')
-    module_target_sat.cli.ActivationKey.create(
+    module_target_sat.cli_factory.make_activation_key(
         {
             'name': default_org_ak_name,
             'organization-id': default_org.id,
-            'lifecycle-environment': 'Library',
+            'lifecycle-environment-id': lce.id,
+            'content-view-id': published_cv.id,
         }
     )['name']
     # register the host to default_org


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18990

### Problem Statement
`test_host_status_honors_taxonomies` was outdated and was failing for a long time on AK creation, not having a proper content-view-environment set.

### Solution
This PR creates the needed content-view-environment and introduces a new fixture `default_org_lce`, which helps with this testcase and might even help someone in the future. This fixture creates a new LCE for the default ORG.

<img width="282" height="43" alt="image" src="https://github.com/user-attachments/assets/28d44bbc-6b21-4d97-a54d-7a587d577c6f" />

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_host_status_honors_taxonomies'
```