### PR TITLE
Fix IoP foreman-maintain tests failing on podman login

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -1,7 +1,6 @@
 from broker import Broker
 import pytest
 
-from robottelo.config import settings
 from robottelo.constants import CAPSULE_REGISTRATION_OPTS
 
 
@@ -21,7 +20,7 @@ def enable_insights(host, satellite, org, activation_key):
 
 
 @pytest.fixture(scope='module')
-def module_target_sat_insights(request, module_target_sat, satellite_factory):
+def module_target_sat_insights(request, module_target_sat, module_satellite_iop):
     """A module-level fixture to provide a Satellite configured for Insights.
     By default, it returns the existing Satellite provided by module_target_sat.
 
@@ -29,12 +28,7 @@ def module_target_sat_insights(request, module_target_sat, satellite_factory):
     iop-advisor-engine (local Insights advisor) configured.
     """
     hosted_insights = getattr(request, 'param', True)
-    satellite = module_target_sat if hosted_insights else satellite_factory()
-    iop_settings = settings.rh_cloud.iop_advisor_engine
-    if not hosted_insights:
-        satellite.configure_insights_on_prem(
-            iop_settings.stage_username, iop_settings.stage_token, iop_settings.stage_registry
-        )
+    satellite = module_target_sat if hosted_insights else module_satellite_iop
     yield satellite
 
     if not hosted_insights:

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -210,14 +210,22 @@ def module_capsule_configured(request, module_capsule_host, module_target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_satellite_iop(request, module_satellite_host):
+def module_unconfigured_satellite(request):
+    deploy_args = settings.server.deploy_arguments
+    deploy_args['workflow'] = 'deploy-unconfigured-satellite'
+    with Broker(**deploy_args, host_class=Satellite) as host:
+        yield host
+
+
+@pytest.fixture(scope='module')
+def module_satellite_iop(request, module_unconfigured_satellite):
     """Deploy and configure Red Hat Lightspeed in Satellite"""
     iop_settings = settings.rh_cloud.iop_advisor_engine
-    module_satellite_host.configure_insights_on_prem(
+    module_unconfigured_satellite.configure_insights_on_prem(
         iop_settings.stage_username, iop_settings.stage_token, iop_settings.stage_registry
     )
-    yield module_satellite_host
-    module_satellite_host.podman_logout(iop_settings.stage_registry)
+    yield module_unconfigured_satellite
+    module_unconfigured_satellite.podman_logout(iop_settings.stage_registry)
 
 
 @pytest.fixture(scope='module')

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -455,6 +455,9 @@ class IoPSetup:
         username = username or iop_settings.username
         password = password or iop_settings.token
         registry = registry or iop_settings.registry
+        self.register_to_cdn()
+        self.setup_rhel_repos()
+        self.setup_satellite_repos()
         self.podman_login(username, password, registry)
         # TODO: Replace this temporary implementation with a permanent solution.
         result = self.execute(

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1597,6 +1597,21 @@ class ContentHost(Host, ContentHostMixins):
                 snap=settings.capsule.version.snap,
             )
 
+    def ensure_podman_installed(self):
+        """Ensure Podman is installed, registering temporarily if needed."""
+        if self.execute('rpm -q podman').status == 0:
+            return
+        was_registered = self.subscription_manager_status().status == 0
+        if not was_registered:
+            self.register_to_cdn()
+        try:
+            result = self.execute('dnf -y install podman --disableplugin=foreman-protector')
+            if result.status != 0:
+                raise ContentHostError(f'Podman installation failed: {result.stdout}')
+        finally:
+            if not was_registered:
+                self.unregister()
+
     def podman_login(self, username=None, password=None, registry=None):
         """Login to a podman registry."""
         iop_settings = settings.rh_cloud.iop_advisor_engine
@@ -1604,6 +1619,7 @@ class ContentHost(Host, ContentHostMixins):
         password = password or iop_settings.token
         registry = registry or iop_settings.registry
         if registry and username and password:
+            self.ensure_podman_installed()
             auth_str = f'{username}:{password}'
             auth_b64 = base64.b64encode(auth_str.encode()).decode()
             auth_data = {'auths': {f'{registry}': {'auth': auth_b64}}}


### PR DESCRIPTION
### Problem Statement
- Foreman mantain tests are failing on registry login because `Podman` is not installed.
- There have been changes in ansible playbook that configure IoP Satellite, it now doesn't work with pre-installed Satellite.

### Solution
- Make sure `Podman` is installed.
- Get an unconfigured satellite using `deploy-unconfigured-satellite` to configure IoP Satellite.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->