### PR TITLE
[SAT-33810] Hosts - VM setup for cases: module_streams, apply_erratum, delete_package

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1260,13 +1260,19 @@ class ContentHost(Host, ContentHostMixins):
         if product_label:
             # Enable custom repositories
             for repo_label in repo_labels:
-                result = self.execute(
-                    f'yum-config-manager --enable {org_label}_{product_label}_{repo_label}'
+                # try first with subscription-manager (SCA)
+                result_sm = self.execute(
+                    f'subscription-manager repos --enable {org_label}_{product_label}_{repo_label}'
                 )
-                if result.status != 0:
-                    raise CLIFactoryError(
-                        f'Failed to enable custom repository {repo_label!s}\n{result.stderr}'
+                if result_sm.status != 0:
+                    result = self.execute(
+                        f'yum-config-manager --enable {org_label}_{product_label}_{repo_label}'
                     )
+                    if result.status != 0:
+                        raise CLIFactoryError(
+                            f'Failed to enable custom repository: {repo_label!s}\n{result.stderr}'
+                            f'\nSubscription-Manager:\n{result_sm.stderr}'
+                        )
 
     def virt_who_hypervisor_config(
         self,

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1371,17 +1371,12 @@ def test_positive_host_details_read_templates(
     assert set(api_templates) == set(ui_templates)
 
 
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_match('N-1')
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
     'module_repos_collection_with_setup',
-    [
-        {
-            'distro': 'rhel8',
-            'YumRepository': {'url': settings.repos.yum_3.url},
-        }
-    ],
-    ids=['yum3'],
+    [{'YumRepository': {'url': settings.repos.yum_3.url}}],
+    ids=['yum_3'],
     indirect=True,
 )
 def test_positive_update_delete_package(
@@ -1409,10 +1404,7 @@ def test_positive_update_delete_package(
     """
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(
-        vm=client,
-        enable_custom_repos=True,
-    )
+    module_repos_collection_with_setup.setup_virtual_machine(client, enable_custom_repos=True)
     with session:
         session.location.select(loc_name=DEFAULT_LOC)
         product_name = module_repos_collection_with_setup.custom_product.name
@@ -1486,16 +1478,11 @@ def test_positive_update_delete_package(
         assert result.status != 0
 
 
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_match('N-1')
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
     'module_repos_collection_with_setup',
-    [
-        {
-            'distro': 'rhel8',
-            'YumRepository': {'url': settings.repos.yum_3.url},
-        }
-    ],
+    [{'YumRepository': {'url': settings.repos.yum_3.url}}],
     ids=['yum3'],
     indirect=True,
 )
@@ -1524,7 +1511,7 @@ def test_positive_apply_erratum(
     # install package
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(client, target_sat)
+    module_repos_collection_with_setup.setup_virtual_machine(client, enable_custom_repos=True)
     errata_id = settings.repos.yum_3.errata[25]
     client.run(f'yum install -y {FAKE_7_CUSTOM_PACKAGE}')
     result = client.run(f'rpm -q {FAKE_7_CUSTOM_PACKAGE}')
@@ -1565,16 +1552,11 @@ def test_positive_apply_erratum(
 
 
 @pytest.mark.e2e
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_match('N-1')
 @pytest.mark.no_containers
 @pytest.mark.parametrize(
     'module_repos_collection_with_setup',
-    [
-        {
-            'distro': 'rhel8',
-            'YumRepository': {'url': settings.repos.module_stream_1.url},
-        }
-    ],
+    [{'YumRepository': {'url': settings.repos.module_stream_1.url}}],
     ids=['module_stream_1'],
     indirect=True,
 )
@@ -1603,13 +1585,12 @@ def test_positive_crud_module_streams(
     module_name = 'duck'
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(client, target_sat)
+    module_repos_collection_with_setup.setup_virtual_machine(client, enable_custom_repos=True)
     with session:
         session.location.select(loc_name=DEFAULT_LOC)
         streams = session.host_new.get_module_streams(client.hostname, module_name)
         assert streams[0]['Name'] == module_name
         assert streams[0]['State'] == 'Default'
-
         # enable module stream
         session.host_new.apply_module_streams_action(client.hostname, module_name, "Enable")
         task_result = target_sat.wait_for_tasks(


### PR DESCRIPTION
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_positive_crud_module_streams or test_positive_apply_erratum or test_positive_update_delete_package'
airgun: 1888
```
Also needs https://github.com/SatelliteQE/airgun/pull/1941 , which fixes most PF5 issues for these views **(Merged)**

_Test issues still exist, the `host_new.get_details()` `.get_repo_sets()` and `.get_module_streams()` return empty, or are not updated after installing a package, erratum, or enabling reposet/modulestream ._
^ @pnovotny has suggested with fixed setup and UI nav, these Hosts tests can be resolved in a follow-up.

Module Streams (`test_positive_crud_module_streams`): unable to see that module_stream is 'Enabled'
Erratum (`test_positive_apply_erratum`): cannot find any 'security_advisory' errata, keyerror
Package (`test_positive_update_delete_package`): is listed as 'Upgradable', when should be 'Up to date'