### PR TITLE
refactor API Registration with update_packages test

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -134,7 +134,7 @@ def test_positive_allow_reregistration_when_dmi_uuid_changed(
 @pytest.mark.rhel_ver_match('N-1')
 def test_positive_registration_with_package_update(
     module_target_sat,
-    module_sca_manifest_org,
+    module_org,
     module_location,
     module_activation_key,
     rhel_contenthost,
@@ -169,7 +169,7 @@ def test_positive_registration_with_package_update(
     # Register with update_packages=True
     result = rhel_contenthost.api_register(
         module_target_sat,
-        organization=module_sca_manifest_org,
+        organization=module_org,
         activation_keys=[module_activation_key.name],
         location=module_location,
         update_packages=True,


### PR DESCRIPTION

### Problem
Rewrite `test_positive_update_packages_registration` so it properly tests `update_packages` feature in the registration process.

### Solution
This PR refactors `test_positive_update_packages_registration` completely as it was not testing that the packages were updated during the registration at all.

After the refactor, the test installs outdated package, then runs registration with `update_packages` set to `True` and then it checks that the package was actually updated.
As part of the test change, I have also renamed the test  
`test_positive_update_packages_registration` -> `test_positive_registration_with_package_update`.

### PRT Example
<img width="334" height="69" alt="image" src="https://github.com/user-attachments/assets/ef9c611d-5c88-412a-b10c-176a9d960b35" />

```
trigger: test-robottelo
pytest: tests/foreman/api/test_registration.py -k "test_positive_registration_with_package_update"
```




