### PR TITLE
[6.18.z] CLI Registration Test Fixes

### DIFF
--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -459,7 +459,9 @@ def test_positive_invalidate_users_tokens(
 
     # Non-Admin user with "edit_users" permission and "Register hosts" role
     non_admin_user = module_target_sat.api.User(
-        login=gen_string('alpha'), password=password, organization=[module_org]
+        login=gen_string('alpha'),
+        password=password,
+        organization=[module_org],
     ).create()
     role = module_target_sat.cli_factory.make_role({'organization-id': module_org.id})
     module_target_sat.cli_factory.add_role_permissions(
@@ -485,6 +487,7 @@ def test_positive_invalidate_users_tokens(
                 'activation-keys': module_activation_key.name,
                 'insecure': 'true',
                 'organization-id': module_org.id,
+                'setup-insights': 'false',
             }
         )
         result = rhel_contenthost.execute(cmd.strip('\n'))
@@ -552,6 +555,7 @@ def test_negative_users_permission_for_invalidating_tokens(
             'activation-keys': module_activation_key.name,
             'insecure': 'true',
             'organization-id': module_org.id,
+            'setup-insights': 'false',
         }
     )
     result = rhel_contenthost.execute(cmd.strip('\n'))


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19493

Set setup_insights to false as it is not needed in this test.

### PRT Example
<img width="278" height="49" alt="image" src="https://github.com/user-attachments/assets/48e14317-7242-46ca-a483-d05c39bdfc0f" />
<img width="390" height="49" alt="image" src="https://github.com/user-attachments/assets/81e6cf9b-9447-4e7d-9a04-92d2b70a55af" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_registration.py -k "test_positive_invalidate_users_tokens or test_negative_users_permission_for_invalidating_tokens"
```




