### PR TITLE
Fix iop setup for foreman maintain tests

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -478,7 +478,7 @@ class IoPSetup:
             cd /root/satellite-iop
             sed -i "s/hosts: all/hosts: localhost/" playbooks/deploy.yaml
             ansible-galaxy collection install -r requirements.yml
-            ansible-playbook -c local playbooks/deploy.yaml
+            ansible-playbook -c local playbooks/deploy.yaml -e "stage_username={username} stage_password={password}"
             ''',
             timeout='20m',
         )


### PR DESCRIPTION
### Problem Statement
IoP setup for maintain tests is failing due to missing creds caused due to MR `satellite-iop/33`

### Solution
Add the creds while running the playbook as extra vars

