### PR TITLE
[6.18.z] facts test fix

### DIFF
--- a/tests/foreman/ui/test_fact.py
+++ b/tests/foreman/ui/test_fact.py
@@ -41,13 +41,10 @@ def test_positive_upload_host_facts(
     with module_target_sat.ui_session() as session:
         session.organization.select(module_sca_manifest_org.name)
         session.location.select(module_location.name)
-        cmd = session.host.get_register_command(
-            {
-                'general.activation_keys': module_activation_key.name,
-                'general.insecure': True,
-            }
+
+        result = rhel_contenthost.register(
+            module_sca_manifest_org, module_location, module_activation_key.name, module_target_sat
         )
-        result = rhel_contenthost.execute(cmd)
         assert result.status == 0, f'Failed to register host: {result.stderr}'
 
         rhel_contenthost.execute('subscription-manager facts --update')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19443

Change the registration procedure in the test.

<img width="228" height="63" alt="image" src="https://github.com/user-attachments/assets/34c3c37c-1fc2-4d36-9558-9825b3209c87" />

### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_fact.py -k "test_positive_upload_host_facts"
```
