### PR TITLE
Get rid of direct LCE assign on CV create

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1202,7 +1202,6 @@ def errata_host(
     org = module_sca_manifest_org
     cv = target_sat.api.ContentView(
         organization=org,
-        environment=[module_lce_library.id],
     ).create()
     target_sat.cli_factory.setup_org_for_a_custom_repo(
         {


### PR DESCRIPTION
### Problem Statement
Some of the errata tests fail in setup with
```
'errors': ["It's not possible to provide environment_ids for anything other than a rolling content view."]
```
since with https://github.com/Katello/katello/pull/11489 the LCE assignment on CV create is possible only for the rolling CVs.


### Solution
Get rid of the `environment` param on create, the setup is done further in the `setup_org_for_a_custom_repo` anyway.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_errata.py -k test_apply_errata_using_default_content_view
```