### PR TITLE
Configure IPv6 system proxy to reach container registry to enable IoP

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1957,6 +1957,7 @@ CAPSULE_ANSWER_FILE = "/etc/foreman-installer/scenarios.d/capsule-answers.yaml"
 MAINTAIN_HAMMER_YML = "/etc/foreman-maintain/foreman-maintain-hammer.yml"
 SATELLITE_MAINTAIN_YML = "/etc/foreman-maintain/foreman_maintain.yml"
 FOREMAN_SETTINGS_YML = '/etc/foreman/settings.yaml'
+PODMAN_AUTHFILE_PATH = '/etc/foreman/registry-auth.json'
 
 FOREMAN_TEMPLATE_IMPORT_URL = 'https://github.com/SatelliteQE/foreman_templates.git'
 FOREMAN_TEMPLATES_IMPORT_COUNT = {

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -468,10 +468,10 @@ class IoPSetup:
         self.register_to_cdn()
         self.setup_rhel_repos()
         self.setup_satellite_repos()
+        self.ensure_podman_installed()
+        self.podman_login(username, password, registry)
         # Set IPv6 podman proxy on Satellite, to pull from container registry
         self.enable_ipv6_podman_proxy()
-
-        self.podman_login(username, password, registry)
         # TODO: Replace this temporary implementation with a permanent solution.
         result = self.execute(
             f'''

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -468,6 +468,9 @@ class IoPSetup:
         self.register_to_cdn()
         self.setup_rhel_repos()
         self.setup_satellite_repos()
+        # Set IPv6 podman proxy on Satellite, to pull from container registry
+        self.enable_ipv6_podman_proxy()
+
         self.podman_login(username, password, registry)
         # TODO: Replace this temporary implementation with a permanent solution.
         result = self.execute(

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -7,7 +7,6 @@ from functools import cached_property, lru_cache
 import importlib
 import io
 import json
-import os
 from pathlib import Path, PurePath
 import random
 import re
@@ -1648,9 +1647,7 @@ class ContentHost(Host, ContentHostMixins):
             auth_b64 = base64.b64encode(auth_str.encode()).decode()
             auth_data = {'auths': {f'{registry}': {'auth': auth_b64}}}
             local_authfile_path = f'{robottelo_tmp_dir}/podman-auth.json'
-            sat_authfile_path = os.path.join(
-                self.execute('echo ${XDG_RUNTIME_DIR}').stdout.strip(), 'containers', 'auth.json'
-            )
+            sat_authfile_path = '/etc/foreman/registry-auth.json'
             with open(local_authfile_path, 'w') as f:
                 json.dump(auth_data, f)
             self.put(local_authfile_path, sat_authfile_path)

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -912,6 +912,15 @@ class ContentHost(Host, ContentHostMixins):
                 f'echo "export HTTPS_PROXY={settings.http_proxy.http_proxy_ipv6_url}" >> ~/.bashrc'
             )
 
+    def enable_ipv6_podman_proxy(self):
+        """Execute procedures for enabling IPv6 HTTP Proxy on Podman engine"""
+        # if not self.network_type.has_ipv4:
+        container_cfg = '/etc/containers/containers.conf'
+        self.execute(
+            f'echo -e "[engine]\\nenv = [\'https_proxy={settings.http_proxy.http_proxy_ipv6_url}\']" >> {container_cfg}'
+        )
+        self.execute(f'echo -e "\\n[containers]\\nhttp_proxy = true" >> {container_cfg}')
+
     def disable_rhsm_proxy(self):
         """Disables HTTP proxy for subscription manager"""
         self.execute('subscription-manager remove server.proxy_hostname server.proxy_port')

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -914,12 +914,14 @@ class ContentHost(Host, ContentHostMixins):
 
     def enable_ipv6_podman_proxy(self):
         """Execute procedures for enabling IPv6 HTTP Proxy on Podman engine"""
-        # if not self.network_type.has_ipv4:
-        container_cfg = '/etc/containers/containers.conf'
-        self.execute(
-            f'echo -e "[engine]\\nenv = [\'https_proxy={settings.http_proxy.http_proxy_ipv6_url}\']" >> {container_cfg}'
-        )
-        self.execute(f'echo -e "\\n[containers]\\nhttp_proxy = true" >> {container_cfg}')
+        if not self.network_type.has_ipv4:
+            container_cfg = '/etc/containers/containers.conf'
+            assert (
+                self.execute(
+                    f'echo -e "[engine]\\nenv = [\'https_proxy={settings.http_proxy.http_proxy_ipv6_url}\']" >> {container_cfg}'
+                ).status
+                == 0
+            )
 
     def disable_rhsm_proxy(self):
         """Disables HTTP proxy for subscription manager"""
@@ -1642,7 +1644,6 @@ class ContentHost(Host, ContentHostMixins):
         password = password or iop_settings.token
         registry = registry or iop_settings.registry
         if registry and username and password:
-            self.ensure_podman_installed()
             auth_str = f'{username}:{password}'
             auth_b64 = base64.b64encode(auth_str.encode()).decode()
             auth_data = {'auths': {f'{registry}': {'auth': auth_b64}}}

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1668,9 +1668,15 @@ class ContentHost(Host, ContentHostMixins):
 
     def is_podman_logged_in(self, registry=None):
         """Check if podman is logged into a registry."""
+        sat_authfile_path = '/etc/foreman/registry-auth.json'
         registry = registry or settings.rh_cloud.iop_advisor_engine.registry
-        cmd_result = self.execute(f'podman login --get-login {registry}')
-        return cmd_result.status == 0
+        return (
+            self.execute(
+                f'podman login --get-login --authfile {sat_authfile_path} {registry}'
+            ).status
+            == 0
+            or self.execute(f'podman login --get-login {registry}').status == 0
+        )
 
     def podman_logout(self, registry=None):
         """Logout of a podman registry."""


### PR DESCRIPTION
### Problem Statement
For enabling IoP in tests, Sat needs to be able to pull images from the quay.io on internet, but during ipv6-only tests we'll need a proxy to do so

### Solution
Configure IPv6 system proxy to reach container registry to enable IoP in tests

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->