### PR TITLE
Add a test case for flatpak app install via Capsule and CV

### DIFF
--- a/pytest_fixtures/component/flatpak.py
+++ b/pytest_fixtures/component/flatpak.py
@@ -26,3 +26,13 @@ def function_flatpak_remote(request, target_sat, function_org):
     assert len(scanned_repos), 'No repositories scanned'
 
     return Box(remote=fr, repos=scanned_repos)
+
+
+@pytest.fixture
+def function_host_cleanup(target_sat, module_flatpak_contenthost):
+    """Cleans up the flatpak contenthost so it can be re-registered with different org"""
+    res = target_sat.api.Host().search(
+        query={'search': f'name="{module_flatpak_contenthost.hostname}"'}
+    )
+    if len(res) == 1:
+        res[0].delete()

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -1042,7 +1042,7 @@ def test_sync_consume_flatpak_repo_via_cv(
             'organization': function_org.name,
             'job-template': 'Flatpak - Set up remote on host',
             'inputs': inputs,
-            'search-query': f"name = {host.hostname}",
+            'search-query': f'name = {host.hostname}',
         }
     )
     res = module_target_sat.cli.JobInvocation.info({'id': job.id})
@@ -1065,7 +1065,7 @@ def test_sync_consume_flatpak_repo_via_cv(
                 f'Flatpak remote name={remote_name}, Application name={app_name}, '
                 'Launch a session bus instance=true'
             ),
-            'search-query': f"name = {host.hostname}",
+            'search-query': f'name = {host.hostname}',
         },
         timeout='800s',
     )

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -49,13 +49,6 @@ def function_user(target_sat, function_role, function_org):
     user.delete()
 
 
-@pytest.fixture
-def function_host_cleanup(target_sat, module_flatpak_contenthost):
-    """Cleans up the flatpak contenthost so it can be re-registered with different org"""
-    if nh := module_flatpak_contenthost.nailgun_host:
-        nh.delete()
-
-
 def test_CRUD_and_sync_flatpak_remote_with_permissions(
     target_sat, function_user, function_role, function_org
 ):


### PR DESCRIPTION
### Problem Statement
Capsule support for flatpak and cert-based authentication has been added and we should have a test case for that.


### Solution
This PR proposes such a test case.


### Related Issues
https://issues.redhat.com/browse/SAT-33261


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_capsulecontent.py -k test_sync_consume_flatpak_repo_via_cv
```