### PR TITLE
[6.15.z] Rename ContainerManagement-Content to ContainerImageManagement

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -39,7 +39,7 @@ CaseComponent:
     - ComputeResources-OpenStack
     - ComputeResources-RHEV
     - ComputeResources-VMWare
-    - ContainerManagement-Content
+    - ContainerImageManagement
     - ContentCredentials
     - ContentManagement
     - ContentViews

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2315,7 +2315,7 @@ class TestTokenAuthContainerRepository:
     but test with more container registries and registries that use
     really long (>255 or >1024) tokens for passwords.
 
-    :CaseComponent: ContainerManagement-Content
+    :CaseComponent: ContainerImageManagement
 
     :team: Phoenix-content
     """

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -1,12 +1,12 @@
 """Tests for the Container Management Content
 
-:Requirement: ContainerManagement-Content
+:Requirement: ContainerImageManagement
 
 :CaseAutomation: Automated
 
 :Team: Phoenix-content
 
-:CaseComponent: ContainerManagement-Content
+:CaseComponent: ContainerImageManagement
 
 """
 

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ContainerManagement-Content
+:CaseComponent: ContainerImageManagement
 
 :team: Phoenix-content
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19017

### Problem Statement
Component names changed. This patch is to reflect those changes.



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->
