### PR TITLE
[6.18.z] Add e2e test for IoP vulnerability service

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -90,7 +90,6 @@ def rhel_insights_vm(
     enable_insights(
         rhel_contenthost, module_target_sat_insights, rhcloud_manifest_org, rhcloud_activation_key
     )
-    assert rhel_contenthost.execute('yum update -y').status == 0
     return rhel_contenthost
 
 

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -90,6 +90,7 @@ def rhel_insights_vm(
     enable_insights(
         rhel_contenthost, module_target_sat_insights, rhcloud_manifest_org, rhcloud_activation_key
     )
+    assert rhel_contenthost.execute('yum update -y').status == 0
     return rhel_contenthost
 
 

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -28,15 +28,7 @@ def module_target_sat_insights(request, module_target_sat):
     iop-advisor-engine (local Insights advisor) configured.
     """
     hosted_insights = getattr(request, 'param', True)
-
-    satellite = (
-        module_target_sat if hosted_insights else request.getfixturevalue('module_satellite_iop')
-    )
-
-    yield satellite
-
-    if not hosted_insights:
-        satellite.teardown()
+    return module_target_sat if hosted_insights else request.getfixturevalue('module_satellite_iop')
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -18,7 +18,7 @@ import pytest
 def create_insights_vulnerability(host):
     """Function to create vulnerabilities for IoP Vulnerability Engine"""
     # Upload insights data to Satellite
-    assert host.execute('insights-client --offline').status == 0
+    assert host.execute('insights-client').status == 0
 
     # Add vulnerability for glibc package - CVE-2025-8058
     assert host.execute('dnf downgrade -y glibc').status == 0
@@ -57,6 +57,14 @@ def test_rhcloud_insights_vulnerabilities_e2e(
 
     # Verify insights-client can update to latest version available from server
     assert rhel_insights_vm.execute('insights-client --version').status == 0
+
+    # Manual VMaaS reposcan sync task
+    assert (
+        module_target_sat_insights.execute(
+            'curl --cert /etc/foreman/client_cert.pem --key /etc/foreman/client_key.pem --cacert /etc/foreman/proxy_ca.pem -X PUT "https://localhost:24443/api/vmaas-reposcan/v1/sync"'
+        ).status
+        == 0
+    )
 
     # Prepare a machine with vulnerability CVE-2025-8058 and upload data to Insights
     create_insights_vulnerability(rhel_insights_vm)

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -14,6 +14,8 @@
 
 import pytest
 
+from robottelo import constants
+
 
 def create_insights_vulnerability(host):
     """Function to create vulnerabilities for IoP Vulnerability Engine"""
@@ -24,15 +26,68 @@ def create_insights_vulnerability(host):
     assert host.execute('dnf downgrade -y glibc').status == 0
 
 
+@pytest.fixture(scope='module')
+def setup_content_for_iop(
+    module_target_sat_insights, rhcloud_manifest_org, module_rhel_contenthost
+):
+    """Fixture to setup an AK with a RHEL content repos, which is used for registering a host."""
+    sat = module_target_sat_insights
+    rhel_ver = module_rhel_contenthost.os_version.major
+    content_view = sat.api.ContentView(organization=rhcloud_manifest_org).create()
+
+    # add IPv6 proxy for IPv6 communication
+    if not module_rhel_contenthost.network_type.has_ipv4:
+        module_rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
+
+    for name in [f'rhel{rhel_ver}_bos', f'rhel{rhel_ver}_aps']:
+        rh_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
+            basearch=constants.DEFAULT_ARCHITECTURE,
+            org_id=rhcloud_manifest_org.id,
+            product=constants.REPOS[name]['product'],
+            repo=constants.REPOS[name]['name'],
+            reposet=constants.REPOS[name]['reposet'],
+            releasever=constants.REPOS[name]['releasever'],
+        )
+        # Sync step because repo is not synced by default
+        rh_repo = sat.api.Repository(id=rh_repo_id).read()
+        task = rh_repo.sync(synchronous=False)
+        sat.wait_for_tasks(
+            search_query=(f'id = {task["id"]}'),
+            poll_timeout=2500,
+        )
+        task_status = sat.api.ForemanTask(id=task['id']).poll()
+        assert task_status['result'] == 'success'
+        content_view.repository.append(rh_repo)
+        content_view.update(['repository'])
+
+    publish = content_view.publish()
+    task_status = sat.wait_for_tasks(
+        search_query=(f'Actions::Katello::ContentView::Publish and id = {publish["id"]}'),
+        search_rate=15,
+        max_tries=10,
+    )
+    assert task_status[0].result == 'success'
+    content_view = sat.api.ContentView(
+        organization=rhcloud_manifest_org, name=content_view.name
+    ).search()[0]
+
+    return sat.api.ActivationKey(
+        organization=rhcloud_manifest_org,
+        content_view=content_view,
+        environment=rhcloud_manifest_org.library.id,
+    ).create()
+
+
 @pytest.mark.e2e
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([10])
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_rhcloud_insights_vulnerabilities_e2e(
     request,
-    rhel_insights_vm,
+    module_rhel_contenthost,
     rhcloud_manifest_org,
     module_target_sat_insights,
+    setup_content_for_iop,
 ):
     """Validate vulnerability data from local Insights,
         verify results are displayed correctly for impacted host in Satellite.
@@ -52,11 +107,19 @@ def test_rhcloud_insights_vulnerabilities_e2e(
 
     :verifies: SAT-30762
     """
-    org_name = rhcloud_manifest_org.name
     CVE_ID = 'CVE-2025-8058'
 
+    result = module_rhel_contenthost.register(
+        rhcloud_manifest_org,
+        None,
+        setup_content_for_iop.name,
+        module_target_sat_insights,
+        setup_insights=True,
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+
     # Verify insights-client can update to latest version available from server
-    assert rhel_insights_vm.execute('insights-client --version').status == 0
+    assert module_rhel_contenthost.execute('insights-client --version').status == 0
 
     # Manual VMaaS reposcan sync task
     assert (
@@ -67,24 +130,24 @@ def test_rhcloud_insights_vulnerabilities_e2e(
     )
 
     # Prepare a machine with vulnerability CVE-2025-8058 and upload data to Insights
-    create_insights_vulnerability(rhel_insights_vm)
+    create_insights_vulnerability(module_rhel_contenthost)
 
     with module_target_sat_insights.ui_session() as session:
-        session.organization.select(org_name=org_name)
+        session.organization.select(org_name=rhcloud_manifest_org.name)
 
-        status = session.host_new.get_host_statuses(rhel_insights_vm.hostname)
+        status = session.host_new.get_host_statuses(module_rhel_contenthost.hostname)
         assert status['Red Hat Lightspeed']['Status'] == 'Reporting'
 
         # Read the CVEs listed on Vulnerabiltities tab on host details page
-        vulnerabilities = session.host_new.get_vulnerabilities(rhel_insights_vm.hostname)
+        vulnerabilities = session.host_new.get_vulnerabilities(module_rhel_contenthost.hostname)
         assert vulnerabilities[0]['CVE ID'] == CVE_ID
 
         # Validate the affected host from vulnerability details and list pages
         affected_host = session.cloudvulnerability.get_affected_hosts_by_cve(CVE_ID)
-        assert affected_host[0]['Name'] == rhel_insights_vm.hostname
+        assert affected_host[0]['Name'] == module_rhel_contenthost.hostname
 
         # Validate the vulnerabilities tab on host details page from CVE list and CVE details
         vulnerabilities = session.cloudvulnerability.validate_cve_to_host_flow(
-            CVE_ID, rhel_insights_vm.hostname
+            CVE_ID, module_rhel_contenthost.hostname
         )
         assert vulnerabilities[0]['CVE ID'] == CVE_ID

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -1,0 +1,79 @@
+"""Tests for RH Cloud - Vulnerability
+
+:Requirement: RHCloud
+
+:CaseAutomation: Automated
+
+:CaseComponent: RHCloud
+
+:Team: Proton
+
+:CaseImportance: High
+
+"""
+
+import pytest
+
+
+def create_insights_vulnerability(host):
+    """Function to create vulnerabilities for IoP Vulnerability Engine"""
+    # Add vulnerability for glibc package - CVE-2025-8058
+    assert host.execute('dnf downgrade -y glibc').status == 0
+
+    # Upload insights data to Satellite
+    result = host.execute('insights-client --offline')
+    assert result.status == 0
+    ARCHIVE_PATH = result.stdout.splitlines()[-1].split('Archive saved at ')[1]
+    result = host.execute(
+        f'insights-client --content-type application/vnd.redhat.advisor.something+tgz --payload {ARCHIVE_PATH}'
+    )
+    assert result.status == 0
+    assert 'Successfully uploaded report for' in result.stdout
+
+
+@pytest.mark.e2e
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_list([10])
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+def test_rhcloud_insights_vulnerabilities_e2e(
+    request,
+    rhel_insights_vm,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+):
+    """Validate vulnerability data from local Insights,
+        verify results are displayed correctly for impacted host in Satellite.
+
+    :id: d952e83c-3faf-4299-a048-2eb6ccb8c9c3
+
+    :steps:
+        1. Enable local Insights/Red Hat Lightspeed on Satellite.
+        2. Import Manifest, Sync RHEL content and create AK with the content.
+        3. Register a VM using AK created.
+        4. Create vulnerabilities for detection by vulnerability engine and upload its data to Insights.
+        5. In Satellite UI, go to vulnerabilities tab on host details page and validate the data.
+
+    :expectedresults:
+        1. Local insights vulnerability engine detects the new vulnerabilities.
+        2. Vulnerability data is displayed correctly for impacted host in Satellite.
+
+    :Verifies: SAT-30762
+    """
+    org_name = rhcloud_manifest_org.name
+    # local_advisor_enabled = module_target_sat_insights.local_advisor_enabled
+
+    # Verify insights-client can update to latest version available from server
+    assert rhel_insights_vm.execute('insights-client --version').status == 0
+
+    # Prepare a machine with vulnerability CVE-2025-8058 and upload data to Insights
+    create_insights_vulnerability(rhel_insights_vm)
+
+    with module_target_sat_insights.ui_session() as session:
+        session.organization.select(org_name=org_name)
+
+        status = session.host_new.get_host_statuses(rhel_insights_vm.hostname)
+        assert status['Red Hat Lightspeed']['Status'] == 'Reporting'
+
+        # Read the recommendations in Insights tab on host details page.
+        vulnerabilities = session.host_new.get_vulnerabilities(rhel_insights_vm.hostname)
+        assert vulnerabilities[0]['CVE ID'] == 'CVE-2025-8058'

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -17,18 +17,11 @@ import pytest
 
 def create_insights_vulnerability(host):
     """Function to create vulnerabilities for IoP Vulnerability Engine"""
+    # Upload insights data to Satellite
+    assert host.execute('insights-client --offline').status == 0
+
     # Add vulnerability for glibc package - CVE-2025-8058
     assert host.execute('dnf downgrade -y glibc').status == 0
-
-    # Upload insights data to Satellite
-    result = host.execute('insights-client --offline')
-    assert result.status == 0
-    ARCHIVE_PATH = result.stdout.splitlines()[-1].split('Archive saved at ')[1]
-    result = host.execute(
-        f'insights-client --content-type application/vnd.redhat.advisor.something+tgz --payload {ARCHIVE_PATH}'
-    )
-    assert result.status == 0
-    assert 'Successfully uploaded report for' in result.stdout
 
 
 @pytest.mark.e2e
@@ -57,7 +50,7 @@ def test_rhcloud_insights_vulnerabilities_e2e(
         1. Local insights vulnerability engine detects the new vulnerabilities.
         2. Vulnerability data is displayed correctly for impacted host in Satellite.
 
-    :Verifies: SAT-30762
+    :verifies: SAT-30762
     """
     org_name = rhcloud_manifest_org.name
     # local_advisor_enabled = module_target_sat_insights.local_advisor_enabled

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -53,7 +53,7 @@ def test_rhcloud_insights_vulnerabilities_e2e(
     :verifies: SAT-30762
     """
     org_name = rhcloud_manifest_org.name
-    # local_advisor_enabled = module_target_sat_insights.local_advisor_enabled
+    CVE_ID = 'CVE-2025-8058'
 
     # Verify insights-client can update to latest version available from server
     assert rhel_insights_vm.execute('insights-client --version').status == 0
@@ -61,7 +61,7 @@ def test_rhcloud_insights_vulnerabilities_e2e(
     # Manual VMaaS reposcan sync task
     assert (
         module_target_sat_insights.execute(
-            'curl --cert /etc/foreman/client_cert.pem --key /etc/foreman/client_key.pem --cacert /etc/foreman/proxy_ca.pem -X PUT "https://localhost:24443/api/vmaas-reposcan/v1/sync"'
+            'curl --fail --cert /etc/foreman/client_cert.pem --key /etc/foreman/client_key.pem --cacert /etc/foreman/proxy_ca.pem -X PUT "https://localhost:24443/api/vmaas-reposcan/v1/sync"'
         ).status
         == 0
     )
@@ -75,6 +75,16 @@ def test_rhcloud_insights_vulnerabilities_e2e(
         status = session.host_new.get_host_statuses(rhel_insights_vm.hostname)
         assert status['Red Hat Lightspeed']['Status'] == 'Reporting'
 
-        # Read the recommendations in Insights tab on host details page.
+        # Read the CVEs listed on Vulnerabiltities tab on host details page
         vulnerabilities = session.host_new.get_vulnerabilities(rhel_insights_vm.hostname)
-        assert vulnerabilities[0]['CVE ID'] == 'CVE-2025-8058'
+        assert vulnerabilities[0]['CVE ID'] == CVE_ID
+
+        # Validate the affected host from vulnerability details and list pages
+        affected_host = session.cloudvulnerability.get_affected_hosts_by_cve(CVE_ID)
+        assert affected_host[0]['Name'] == rhel_insights_vm.hostname
+
+        # Validate the vulnerabilities tab on host details page from CVE list and CVE details
+        vulnerabilities = session.cloudvulnerability.validate_cve_to_host_flow(
+            CVE_ID, rhel_insights_vm.hostname
+        )
+        assert vulnerabilities[0]['CVE ID'] == CVE_ID

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -36,8 +36,7 @@ def setup_content_for_iop(
     content_view = sat.api.ContentView(organization=rhcloud_manifest_org).create()
 
     # add IPv6 proxy for IPv6 communication
-    if not module_rhel_contenthost.network_type.has_ipv4:
-        module_rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
+    module_rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
 
     for name in [f'rhel{rhel_ver}_bos', f'rhel{rhel_ver}_aps']:
         rh_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
@@ -114,9 +113,11 @@ def test_rhcloud_insights_vulnerabilities_e2e(
         None,
         setup_content_for_iop.name,
         module_target_sat_insights,
+        update_packages=True,
         setup_insights=True,
     )
     assert result.status == 0, f'Failed to register host: {result.stderr}'
+    request.addfinalizer(lambda: module_rhel_contenthost.unregister())
 
     # Verify insights-client can update to latest version available from server
     assert module_rhel_contenthost.execute('insights-client --version').status == 0
@@ -138,7 +139,6 @@ def test_rhcloud_insights_vulnerabilities_e2e(
         status = session.host_new.get_host_statuses(module_rhel_contenthost.hostname)
         assert status['Red Hat Lightspeed']['Status'] == 'Reporting'
 
-        # Read the CVEs listed on Vulnerabiltities tab on host details page
         vulnerabilities = session.host_new.get_vulnerabilities(module_rhel_contenthost.hostname)
         assert vulnerabilities[0]['CVE ID'] == CVE_ID
 
@@ -147,7 +147,7 @@ def test_rhcloud_insights_vulnerabilities_e2e(
         assert affected_host[0]['Name'] == module_rhel_contenthost.hostname
 
         # Validate the vulnerabilities tab on host details page from CVE list and CVE details
-        vulnerabilities = session.cloudvulnerability.validate_cve_to_host_flow(
+        vulnerabilities = session.cloudvulnerability.validate_cve_to_host_details_flow(
             CVE_ID, module_rhel_contenthost.hostname
         )
         assert vulnerabilities[0]['CVE ID'] == CVE_ID


### PR DESCRIPTION
Manual cherrypick of https://github.com/SatelliteQE/robottelo/pull/19272

### Problem Statement
Missing e2e test for new IoP vulnerability service

### Solution
Add e2e test for new IoP vulnerability service

### Related Issues
https://github.com/SatelliteQE/airgun/pull/2033

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->