### PR TITLE
Add new dependency_merge_zstream GHA for zstream branches

### DIFF
--- a/.github/workflows/auto_branching.yml
+++ b/.github/workflows/auto_branching.yml
@@ -103,6 +103,7 @@ jobs:
         run: |
             rm -rf ./.github/workflows/dispatch_release.yml
             rm -rf ./.github/workflows/auto_branching.yml
+            rm -rf ./.github/workflows/dependency_merge.yml
 
       - name: Remove CODEOWNERS
         id: remove-codeowners

--- a/.github/workflows/dependency_merge_zstream.yml
+++ b/.github/workflows/dependency_merge_zstream.yml
@@ -1,0 +1,63 @@
+name: Dependabot Auto Merge - ZStream
+on:
+  pull_request_target:
+    branches-ignore:
+      - master
+
+jobs:
+  dependabot:
+    name: dependabot-auto-merge
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+    steps:
+      - id: find-prt-comment
+        name: Find the prt comment
+        uses: peter-evans/find-comment@v2
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: "trigger: test-robottelo"
+          direction: last
+
+      - name: Wait for PRT checks to get initiated
+        if: steps.find-prt-comment.outputs.comment-body != ''
+        run: |
+          echo "Waiting for ~ 10 mins, PRT to be initiated." && sleep 600
+
+      - name: Fetch and Verify the PRT status
+        if: steps.find-prt-comment.outputs.comment-body != ''
+        id: outcome
+        uses: omkarkhatavkar/wait-for-status-checks@main
+        with:
+          ref: ${{ github.head_ref }}
+          context: 'Robottelo-Runner'
+          wait-interval: 60
+          count: 100
+
+      - name: Wait for other status checks to Pass
+        id: waitforstatuschecks
+        uses: lewagon/wait-on-check-action@v1.4.0
+        with:
+          ref: ${{ github.head_ref }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 60
+          running-workflow-name: 'dependabot-auto-merge'
+          allowed-conclusions: success,skipped
+
+      - id: automerge
+        name: Auto merge of dependabot PRs.
+        uses: "pascalgn/automerge-action@v0.16.4"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "dependencies"
+          MERGE_METHOD: "squash"
+          MERGE_RETRIES: 5
+          MERGE_RETRY_SLEEP: 900000
+
+      - name: Auto Merge Status
+        run: |
+          if [ "${{ steps.automerge.outputs.mergeResult }}" == 'merged' ]; then
+            echo "Pull request ${{ steps.automerge.outputs.pullRequestNumber }} is Auto Merged !"
+          else
+            echo "::error Auto Merge for Pull request failed !"
+            exit 1
+          fi


### PR DESCRIPTION
### Problem Statement
We've dependency_merge GHA which is specific to master branch, and every time we branch using auto-branching workflow, we require to update the workflow in zstream branches for auto-merging like https://github.com/SatelliteQE/robottelo/pull/19344

### Solution

- Add new dependency_merge_zstream GHA for zstream branches in master

- Remove dependency_merge GHA which is master specific while auto-branching

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->