### PR TITLE
Fix use of workflow arg in module_unconfigured_satellite

### DIFF
--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -32,6 +32,7 @@ SERVER:
   DEPLOY_WORKFLOWS:
     PRODUCT: deploy-satellite  # workflow to deploy OS with product running on top of it
     OS: deploy-rhel  # workflow to deploy OS that is ready to run the product
+    UNCONFIGURED: deploy-unconfigured-satellite # workflow to deploy unconfigured sat
   # Dictionary of arguments which should be passed along to the deploy workflow
   # DEPLOY_ARGUMENTS:
   #  deploy_network_type: '@format { this.server.network_type }'

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -212,8 +212,9 @@ def module_capsule_configured(request, module_capsule_host, module_target_sat):
 @pytest.fixture(scope='module')
 def module_unconfigured_satellite(request):
     deploy_args = settings.server.deploy_arguments
-    deploy_args['workflow'] = 'deploy-unconfigured-satellite'
-    with Broker(**deploy_args, host_class=Satellite) as host:
+    with Broker(
+        workflow=settings.server.deploy_workflows.unconfigured, **deploy_args, host_class=Satellite
+    ) as host:
         yield host
 
 


### PR DESCRIPTION
### Problem Statement
Due to incorrect use of workflow arg in module_unconfigured_satellite fixture, it fails currently with below error
```
pytest_fixtures/core/sat_cap_factory.py:85: in factory
    vmb = Broker(
E   TypeError: broker.broker.Broker() got multiple values for keyword argument 'workflow'
```

### Solution
1. Using workflow arg for passing workflow in module_unconfigured_satellite
2. Adding unconfigured sat workflow to deploy_workflows in server config

### Related Issues
satellite-jenkins MR#1760 and see test results on Jenkins MR

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->