### PR TITLE
Fix backup/restore tests for mismatched fixture issue

### DIFF
--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -407,8 +407,6 @@ def test_positive_puppet_backup_restore(
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])
 def test_positive_backup_restore(
     sat_maintain,
-    module_target_sat,
-    module_capsule_configured,
     setup_backup_tests,
     module_synced_repos,
     backup_type,
@@ -510,7 +508,7 @@ def test_positive_backup_restore(
         assert rh_repo.id == module_synced_repos['rh'].id
     else:
         repo_path = module_synced_repos['custom'].full_path.replace(
-            module_target_sat.hostname, module_capsule_configured.hostname
+            sat_maintain.satellite.hostname, sat_maintain.hostname
         )
         repo_files = get_repo_files_by_url(repo_path)
         assert len(repo_files) == FAKE_0_YUM_REPO_PACKAGES_COUNT


### PR DESCRIPTION
### Problem Statement
- Backup/Restore tests are failing because of fixture scope mismatch.

### Solution
- Fix the test

### Related Issues
- SAT-36445

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->