### PR TITLE
Harden flatpak e2e cases

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1556,7 +1556,6 @@ class TestContentViewSync:
                 ),
                 'search-query': f"name = {module_flatpak_contenthost.hostname}",
             },
-            timeout='800s',
         )
         res = module_import_sat.cli.JobInvocation.info({'id': job.id})
         assert 'succeeded' in res['status']


### PR DESCRIPTION
### Proposed changes
This PR proposes two changes to harden the flatpak e2e cases:
1) It ensures the LCE/CV isolation works properly when cert-based authentication is used for both, Satellite and Capsule.
2) Removes `timeout` from Flatpak-install job invocation to bring back time sensitivity for the issue bellow.


### Related Issues
https://issues.redhat.com/browse/SAT-34089


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli -k test_sync_consume_flatpak_repo_via_cv
```