### PR TITLE
[6.17.z] Removing check for mac-address as its no longer valid use case as per SAT-27056

### DIFF
--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -17,7 +17,6 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.enums import NetworkType
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.mark.upgrade
@@ -130,8 +129,6 @@ def test_positive_facts_end_to_end(
         'ansible_distribution_major_version': str(rhel_contenthost.os_version.major),
         'ansible_fqdn': rhel_contenthost.hostname,
     }
-    if not is_open('SAT-27056'):
-        expected_values['net::interface::eth1::mac_address'] = mac_address.lower()
     for fact, expected_value in expected_values.items():
         actual_value = facts_dict.get(fact)
         assert actual_value == expected_value, (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19270


### Problem Statement
There was a check on the mac address as a part of [SAT-27056 ](https://issues.redhat.com/browse/SAT-27056) but that issue has been closed saying not going to implement. which start failing check for mac address.

### Solution
Removing that check as its no longer valid

### Related Issues
SAT-27056


### PRT test Cases example
trigger: test-robottelo
pytest:  tests/foreman/cli/test_fact.py -k 'test_positive_facts_end_to_end'

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->