### PR TITLE
[6.15.z] Fix deploy_configure_by_script for Virtwho tests

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -351,7 +351,7 @@ def deploy_configure_by_script(
     register_system(get_system(hypervisor_type), org=org)
     with open(script_filename, 'w') as fp:
         fp.write(script_content)
-    ssh.get_client().put(script_filename)
+    ssh.get_client().put(script_filename, script_filename)
     ret, stdout = runcmd(f'sh {script_filename}')
     if ret != 0 or 'Finished successfully' not in stdout:
         raise VirtWhoError(f"Failed to deploy configure by {script_filename}")


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19151

### Problem Statement
- Test which configures Virtwho with scripts fails because `deploy_configure_by_script` fail to put the script on satellite.

```
../../lib64/python3.12/site-packages/pytest_asyncio/plugin.py:681: in pytest_fixture_setup
    return (yield)
            ^^^^^
tests/foreman/conftest.py:74: in ui_session_record_property
    request.getfixturevalue(fixture), Satellite
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../lib64/python3.12/site-packages/pytest_asyncio/plugin.py:681: in pytest_fixture_setup
    return (yield)
            ^^^^^
pytest_fixtures/component/virtwho_config.py:345: in deploy_type_ui
    hypervisor_name, guest_name = deploy_configure_by_script(
robottelo/utils/virtwho.py:357: in deploy_configure_by_script
    raise VirtWhoError(f"Failed to deploy configure by {script_filename}")
E   robottelo.utils.virtwho.VirtWhoError: Failed to deploy configure by /tmp/deploy_script.sh
```

### Solution
- Fix `deploy_configure_by_script`

### Related Issues
- SAT-36504

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->