### PR TITLE
[6.18.z] UI RegistrationWithNonAdmin Fix

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -551,6 +551,7 @@ def test_positive_host_registration_with_non_admin_user(
             {
                 'general.insecure': True,
                 'general.activation_keys': module_activation_key.name,
+                'advanced.setup_insights': 'No (override)',
             }
         )
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19491

Set setup_insights to false as it is not needed in this test.

### PRT Example
<img width="379" height="44" alt="image" src="https://github.com/user-attachments/assets/17ad0a7c-99d8-457b-9076-aed3232fe4f3" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_registration.py -k "test_positive_host_registration_with_non_admin_user"
```




