### PR TITLE
Cover SAT-36783 in cockpit test

### DIFF
--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -47,7 +47,7 @@ class TestHostCockpit:
             1. cockpit service is restarted after the services restart.
             2. cockpit page is loaded and displays sat host info
 
-        :Verifies: SAT-27411
+        :Verifies: SAT-27411, SAT-36783
 
         :customerscenario: true
 
@@ -70,6 +70,19 @@ class TestHostCockpit:
 
             service_restart = class_cockpit_sat.cli.Service.restart()
             assert service_restart.status == 0
+            # SAT-36783 can be triggered by just having wide characters anywhere
+            # in the payload that gets sent between Satellite, Capsule and
+            # cockpit. The password doesn't have to be accepted, it doesn't even
+            # have to be used. Its mere presence in the communication should be
+            # enough to trigger the bug.
+            class_cockpit_sat.cli.Host.set_parameter(
+                {
+                    'host': cockpit_host.hostname,
+                    'name': 'remote_execution_ssh_password',
+                    'value': '「£」はポンド記号です',
+                }
+            )
+
             session.browser.switch_to_window(session.browser.window_handles[0])
             session.browser.close_window(session.browser.window_handles[-1])
             hostname_inside_cockpit = session.host.get_webconsole_content(


### PR DESCRIPTION
### Problem Statement
SAT-36783 states that remote execution cockpit integration fails if wide characters are present anywhere in the communication. This can typically happen in passwords. This PR extends the existing cockpit test to cover this situation.

### Solution
Set a password on the test host as a parameter. Its value should get propagated to the communication, making the test fail until the bug is resolved.

### Related Issues
https://issues.redhat.com/browse/SAT-36783
Companion to https://github.com/theforeman/foreman_remote_execution/pull/1004

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->