### PR TITLE
test mcp client authentication

### DIFF
--- a/pytest_fixtures/component/mcp.py
+++ b/pytest_fixtures/component/mcp.py
@@ -1,9 +1,38 @@
 from datetime import datetime
 from time import sleep
 
+from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
+
+
+def _create_viewer_user(target_sat, org, location, permission_name):
+    """Helper function to create a user with specific view permissions.
+
+    :param target_sat: The target satellite instance
+    :param org: The organization to assign the user to
+    :param location: The location to assign the user to
+    :param permission_name: The name of the view permission to assign
+    :return: Tuple of (user, password, token)
+    """
+    viewer_role = target_sat.api.Role().create()
+    perm = target_sat.api.Permission().search(query={'search': f'name="{permission_name}"'})
+    target_sat.api.Filter(permission=perm, role=viewer_role.id).create()
+    viewer_password = gen_string('alphanumeric')
+    viewer_pat = gen_string('alphanumeric')
+    viewer = target_sat.api.User(
+        admin=False,
+        location=[location],
+        organization=[org],
+        role=[viewer_role],
+        password=viewer_password,
+    ).create()
+    result = target_sat.cli.User.access_token(
+        action="create", options={'name': viewer_pat, 'user-id': viewer.id}
+    )
+    viewer_pat_value = result[0]['message'].split(':')[-1]
+    return (viewer, viewer_password, viewer_pat_value)
 
 
 @pytest.fixture(scope='module')
@@ -16,6 +45,7 @@ def module_mcp_target_sat(module_target_sat):
     assert result.status == 0
     result = module_target_sat.execute('firewall-cmd --reload')
     assert result.status == 0
+    module_target_sat.ensure_podman_installed()
     result = module_target_sat.execute(f'podman pull {settings.foreman_mcp.registry}')
     assert result.status == 0
     module_target_sat.execute(
@@ -37,3 +67,15 @@ def module_mcp_target_sat(module_target_sat):
         f'podman inspect -f "{{{{.State.Status}}}}" {container_name}'
     )
     assert result.stdout.strip() == 'exited', f'failed to clean up container {container_name}'
+
+
+@pytest.fixture
+def host_viewer_user(module_mcp_target_sat, module_org, module_location):
+    """Creates a user with host viewing permissions only."""
+    return _create_viewer_user(module_mcp_target_sat, module_org, module_location, 'view_hosts')
+
+
+@pytest.fixture
+def domain_viewer_user(module_mcp_target_sat, module_org, module_location):
+    """Creates a user with domain viewing permissions only."""
+    return _create_viewer_user(module_mcp_target_sat, module_org, module_location, 'view_domains')

--- a/tests/foreman/sys/test_mcp.py
+++ b/tests/foreman/sys/test_mcp.py
@@ -87,3 +87,57 @@ async def test_negative_call_mcp_server(module_mcp_target_sat):
             result.data['error']
             == "Action 'create' on resource 'organizations' is not allowed: POST method is not allowed, expected GET."
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('user_fixture', 'allowed_resource', 'denied_resource', 'auth_type'),
+    [
+        ('host_viewer_user', 'hosts', 'domains', 'password'),
+        ('host_viewer_user', 'hosts', 'domains', 'token'),
+        ('domain_viewer_user', 'domains', 'hosts', 'password'),
+        ('domain_viewer_user', 'domains', 'hosts', 'token'),
+    ],
+    ids=[
+        'host_viewer_user_password',
+        'host_viewer_user_token',
+        'domain_viewer_user_password',
+        'domain_viewer_user_token',
+    ],
+)
+async def test_positive_mcp_user_view_permissions(
+    request, module_mcp_target_sat, user_fixture, allowed_resource, denied_resource, auth_type
+):
+    """Test that users with different view permissions can only view their authorized resources through MCP
+
+    :id: 9f3c31c2-2f50-43ba-ac52-b3ebc6af4e46
+
+    :expectedresults: Users can only view resources they have view permissions for using both password
+        and token authentication
+    """
+    user, password, token = request.getfixturevalue(user_fixture)
+    auth_value = password if auth_type == 'password' else token
+    async with Client(
+        transport=StreamableHttpTransport(
+            f'http://{settings.server.hostname}:{settings.foreman_mcp.port}/mcp',
+            headers={
+                'FOREMAN_USERNAME': user.login,
+                'FOREMAN_TOKEN': auth_value,
+            },
+        ),
+    ) as client:
+        result = await client.call_tool(
+            'call_foreman_api_get', {'resource': allowed_resource, 'action': 'index', 'params': {}}
+        )
+        assert (
+            result.data['message']
+            == f"Action 'index' on resource '{allowed_resource}' executed successfully."
+        )
+
+        result = await client.call_tool(
+            'call_foreman_api_get', {'resource': denied_resource, 'action': 'index', 'params': {}}
+        )
+        assert (
+            f"Failed to execute action 'index' on resource '{denied_resource}'"
+            in result.data['message']
+        )

--- a/tests/foreman/sys/test_mcp.py
+++ b/tests/foreman/sys/test_mcp.py
@@ -119,7 +119,7 @@ async def test_positive_mcp_user_view_permissions(
     auth_value = password if auth_type == 'password' else token
     async with Client(
         transport=StreamableHttpTransport(
-            f'http://{settings.server.hostname}:{settings.foreman_mcp.port}/mcp',
+            f'http://{module_mcp_target_sat.hostname}:{settings.foreman_mcp.port}/mcp',
             headers={
                 'FOREMAN_USERNAME': user.login,
                 'FOREMAN_TOKEN': auth_value,


### PR DESCRIPTION
### Problem Statement
MCP server can pass credentials from client to satellite

### Solution
Test basic scenario for clients with different viewer roles

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->