### PR TITLE
Disassociate Multiple Hosts Fix

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -3085,7 +3085,7 @@ def test_disassociate_multiple_hosts(
             hostgroup_name, {'host_group.deploy': f'{cr_name} ({FOREMAN_PROVIDERS["vmware"]})'}
         )
 
-        cr_vm_names = [settings.vmware.vm_name, 'proton-testing-guest-rhel-8']
+        cr_vm_names = [settings.vmware.vm_name, 'phoenix-testing-guest-rhel-8']
         vm_names_with_domains = [f'{name.replace(".", "")}.{domain.name}' for name in cr_vm_names]
 
         # Import VMs from VMware compute resource


### PR DESCRIPTION
### Problem Statement
Used VM name was changed by https://github.com/SatelliteQE/robottelo/pull/19130

### Solution
Change VM name back to `phoenix-testing-guest-rhel-8`


### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k test_disassociate_multiple_hosts
```