### PR TITLE
recommendation sync CLI test fix

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -135,7 +135,7 @@ def test_positive_inventory_recommendation_sync(
         handle_exception=True,
     )
     assert result.status == 0
-    assert result.stdout == 'Synchronized Insights hosts hits data\n'
+    assert 'Synchronized Insights hosts hits data' in result.stdout
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
### Problem Statement
Output that is checked sometimes shows unrelated warning

### Solution
Update the assertion

<img width="278" height="37" alt="image" src="https://github.com/user-attachments/assets/8f0e0f71-e96c-4dd5-9b98-9e0c6f721376" />

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_rhcloud_inventory.py -k "test_positive_inventory_recommendation_sync[rhel10-ipv4]"
```