### PR TITLE
Move bootc tests to the Artemis team

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1046,9 +1046,11 @@ def test_positive_bootc_api_actions(target_sat, bootc_host, function_ak_with_cv,
 
     :expectedresults: Upon registering a Bootc host, the API returns correct information across multiple endpoints
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent: Hosts-Content
 
-    :Verifies:SAT-27168, SAT-27170, SAT-27173
+    :Team: Artemis
+
+    :Verifies: SAT-27168, SAT-27170, SAT-27173
 
     :CaseImportance: Critical
     """

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1920,9 +1920,11 @@ def test_positive_bootc_cli_actions(target_sat, bootc_host, function_ak_with_cv,
 
     :expectedresults: Upon registering a Bootc host, the facts are attached to the host, and are accurate. Hammer host bootc also returns proper info.
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent: Hosts-Content
 
-    :Verifies:SAT-27168, SAT-27170, SAT-30211
+    :Team: Artemis
+
+    :Verifies: SAT-27168, SAT-27170, SAT-30211
 
     :CaseImportance: Critical
     """


### PR DESCRIPTION
### Problem Statement
Some of the team Artemis owned tests are reported to team Proton based on the module doc-string. 


### Solution
Assign them individually to Artemis for now.
