### PR TITLE
[6.18.z] Add test for IOP inventory tags

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -1,4 +1,3 @@
-from broker import Broker
 import pytest
 
 from robottelo.constants import CAPSULE_REGISTRATION_OPTS
@@ -38,7 +37,6 @@ def module_target_sat_insights(request, module_target_sat):
 
     if not hosted_insights:
         satellite.teardown()
-        Broker(hosts=[satellite]).checkin()
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/api/test_rhcloud_iop.py
+++ b/tests/foreman/api/test_rhcloud_iop.py
@@ -1,0 +1,56 @@
+"""Tests for RH Cloud - IOP
+
+:Requirement: RHCloud
+
+:CaseAutomation: Automated
+
+:CaseComponent: RHCloud
+
+:Team: Proton
+
+:CaseImportance: High
+
+"""
+
+import json
+from pathlib import Path
+
+from box import Box
+import pytest
+
+
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_list(r'^[\d]+$')
+@pytest.mark.parametrize(
+    "module_target_sat_insights",
+    [False],
+    ids=["local"],
+    indirect=True,
+)
+def test_positive_iop_inventory_tags_present(module_target_sat_insights, rhel_insights_vm):
+    """Verify that IOP inventory tags exist on a host registered to IOP
+
+    :id: 70dc4438-d27d-477d-80fd-214c4f784c9e
+
+    :steps:
+
+        1. Configure IOP on a Satellite.
+        2. Register a host to the Satellite and to IOP.
+        3. Assert that the subscription_manager_id, satellite_id, and org_id facts are present in
+           the local host details file.
+
+    :expectedresults: The ID facts are present in the local host details file.
+
+    :CaseImportance: Medium
+
+    :verifies: SAT-36164
+
+    :customerscenario: false
+    """
+    details_path = Path('/var/lib/insights/host-details.json')
+    rhel_insights_vm.execute('insights-client')
+    host_details = Box(json.loads(rhel_insights_vm.execute(f'cat {details_path}').stdout))
+    assert host_details.results[0].subscription_manager_id
+    assert host_details.results[0].satellite_id
+    assert host_details.results[0].org_id
+    assert host_details.results[0].insights_id


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19338

This PR adds a new test module for IOP API tests and a single test checking for the present of inventory tags on a host reporting to an IOP instance.