### PR TITLE
[6.15.z] fix KeyError included container image tags

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -937,15 +937,11 @@ class TestRepository:
         tags = 'latest'
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = _validated_image_tags_count(repo=repo, sat=target_sat)
-        if not is_open('SAT-26322'):
-            assert not repo['included-container-image-tags']
         tags_count = int(repo['content-counts']['container-tags'])
         assert tags_count >= 2, 'insufficient tags count in the repo'
         target_sat.cli.Repository.update({'id': repo['id'], 'include-tags': tags})
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = _validated_image_tags_count(repo=repo, sat=target_sat)
-        if not is_open('SAT-26322'):
-            assert tags in repo['included-container-image-tags']
         assert int(repo['content-counts']['container-tags']) == len(tags.split(',')) < tags_count, (
             'unexpected change of tags count'
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19301

### Problem Statement
There was a `KeyError: 'included-container-image-tags'` and bug `SAT-26322` has been closed with Won't Do status so need to remove if condition 

### Solution
Removed the if condition block

### Related Issues
[SAT-26322](https://issues.redhat.com/browse/SAT-26322)

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_repository.py -k 'test_positive_synchronize_docker_repo_set_tags_later_content_only'
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->