### PR TITLE
[6.16.z] Removing check for mac-address as its no longer valid use case as per SAT-27056'

### DIFF
--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -17,6 +17,7 @@ import pytest
 
 from robottelo.config import settings
 
+
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'fact',


### PR DESCRIPTION
 (#19270) [#19278 ](https://github.com/SatelliteQE/robottelo/issues/19278)
### Resolving conflict in AutoMerged-Cherry-Pick 
* Removing check for mac-address as its no longer valid use case as per SAT-27056

* [pre-commit.ci] auto fixes from pre-commit.com hooks


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_fact.py -k 'test_positive_facts_end_to_end'

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->