### PR TITLE
[6.17.z] hosts subscribed property extension

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -220,8 +220,13 @@ class ContentHost(Host, ContentHostMixins):
 
     @property
     def subscribed(self):
-        """Boolean representation of a content host's subscription status"""
-        return 'Overall Status: Unknown' not in self.execute('subscription-manager status').stdout
+        """Returns True if host is registered, False otherwise"""
+        result_status = self.execute('subscription-manager identity').status
+        if result_status not in [0, 1]:
+            raise ValueError(
+                'Unexpected output from subscription-manager identity, anything else than RC:0 or RC:1 is unexpected!'
+            )
+        return not bool(result_status)
 
     @property
     def identity(self):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19436

### Problem Statement
Now the `subscribed` property reports falsely on the hosts that present their Unregistered state by this message `'Overall Status: Not registered'`

### Solution
Use the status of `subscription-manager identity` which works like this:
RC:0 registered
RC:1 not registered
RC:anythingElse error

This approach should be future-proof of different subscription-manager status outputs

### Testing
How did I test this change?
```python
@pytest.mark.rhel_ver_list([7, 8, 9, 10])
@pytest.mark.no_containers
def test_subscribed_property(
    rhel_contenthost,
    target_sat,
    module_ak,
    module_org,
):
    
    rhel_contenthost.execute(r'subscription-manager unregister')
    rhel_contenthost.execute(r'subscription-manager clean')
    assert not rhel_contenthost.subscribed

    rhel_contenthost.api_register(
        target_sat,
        organization=module_org,
        activation_keys=[module_ak.name],
    )
    assert rhel_contenthost.subscribed
 ```
 Before the change:
<img width="188" height="95" alt="image" src="https://github.com/user-attachments/assets/4e76c576-6f2b-4156-9bf1-996799952981" />

After the change:
<img width="188" height="95" alt="image" src="https://github.com/user-attachments/assets/2b81a012-5d90-4370-ba30-0f41aa7cd693" />
 ### Notes from investigating this issue:
 ```
 ***************************************************************
 RHEL7 SUBMAN
[RHEL7]# subscription-manager version
server type: This system is currently not registered.
subscription management server: 4.6.3-1
subscription management rules: 5.44
subscription-manager: 1.24.54-1.el7_9

Not registered message:
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Unknown

System Purpose Status: Unknown
***************************************************************
RHEL8 SUBMAN
[RHEL8]# subscription-manager version
server type: This system is currently not registered.
subscription management server: 4.6.3-1
subscription management rules: 5.44
subscription-manager: 1.28.44-1.el8_10

Not registered message:

+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Not registered

RHEL8 CONTAINER SUBMAN
stdout:
server type: This system is currently not registered.
subscription management server: 4.6.3-1
subscription management rules: 5.44
subscription-manager: 1.28.42-1.el8

Not registered message:
stdout:
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Unknown

System Purpose Status: Unknown
***************************************************************
RHEL9 SUBMAN 
[RHEL9]# subscription-manager version
server type: Red Hat Subscription Management
subscription management server: 4.6.3-1
subscription management rules: 5.44
subscription-manager: 1.29.45.1-1.el9_6

Not registered message:

+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Unknown

System Purpose Status: Unknown
***************************************************************
RHEL10 SUBMAN
[RHEL10]# subscription-manager version
server type: This system is currently not registered.
subscription management server: 4.6.3-1
subscription management rules: 5.44
subscription-manager: 1.30.6.1-1.el10_0

Not registered message:

+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Not registered
```
 