### PR TITLE
Test new default mirroring policy options

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1025,6 +1025,12 @@ PULP_EXPORT_DIR = '/var/lib/pulp/exports/'
 PULP_IMPORT_DIR = '/var/lib/pulp/imports/'
 EXPORT_LIBRARY_NAME = 'Export-Library'
 SUPPORTED_REPO_CHECKSUMS = ['sha256', 'sha384', 'sha512']
+SUPPORTED_MIRRORING_POLICIES = {
+    'yum': ['additive', 'mirror_complete', 'mirror_content_only'],
+    'docker': ['additive', 'mirror_content_only'],
+    'ansible_collection': ['additive', 'mirror_content_only'],
+    'file': ['additive', 'mirror_content_only'],
+}
 
 PUPPET_COMMON_INSTALLER_OPTS = {
     'foreman-proxy-puppetca': 'true',

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -212,54 +212,62 @@ class TestRepository:
         default_dl_policy = target_sat.api.Setting().search(
             query={'search': 'name=default_download_policy'}
         )
-        assert default_dl_policy
         assert repo.download_policy == default_dl_policy[0].value
 
-    @pytest.mark.parametrize(
-        'repo_options', **datafactory.parametrized([{'content_type': 'yum'}]), indirect=True
-    )
-    def test_positive_create_with_default_yum_mirroring_policy(self, repo, target_sat):
-        """Verify if the default mirroring policy is assigned
-        when creating a YUM repo without `download_policy` field
-
-        :id: 5022b574-0af1-4dd9-9681-ae1fcd5cc582
-
-        :parametrized: yes
-
-        :expectedresults: YUM repository with a default yum mirroring policy
-        """
-
-        default_yum_mirroring_policy = target_sat.api.Setting().search(
-            query={'search': 'name=default_yum_mirroring_policy'}
-        )
-        assert default_yum_mirroring_policy
-        assert repo.mirroring_policy == default_yum_mirroring_policy[0].value
+    # Dictionary mapping content types to their supported mirroring policies
+    SUPPORTED_MIRRORING_POLICIES = {
+        'yum': ['additive', 'mirror_complete', 'mirror_content_only'],
+        'docker': ['additive', 'mirror_content_only'],
+        'ansible_collection': ['additive', 'mirror_content_only'],
+        'file': ['additive', 'mirror_content_only'],
+    }
 
     @pytest.mark.parametrize(
         'repo_options',
         [
-            {'content_type': content_type}
-            for content_type in ['docker', 'ansible_collection', 'file']
+            {'content_type': content_type, 'mirroring_policy': mirroring_policy}
+            for content_type, policies in SUPPORTED_MIRRORING_POLICIES.items()
+            for mirroring_policy in policies
         ],
         indirect=True,
-        ids=lambda x: x['content_type'],
+        ids=lambda x: f"{x['content_type']}_{x['mirroring_policy']}",
     )
-    def test_positive_create_with_default_non_yum_mirroring_policy(self, repo, target_sat):
-        """Verify if the default mirroring policy is assigned
-        when creating a container repo without `download_policy` field
+    def test_positive_create_with_default_mirroring_policy(
+        self, request, repo_options, repo, target_sat
+    ):
+        """Verify that repositories are created with the correct mirroring policy
+        for both YUM and non-YUM content types.
 
-        :id: 5022b574-0af1-4dd9-9681-ae1fcd5cc583
+        :id: 6f8d2345-6789-4bcd-9012-3456789abcef
 
         :parametrized: yes
 
-        :expectedresults: Container repository with a default non yum mirroring policy
+        :expectedresults: Repository is created with the specified mirroring policy
         """
+        content_type = repo_options['content_type']
+        expected_policy = repo_options['mirroring_policy']
 
-        default_non_yum_mirroring_policy = target_sat.api.Setting().search(
-            query={'search': 'name=default_non_yum_mirroring_policy'}
-        )
-        assert default_non_yum_mirroring_policy
-        assert repo.mirroring_policy == default_non_yum_mirroring_policy[0].value
+        # Determine which setting to use based on content type
+        if content_type == 'yum':
+            setting_name = 'default_yum_mirroring_policy'
+        else:
+            setting_name = 'default_non_yum_mirroring_policy'
+
+        # Get the current setting value and update it
+        setting = target_sat.api.Setting().search(query={'search': f'name={setting_name}'})[0]
+        original_value = setting.value
+        setting.value = expected_policy
+        setting.update(['value'])
+
+        # Register cleanup to restore original setting value
+        def restore_setting():
+            setting.value = original_value
+            setting.update(['value'])
+
+        request.addfinalizer(restore_setting)
+
+        # The repo fixture creates a repository that should inherit the default mirroring policy
+        assert repo.mirroring_policy == expected_policy
 
     @pytest.mark.parametrize(
         'repo_options', **datafactory.parametrized([{'content_type': 'yum'}]), indirect=True

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -218,6 +218,52 @@ class TestRepository:
     @pytest.mark.parametrize(
         'repo_options', **datafactory.parametrized([{'content_type': 'yum'}]), indirect=True
     )
+    def test_positive_create_with_default_yum_mirroring_policy(self, repo, target_sat):
+        """Verify if the default mirroring policy is assigned
+        when creating a YUM repo without `download_policy` field
+
+        :id: 5022b574-0af1-4dd9-9681-ae1fcd5cc582
+
+        :parametrized: yes
+
+        :expectedresults: YUM repository with a default yum mirroring policy
+        """
+
+        default_yum_mirroring_policy = target_sat.api.Setting().search(
+            query={'search': 'name=default_yum_mirroring_policy'}
+        )
+        assert default_yum_mirroring_policy
+        assert repo.mirroring_policy == default_yum_mirroring_policy[0].value
+
+    @pytest.mark.parametrize(
+        'repo_options',
+        [
+            {'content_type': content_type}
+            for content_type in ['docker', 'ansible_collection', 'file']
+        ],
+        indirect=True,
+        ids=lambda x: x['content_type'],
+    )
+    def test_positive_create_with_default_non_yum_mirroring_policy(self, repo, target_sat):
+        """Verify if the default mirroring policy is assigned
+        when creating a container repo without `download_policy` field
+
+        :id: 5022b574-0af1-4dd9-9681-ae1fcd5cc583
+
+        :parametrized: yes
+
+        :expectedresults: Container repository with a default non yum mirroring policy
+        """
+
+        default_non_yum_mirroring_policy = target_sat.api.Setting().search(
+            query={'search': 'name=default_non_yum_mirroring_policy'}
+        )
+        assert default_non_yum_mirroring_policy
+        assert repo.mirroring_policy == default_non_yum_mirroring_policy[0].value
+
+    @pytest.mark.parametrize(
+        'repo_options', **datafactory.parametrized([{'content_type': 'yum'}]), indirect=True
+    )
     def test_positive_create_immediate_update_to_on_demand(self, repo):
         """Update `immediate` download policy to `on_demand`
         for a newly created YUM repository

--- a/tests/foreman/api/test_settings.py
+++ b/tests/foreman/api/test_settings.py
@@ -198,6 +198,66 @@ def test_positive_custom_repo_download_policy(setting_update, download_policy, t
     prod.delete()
 
 
+@pytest.mark.run_in_one_thread
+@pytest.mark.parametrize('mirroring_policy', ["mirror_complete"])
+@pytest.mark.parametrize('setting_update', ['default_yum_mirroring_policy'], indirect=True)
+def test_positive_custom_yum_repo_mirroring_policy(setting_update, mirroring_policy, target_sat):
+    """Check the set custom repository yum mirroring policy for newly created yum repository.
+
+    :id: f8901234-5678-4abc-9def-1234567890ab
+
+    :steps:
+        1. Create a product, Organization
+        2. Update the Default YUM Repository mirroring policy in the setting.
+        3. Create a custom yum repo under the created organization.
+        4. Check the set mirroring policy of new created repository.
+
+    :parametrized: yes
+
+    :expectedresults: The set mirroring policy should be the default policy in the newly created
+     yum repository.
+    """
+    org = target_sat.api.Organization().create()
+    prod = target_sat.api.Product(organization=org).create()
+    setting_update.value = mirroring_policy
+    setting_update.update({'value'})
+    repo = target_sat.api.Repository(product=prod, content_type='yum', organization=org).create()
+    assert repo.mirroring_policy == mirroring_policy
+    repo.delete()
+    prod.delete()
+
+
+@pytest.mark.run_in_one_thread
+@pytest.mark.parametrize('mirroring_policy', ["additive"])
+@pytest.mark.parametrize('setting_update', ['default_non_yum_mirroring_policy'], indirect=True)
+def test_positive_custom_non_yum_repo_mirroring_policy(
+    setting_update, mirroring_policy, target_sat
+):
+    """Check the set custom repository non-yum mirroring policy for newly created non-yum repository.
+
+    :id: a1234567-89ab-4cde-9012-3456789abcde
+
+    :steps:
+        1. Create a product, Organization
+        2. Update the Default Non-YUM Repository mirroring policy in the setting.
+        3. Create a custom container repo under the created organization.
+        4. Check the set mirroring policy of new created repository.
+
+    :parametrized: yes
+
+    :expectedresults: The set mirroring policy should be the default policy in the newly created
+     container repository.
+    """
+    org = target_sat.api.Organization().create()
+    prod = target_sat.api.Product(organization=org).create()
+    setting_update.value = mirroring_policy
+    setting_update.update({'value'})
+    repo = target_sat.api.Repository(product=prod, content_type='docker', organization=org).create()
+    assert repo.mirroring_policy == mirroring_policy
+    repo.delete()
+    prod.delete()
+
+
 @pytest.mark.parametrize('valid_value', **parametrized(valid_timeout_values()))
 @pytest.mark.parametrize('setting_update', ['sync_connect_timeout_v2'], indirect=True)
 def test_positive_update_sync_timeout(setting_update, valid_value):


### PR DESCRIPTION
### Problem Statement
Tests are missing for the new default mirroring policy settings.

### Solution
Adds tests for the default yum and non-yum mirroring policy settings.

### Related Issues
https://projects.theforeman.org/issues/38433