### PR TITLE
[6.18.z] Configure IPv6 system proxy to reach container registry to enable IoP

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1957,6 +1957,7 @@ CAPSULE_ANSWER_FILE = "/etc/foreman-installer/scenarios.d/capsule-answers.yaml"
 MAINTAIN_HAMMER_YML = "/etc/foreman-maintain/foreman-maintain-hammer.yml"
 SATELLITE_MAINTAIN_YML = "/etc/foreman-maintain/foreman_maintain.yml"
 FOREMAN_SETTINGS_YML = '/etc/foreman/settings.yaml'
+PODMAN_AUTHFILE_PATH = '/etc/foreman/registry-auth.json'
 
 FOREMAN_TEMPLATE_IMPORT_URL = 'https://github.com/SatelliteQE/foreman_templates.git'
 FOREMAN_TEMPLATES_IMPORT_COUNT = {

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -468,7 +468,10 @@ class IoPSetup:
         self.register_to_cdn()
         self.setup_rhel_repos()
         self.setup_satellite_repos()
+        self.ensure_podman_installed()
         self.podman_login(username, password, registry)
+        # Set IPv6 podman proxy on Satellite, to pull from container registry
+        self.enable_ipv6_podman_proxy()
         # TODO: Replace this temporary implementation with a permanent solution.
         result = self.execute(
             f'''


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19331

### Problem Statement
For enabling IoP in tests, Sat needs to be able to pull images from the quay.io on internet, but during ipv6-only tests we'll need a proxy to do so

### Solution
Configure IPv6 system proxy to reach container registry to enable IoP in tests

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->