### PR TITLE
Add possibility to configure ansible role names in settings

### DIFF
--- a/conf/ansible.yaml.template
+++ b/conf/ansible.yaml.template
@@ -1,3 +1,4 @@
+---
 AAP_INTEGRATION:
   AAP_FQDN: env-aap-01.example.com
   # USERNAME: Login for AAP
@@ -11,3 +12,11 @@ AAP_INTEGRATION:
   # Job template and host_config_key for ansible-callback with Satellite testing
   CALLBACK_JOB_TEMPLATE:
   HOST_CONFIG_KEY:
+
+ANSIBLE:
+  ROLE_NAMES:
+    - 'theforeman.foreman_scap_client'
+    - 'redhat.satellite.hostgroups'
+    - 'RedHatInsights.insights-client'
+    - 'redhat.satellite.compute_resources'
+...

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -57,6 +57,19 @@ VALIDATORS = dict(
         Validator('subscription.rhn_poolid', must_exist=True),
         Validator('subscription.lifecycle_api_url', must_exist=True),
     ],
+    ansible=[
+        Validator(
+            'ansible.role_names',
+            must_exist=True,
+            is_type_of=list,
+            default=[
+                'theforeman.foreman_scap_client',
+                'redhat.satellite.hostgroups',
+                'RedHatInsights.insights-client',
+                'redhat.satellite.compute_resources',
+            ],
+        ),
+    ],
     ansible_hub=[
         Validator('ansible_hub.url', must_exist=True),
         Validator('ansible_hub.token', must_exist=True),

--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -130,12 +130,8 @@ class TestAnsibleCfgMgmt:
 
         :BZ: 2164400
         """
-        ROLE_NAMES = [
-            'theforeman.foreman_scap_client',
-            'redhat.satellite.hostgroups',
-            'RedHatInsights.insights-client',
-            'redhat.satellite.compute_resources',
-        ]
+        ROLE_NAMES = settings.ansible.role_names
+
         hg = target_sat.api.HostGroup(name=gen_string('alpha')).create()
         hg_nested = target_sat.api.HostGroup(name=gen_string('alpha'), parent=hg).create()
         proxy_id = target_sat.nailgun_smart_proxy.id
@@ -211,11 +207,8 @@ class TestAnsibleCfgMgmt:
 
         :customerscenario: true
         """
-        ROLE_NAMES = [
-            'theforeman.foreman_scap_client',
-            'RedHatInsights.insights-client',
-            'redhat.satellite.compute_resources',
-        ]
+        ROLE_NAMES = settings.ansible.role_names
+
         proxy_id = target_sat.nailgun_smart_proxy.id
         host = target_sat.api.Host(organization=module_org, location=module_location).create()
         hg = target_sat.api.HostGroup(name=gen_string('alpha'), organization=[module_org]).create()

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -170,11 +170,8 @@ class TestAnsibleCfgMgmt:
 
         :BZ: 2029402
         """
-        ROLES = [
-            'theforeman.foreman_scap_client',
-            'redhat.satellite.hostgroups',
-            'RedHatInsights.insights-client',
-        ]
+        ROLES = settings.ansible.role_names
+
         proxy_id = target_sat.nailgun_smart_proxy.id
         hg_name = gen_string('alpha')
         result = target_sat.cli.HostGroup.create({'name': hg_name})


### PR DESCRIPTION
### Problem Statement

ansible role names are hardcoded

### Solution

Make ansible  role names configurable as setting

### Tests to run
```
tests/foreman/api/test_ansible.py::TestAnsibleCfgMgmt::test_add_and_remove_ansible_role_hostgroup
tests/foreman/api/test_ansible.py::TestAnsibleCfgMgmt::test_positive_ansible_roles_inherited_from_hostgroup
tests/foreman/cli/test_ansible.py::TestAnsibleCfgMgmt::test_add_and_remove_ansible_role_hostgroup

```