### PR TITLE
Use fixtures.pulpproject.org instead of repos.fedorapeople.org for FAM

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -127,6 +127,12 @@ def setup_fam(module_target_sat, module_sca_manifest, install_import_ansible_rol
         f"sed -i '/hosts:/ s/foreman/localhost/' {FAM_ROOT_DIR}/tests/test_playbooks/content_import_*.yml"
     )
 
+    # Edit repos used in tests
+    # Until https://github.com/theforeman/foreman-ansible-modules/pull/1899 is in
+    module_target_sat.execute(
+        f"sed -i 's#https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/#https://fixtures.pulpproject.org/rpm-signed/#' {FAM_ROOT_DIR}/tests/test_playbooks/*.yml"
+    )
+
     # Upload manifest to test playbooks directory
     module_target_sat.put(str(module_sca_manifest.path), str(module_sca_manifest.name))
     module_target_sat.execute(


### PR DESCRIPTION
### Problem Statement

repos.fedorapeople.org/pulp is gone and the tests that tried to sync content from there fail.
However, that host is used in the test files that FAM ships (will be updated in https://github.com/theforeman/foreman-ansible-modules/pull/1899)

### Solution

Replace the use of repos.fedorapeople.org with fixtures.pulpproject.org like in https://github.com/theforeman/foreman-ansible-modules/pull/1899
This workaround can be dropped once the change in FAM is present in all supported Satellite branches.

### Related Issues

### PRT test Cases example
```
trigger: test-robottelo
pytest: -v tests/foreman/sys/test_fam.py::test_positive_run_modules_and_roles[content_view_filter_info]
```