### PR TITLE
Adding network parameter in new upgrade's checkout fixtures module

### DIFF
--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -56,6 +56,7 @@ def shared_checkout(shared_name):
     bx_inst = Broker(
         workflow=settings.SERVER.deploy_workflows.product,
         deploy_sat_version=settings.UPGRADE.FROM_VERSION,
+        deploy_network_type=settings.SERVER.network_type,
         host_class=Satellite,
         upgrade_group=f"{shared_name}_shared_checkout",
     )


### PR DESCRIPTION
### Problem Statement

deploy network parameter is missing in the  broker arguments which causes the checkout to happen only for the default network type

### Solution

Added missing network parameter in the new upgrade's checkout fixtures module. 

### Related Issues

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Include deploy_network_type in the new upgrades shared_checkout fixture's Broker initialization