### PR TITLE
[6.18.z] Skip OEL7 & CentOS7 conversions on FIPs enabled SAT on EL9

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2226,6 +2226,10 @@ class Satellite(Capsule, SatelliteMixins):
             self.execute(f'grep "db_manage: false" {constants.SATELLITE_ANSWER_FILE}').status == 0
         )
 
+    def is_fips_enabled(self):
+        """Check if FIPS mode is enabled on the system."""
+        return int(self.execute('cat /proc/sys/crypto/fips_enabled').stdout)
+
     def setup_firewall(self):
         # Setups firewall on Satellite
         assert (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19541

### Problem Statement
We see a below issue while registering OEL7 & CentOS7 clients for conversion on FIPs enabled SAT on EL9, which is same issue as EL7 client registration, for which we took following action in past https://github.com/SatelliteQE/robottelo/pull/18298
```
failed on setup with "AssertionError: Failed to register host: Unable to verify server's identity: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:618)
```

### Solution
Skipping OEL7 & CentOS7 conversions from test, same as EL7 client testing on FIPs enabled SAT on EL9

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Skip OEL7 and CentOS7 conversions on FIPS-enabled Satellite 9 hosts by detecting FIPS mode and skipping the corresponding tests

Enhancements:
- Add is_fips_enabled method to detect FIPS mode on Satellite hosts

Tests:
- Skip Oracle Linux 7 conversion test when FIPS is enabled
- Skip CentOS 7 conversion test when FIPS is enabled