### PR TITLE
Add upgrade test for Red Hat Cloud plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,9 +119,10 @@ tests/foreman/ui/test_rhcloud_insights.py @SatelliteQE/team-proton
 tests/foreman/ui/test_rhcloud_inventory.py @SatelliteQE/team-proton
 tests/foreman/ui/test_subscription.py @SatelliteQE/team-proton
 tests/foreman/virtwho/ @SatelliteQE/team-proton
-tests/new_upgrades/test_activation_key @SatelliteQE/team-proton
+tests/new_upgrades/test_activation_key.py @SatelliteQE/team-proton
 tests/new_upgrades/test_hostcontent.py @SatelliteQE/team-proton
 tests/new_upgrades/test_subscription.py @SatelliteQE/team-proton
+tests/new_upgrades/test_rhcloud_insights.py @SatelliteQE/team-proton
 tests/upgrades/test_activation_key.py @SatelliteQE/team-proton
 tests/upgrades/test_client.py @SatelliteQE/team-proton
 tests/upgrades/test_hostcontent.py @SatelliteQE/team-proton

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1957,7 +1957,56 @@ CAPSULE_ANSWER_FILE = "/etc/foreman-installer/scenarios.d/capsule-answers.yaml"
 MAINTAIN_HAMMER_YML = "/etc/foreman-maintain/foreman-maintain-hammer.yml"
 SATELLITE_MAINTAIN_YML = "/etc/foreman-maintain/foreman_maintain.yml"
 FOREMAN_SETTINGS_YML = '/etc/foreman/settings.yaml'
+
+CUSTOM_HIERA_LOCATION = '/etc/foreman-installer/custom-hiera.yaml'
+
 PODMAN_AUTHFILE_PATH = '/etc/foreman/registry-auth.json'
