### PR TITLE
remediate multiple hosts extension and IOP parametrization removal

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -160,7 +160,7 @@ def test_rhcloud_insights_remediate_multiple_hosts(
     rhcloud_manifest_org,
     module_target_sat_insights,
 ):
-    """Get rule hits data for multiple Hosts from hosted or local Insights Advisor, verify results are displayed in Satellite, and run remediations for all Hosts simultaneously.
+    """Get rule hits data for multiple Hosts from hosted Insights Advisor, verify results are displayed in Satellite, and run remediations for all Hosts simultaneously.
 
     :id: 33463576-ccc0-4200-a5c0-6e7ffc9a03f7
 


### PR DESCRIPTION
Add an assertion to the `test_rhcloud_insights_remediate_multiple_hosts`

`local` test is now failing for some issue that is unrelated to the test and needs further investigation, thus running PRT just for `hosted` one.

It also removes the parametrization for IOP from the test, as the Recommendations and Vulnerabilities pages are different enough between hosted and IOP that we will be creating separate test modules and Airgun entities/views for the on-prem scenario.

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_insights.py -k "test_rhcloud_insights_remediate_multiple_hosts[rhel10-ipv4-hosted]"
```


