### PR TITLE
[6.17.z] Fix CLI e2e test, by incorporating changes from SAT-35580

### DIFF
--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -252,17 +252,13 @@ def test_positive_cli_end_to_end(function_sca_manifest, target_sat, rhel_content
 
     # check that content view matches what we passed
     assert (
-        content_host['content-information']['content-view-environments']['1']['content-view'][
-            'name'
-        ]
+        content_host['content-information']['content-view-environments']['1']['cv-name']
         == content_view['name']
     )
 
     # check that lifecycle environment matches
     assert (
-        content_host['content-information']['content-view-environments']['1'][
-            'lifecycle-environment'
-        ]['name']
+        content_host['content-information']['content-view-environments']['1']['le-name']
         == lifecycle_environment['name']
     )
 


### PR DESCRIPTION
(cherry picked from commit 2a4bf7ad8eac8de6a01db74aa8e5c7022f13816f)

### Problem Statement
Earlier we cherrypicked https://github.com/SatelliteQE/robottelo/pull/18945 to 6.17.z, which didn't incorporate changes from SAT-35580, which is fixed recently in 6.17.z

### Solution
Fixing CLI e2e test, by incorporating changes from SAT-35580

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->