### PR TITLE
[6.17.z] Make non-proxy traffic blocking fixture IPv6 ready

### DIFF
--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -77,20 +77,29 @@ def block_fake_repo_access(session_target_sat):
     repo_server_port = '.'.join(
         urlparse(settings.robottelo.REPOS_HOSTING_URL).netloc.split(':')[1:]
     )
-    cmd_result = session_target_sat.execute(f'nc -z {repo_server_name} {repo_server_port}')
-    if cmd_result.status != 0:
-        raise SatelliteHostError(
-            f'Error, port {repo_server_name} {repo_server_port} incorrect or already blocked.'
+    ip_versions = [v for v in [4, 6] if getattr(session_target_sat.network_type, f'has_ipv{v}')]
+    for ipv in ip_versions:
+        cmd_result = session_target_sat.execute(
+            f'nc -{ipv} -z {repo_server_name} {repo_server_port}'
         )
-    session_target_sat.execute(
-        'firewall-cmd --direct --add-rule ipv4 filter OUTPUT 0 -p tcp -m tcp'
-        f' --dport={repo_server_port} -j DROP'
-    )
-    cmd_result = session_target_sat.execute(f'nc -z {repo_server_name} {repo_server_port}')
-    if cmd_result.status != 1:
-        raise SatelliteHostError(f'Error, port {repo_server_name} {repo_server_port} not blocked.')
+        if cmd_result.status != 0:
+            raise SatelliteHostError(
+                f'IPv{ipv} destination port {repo_server_name}:{repo_server_port} incorrect or already blocked.'
+            )
+        session_target_sat.execute(
+            f'firewall-cmd --direct --add-rule ipv{ipv} filter OUTPUT 0 -p tcp -m tcp'
+            f' --dport={repo_server_port} -j DROP'
+        )
+        cmd_result = session_target_sat.execute(
+            f'nc -{ipv} -z {repo_server_name} {repo_server_port}'
+        )
+        if cmd_result.status != 1:
+            raise SatelliteHostError(
+                f'IPv{ipv} destination port {repo_server_name}:{repo_server_port} not blocked.'
+            )
     yield
-    session_target_sat.execute(
-        'firewall-cmd --direct --remove-rule ipv4 filter OUTPUT 0 -p tcp -m tcp'
-        f' --dport={repo_server_port} -j DROP'
-    )
+    for ipv in ip_versions:
+        session_target_sat.execute(
+            f'firewall-cmd --direct --remove-rule ipv{ipv} filter OUTPUT 0 -p tcp -m tcp'
+            f' --dport={repo_server_port} -j DROP'
+        )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19109

### Problem Statement
Fixture `block_fake_repo_access` used in HTTP Proxy testing is lacking IPv6 support
```
    pytest_fixtures/core/sys.py:91: in block_fake_repo_access
        raise SatelliteHostError(f'Error, port {repo_server_name} {repo_server_port} not blocked.')
    E   robottelo.hosts.SatelliteHostError: Error, port infra-podman-ipv6.example.com 50123 not blocked.

```



### Solution
Implement IPv6 support in non-proxy traffic blocking fixture (`block_fake_repo_access`)

### Related Issues
[SAT-36407](https://issues.redhat.com/browse/SAT-36407)


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->