### PR TITLE
[6.17.z] Host Group Test Fix 

### DIFF
--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -315,9 +315,11 @@ def test_positive_clone_host_groups(
         )
         assert target_sat.api.HostGroup().search(query={'search': f'name={clone_hg_name}'})
         clone_hostgroup_values = session.hostgroup.read(clone_hg_name)
-        assert module_ak_cv_lce.name in clone_hostgroup_values['host_group']['lce']
+        assert module_lce.name in clone_hostgroup_values['host_group']['lce']
         assert module_published_cv.name in clone_hostgroup_values['host_group']['content_view']
-        assert module_ak_cv_lce.name in clone_hostgroup_values['activation_keys']['activation_keys']
+        assert (
+            module_ak_cv_lce.name in clone_hostgroup_values['activation_keys']['ak_chip_group'][0]
+        )
         assert os_name in clone_hostgroup_values['operating_system']['operating_system']
         assert architecture.name in clone_hostgroup_values['operating_system']['architecture']
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19418

### Problem Statement
Fix loooong failing `test_positive_clone_host_groups`.

### Solution
Change asserts,
update airgun.

### Related Issues
Needs: https://github.com/SatelliteQE/airgun/pull/2022
<img width="219" height="38" alt="image" src="https://github.com/user-attachments/assets/471677f5-9de5-4229-9bf0-a37295ef17ed" />

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostgroup.py -k 'test_positive_clone_host_groups'
airgun: 2022
```