### PR TITLE
Remove manage_crond setup from test_positive_maintenance_mode

### DIFF
--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -5,7 +5,6 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.constants import SATELLITE_MAINTAIN_YML
 from robottelo.exceptions import SatelliteHostError
 from robottelo.hosts import Capsule, Satellite
 from robottelo.logging import logger
@@ -137,16 +136,12 @@ def setup_sync_plan(request, sat_maintain):
             'sync-date': datetime.datetime.today().strftime("%Y-%m-%d"),
         }
     )
-    sat_maintain.execute(f'cp {SATELLITE_MAINTAIN_YML} foreman_maintain.yml')
-    sat_maintain.execute(f'sed -i "$ a :manage_crond: true" {SATELLITE_MAINTAIN_YML}')
 
     yield sat_maintain.api.SyncPlan(organization=org.label).search(query={'search': 'enabled=true'})
 
     @request.addfinalizer
     def _finalize():
         assert sat_maintain.cli.MaintenanceMode.stop().status == 0
-        sat_maintain.execute(f'cp foreman_maintain.yml {SATELLITE_MAINTAIN_YML}')
-        sat_maintain.execute('rm -rf foreman_maintain.yml')
         result = sat_maintain.cli.SyncPlan.delete(
             {'name': new_sync_plan.name, 'organization-id': org.id}
         )

--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -28,7 +28,6 @@ def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
     :setup:
         1. Get a Satellite(default and/or IoP-enabled Satellite)
         2. Create a sync-plan which is enabled
-        3. set ':manage_crond: true' in /etc/foreman-maintain/foreman_maintain.yml
 
     :steps:
         1. Verify that maintenance-mode is Off.


### PR DESCRIPTION
### Problem Statement
- test_positive_maintenance_mode sets ':manage_crond: true' in /etc/foreman-maintain/foreman_maintain.yml But with since https://github.com/theforeman/foreman_maintain/pull/910 we don't need to do that.

### Solution
- Remove manage_crond setup code from the test

### Related Issues
- SAT-36764

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->