### PR TITLE
[6.16.z] Use url method to obtain correct protocol and adapt port accordingly

### DIFF
--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -62,10 +62,8 @@ def test_positive_puppet_bootstrap(
     ).create()
 
     render = requests.get(
-        (
-            f'http://{session_puppet_enabled_sat.hostname}:8000/'
-            f'unattended/provision?token={host.token}'
-        ),
+        f'{session_puppet_enabled_sat.url}:9090/unattended/provision?token={host.token}',
+        verify=False,
     ).text
 
     puppet_config = (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/18696

### Problem Statement

Puppet test unable to reach url with specific port


### Solution

see commit message

### Tests to run
```
tests/foreman/api/test_provisioning_puppet.py::test_positive_puppet_bootstrap
```