### PR TITLE
[6.18.z] Automate stubbed testcase for Libvirt CR with custom large profile

### DIFF
--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -294,9 +294,10 @@ def test_positive_image_end_to_end(
         )
 
 
-@pytest.mark.stubbed
-def test_positive_associate_with_custom_profile():
-    """Associate custom default (3-Large) compute profile to libvirt compute resource.
+def test_positive_associate_with_custom_profile(
+    request, session, target_sat, module_target_sat, module_org, module_location
+):
+    """Associate custom default (1-Small) compute profile to libvirt compute resource.
 
     :id: e7698154-62ff-492b-8e56-c5dc70f0c9df
 
@@ -304,13 +305,66 @@ def test_positive_associate_with_custom_profile():
         1. Create a compute resource of type libvirt.
         2. Select the created libvirt CR.
         3. Click Compute Profile tab.
-        4. Edit (3-Large) with valid configurations and submit.
+        4. Edit (1-Small) with valid configurations and submit.
 
-    :expectedresults: The Compute Resource created and associated to compute profile (3-Large)
+    :expectedresults: The Compute Resource created and associated to compute profile (1-Small)
         with provided values.
-
-    :CaseAutomation: NotAutomated
     """
+    cr_name = gen_string('alpha')
+    cr_description = gen_string('alpha')
+    display_type = choice(('VNC', 'SPICE'))
+    console_passwords = choice((True, False))
+    storage_data = {'storage_pool': 'default', 'size': '20', 'storage_type': 'QCOW2'}
+    network_data = {
+        'network_type': 'Physical (Bridge)',
+        'network': 'br-420',  # hardcoding network here as this test won't be doing actual provisioning
+        'nic_type': 'virtio',
+    }
+    module_target_sat.configure_libvirt_cr()
+    with session:
+        session.computeresource.create(
+            {
+                'name': cr_name,
+                'description': cr_description,
+                'provider': FOREMAN_PROVIDERS['libvirt'],
+                'provider_content.url': LIBVIRT_URL,
+                'provider_content.display_type': display_type,
+                'provider_content.console_passwords': console_passwords,
+                'organizations.resources.assigned': [module_org.name],
+                'locations.resources.assigned': [module_location.name],
+            }
+        )
+        assert session.computeresource.search(cr_name)[0]['Name'] == cr_name
+
+        @request.addfinalizer
+        def _finalize():
+            cr = target_sat.api.LibvirtComputeResource().search(query={'search': f'name={cr_name}'})
+            if cr:
+                target_sat.api.LibvirtComputeResource(id=cr[0].id).delete()
+
+        session.computeresource.update_computeprofile(
+            cr_name,
+            COMPUTE_PROFILE_SMALL,
+            {
+                'provider_content.cpus': '1',
+                'provider_content.memory': '6144',
+                'provider_content.network_interfaces': [network_data],
+                'provider_content.storage': [storage_data],
+            },
+        )
+        values = session.computeresource.read_computeprofile(cr_name, COMPUTE_PROFILE_SMALL)
+        provider_content = values['provider_content']
+        assert provider_content['cpus'] == "1"
+        assert provider_content['memory'] == '6144 MB'
+        assert provider_content['storage'][0]['storage_type'] == storage_data['storage_type']
+        assert provider_content['storage'][0]['storage_pool'] == storage_data['storage_pool']
+        assert provider_content['storage'][0]['size'] == storage_data['size']
+        assert (
+            provider_content['network_interfaces'][0]['network_type']
+            == network_data['network_type']
+        )
+        assert provider_content['network_interfaces'][0]['network'] == network_data['network']
+        assert provider_content['network_interfaces'][0]['nic_type'] == network_data['nic_type']
 
 
 @pytest.mark.stubbed


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19308

### Problem Statement

test_positive_associate_with_custom_profile test case was not automated and marked as stubbed

### Solution

Automate the test_positive_associate_with_custom_profile testcase with valid selections

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_computeresource_libvirt.py -k 'test_positive_associate_with_custom_profile'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->