### PR TITLE
Fix virtwho tests failing on subscription-manager registration

### DIFF
--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -234,7 +234,7 @@ def form_data_ui(request, target_sat, org_module):
 
 
 @pytest.fixture
-def virtwho_config_cli(form_data_cli, target_sat):
+def virtwho_config_cli(form_data_cli, target_sat, register_sat_and_enable_aps_repo):
     virtwho_config_cli = target_sat.cli.VirtWhoConfig.create(form_data_cli)['general-information']
     yield virtwho_config_cli
     target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config_cli['name']})
@@ -242,7 +242,7 @@ def virtwho_config_cli(form_data_cli, target_sat):
 
 
 @pytest.fixture
-def virtwho_config_api(form_data_api, target_sat):
+def virtwho_config_api(form_data_api, target_sat, register_sat_and_enable_aps_repo):
     virtwho_config_api = target_sat.api.VirtWhoConfig(**form_data_api).create()
     yield virtwho_config_api
     virtwho_config_api.delete()
@@ -252,7 +252,7 @@ def virtwho_config_api(form_data_api, target_sat):
 
 
 @pytest.fixture
-def virtwho_config_ui(form_data_ui, target_sat, org_session):
+def virtwho_config_ui(form_data_ui, target_sat, org_session, register_sat_and_enable_aps_repo):
     name = gen_string('alpha')
     form_data_ui['name'] = name
     with org_session:

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -103,7 +103,7 @@ def register_system(system, activation_key=None, org='Default_Organization', env
         f'rpm -ihv http://{settings.server.hostname}/pub/katello-ca-consumer-latest.noarch.rpm',
         system,
     )
-    cmd = f'subscription-manager register --org={org} --environment={env} '
+    cmd = f'subscription-manager register --org={org} --environment={env} --force '
     if activation_key is not None:
         cmd += f'--activationkey={activation_key}'
     else:


### PR DESCRIPTION
### Problem Statement
- Currently, some of the virtwho tests are failing on subscription-manager registration for host with `This system is already registered. Use --force to override` error.
- Also, the satellite doesn't have base repos enabled, causing test failure on virt-who package install.

### Solution
- Use the `--force` option during host registration.
- Register Satellite with CDN.

### Related Issues
- SAT-36522

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->