### PR TITLE
module_target_sat_insights refactor

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -30,10 +30,9 @@ def module_target_sat_insights(request, module_target_sat):
     """
     hosted_insights = getattr(request, 'param', True)
 
-    if hosted_insights:
-        satellite = module_target_sat
-    else:
-        satellite = request.getfixturevalue('module_satellite_iop')
+    satellite = (
+        module_target_sat if hosted_insights else request.getfixturevalue('module_satellite_iop')
+    )
 
     yield satellite
 

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -480,7 +480,7 @@ class IoPSetup:
             ansible-galaxy collection install -r requirements.yml
             ansible-playbook -c local playbooks/deploy.yaml
             ''',
-            timeout='60m',
+            timeout='20m',
         )
         assert result.status == 0, f'Failed to configure IoP: {result.stdout}'
         assert self.local_advisor_enabled


### PR DESCRIPTION
### Problem statement
`module_target_sat_insights` was checkouting unconfigured sat even if it was supposed to just use satellite from the module_target_sat in the hosted scenario

### Solution
Do not use `module_satellite_iop` in the fixture definition.
