### PR TITLE
[6.17.z] recommendation sync CLI test fix

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -134,7 +134,7 @@ def test_positive_inventory_recommendation_sync(
         handle_exception=True,
     )
     assert result.status == 0
-    assert result.stdout == 'Synchronized Insights hosts hits data\n'
+    assert 'Synchronized Insights hosts hits data' in result.stdout
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Manual cherrypick of https://github.com/SatelliteQE/robottelo/pull/19066

<img width="298" height="42" alt="image" src="https://github.com/user-attachments/assets/f767e991-0a64-4c43-a04a-50171219fae5" />

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_rhcloud_inventory.py -k "test_positive_inventory_recommendation_sync[rhel10-ipv4]"
```