### PR TITLE
[6.18.z] Fix assertions and skip IPv6 in FM DHCP config test

### DIFF
--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -18,6 +18,7 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
+from robottelo.enums import NetworkType
 from robottelo.utils.installer import InstallerCommand
 
 upstream_url = {
@@ -587,6 +588,10 @@ def test_positive_health_check_env_proxy(sat_maintain):
     assert 'FAIL' not in result.stdout
 
 
+@pytest.mark.skipif(
+    settings.server.network_type == NetworkType.IPV6,
+    reason='Skipping as DHCPv6 is not managed on IPv6-only setup',
+)
 def test_positive_health_check_foreman_proxy_verify_dhcp_config_syntax(sat_maintain):
     """Verify foreman-proxy-verify-dhcp-config-syntax
 
@@ -610,8 +615,6 @@ def test_positive_health_check_foreman_proxy_verify_dhcp_config_syntax(sat_maint
                       is set other than `dhcp_isc`, and also not on DHCP disabled Satellite.
 
     :CaseImportance: Medium
-
-    :CaseAutomation: Automated
     """
     # Set dhcp.yml to `:use_provider: dhcp_isc`
     sat_maintain.execute(
@@ -626,8 +629,8 @@ def test_positive_health_check_foreman_proxy_verify_dhcp_config_syntax(sat_maint
     result = sat_maintain.cli.Health.check(
         options={'label': 'foreman-proxy-verify-dhcp-config-syntax'}
     )
-    assert 'No scenario matching label'
-    assert 'foreman-proxy-verify-dhcp-config-syntax' in result.stdout
+    assert result.status == 1
+    assert 'No scenario matching label [foreman-proxy-verify-dhcp-config-syntax]' in result.stdout
     # Enable DHCP
     installer = sat_maintain.install(
         InstallerCommand('enable-foreman-proxy-plugin-dhcp-remote-isc', 'foreman-proxy-dhcp true')
@@ -639,6 +642,7 @@ def test_positive_health_check_foreman_proxy_verify_dhcp_config_syntax(sat_maint
     result = sat_maintain.cli.Health.check(
         options={'label': 'foreman-proxy-verify-dhcp-config-syntax'}
     )
+    assert result.status == 0
     assert 'OK' in result.stdout
     # Set dhcp.yml `:use_provider: dhcp_infoblox`
     sat_maintain.execute(
@@ -653,8 +657,8 @@ def test_positive_health_check_foreman_proxy_verify_dhcp_config_syntax(sat_maint
     result = sat_maintain.cli.Health.check(
         options={'label': 'foreman-proxy-verify-dhcp-config-syntax'}
     )
-    assert 'No scenario matching label'
-    assert 'foreman-proxy-verify-dhcp-config-syntax' in result.stdout
+    assert result.status == 1
+    assert 'No scenario matching label [foreman-proxy-verify-dhcp-config-syntax]' in result.stdout
 
 
 def test_positive_remove_job_file(sat_maintain):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19329

### Problem Statement
1. After applying https://github.com/SatelliteQE/robottelo/pull/12796, the assertions were incorrectly changed
2. foreman-maintain test to validate DHCP config fails for IPv6 run in installer

### Solution
1. Fixed the existing assertions, and added assertions for checking RC of f-m commands
2. Skipping the test as DHCPv6 is not managed on IPv6-only setup, so it doesn't makes sense to test this scenario on IPv6.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->