### PR TITLE
Automate stubbed testcase to export report

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -292,8 +292,7 @@ def test_positive_lock_clone_nodelete_unlock_report(target_sat):
     )
 
 
-@pytest.mark.stubbed
-def test_positive_export_report():
+def test_positive_export_report(target_sat):
     """Export report template
 
     :id: a4b577db-144e-4761-a42e-a83887464986
@@ -306,8 +305,13 @@ def test_positive_export_report():
 
     :expectedresults: Report script is shown
 
-    :CaseImportance: High
     """
+    template_name = gen_string('alpha').lower()
+    template1 = gen_string('alpha')
+    rt = target_sat.api.ReportTemplate(name=template_name, template=template1).create()
+    res = rt.export()
+    assert template_name in res
+    assert template1 in res
 
 
 @pytest.mark.stubbed


### PR DESCRIPTION
### Problem Statement

QE coverage for exporting report is missing for report template

### Solution

Adding Coverage for exporting report in report template

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_reporttemplates.py -k 'test_positive_export_report'
nailgun: 1349
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->