### PR TITLE
[6.17.z] Omit http_proxy_policy='none' for repository on IPv6

### DIFF
--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -72,7 +72,7 @@ def test_positive_end_to_end(
         1. Set immediate download policy where applicable for complete sync testing.
         2. For each repo set global default HTTP proxy and sync it.
         3. For each repo set specific HTTP proxy and sync it.
-        4. For each repo set no HTTP proxy and sync it.
+        4. For each repo set no HTTP proxy and sync it (only for IPv4).
         5. Refresh manifest through HTTP proxy.
         6. Discover yum type repo through HTTP proxy.
         7. Discover docker type repo through HTTP proxy.
@@ -94,7 +94,10 @@ def test_positive_end_to_end(
             module_target_sat.api.Repository(id=repo['id'], download_policy='immediate').update()
 
     # For each repo set global/specific/no HTTP proxy and sync it
-    for policy in ['global_default_http_proxy', 'use_selected_http_proxy', 'none']:
+    http_proxy_policies = ['global_default_http_proxy', 'use_selected_http_proxy']
+    if module_target_sat.network_type.has_ipv4:
+        http_proxy_policies.append('none')
+    for policy in http_proxy_policies:
         for repo in module_repos_collection_with_manifest.repos_info:
             repo = module_target_sat.api.Repository(
                 id=repo['id'],


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19131

### Problem Statement
CDN is not accessible from Red Hat's internal IPv6 network and setting `http_proxy_policy='none'` makes repository sync to fail:
```
    E   nailgun.entity_mixins.TaskFailedError: Task 7508be1d-bd0f-4f6d-bd4e-374dc8116de1 did not succeed. Task information: {'id': '7508be1d-bd0f-4f6d-bd4e-374dc8116de1', 'label': 'Actions::Katello::Repository::Sync'
...
'errors': ['Cannot connect to host cdn.redhat.com:443 ssl:default [Network is unreachable]']
...
```

### Solution
Omit setting `http_proxy_policy='none'` for repository on IPv6

### Related Issues
[SAT-36461](https://issues.redhat.com/browse/SAT-36461)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->