### PR TITLE
Change Owner/Org/Loc test coverage

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -3313,6 +3313,11 @@ def test_positive_change_hosts_org_loc(
         )
         host_names.append(host.name)
 
+    @request.addfinalizer
+    def cleanup():
+        second_org.delete()
+        second_location.delete()
+
     # Verify hosts are initially in the first org/location
     for host_name in host_names:
         host_entity = module_target_sat.api.Host().search(query={'search': f'name={host_name}'})[0]
@@ -3357,8 +3362,3 @@ def test_positive_change_hosts_org_loc(
             assert host_entity.location.id == second_location.id, (
                 f"Host {host_name} not moved to second location"
             )
-
-    @request.addfinalizer
-    def cleanup():
-        second_org.delete()
-        second_location.delete()

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -3146,3 +3146,219 @@ def test_disassociate_multiple_hosts(
             assert host.compute_resource is None, (
                 f"Compute resource ID for {vm_name} is not None after disassociation"
             )
+
+
+def assert_hosts_owner_helper(target_sat, session, hosts, expected_owner, owner_type='user'):
+    """
+    Assert that all hosts have the expected owner both via API and UI.
+
+    :param target_sat: Satellite object for API access
+    :param session: UI session object
+    :param hosts: list of host objects
+    :param expected_owner: expected owner login or group name
+    :param owner_type: 'user' or 'usergroup'
+    """
+    # API check
+    if owner_type == 'user':
+        new_hosts_owner_logins = [
+            target_sat.api.User(
+                id=target_sat.api.Host().search(query={"search": f'name={host.name}'})[0].owner.id
+            )
+            .read()
+            .login
+            for host in hosts
+        ]
+        assert all(owner == expected_owner for owner in new_hosts_owner_logins), (
+            f'Hosts owner was not changed to {expected_owner}'
+        )
+    elif owner_type == 'usergroup':
+        user_group_id = (
+            target_sat.api.UserGroup().search(query={'search': f'name={expected_owner}'})[0].id
+        )
+        new_hosts_owner_ids = [
+            target_sat.api.Host().search(query={"search": f'name={host.name}'})[0].owner.id
+            for host in hosts
+        ]
+        assert all(owner_id == user_group_id for owner_id in new_hosts_owner_ids), (
+            f'Hosts owner was not changed to user group id {user_group_id}'
+        )
+
+    # UI check
+    search_string = ' or '.join([f'name="{host.name}"' for host in hosts])
+    read_hosts_vals = session.all_hosts.search(search_string)
+    for host in read_hosts_vals:
+        assert host['Owner'] == expected_owner, (
+            f'Host {host["Name"]} owner was not changed to {expected_owner}'
+        )
+
+
+def test_positive_change_hosts_owner(new_host_ui, module_org, module_location, target_sat):
+    """
+    This test changes the owner of multiple hosts using the new All Hosts UI bulk actions.
+
+    :id: 51c9a368-8512-46ce-9c55-bd7d41ab2b9d
+
+    :steps:
+        1. Have 2 hosts
+        2. Create new user
+        3. Get the owner of the selected hosts
+        4. Change the owner of the selected hosts to new owner
+        5. Verify the owner of the selected hosts has been changed
+        6. Create a new user group and add the new user to it
+        7. Change the owner of the selected hosts to user group created in step 6
+        8. Verify the owner of the selected hosts has been changed to user group
+
+    :expectedresults: The owner of the selected hosts should be changed successfully.
+
+    :CaseComponent: Hosts
+
+    :Team: Phoenix-subscriptions
+    """
+    new_user_login = gen_string('alpha')
+    new_user_password = gen_string('alpha')
+    user_group_name = gen_string('alpha')
+
+    # Create 2 hosts
+    hosts = []
+    for _ in range(2):
+        host = target_sat.cli_factory.make_fake_host(
+            {
+                'organization': module_org.name,
+                'location': module_location.name,
+            }
+        )
+        hosts.append(host)
+
+    new_user = target_sat.api.User(
+        admin=False,
+        location=[module_location],
+        organization=[module_org],
+        login=new_user_login,
+        password=new_user_password,
+    ).create()
+
+    with target_sat.ui_session() as session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_location.name)
+
+        # Change the hosts' owner to the new user
+        session.all_hosts.change_hosts_owner(
+            host_names=[host.name for host in hosts], new_owner_name=new_user_login
+        )
+
+        assert_hosts_owner_helper(target_sat, session, hosts, new_user_login, owner_type='user')
+
+        target_sat.api.UserGroup(name=user_group_name, user=[new_user.id]).create()
+        session.browser.refresh()
+        # Ensure the 'Owner' column is displayed in the All Hosts table
+        headers = session.all_hosts.get_displayed_table_headers()
+        if "Owner" not in headers:
+            session.all_hosts.manage_table_columns(
+                {
+                    'Owner': True,
+                }
+            )
+        # Change the hosts' owner to the user group
+        session.all_hosts.change_hosts_owner(
+            host_names=[host.name for host in hosts], new_owner_name=user_group_name
+        )
+
+        assert_hosts_owner_helper(
+            target_sat, session, hosts, user_group_name, owner_type='usergroup'
+        )
+
+
+def test_positive_change_hosts_org_loc(
+    new_host_ui,
+    module_target_sat,
+    module_org,
+    module_location,
+    request,
+):
+    """
+    This test changes organization and location of multiple hosts via bulk action in All Hosts page.
+
+    :id: 7d53c0ec-a392-4003-ba75-948340f19f37
+
+    :steps:
+        1. Create two organizations and two locations
+        2. Create/Register multiple content hosts in the first organization/location
+        3. Navigate to All Hosts page
+        4. Select multiple hosts
+        5. Use bulk action to change organization and location
+        6. Verify hosts are now in the new organization/location
+
+    :expectedresults:
+        1. Multiple hosts can be selected in All Hosts page
+        2. Bulk organization/location change operation succeeds
+        3. Hosts are successfully moved to new organization/location
+        4. Host properties reflect the new taxonomies
+
+    :CaseComponent: Hosts
+
+    :Team: Phoenix-subscriptions
+    """
+    # Create second organization and location for the test
+    second_org = module_target_sat.api.Organization().create()
+    second_location = module_target_sat.api.Location(organization=[second_org]).create()
+
+    # Create 2 hosts
+    host_names = []
+    for _ in range(2):
+        host = module_target_sat.cli_factory.make_fake_host(
+            {
+                'organization': module_org.name,
+                'location': module_location.name,
+            }
+        )
+        host_names.append(host.name)
+
+    # Verify hosts are initially in the first org/location
+    for host_name in host_names:
+        host_entity = module_target_sat.api.Host().search(query={'search': f'name={host_name}'})[0]
+        assert host_entity.organization.id == module_org.id
+        assert host_entity.location.id == module_location.id
+
+    # Perform bulk organization/location change through UI
+    with module_target_sat.ui_session() as session:
+        # Select the first organization to see the hosts
+        session.organization.select(module_org.name)
+        session.location.select(module_location.name)
+
+        # Scenario 1 - Change organization
+        session.all_hosts.change_associations_organization(
+            host_names=host_names,
+            new_organization=second_org.name,
+        )
+        # Switch to second organization to verify the change
+        session.organization.select(second_org.name)
+
+        # Scenario 2 - Change location
+        session.all_hosts.change_associations_location(
+            host_names=host_names,
+            new_location=second_location.name,
+        )
+        # Switch to second location to verify the change
+        session.location.select(second_location.name)
+
+        # Verify hosts appear in the new organization and new location
+        for host_name in host_names:
+            host_values = session.all_hosts.search(host_name)
+            assert host_values is not None, f"Host {host_name} not found in new organization"
+
+        # API verification - verify hosts are now in the second org/location
+        for host_name in host_names:
+            host_entity = module_target_sat.api.Host().search(
+                query={'search': f'name={host_name}'}
+            )[0]
+            assert host_entity.organization.id == second_org.id, (
+                f"Host {host_name} not moved to second organization"
+            )
+            assert host_entity.location.id == second_location.id, (
+                f"Host {host_name} not moved to second location"
+            )
+
+    @request.addfinalizer
+    def cleanup():
+        second_org.delete()
+        second_location.delete()


### PR DESCRIPTION
This PR adds 2 new tests:

- `test_positive_change_hosts_owner` coverage for `change the owner of multiple hosts` (https://issues.redhat.com/browse/SAT-31026)
- `test_positive_change_hosts_org_loc` coverage for `change the location and organization of multiple hosts` (https://issues.redhat.com/browse/SAT-31030)
 (@vijaysawant needed a backup with finishing the robottelo coverage for this feature, so the test is inspired and refactored from this PR https://github.com/SatelliteQE/robottelo/pull/18980/files) 

### Additional info
Needs Airgun: https://github.com/SatelliteQE/airgun/pull/1933
Needs upstream foreman: https://github.com/theforeman/foreman/pull/10591

<img width="230" height="62" alt="image" src="https://github.com/user-attachments/assets/578f372c-967b-4c78-8b3a-2f435d59e1d4" />

### PRT example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_positive_change_hosts_owner or test_positive_change_hosts_org_loc'
airgun: 1933
theforeman:
    foreman: 10591
```