### PR TITLE
install Errata UI test fix

### DIFF
--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -501,9 +501,7 @@ def test_positive_install_errata(
             settings.repos.yum_6.errata[2],
             install_via='via remote execution',
         )
-        assert result['job_status'] == 'Success'
-        assert result['job_status_progress'] == '100%'
-        assert int(result['total_hosts']) == 2
+        assert int(result['overall_status']['succeeded_hosts']) == 2
         assert _is_package_installed(vm_content_hosts, constants.FAKE_2_CUSTOM_PACKAGE)
 
 


### PR DESCRIPTION
`test_positive_install_errata` needed refactoring after new job details page reads have been implemented in https://github.com/SatelliteQE/airgun/pull/1962
<img width="231" height="40" alt="image" src="https://github.com/user-attachments/assets/2d4b186a-3b33-45a0-b246-a4d685ed43ab" />

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostcollection.py -k "test_positive_install_errata"
airgun: 1962
```