### PR TITLE
Update sat_maintain fixture to work with module_synced_repos fixture

### DIFF
--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -12,6 +12,15 @@ from robottelo.logging import logger
 synced_repos = pytest.StashKey[dict]
 
 
+def _get_satellite_host(request):
+    """Return the correct Satellite host depending on settings."""
+    if settings.remotedb.server:
+        logger.info(f'Creating Satellite with remotedb.server: {settings.remotedb.server}')
+        return Satellite(settings.remotedb.server)
+    logger.info('Using module_target_sat fallback')
+    return request.getfixturevalue('module_target_sat')
+
+
 @pytest.fixture(scope='module')
 def module_stash(request):
     """Module scoped stash for storing data between tests"""
@@ -21,31 +30,77 @@ def module_stash(request):
     return request.node.stash
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
+def module_capsule_maintain(request, module_capsule_host):
+    """
+    Configure the capsule instance with the satellite.
+    Ensures IPv6 proxy and CDN registration.
+    """
+    infra_sat_host = _get_satellite_host(request)
+    infra_sat_host.enable_satellite_ipv6_http_proxy()
+    infra_sat_host.register_to_cdn()
+    module_capsule_host.capsule_setup(sat_host=infra_sat_host)
+    return module_capsule_host
+
+
+@pytest.fixture(scope='module')
 def sat_maintain(request):
-    """Function scoped fixture to be used in satellite_maintain tests. It returns the right host based on request parameters"""
-    iop_settings = settings.rh_cloud.iop_advisor_engine
-    if settings.remotedb.server:
-        logger.info('Using Satellite with external DB server')
-        satellite = Satellite(settings.remotedb.server)
-        satellite.enable_satellite_ipv6_http_proxy()
-        yield satellite
+    """
+    Returns the correct host (Satellite, Capsule, or Satellite IOP) based on request.param.
+    Handles podman login for Satellite IOP if needed.
+    """
+    host_type = getattr(request, 'param', 'satellite')
+
+    if host_type == 'capsule':
+        infra_host = request.getfixturevalue('module_capsule_maintain')
+    elif host_type == 'satellite_iop':
+        infra_host = request.getfixturevalue('module_satellite_iop')
     else:
-        infra_host_type = getattr(request, 'param', 'satellite')
-        if infra_host_type == 'capsule':
-            infra_host = request.getfixturevalue('module_capsule_configured')
-        elif infra_host_type == 'satellite_iop':
-            infra_host = request.getfixturevalue('module_satellite_iop')
-        else:
-            infra_host = request.getfixturevalue('module_target_sat')
-        infra_host.register_to_cdn()
-        yield infra_host
-        if infra_host_type == 'satellite_iop' and not infra_host.is_podman_logged_in(
-            iop_settings.stage_registry
-        ):
+        infra_host = _get_satellite_host(request)
+
+    yield infra_host
+
+    if host_type == 'satellite_iop':
+        iop_settings = settings.rh_cloud.iop_advisor_engine
+        if not infra_host.is_podman_logged_in(iop_settings.stage_registry):
             infra_host.podman_login(
-                iop_settings.stage_username, iop_settings.stage_token, iop_settings.stage_registry
+                iop_settings.stage_username,
+                iop_settings.stage_token,
+                iop_settings.stage_registry,
             )
+
+
+def _sync_repositories(sat_host, manifest):
+    """Helper to upload manifest, sync custom and RH repos."""
+    if type(sat_host) is Satellite:
+        satellite = sat_host
+        logger.info(f'Using Satellite object directly, hostname: {satellite.hostname}')
+    else:
+        satellite = sat_host.satellite
+        logger.info(f"Using Capsule's satellite property, satellite hostname: {satellite.hostname}")
+
+    org = satellite.api.Organization().create()
+    satellite.upload_manifest(org.id, manifest.content)
+
+    # Sync custom repo
+    cust_prod = satellite.api.Product(organization=org).create()
+    cust_repo = satellite.api.Repository(url=settings.repos.yum_1.url, product=cust_prod).create()
+    cust_repo.sync()
+
+    # Sync RH repo
+    product = satellite.api.Product(name=constants.PRDS['rhae'], organization=org.id).search()[0]
+    r_set = satellite.api.RepositorySet(name=constants.REPOSET['rhae2'], product=product).search()[
+        0
+    ]
+    payload = {'basearch': constants.DEFAULT_ARCHITECTURE, 'product_id': product.id}
+    r_set.enable(data=payload)
+    result = satellite.api.Repository(name=constants.REPOS['rhae2']['name']).search(
+        query={'organization_id': org.id}
+    )
+    rh_repo = satellite.api.Repository(id=result[0].id).read()
+    rh_repo.sync()
+
+    return {'org': org, 'cust_repo': cust_repo, 'rh_repo': rh_repo}
 
 
 @pytest.fixture
