### PR TITLE
skip host_errata_info test for FAM

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -328,6 +328,7 @@ def common_test_positive_run_modules_and_roles(satellite, ansible_module, extra_
     """Common part of test_positive_run_modules_and_roles and test_positive_run_modules_and_roles_kerberos_auth"""
     # Skip FAM tests w/o proper setups
     if ansible_module in [
+        "host_errata_info",  # this test requires a host with non-applied errata
         "host_power",  # this test tries to power off non-existent VM
         "realm",  # realm feature is not set up on Capsule
     ]:


### PR DESCRIPTION
### Problem Statement

this test requires a setup with a dedicated host that has unapplied errata, and we do not have such a setup available right now

### Solution

skip the test for now

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->