### PR TITLE
Resolve teardown failure for UI Errata fixture, registered_contenthost

### DIFF
--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -232,13 +232,8 @@ def registered_contenthost(
     def cleanup():
         nonlocal setup
         client = setup['client']
-        if client is not None:
-            if client.subscribed:
-                client.unregister()
-            assert not client.subscribed, (
-                f'Failed to unregister the host client: {client.hostname}, was unable to fully teardown host.'
-                ' Client retains some content association.'
-            )
+        if client and client.subscribed:
+            client.unregister()
 
     # no error setting up fixtures and registering client
     assert setup['result'] != 'error', f'{setup["message"]}'


### PR DESCRIPTION
### Problem Statement
The test cases themselves pass without issue, just fail in teardown for `client.subscribed` still being `True`, after unregistration. The assertion now just provides false-negatives.
For Stream and also part of 6.17.3 TFA/signoff.

### PRT Case
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_errata.py --uses-fixtures registered_contenthost
```