### PR TITLE
Details from job invocation page has been changed

### DIFF
--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -281,10 +281,10 @@ def test_negative_install_via_remote_execution(
             action='install',
             action_via='via remote execution',
         )
-        assert job_values['job_status'] == 'Failed'
-        assert job_values['job_status_progress'] == '100%'
-        assert int(job_values['total_hosts']) == len(hosts)
-        assert {host.name for host in hosts} == {host['Host'] for host in job_values['hosts_table']}
+        assert job_values['status']['Failed'] == len(hosts)
+        assert job_values['overall_status']['succeeded_hosts'] == 0
+        assert job_values['overall_status']['total_hosts'] == len(hosts)
+        assert {host.name for host in hosts} == {host['Name'] for host in job_values['hosts']}
 
 
 def test_negative_install_via_custom_remote_execution(
@@ -319,10 +319,10 @@ def test_negative_install_via_custom_remote_execution(
             action='install',
             action_via='via remote execution - customize first',
         )
-        assert job_values['job_status'] == 'Failed'
-        assert job_values['job_status_progress'] == '100%'
-        assert int(job_values['total_hosts']) == len(hosts)
-        assert {host.name for host in hosts} == {host['Host'] for host in job_values['hosts_table']}
+        assert job_values['status']['Failed'] == len(hosts)
+        assert job_values['overall_status']['succeeded_hosts'] == 0
+        assert job_values['overall_status']['total_hosts'] == len(hosts)
+        assert {host.name for host in hosts} == {host['Name'] for host in job_values['hosts']}
 
 
 @pytest.mark.upgrade


### PR DESCRIPTION
### Problem Statement
Fields on Job invocation detail page has been changed 

### Solution
Added fix to fetch details as per new page
New details are coming in below format 
`{'menu': ['NlDDexjLMl', 'oIEnrYtkKyi'], 'menu_search': '', 'flash': [], 'logout': 'Log Out', 'current_user': 'Admin User', 'account_menu': 'Admin User', 'product': 'foreman', 'breadcrumb': 'Install package(s) bear', 'title': 'Install package(s) bear', 'create_report': 'Create report', 'actions': '', 'rerun_all': 'Rerun all', 'overall_status': {'succeeded_hosts': 0, 'total_hosts': 2, 'is_success': False}, 'status': {'Succeeded': 0, 'Failed': 2, 'In Progress': 0, 'Cancelled': 0}, 'overview': {'Effective user': 'root', 'Started at': 'Aug 29, 2025, 14:39 GMT+5:30', 'SSH user': 'Not available', 'Template': 'Install Package - Katello Script Default'}, 'target_hosts': {'search_query': 'name ^ (mlkessl.yattojxaxs, uervgiavpgtm.rkkjirx3vd)', 'data': {'Organization': 'NlDDexjLMl', 'Location': 'oIEnrYtkKyi', 'Execution order': 'Alphabetical'}}, 'user_inputs': {'data': {'package': 'bear'}}, 'leapp_preupgrade_report': {}, 'hosts': [{1: False, 2: '', 'Name': 'mlkessl.yattojxaxs', 'Host group': '', 'OS': 'zcoqviCymMJW 25010', 'Capsule': 'satellite.example.com', 'Status': 'Failed'}, {1: False, 2: '', 'Name': 'uervgiavpgtm.rkkjirx3vd', 'Host group': '', 'OS': 'ctLKjusCLO 2', 'Capsule': 'satellite.example.com', 'Status': 'Failed'}]}
`
### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostcollection.py -k test_negative_install_via_custom_remote_execution

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->