### PR TITLE
[6.18.z] Fix for test_negative_installer_invalid_dns_forwarder failure on jenkins

### DIFF
--- a/tests/foreman/destructive/test_installer.py
+++ b/tests/foreman/destructive/test_installer.py
@@ -252,7 +252,7 @@ def test_negative_installer_invalid_dns_forwarder(target_sat):
     assert 'DNS forwarders (current: [])' in result.stdout
 
     # attempt to use invalid dns_forwarder
-    for dns_forwarder in ['', gen_string('alpha')]:
+    for dns_forwarder in ['""', gen_string('alpha')]:
         result = target_sat.install(InstallerCommand(foreman_proxy_dns_forwarders=dns_forwarder))
         assert result.status != 0
         assert 'Parameter foreman-proxy-dns-forwarders invalid:' in result.stdout


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19307

### Problem Statement

test_negative_installer_invalid_dns_forwarder fails on jenkins because of Output handling difference between local and Jenkins environments.
Jenkins captures the error in stderr instead of stdout.

### Solution

Combine both stdout and stderr before assertion.
• Updated assertion:

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/destructive/test_installer.py -k 'test_negative_installer_invalid_dns_forwarder'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->