### PR TITLE
Fix Satellite's local_advisor_enabled property

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2663,7 +2663,7 @@ class Satellite(Capsule, SatelliteMixins):
     @property
     def local_advisor_enabled(self):
         """Return boolean indicating whether local Insights advisor engine is enabled."""
-        return self.api.RHCloud().advisor_engine_config()['use_local_advisor_engine']
+        return self.api.RHCloud().advisor_engine_config()['use_iop_mode']
 
 
 class SSOHost(Host):


### PR DESCRIPTION
### Problem Statement
Property `local_advisor_enabled` started failing with 
```
KeyError: 'use_local_advisor_engine'
```

### Solution
Use new key `use_iop_mode`.

### How to test this PR?
<img width="795" height="142" alt="image" src="https://github.com/user-attachments/assets/e2772c3c-4fd0-4ef0-af2b-14e5f3347f38" />

```
from robottelo.hosts import Satellite

target_sat = Satellite('sat.stream.com') # stream 120

# print(target_sat.api.RHCloud().advisor_engine_config()['use_local_advisor_engine']) # Does not work anymore
print(target_sat.api.RHCloud().advisor_engine_config()['use_iop_mode']) # Works
```