### PR TITLE
Fix installation test failing due to addition of iop module

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -82,6 +82,7 @@ DOWNSTREAM_MODULES = {
     'foreman_proxy::plugin::remote_execution::script',
     'foreman_proxy::plugin::shellhooks',
     'foreman_proxy_content',
+    'iop',
     'katello',
     'puppet',
 }


### PR DESCRIPTION
### Problem Statement
Installation test is failing as the iop module is introduced now

### Solution
Add iop module to the `DOWNSTREAM_MODULES`