+IOP_SERVICES = [
+    'iop-core-engine.service',
+    'iop-core-gateway.service',
+    'iop-core-host-inventory-api.service',
+    'iop-core-host-inventory-migrate.service',
+    'iop-core-host-inventory.service',
+    'iop-core-ingress.service',
+    'iop-core-kafka.service',
+    'iop-core-puptoo.service',
+    'iop-core-yuptoo.service',
+    'iop-service-advisor-backend-api.service',
+    'iop-service-advisor-backend-service.service',
+    'iop-service-remediations-api.service',
+    'iop-service-vmaas-reposcan.service',
+    'iop-service-vmaas-webapp-go.service',
+    'iop-service-vuln-dbupgrade.service',
+    'iop-service-vuln-evaluator-recalc.service',
+    'iop-service-vuln-evaluator-upload.service',
+    'iop-service-vuln-grouper.service',
+    'iop-service-vuln-listener.service',
+    'iop-service-vuln-manager.service',
+    'iop-service-vuln-taskomatic.service',
+]
+
+SATELLITE_SERVICES = [
+    'dynflow-sidekiq@.service',
+    'foreman-proxy.service',
+    'foreman.service',
+    'httpd.service',
+    'postgresql.service',
+    'pulpcore-api.service',
+    'pulpcore-content.service',
+    'pulpcore-worker@.service',
+    'redis.service',
+    'tomcat.service',
+]
+
+CAPSULE_SERVICES = [
+    'foreman-proxy.service',
+    'httpd.service',
+    'postgresql.service',
+    'pulpcore-api.service',
+    'pulpcore-content.service',
+    'pulpcore-worker@.service',
+    'redis.service',
+]
 
 FOREMAN_TEMPLATE_IMPORT_URL = 'https://github.com/SatelliteQE/foreman_templates.git'
 FOREMAN_TEMPLATES_IMPORT_COUNT = {

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -473,11 +473,11 @@ class IoPSetup:
         # Set IPv6 podman proxy on Satellite, to pull from container registry
         self.enable_ipv6_podman_proxy()
         # TODO: Replace this temporary implementation with a permanent solution.
-        result = self.execute(
+        cmd_result = self.execute(
             f'''
             set -e
             [ -d /root/satellite-iop ] && rm -rf /root/satellite-iop
-            git clone {settings.rh_cloud.iop_advisor_engine.satellite_iop_repo} /root/satellite-iop
+            git clone {iop_settings.satellite_iop_repo} /root/satellite-iop
             cd /root/satellite-iop
             sed -i "s/hosts: all/hosts: localhost/" playbooks/deploy.yaml
             ansible-galaxy collection install -r requirements.yml
@@ -485,5 +485,5 @@ class IoPSetup:
             ''',
             timeout='20m',
         )
-        assert result.status == 0, f'Failed to configure IoP: {result.stdout}'
+        assert cmd_result.status == 0, f'Failed to configure IoP: {cmd_result.stdout}'
         assert self.local_advisor_enabled

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1183,12 +1183,16 @@ class ContentHost(Host, ContentHostMixins):
         if register:
             if not activation_key:
                 activation_key = satellite.api.ActivationKey(
+                    name=gen_string('alpha'),
                     content_view=org.default_content_view.id,
                     environment=org.library.id,
                     organization=org,
                 ).create()
-            self.register(
-                org, None, activation_key.name, satellite, setup_insights=register_insights
+            self.api_register(
+                satellite,
+                organization=org,
+                activation_keys=[activation_key.name],
+                setup_insights=register_insights,
             )
 
     def unregister_insights(self):
@@ -1694,6 +1698,34 @@ class ContentHost(Host, ContentHostMixins):
         else:
             logger.warning(f'Podman is not logged into container registry {registry}')
 
+    def create_insights_vulnerability(self):
+        """Function to create vulnerabilities that can be remediated."""
+
+        # Add vulnerability for DNF_RECOMMENDATION (RHEL 8+)
+        if self.os_version.major > 7:
+            self.run('dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf')
+
+        # Add vulnerability for SSH_RECOMMENDATION
+        self.run('chmod 777 /etc/ssh/sshd_config')
+
+        # Upload insights data to Satellite
+        result = self.run('insights-client')
+        assert result.status == 0
+
+    def enable_insights(self, satellite, org, activation_key):
+        """Configure remote execution and insights-client on a host"""
+        self.configure_rex(satellite=satellite, org=org, register=False)
+        self.configure_insights_client(
+            satellite=satellite,
+            activation_key=activation_key,
+            org=org,
+            rhel_distro=f"rhel{self.os_version.major}",
+        )
+        # Sync inventory if using hosted Insights
+        if not satellite.local_advisor_enabled:
+            satellite.generate_inventory_report(org)
+            satellite.sync_inventory_status(org)
+
 
 class Capsule(ContentHost, CapsuleMixins):
     rex_key_path = '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
@@ -1739,7 +1771,7 @@ class Capsule(ContentHost, CapsuleMixins):
                 self._satellite = Satellite()
         return self._satellite
 
-    @cached_property
+    @property
     def is_upstream(self):
         """Figure out which product distribution is installed on the server.
 
@@ -1748,7 +1780,7 @@ class Capsule(ContentHost, CapsuleMixins):
         """
         return self.execute(f'rpm -q {self.product_rpm_name}').status != 0
 
-    @cached_property
+    @property
     def is_stream(self):
         """Check if the Capsule is a stream release or not
 
@@ -1761,7 +1793,7 @@ class Capsule(ContentHost, CapsuleMixins):
             'stream' in self.execute(f'rpm -q --qf "%{{RELEASE}}" {self.product_rpm_name}').stdout
         )
 
-    @cached_property
+    @property
     def version(self):
         rpm_name = self.upstream_rpm_name if self.is_upstream else self.product_rpm_name
         return self.execute(f'rpm -q --qf "%{{VERSION}}" {rpm_name}').stdout

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -18,58 +18,14 @@ from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import (
+    CAPSULE_SERVICES,
     HAMMER_CONFIG,
+    IOP_SERVICES,
     MAINTAIN_HAMMER_YML,
     SATELLITE_ANSWER_FILE,
+    SATELLITE_SERVICES,
 )
 from robottelo.hosts import Satellite
-
-IOP_SERVICES = [
-    'iop-core-engine.service',
-    'iop-core-gateway.service',
-    'iop-core-host-inventory-api.service',
-    'iop-core-host-inventory-migrate.service',
-    'iop-core-host-inventory.service',
-    'iop-core-ingress.service',
-    'iop-core-kafka.service',
-    'iop-core-puptoo.service',
-    'iop-core-yuptoo.service',
-    'iop-service-advisor-backend-api.service',
-    'iop-service-advisor-backend-service.service',
-    'iop-service-remediations-api.service',
-    'iop-service-vmaas-reposcan.service',
-    'iop-service-vmaas-webapp-go.service',
-    'iop-service-vuln-dbupgrade.service',
-    'iop-service-vuln-evaluator-recalc.service',
-    'iop-service-vuln-evaluator-upload.service',
-    'iop-service-vuln-grouper.service',
-    'iop-service-vuln-listener.service',
-    'iop-service-vuln-manager.service',
-    'iop-service-vuln-taskomatic.service',
-]
-
-SATELLITE_SERVICES = [
-    'dynflow-sidekiq@.service',
-    'foreman-proxy.service',
-    'foreman.service',
-    'httpd.service',
-    'postgresql.service',
-    'pulpcore-api.service',
-    'pulpcore-content.service',
-    'pulpcore-worker@.service',
-    'redis.service',
-    'tomcat.service',
-]
-
-CAPSULE_SERVICES = [
-    'foreman-proxy.service',
-    'httpd.service',
-    'postgresql.service',
-    'pulpcore-api.service',
-    'pulpcore-content.service',
-    'pulpcore-worker@.service',
-    'redis.service',
-]
 
 
 @pytest.fixture

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -21,21 +21,6 @@ from robottelo.config import settings
 from robottelo.constants import DNF_RECOMMENDATION, OPENSSH_RECOMMENDATION
 
 
-def create_insights_vulnerability(host):
-    """Function to create vulnerabilities that can be remediated."""
-
-    # Add vulnerability for DNF_RECOMMENDATION (RHEL 8+)
-    if host.os_version.major > 7:
-        host.run('dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf')
-
-    # Add vulnerability for SSH_RECOMMENDATION
-    host.run('chmod 777 /etc/ssh/sshd_config')
-
-    # Upload insights data to Satellite
-    result = host.run('insights-client')
-    assert result.status == 0
-
-
 def sync_recommendations(session):
     timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
     session.cloudinsights.sync_hits()
@@ -96,7 +81,7 @@ def test_rhcloud_insights_e2e(
     assert rhel_insights_vm.execute('insights-client --version').status == 0
 
     # Prepare misconfigured machine and upload data to Insights
-    create_insights_vulnerability(rhel_insights_vm)
+    rhel_insights_vm.create_insights_vulnerability()
 
     with module_target_sat_insights.ui_session() as session:
         session.organization.select(org_name=org_name)
@@ -184,7 +169,7 @@ def test_rhcloud_insights_remediate_multiple_hosts(
 
     # Prepare the misconfigured hosts and upload Insights data
     for vm in rhel_insights_vms:
-        create_insights_vulnerability(vm)
+        vm.create_insights_vulnerability()
 
     with module_target_sat_insights.ui_session() as session:
         session.organization.select(org_name=org_name)
@@ -347,7 +332,7 @@ def test_host_details_page(
     org_name = rhcloud_manifest_org.name
 
     # Prepare misconfigured machine and upload data to Insights.
-    create_insights_vulnerability(rhel_insights_vm)
+    rhel_insights_vm.create_insights_vulnerability()
 
     with module_target_sat_insights.ui_session() as session:
         session.organization.select(org_name=org_name)

--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -46,6 +46,8 @@ def pytest_configure(config):
         "discovery_upgrades: Discovery upgrade tests that use SharedResource.",
         "capsule_upgrades: Capsule upgrade tests that use SharedResource.",
         "puppet_upgrades: Puppet upgrade tests that use SharedResource.",
+        "local_insights_upgrades: Local insights(IoP) upgrade tests that use SharedResource.",
+        "hosted_insights_upgrades: Hosted insights upgrade tests that use SharedResource.",
     ]
     for marker in markers:
         config.addinivalue_line("markers", marker)
@@ -394,3 +396,46 @@ def shared_gce_cert(puppet_upgrade_shared_satellite):
             f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."
         )
     return cert
+
+
+@pytest.fixture(scope='module')
+def local_insights_upgrade():
+    """Mark tests using this fixture with pytest.mark.local_insights_upgrades."""
+    sat_instance = shared_checkout("local_insights_upgrade")
+    with SharedResource(
+        "local_insights_upgrade_tests", shared_checkin, sat_instance=sat_instance
+    ) as test_duration:
+        iop_settings = settings.rh_cloud.iop_advisor_engine
+        sat_instance.configure_insights_on_prem(
+            iop_settings.username, iop_settings.token, iop_settings.registry
+        )
+        yield sat_instance
+        test_duration.ready()
+
+
+@pytest.fixture(scope='module')
+def hosted_insights_upgrade():
+    """Mark tests using this fixture with pytest.mark.hosted_insights_upgrades."""
+    sat_instance = shared_checkout("hosted_insights_upgrade")
+    with SharedResource(
+        "hosted_insights_upgrade_tests", shared_checkin, sat_instance=sat_instance
+    ) as test_duration:
+        yield sat_instance
+        test_duration.ready()
+
+
+@pytest.fixture(scope='module')
+def module_target_sat_insights(request):
+    """
+    A module-level fixture to provide a Satellite configured for Insights.
+    By default, it returns hosted_insights_upgrade satellite instance.
+
+    If parametrized with a false value, then it will deploy and return a Satellite with
+    iop-advisor-engine (local Insights advisor) configured.
+    """
+    hosted_insights = getattr(request, 'param', True)
+    return (
+        request.getfixturevalue('hosted_insights_upgrade')
+        if hosted_insights
+        else request.getfixturevalue('local_insights_upgrade')
+    )

--- a/tests/new_upgrades/test_rhcloud_insights.py
+++ b/tests/new_upgrades/test_rhcloud_insights.py
@@ -1,0 +1,156 @@
+"""Tests for RH Cloud - Inventory
+
+:Requirement: RHCloud
+
+:CaseAutomation: Automated
+
+:CaseComponent: RHCloud
+
+:Team: Proton
+
+:CaseImportance: High
+
+"""
+
+from datetime import UTC, datetime
+
+from box import Box
+import pytest
+from wait_for import wait_for
+
+from robottelo.config import settings
+from robottelo.constants import (
+    CUSTOM_HIERA_LOCATION,
+    IOP_SERVICES,
+    OPENSSH_RECOMMENDATION,
+    SATELLITE_SERVICES,
+)
+from robottelo.utils.shared_resource import SharedResource
+
+
+def sync_recommendations(target_sat, org):
+    cmd = f'organization_id={org.id} foreman-rake rh_cloud_insights:sync'
+    timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
+    result = target_sat.execute(cmd)
+    wait_for(
+        lambda: target_sat.api.ForemanTask()
+        .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
+        .result
+        == 'success',
+        timeout=400,
+        delay=15,
+        silent_failure=True,
+        handle_exception=True,
+    )
+    assert result.status == 0
+    assert 'Synchronized Insights hosts hits data' in result.stdout
+
+
+@pytest.fixture
+def iop_upgrade_setup(
+    request,
+    upgrade_action,
+    rhel_insights_vm,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+):
+    """Configure local advisor Satellite and register content host with insights client."""
+    target_sat = module_target_sat_insights
+    with SharedResource(target_sat.hostname, upgrade_action, target_sat=target_sat) as sat_upgrade:
+        test_data = Box(
+            {
+                'target_sat': target_sat,
+                'org': rhcloud_manifest_org,
+                'rhel_insights_vm': rhel_insights_vm,
+            }
+        )
+        org = rhcloud_manifest_org
+        local_advisor_enabled = target_sat.local_advisor_enabled
+        # Verify insights-client can update to latest version available from server
+        assert rhel_insights_vm.execute('insights-client --version').status == 0
+        # Prepare misconfigured machine and upload data to Insights
+        rhel_insights_vm.create_insights_vulnerability()
+        if local_advisor_enabled:
+            target_sat.execute(
+                f'wget -O {CUSTOM_HIERA_LOCATION} {settings.rh_cloud.iop_advisor_engine.satellite_iop_repo[:-4]}/-/raw/main/playbooks/custom-hiera.yaml'
+            )
+        else:
+            sync_recommendations(target_sat, org)
+        sat_upgrade.ready()
+        target_sat._session = None
+        yield test_data
+
+
+@pytest.mark.local_insights_upgrades
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+@pytest.mark.parametrize("module_target_sat_insights", [False], ids=["local"], indirect=True)
+def test_rhcloud_insights_upgrade(request, iop_upgrade_setup, module_target_sat_insights):
+    """Verify Satellite upgrade for local advisor with Insights client.
+
+    :id: fce16a0a-da24-47fa-9df1-e94c1f4642a7
+
+    :steps:
+        1. Have Satellite with local Insights advisor enabled.
+        2. Prepare misconfigured machine and upload its data to Insights.
+        3. In Satellite UI, go to Insights > Recommendations.
+        4. Verify recommendation related to "OpenSSH config permissions" issue is listed
+        5. Perform Satellite upgrade.
+        6. After Satellite upgrade, verify recommendation is still listed.
+        7. Run remediation for "OpenSSH config permissions" recommendation against host.
+        8. Verify that the remediation job completed successfully.
+        9. Search for previously remediated issue.
+
+    :expectedresults:
+        1. Insights recommendation related to "OpenSSH config permissions" issue is listed
+            for misconfigured machine.
+        2. Satellite upgrade completed successfully
+        3. IoP services are running.
+        4. Recommendation is listed on upgraded Satellite UI.
+        5. Remediation job finished successfully.
+        6. Insights recommendation related to "OpenSSH config permissions" issue is not listed.
+
+    :CaseImportance: Critical
+
+    :parametrized: yes
+
+    :CaseAutomation: Automated
+    """
+    target_sat = iop_upgrade_setup.target_sat
+    rhel_insights_vm = iop_upgrade_setup.rhel_insights_vm
+    org = iop_upgrade_setup.org
+    REC_QUERY = f'hostname = "{rhel_insights_vm.hostname}" and title = "{OPENSSH_RECOMMENDATION}"'
+    local_insights = 'local' in request.node.name
+    local_advisor_enabled = target_sat.local_advisor_enabled
+    service_status = target_sat.cli.Service.status(options={'brief': True})
+    assert 'FAIL' not in service_status.stdout
+    assert service_status.status == 0
+    service_list = target_sat.cli.Service.list()
+    assert 'FAIL' not in service_list.stdout
+    assert service_list.status == 0
+    for service in IOP_SERVICES + SATELLITE_SERVICES if local_insights else SATELLITE_SERVICES:
+        assert service in service_list.stdout
+    if local_insights:
+        assert local_advisor_enabled
+        assert rhel_insights_vm.execute('insights-client --unregister --force').status == 0
+        assert rhel_insights_vm.execute('insights-client --register').status == 0
+    assert rhel_insights_vm.execute('insights-client --test-connection').status == 0
+    assert rhel_insights_vm.execute('insights-client --status').status == 0
+    # Verify that we can see the rule hit via insights-client
+    diagnosis_result = rhel_insights_vm.execute('insights-client --diagnosis')
+    assert diagnosis_result.status == 0
+    assert 'OPENSSH_HARDENING_CONFIG_PERMS' in diagnosis_result.stdout
+    with target_sat.ui_session() as session:
+        session.organization.select(org_name=org.name)
+        # Search for the recommendation.
+        search_result = session.cloudinsights.search(REC_QUERY)[0]
+        assert search_result['Hostname'] == rhel_insights_vm.hostname
+        assert search_result['Recommendation'] == OPENSSH_RECOMMENDATION
+        # Run the remediation.
+        session.cloudinsights.remediate(OPENSSH_RECOMMENDATION)
+        session.jobinvocation.wait_job_invocation_state(
+            entity_name='Insights remediations for selected issues',
+            host_name=rhel_insights_vm.hostname,
+        )
+        # Verify that the recommendation is not listed anymore.
+        assert not session.cloudinsights.search(REC_QUERY)


### PR DESCRIPTION
### Problem Statement
- We're missing upgrade coverage for the hosted and local Satellite advisor. 

### Solution
- Add upgrade test

### Related Issues
- SAT-34511

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->