### PR TITLE
[6.17.z] Skip Discovery rule test for IPv6-only run

### DIFF
--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -15,6 +15,9 @@
 from fauxfactory import gen_integer, gen_ipaddr, gen_string
 import pytest
 
+from robottelo.config import settings
+from robottelo.enums import NetworkType
+
 
 @pytest.fixture
 def module_discovery_env(module_org, module_location, module_target_sat):
@@ -165,6 +168,10 @@ def test_negative_delete_rule_with_non_admin_user(
 
 
 @pytest.mark.run_in_one_thread
+@pytest.mark.skipif(
+    settings.server.network_type == NetworkType.IPV6,
+    reason='Skipping as Discovery is not supported on IPv6-only setup',
+)
 def test_positive_list_host_based_on_rule_search_query(
     request,
     session,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19330

### Problem Statement
Discovery rule test `test_positive_list_host_based_on_rule_search_query` fails as no hosts gets discovered on the IPv6-only setups.

### Solution
Skipping Discovery rule test for IPv6-only run, as Discovery isn't supported for IPv6

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->