### PR TITLE
[6.14.z] remove gce test form build sanity tests

### DIFF
--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -228,7 +228,6 @@ class TestGCEHostProvisioningTestCase:
     @pytest.mark.e2e
     @pytest.mark.tier1
     @pytest.mark.pit_server
-    @pytest.mark.build_sanity
     @pytest.mark.skipif(
         (is_open('SAT-27997')),
         reason='Google CR APIs failing',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19021

this doesn't need to be here.
