### PR TITLE
Added test for Settings info CLI command

### DIFF
--- a/robottelo/cli/settings.py
+++ b/robottelo/cli/settings.py
@@ -29,14 +29,3 @@ class Settings(Base):
         cls.command_sub = 'set'
 
         return cls.execute(cls._construct_command(options))
-
-    @classmethod
-    def info(cls, options=None, output_format=None, return_raw_response=None):
-        """Show setting info"""
-        cls.command_sub = 'info'
-
-        return cls.execute(
-            cls._construct_command(options),
-            output_format=output_format,
-            return_raw_response=return_raw_response,
-        )

--- a/robottelo/cli/settings.py
+++ b/robottelo/cli/settings.py
@@ -12,6 +12,7 @@ Subcommands::
 
     list                          List all settings
     set                           Update a setting
+    info                          Show a setting
 """
 
 from robottelo.cli.base import Base
@@ -28,3 +29,14 @@ class Settings(Base):
         cls.command_sub = 'set'
 
         return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def info(cls, options=None, output_format=None, return_raw_response=None):
+        """Show setting info"""
+        cls.command_sub = 'info'
+
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=output_format,
+            return_raw_response=return_raw_response,
+        )

--- a/tests/foreman/cli/test_settings.py
+++ b/tests/foreman/cli/test_settings.py
@@ -15,6 +15,7 @@
 import random
 from time import sleep
 
+from fauxfactory import gen_integer
 import pytest
 
 from robottelo.config import settings
@@ -457,3 +458,42 @@ def test_positive_failed_login_attempts_limit(setting_update, target_sat):
     assert target_sat.execute(f'hammer -u {username} -p {password} user list').status == 0
     target_sat.cli.Settings.set({'name': 'failed_login_attempts_limit', 'value': '0'})
     assert target_sat.cli.Settings.info({'name': 'failed_login_attempts_limit'})['value'] == '0'
+
+
+@pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
+def test_positive_get_setting_info(setting_update, module_target_sat):
+    """Get setting info for a existing setting
+
+    :id: 73568bf2-8419-11f0-9102-c6fadc44396c
+
+    :parametrized: yes
+
+    :expectedresults: Setting info is returned successfully
+
+    :CaseAutomation: Automated
+    """
+
+    setting_info = module_target_sat.cli.Settings.info({'id': 'login_text'}, output_format='json')
+
+    assert setting_info['name'] == setting_update.name
+    assert setting_info['value'] == setting_update.value
+    assert setting_info['description'] == setting_update.description
+    assert setting_info['settings-type'] == setting_update.settings_type
+
+
+def test_positive_get_non_existing_setting_info(module_target_sat):
+    """Get setting info for non existing setting
+
+    :id: 7b8b83d6-8419-11f0-9102-c6fadc44396c
+
+    :expectedresults: Correct error message is returned
+
+    :Verifies: SAT-20238
+
+    :CaseAutomation: Automated
+    """
+    non_existing_id = gen_integer(min_value=1, max_value=10000)
+    with pytest.raises(CLIReturnCodeError) as exc_info:
+        module_target_sat.cli.Settings.info({'id': non_existing_id})
+
+    assert f"Resource setting not found by id '{non_existing_id}'" in str(exc_info.value)

--- a/tests/foreman/cli/test_settings.py
+++ b/tests/foreman/cli/test_settings.py
@@ -493,4 +493,3 @@ def test_positive_get_non_existing_setting_info(module_target_sat):
         module_target_sat.cli.Settings.info({'id': non_existing_id})
 
     assert f"Resource setting not found by id '{non_existing_id}'" in error.value.message
-

--- a/tests/foreman/cli/test_settings.py
+++ b/tests/foreman/cli/test_settings.py
@@ -469,11 +469,9 @@ def test_positive_get_setting_info(setting_update, module_target_sat):
     :parametrized: yes
 
     :expectedresults: Setting info is returned successfully
-
-    :CaseAutomation: Automated
     """
 
-    setting_info = module_target_sat.cli.Settings.info({'id': 'login_text'}, output_format='json')
+    setting_info = module_target_sat.cli.Settings.info({'id': 'login_text'})
 
     assert setting_info['name'] == setting_update.name
     assert setting_info['value'] == setting_update.value
@@ -488,12 +486,11 @@ def test_positive_get_non_existing_setting_info(module_target_sat):
 
     :expectedresults: Correct error message is returned
 
-    :Verifies: SAT-20238
-
-    :CaseAutomation: Automated
+    :verifies: SAT-20238
     """
     non_existing_id = gen_integer(min_value=1, max_value=10000)
-    with pytest.raises(CLIReturnCodeError) as exc_info:
+    with pytest.raises(CLIReturnCodeError) as error:
         module_target_sat.cli.Settings.info({'id': non_existing_id})
 
-    assert f"Resource setting not found by id '{non_existing_id}'" in str(exc_info.value)
+    assert f"Resource setting not found by id '{non_existing_id}'" in error.value.message
+

--- a/tests/foreman/cli/test_settings.py
+++ b/tests/foreman/cli/test_settings.py
@@ -461,7 +461,7 @@ def test_positive_failed_login_attempts_limit(setting_update, target_sat):
 
 
 @pytest.mark.parametrize('setting_update', ['login_text'], indirect=True)
-def test_positive_get_setting_info(setting_update, module_target_sat):
+def test_positive_existing_setting_info(setting_update, module_target_sat):
     """Get setting info for a existing setting
 
     :id: 73568bf2-8419-11f0-9102-c6fadc44396c
@@ -470,16 +470,14 @@ def test_positive_get_setting_info(setting_update, module_target_sat):
 
     :expectedresults: Setting info is returned successfully
     """
-
     setting_info = module_target_sat.cli.Settings.info({'id': 'login_text'})
-
     assert setting_info['name'] == setting_update.name
     assert setting_info['value'] == setting_update.value
     assert setting_info['description'] == setting_update.description
     assert setting_info['settings-type'] == setting_update.settings_type
 
 
-def test_positive_get_non_existing_setting_info(module_target_sat):
+def test_negative_non_existing_setting_info(module_target_sat):
     """Get setting info for non existing setting
 
     :id: 7b8b83d6-8419-11f0-9102-c6fadc44396c
@@ -491,5 +489,4 @@ def test_positive_get_non_existing_setting_info(module_target_sat):
     non_existing_id = gen_integer(min_value=1, max_value=10000)
     with pytest.raises(CLIReturnCodeError) as error:
         module_target_sat.cli.Settings.info({'id': non_existing_id})
-
     assert f"Resource setting not found by id '{non_existing_id}'" in error.value.message


### PR DESCRIPTION
### Problem Statement
Missing test for hammer settings info command

### Solution
Added test for hammer settings info

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest tests/foreman/cli/test_settings.py -k 'test_positive_existing_setting_info or test_negative_non_existing_setting_info'
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->