### PR TITLE
mqtt capsule now equipped with lce

### DIFF
--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -124,6 +124,9 @@ def test_negative_time_to_pickup(
             'location-ids': smart_proxy_location.id,
         }
     )
+    module_capsule_configured_mqtt.nailgun_capsule.content_add_lifecycle_environment(
+        data={'environment_id': module_ak_with_cv.environment.id}
+    )
     # register host with pull provider rex
     result = client.register(
         module_org,

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1207,6 +1207,9 @@ class TestPullProviderRex:
                 'location-ids': smart_proxy_location.id,
             }
         )
+        module_capsule_configured_mqtt.nailgun_capsule.content_add_lifecycle_environment(
+            data={'environment_id': module_ak_with_cv.environment.id}
+        )
         # register host with rex, enable client repo, install katello-agent
         result = client.register(
             module_org,
@@ -1301,6 +1304,9 @@ class TestPullProviderRex:
                 'organization-ids': module_org.id,
                 'location-ids': smart_proxy_location.id,
             }
+        )
+        module_capsule_configured_mqtt.nailgun_capsule.content_add_lifecycle_environment(
+            data={'environment_id': module_ak_with_cv.environment.id}
         )
         # register host with pull provider rex
         result = client.register(
@@ -1416,6 +1422,9 @@ class TestPullProviderRex:
                 'organization-ids': module_org.id,
                 'location-ids': smart_proxy_location.id,
             }
+        )
+        module_capsule_configured_mqtt.nailgun_capsule.content_add_lifecycle_environment(
+            data={'environment_id': module_ak_with_cv.environment.id}
         )
         # register host with pull provider rex (SAT-1677)
         result = client.register(
@@ -1537,6 +1546,9 @@ class TestPullProviderRex:
                 'location-ids': smart_proxy_location.id,
             }
         )
+        module_capsule_configured_mqtt.nailgun_capsule.content_add_lifecycle_environment(
+            data={'environment_id': module_ak_with_cv.environment.id}
+        )
         result = client.register(
             module_org,
             smart_proxy_location,
@@ -1624,6 +1636,9 @@ class TestPullProviderRex:
                 'organization-ids': module_org.id,
                 'location-ids': smart_proxy_location.id,
             }
+        )
+        module_capsule_configured_mqtt.nailgun_capsule.content_add_lifecycle_environment(
+            data={'environment_id': module_ak_with_cv.environment.id}
         )
         # register host with pull provider rex (SAT-1677)
         result = client.register(


### PR DESCRIPTION
### Problem Statement
couple of streams ago registration to mqtt capsule started to return `Content view environment content facets invalid: The content source must sync the lifecycle environment assigned to the host.` The test function is not really affected by this, still we probably want clean registration 

### Solution
add lce to the capsule

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->