### PR TITLE
Log warning on OS/Sat version get failure

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -99,7 +99,8 @@ def get_sat_version():
 
     try:
         sat_version = Satellite().version
-    except (AuthenticationError, ContentHostError, BoxKeyError):
+    except (AuthenticationError, ContentHostError, BoxKeyError) as err:
+        logger.warning('Failed to get Satellite version: %s', err)
         if sat_version := str(settings.server.version.get('release')) == 'stream':
             sat_version = str(settings.robottelo.get('satellite_version'))
         if not sat_version:
@@ -113,7 +114,8 @@ def get_sat_rhel_version():
 
     try:
         return Satellite().os_version
-    except (AuthenticationError, ContentHostError, BoxKeyError):
+    except (AuthenticationError, ContentHostError, BoxKeyError) as err:
+        logger.warning('Failed to get RHEL version from Satellite: %s', err)
         if hasattr(settings.server.version, 'rhel_version'):
             rhel_version = str(settings.server.version.rhel_version)
         elif hasattr(settings.robottelo, 'rhel_version'):


### PR DESCRIPTION
## Summary
• Log warning when OS/Satellite version retrieval fails to help trace version mismatch issues
• Known issue: settings show version "9" but Satellite.os_version returns "9.6" - need debugging context

🤖 Generated with [Claude Code](https://claude.ai/code)