### PR TITLE
[6.17.z] Automate SAT-36449 and remove IOP parametrization

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -51,16 +51,13 @@ def sync_recommendations(session):
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_list(r'^[\d]+$')
-@pytest.mark.parametrize(
-    "module_target_sat_insights", [True, False], ids=["hosted", "local"], indirect=True
-)
+@pytest.mark.rhel_ver_match('N-1')
 def test_rhcloud_insights_e2e(
     rhel_insights_vm,
     rhcloud_manifest_org,
     module_target_sat_insights,
 ):
-    """Synchronize hits data from hosted or local Insights Advisor, verify results are displayed in Satellite, and run remediation.
+    """Synchronize hits data from hosted, verify results are displayed in Satellite, and run remediation.
 
     :id: d952e83c-3faf-4299-a048-2eb6ccb8c9c2
 
@@ -69,7 +66,7 @@ def test_rhcloud_insights_e2e(
         2. In Satellite UI, go to Insights > Recommendations.
         3. Run remediation for "OpenSSH config permissions" recommendation against host.
         4. Verify that the remediation job completed successfully.
-        5. Refresh Insights recommendations (re-sync if using hosted Insights).
+        5. Re-sync recommendations.
         6. Search for previously remediated issue.
 
     :expectedresults:
@@ -82,6 +79,8 @@ def test_rhcloud_insights_e2e(
 
     :BZ: 1965901, 1962048, 1976754
 
+    :Verifies: SAT-36449
+
     :customerscenario: true
 
     :parametrized: yes
@@ -89,7 +88,6 @@ def test_rhcloud_insights_e2e(
     :CaseAutomation: Automated
     """
     org_name = rhcloud_manifest_org.name
-    local_advisor_enabled = module_target_sat_insights.local_advisor_enabled
 
     # Query for searching the available recommendation
     REC_QUERY = f'hostname = "{rhel_insights_vm.hostname}" and title = "{OPENSSH_RECOMMENDATION}"'
@@ -103,14 +101,23 @@ def test_rhcloud_insights_e2e(
     with module_target_sat_insights.ui_session() as session:
         session.organization.select(org_name=org_name)
 
-        # Sync the recommendations (hosted Insights only).
-        if not local_advisor_enabled:
-            sync_recommendations(session)
+        # Sync the recommendations
+        sync_recommendations(session)
 
         # Verify that we can see the rule hit via insights-client
         result = rhel_insights_vm.execute('insights-client --diagnosis')
         assert result.status == 0
         assert 'OPENSSH_HARDENING_CONFIG_PERMS' in result.stdout
+
+        # Verify that errors are not present in production.log (SAT-36449)
+        result = module_target_sat_insights.execute(
+            'grep "500 Internal Server Error" /var/log/foreman/production.log'
+        )
+        assert result.status != 0
+        result = module_target_sat_insights.execute(
+            'grep "uninitialized constant" /var/log/foreman/production.log'
+        )
+        assert result.status != 0
 
         # Search for the recommendation.
         result = session.cloudinsights.search(REC_QUERY)[0]
@@ -124,9 +131,8 @@ def test_rhcloud_insights_e2e(
             host_name=rhel_insights_vm.hostname,
         )
 
-        # Re-sync the recommendations (hosted Insights only).
-        if not local_advisor_enabled:
-            sync_recommendations(session)
+        # Re-sync the recommendations
+        sync_recommendations(session)
 
         # Verify that the recommendation is not listed anymore.
         assert not session.cloudinsights.search(REC_QUERY)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19286

This PR adds assertions to ensure that the errors detailed in SAT-36449 are not present. It also removes the parametrization for IOP from the RH Cloud Insights end-to-end test, as the Recommendations and Vulnerabilities pages are different enough between hosted and IOP that we will be creating separate test modules and Airgun entities/views for the on-prem scenario.