### PR TITLE
API Registration Test Install from repo fix

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -767,6 +767,7 @@ def test_subscription_manager_install_from_repository(
                 'advanced.force': True,
                 'advanced.install_packages': 'subscription-manager',
                 'advanced.repository': repo_url,
+                'advanced.setup_insights': 'No (override)',
             }
         )
 


### PR DESCRIPTION
Set setup_insights to false as it is not needed in this test.

Similar to https://github.com/SatelliteQE/robottelo/pull/19465

### PRT Example
<img width="360" height="44" alt="image" src="https://github.com/user-attachments/assets/7d36c96b-63ad-44d8-9fc0-e1aeb73214c1" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_registration.py -k "test_subscription_manager_install_from_repository[rhel10-ipv4]"
```




