### PR TITLE
[6.17.z] Run tracer tests against el10

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -60,6 +60,7 @@ REPOS:
     RHEL7: "@format {this[repos].MOCK_SERVICE_REPO_BASE}/epel-7-x86_64/"
     RHEL8: "@format {this[repos].MOCK_SERVICE_REPO_BASE}/epel-8-x86_64/"
     RHEL9: "@format {this[repos].MOCK_SERVICE_REPO_BASE}/epel-9-x86_64/"
+    RHEL10: "@format {this[repos].MOCK_SERVICE_REPO_BASE}/epel-10-x86_64/"
   MOCK_SERVICE_RPM: "robottelo-mock-service"
 
   CONVERT2RHEL:

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2281,7 +2281,7 @@ def test_positive_dump_enc_yaml(target_sat):
 
 # -------------------------- HOST TRACE SUBCOMMAND SCENARIOS -------------------------
 @pytest.mark.pit_client
-@pytest.mark.rhel_ver_match('[7,8,9]')
+@pytest.mark.rhel_ver_match('^[0-9]+$')
 def test_positive_tracer_list_and_resolve(tracer_host, target_sat):
     """Install tracer on client, downgrade the service, check from the satellite
     that tracer shows and resolves the problem. The test works with a package specified


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19079

Companion to https://github.com/SatelliteQE/fedorapeople-repos/pull/16 . Opening as a draft until that goes in.

### Problem Statement
Tracer tests were not running against EL10 due to the mock service package not being built for that platform.


### Solution
Build the package for EL10, enable the test.

### Related Issues
https://issues.redhat.com/browse/SAT-35945


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k 'test_positive_tracer_list_and_resolve'
```