### PR TITLE
enable Satellite proxy if we have no ipv4 networking

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -250,8 +250,11 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
         'ANSIBLE_HOST_PATTERN_MISMATCH=ignore',
     ]
 
-    if not module_target_sat.network_type.has_ipv4 and ansible_module in ['redhat_manifest']:
-        env.append(f'HTTPS_PROXY={settings.http_proxy.http_proxy_ipv6_url}')
+    if not module_target_sat.network_type.has_ipv4:
+        if ansible_module in ['redhat_manifest']:
+            env.append(f'HTTPS_PROXY={settings.http_proxy.http_proxy_ipv6_url}')
+
+        module_target_sat.enable_satellite_http_proxy()
 
     # Execute test_playbook
     result = module_target_sat.execute(


### PR DESCRIPTION
### Problem Statement

FAM tests require data from the internet, but during ipv6-only tests we need a proxy to do so

### Solution

enable the Satellite proxy

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->