### PR TITLE
Scope flatpak remote-ls for particular remote and fix uninstall

### DIFF
--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -899,7 +899,7 @@ def test_sync_consume_flatpak_repo_via_library(
     assert remote_name in res.stdout
 
     app_name = 'firefox'  # or 'org.mozilla.firefox'
-    res = host.execute('flatpak remote-ls')
+    res = host.execute(f'flatpak remote-ls {remote_name}')
     assert app_name in res.stdout
 
     job = module_target_sat.cli_factory.job_invocation(
@@ -1067,7 +1067,7 @@ def test_sync_consume_flatpak_repo_via_cv(
     assert remote_name in res.stdout
 
     # Ensure only the proper Apps are available (exclusion for cert-based auth only).
-    res = host.execute('flatpak remote-ls')
+    res = host.execute(f'flatpak remote-ls {remote_name}')
     assert all(app_name in res.stdout for app_name in ['Thunderbird', 'Platform'])
     if cert_login:
         assert 'firefox' not in res.stdout.lower()

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -332,7 +332,7 @@ def test_sync_consume_flatpak_repo_via_library(
 
     # 5. Install flatpak app from the repo via REX on the contenthost.
     app_name = 'firefox'  # or 'org.mozilla.firefox'
-    res = host.execute('flatpak remote-ls')
+    res = host.execute(f'flatpak remote-ls {remote_name}')
     assert app_name in res.stdout
 
     job = module_target_sat.cli_factory.job_invocation(
@@ -349,7 +349,7 @@ def test_sync_consume_flatpak_repo_via_library(
     res = module_target_sat.cli.JobInvocation.info({'id': job.id})
     assert 'succeeded' in res['status']
     request.addfinalizer(
-        lambda: host.execute(f'flatpak uninstall {remote_name} {app_name} com.redhat.Platform -y')
+        lambda: host.execute(f'flatpak uninstall {app_name} com.redhat.Platform -y')
     )
 
     # 6. Ensure the app has been installed successfully.
@@ -481,7 +481,7 @@ def test_sync_consume_flatpak_repo_via_cv(
     assert remote_name in res.stdout
 
     # 6. Ensure only the proper Apps are available (exclusion for cert-based auth only).
-    res = host.execute('flatpak remote-ls')
+    res = host.execute(f'flatpak remote-ls {remote_name}')
     assert all(app_name in res.stdout for app_name in ['Thunderbird', 'Platform'])
     if cert_login:
         assert 'firefox' not in res.stdout.lower()

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1543,7 +1543,7 @@ class TestContentViewSync:
         assert remote_name in res.stdout
 
         app_name = 'firefox'
-        res = module_flatpak_contenthost.execute('flatpak remote-ls')
+        res = module_flatpak_contenthost.execute(f'flatpak remote-ls {remote_name}')
         assert app_name in res.stdout
 
         job = module_import_sat.cli_factory.job_invocation(
@@ -1561,7 +1561,7 @@ class TestContentViewSync:
         assert 'succeeded' in res['status']
         request.addfinalizer(
             lambda: module_flatpak_contenthost.execute(
-                f'flatpak uninstall {remote_name} {app_name} com.redhat.Platform -y'
+                f'flatpak uninstall {app_name} com.redhat.Platform -y'
             )
         )
 


### PR DESCRIPTION
### Problem Statement

1. I've bumped into a test interference during `6.17.z` FTA. In short - the `flatpak remote-ls` lists all installable apps regardless the remote source they come from. Thus in case of parallel tests run there can be more remotes created on the _module-scoped_ contenthost, resulting in false positive assertion error where the tested app is offered by another remote, not the tested one.

```
    tests/foreman/cli/test_flatpak.py:479: in test_sync_consume_flatpak_repo_via_cv
        assert 'firefox' not in res.stdout
    E   AssertionError: assert 'firefox' not in 'firefox\tor...dplQDawbeD\n'
    E     
    E     'firefox' is contained here:
    E       firefox	org.mozilla.firefox		stable	x86_64	SAT-remote-lVctwtBNnI
    E     ? +++++++
    E       redhat platform	com.redhat.Platform		el10	x86_64	SAT-remote-lVctwtBNnI
    E       Thunderbird	org.mozilla.Thunderbird		stable	x86_64	SAT-remote-dplQDawbeD
    E       redhat platform	com.redhat.Platform		el10	x86_64	SAT-remote-dplQDawbeD
```
(`firefox` is offered by `SAT-remote-lVctwtBNnI` while we are testing `SAT-remote-dplQDawbeD` remote, which does not offer it correctly).

2. The `flatpak uninstall` command (used in finalizer) shall not reference the remote, only the apps to be uninstalled. There is a couple of places where the remote has been forgotten.


### Solution
This PR tries to fix both
1. by narrowing `flatpak remote-ls` command with particular remote name.
2. by removing the remote name from `flatpak uninstall` command.


### TODO
Cherry-pick this manually since there are 2 more places where `uninstall` needs to be fixed.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli -k sync_consume_flatpak_repo
```