### PR TITLE
[6.18.z] disable insights in api_register() so it is the same as in register()

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -718,6 +718,7 @@ class ContentHost(Host, ContentHostMixins):
         :return: The result of the API call.
         """
         kwargs['insecure'] = kwargs.get('insecure', True)
+        kwargs['setup_insights'] = kwargs.get('setup_insights', False)
         self._satellite = target.satellite
         command = target.satellite.api.RegistrationCommand(**kwargs).create()
         return self.execute(command.strip('\n'))


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19445

### Problem statement
At this moment, there is a difference between `rhel_contenthost.register()` and `rhel_contenthost.api_register()`.

`rhel_contenthost.register()` explicitly says `setup_insights=False,`

and

`rhel_contenthost.api_register()` does not.

Not every test needs insights to be set up so I am making this change for us to be consistent in the registration procedure which we use in robottelo.

### Solution
Add `kwargs['setup_insights'] = kwargs.get('setup_insights', False)` to `api_regiter()`

### Additional info
This change also fixes several tests which fail while running the registration command with RC:1 due to the repos not being enabled. 

Currently, `api_register()` is not used in any RHCloudInsights tests.

### PRT Example
<img width="228" height="39" alt="image" src="https://github.com/user-attachments/assets/52eb5c70-1eb5-43c2-b9da-38b0ad0ccf4f" />

```
trigger: test-robottelo
pytest: tests/foreman/api/test_registration.py -k "test_host_registration_end_to_end[rhel9-ipv4]"
```