@@ -70,49 +125,28 @@ def setup_backup_tests(request, sat_maintain):
 
 
 @pytest.fixture(scope='module')
-def module_synced_repos(module_capsule_configured, module_sca_manifest, module_stash):
+def module_synced_repos(sat_maintain, module_sca_manifest, module_stash):
+    """
+    Syncs custom and RH repositories if not already synced.
+    Assigns Library LCE to Capsule if applicable and ensures Capsule sync.
+    """
     if not module_stash[synced_repos]:
-        org = module_capsule_configured.satellite.api.Organization().create()
-        module_capsule_configured.satellite.upload_manifest(org.id, module_sca_manifest.content)
-        # sync custom repo
-        cust_prod = module_capsule_configured.satellite.api.Product(organization=org).create()
-        cust_repo = module_capsule_configured.satellite.api.Repository(
-            url=settings.repos.yum_1.url, product=cust_prod
-        ).create()
-        cust_repo.sync()
+        synced = _sync_repositories(sat_maintain, module_sca_manifest)
+        module_stash[synced_repos].update(synced)
 
-        # sync RH repo
-        product = module_capsule_configured.satellite.api.Product(
-            name=constants.PRDS['rhae'], organization=org.id
-        ).search()[0]
-        r_set = module_capsule_configured.satellite.api.RepositorySet(
-            name=constants.REPOSET['rhae2'], product=product
-        ).search()[0]
-        payload = {'basearch': constants.DEFAULT_ARCHITECTURE, 'product_id': product.id}
-        r_set.enable(data=payload)
-        result = module_capsule_configured.satellite.api.Repository(
-            name=constants.REPOS['rhae2']['name']
-        ).search(query={'organization_id': org.id})
-        rh_repo_id = result[0].id
-        rh_repo = module_capsule_configured.satellite.api.Repository(id=rh_repo_id).read()
-        rh_repo.sync()
+    if type(sat_maintain) is Capsule:
+        org = module_stash[synced_repos]['org']
+        lce = sat_maintain.satellite.api.LifecycleEnvironment(organization=org).search(
+            query={'search': f'name={constants.ENVIRONMENT}'}
+        )[0]
 
-        module_stash[synced_repos]['rh_repo'] = rh_repo
-        module_stash[synced_repos]['cust_repo'] = cust_repo
-        module_stash[synced_repos]['org'] = org
-
-    if type(module_capsule_configured) is Capsule:
-        # assign the Library LCE to the Capsule
-        lce = module_capsule_configured.satellite.api.LifecycleEnvironment(
-            organization=module_stash[synced_repos]['org']
-        ).search(query={'search': f'name={constants.ENVIRONMENT}'})[0]
-        module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
+        sat_maintain.nailgun_capsule.content_add_lifecycle_environment(
             data={'environment_id': lce.id}
         )
-        result = module_capsule_configured.nailgun_capsule.content_lifecycle_environments()
-        assert lce.id in [capsule_lce['id'] for capsule_lce in result['results']]
-        # sync the Capsule
-        sync_status = module_capsule_configured.nailgun_capsule.content_sync()
+        envs = sat_maintain.nailgun_capsule.content_lifecycle_environments()
+        assert lce.id in [e['id'] for e in envs['results']]
+
+        sync_status = sat_maintain.nailgun_capsule.content_sync()
         assert sync_status['result'] == 'success'
 
     return {
@@ -133,7 +167,7 @@ def setup_sync_plan(request, sat_maintain):
             'enabled': 'true',
             'interval': 'weekly',
             'organization-id': org.id,
-            'sync-date': datetime.datetime.today().strftime("%Y-%m-%d"),
+            'sync-date': datetime.datetime.today().strftime('%Y-%m-%d'),
         }
     )
 


### PR DESCRIPTION
### Problem Statement
-  Remotedb tests have been failing because module_synced_repos is using a different Satellite and Capsule than the one provided by the sat_maintain fixture. Historically, they were passing, but still they were using a different satellite than the remotedb DB one, which it shouldn't have. We didn't catch it because the test passed as it was able to checkout satellite using module_target_sat. It started to fail when changes were introduced by IoP automation, which removed unnecessary checkout.

### Solution
- Update `sat_maintain` and `module_synced_repos` fixtures.

### Related Issues
- SAT-38368

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Centralize and streamline Satellite and Capsule fixture logic by extracting common host selection and repository sync routines, converting fixtures to module scope, and reducing duplicated code in module_synced_repos.

Enhancements:
- Add _get_satellite_host helper to select the correct Satellite host based on remotedb settings
- Introduce module_capsule_maintain fixture to configure capsule with IPv6 proxy and CDN registration
- Refactor sat_maintain fixture to module scope, unify host selection logic, and handle Satellite IOP podman login
- Extract repository synchronization logic into a reusable _sync_repositories helper
- Simplify module_synced_repos fixture to use sat_maintain and _sync_repositories, and stash synced organization and repositories