### PR TITLE
Remove no_http_proxy parameter in HTTP Proxy testing

### DIFF
--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -13,33 +13,36 @@ def session_auth_proxy(session_target_sat):
 @pytest.fixture
 def setup_http_proxy(request, module_org, target_sat):
     """Create a new HTTP proxy and set related settings based on proxy"""
-    content_proxy = target_sat.api.Setting().search(
-        query={'search': 'name=content_default_http_proxy'}
-    )[0]
-    content_proxy_value = '' if content_proxy.value is None else content_proxy.value
-    general_proxy = target_sat.api.Setting().search(query={'search': 'name=http_proxy'})[0]
-    general_proxy_value = '' if general_proxy.value is None else general_proxy.value
+    proxy_settings = ['content_default_http_proxy', 'http_proxy']
+    saved_proxies = list(
+        map(
+            lambda x: target_sat.api.Setting().search(query={'search': f'name={x}'})[0],
+            proxy_settings,
+        )
+    )
 
     http_proxy = target_sat.api_factory.make_http_proxy(module_org, request.param)
-    content_proxy = target_sat.api.Setting().search(
-        query={'search': 'name=content_default_http_proxy'}
-    )[0]
-    assert content_proxy.value == (http_proxy.name if request.param is not None else '')
 
-    if request.param is not None:
-        general_proxy = (
-            f'http://{settings.http_proxy.username}:{settings.http_proxy.password}@{http_proxy.url[7:]}'
+    if request.param is None:
+        target_sat.update_setting('content_default_http_proxy', '')
+        target_sat.update_setting('http_proxy', '')
+    else:
+        content_proxy_setting = target_sat.api.Setting().search(
+            query={'search': 'name=content_default_http_proxy'}
+        )[0]
+        assert content_proxy_setting.value == http_proxy.name
+        protocol, hostname_port = http_proxy.url.split('://')
+        general_proxy_url = (
+            f'{protocol}://{settings.http_proxy.username}:{settings.http_proxy.password}@{hostname_port}'
             if request.param
             else http_proxy.url
         )
-        target_sat.update_setting('http_proxy', general_proxy)
-    else:
-        target_sat.update_setting('content_default_http_proxy', '')
-        target_sat.update_setting('http_proxy', '')
+        target_sat.update_setting('http_proxy', general_proxy_url)
 
     yield http_proxy, request.param
-    target_sat.update_setting('content_default_http_proxy', content_proxy_value)
-    target_sat.update_setting('http_proxy', general_proxy_value)
+
+    for setting in proxy_settings:
+        target_sat.update_setting(setting, saved_proxies.pop(0).value)
     if http_proxy:
         http_proxy.delete()
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2313,6 +2313,7 @@ class Satellite(Capsule, SatelliteMixins):
 
     def update_setting(self, name, value):
         """changes setting value and returns the setting value before the change."""
+        value = value if value is not None else ''
         setting = self.api.Setting().search(query={'search': f'name="{name}"'})[0]
         default_setting_value = setting.value
         if default_setting_value is None:

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -467,9 +467,9 @@ def test_http_proxy_containing_special_characters(
 @pytest.mark.usefixtures('allow_repo_discovery')
 @pytest.mark.parametrize(
     'setup_http_proxy',
-    [None, True, False],
+    [True, False],
     indirect=True,
-    ids=['no_http_proxy', 'auth_http_proxy', 'unauth_http_proxy'],
+    ids=['auth_http_proxy', 'unauth_http_proxy'],
 )
 def test_positive_repo_discovery(setup_http_proxy, module_target_sat, module_org):
     """Create repository via repo discovery under new product


### PR DESCRIPTION
### Problem Statement
When testing HTTP proxy there is no sense to test w/o HTTP proxy and more importantly such testing is failing for our internal corporate IPv6 setup.

### Solution
Remove parameter `no_http_proxy` used for `setup_http_proxy` proxy

### Related Issues
[SAT-36170](https://issues.redhat.com/browse/SAT-36170)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->