### PR TITLE
[6.18.z] invalidate_users_tokens test fix

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -508,6 +508,7 @@ def test_positive_invalidate_users_tokens(
             location=module_location,
             activation_keys=[module_activation_key.name],
             insecure=True,
+            setup_insights=False,
         ).create()
         result = rhel_contenthost.execute(cmd.strip('\n'))
         assert result.status == 0, f'Failed to register host: {result.stderr}'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19465


Set setup_insights to false as it is not needed in this test.

### PRT Example
<img width="298" height="39" alt="image" src="https://github.com/user-attachments/assets/c99c2314-ce73-4fa3-a4a6-ccd34ee8a56e" />

```
trigger: test-robottelo
pytest: tests/foreman/api/test_registration.py -k "test_positive_invalidate_users_tokens"
```




