### PR TITLE
RHC HostDetailsTest Fix and IOP parametrization removal

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -304,7 +304,7 @@ def test_host_sorting_based_on_recommendation_count():
 
 
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_list([10])
+@pytest.mark.rhel_ver_match('N-0')
 def test_host_details_page(
     rhel_insights_vm,
     rhcloud_manifest_org,


### PR DESCRIPTION
### Problem statement
Update def `test_host_details_page`, reduce the RHEL_version count

and remove the parametrization for IOP from the test, as the Recommendations and Vulnerabilities pages are different enough between hosted and IOP that we will be creating separate test modules and Airgun entities/views for the on-prem scenario.

<img width="160" height="47" alt="image" src="https://github.com/user-attachments/assets/be7d2813-956b-4c41-9a30-1c346a4499ab" />

### PRT Example

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_insights.py -k "test_host_details_page"
```


