### PR TITLE
[6.17.z] Remove conditions for an unfixed bug

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -52,7 +52,6 @@ from robottelo.utils.datafactory import (
     valid_docker_repository_names,
     valid_http_credentials,
 )
-from robottelo.utils.issue_handlers import is_open
 from tests.foreman.api.test_contentview import content_view
 
 YUM_REPOS = (
@@ -830,14 +829,11 @@ class TestRepository:
         tags = 'latest'
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = _validated_image_tags_count(repo=repo, sat=target_sat)
-        if not is_open('SAT-26322'):
-            assert not repo['included-container-image-tags']
         tags_count = int(repo['content-counts']['container-tags'])
         assert tags_count >= 2, 'insufficient tags count in the repo'
         target_sat.cli.Repository.update({'id': repo['id'], 'include-tags': tags})
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = _validated_image_tags_count(repo=repo, sat=target_sat)
-        # assert tags in repo['container-image-tags-filter']
         assert int(repo['content-counts']['container-tags']) == tags_count, (
             'unexpected change of tags count'
         )
@@ -908,9 +904,6 @@ class TestRepository:
         """
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = _validated_image_tags_count(repo=repo, sat=target_sat)
-        if not is_open('SAT-26322'):
-            for tag in repo_options['include-tags'].split(','):
-                assert tag in repo['included-container-image-tags']
         assert int(repo['content-counts']['container-tags']) == 1
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19551

### Problem Statement
The issue bellow has been closed as "Won't do", but we already have some assertions hooked on that bug resolution.


### Solution
Since they "Won't do" the fix, just remove the conditioned assertions.


### Related Issues
https://issues.redhat.com/browse/SAT-26322


### PRT test Cases example
```
trigger: test-robottelo
pytest:  tests/foreman/cli/test_repository.py -k 'set_tags_later_additive or set_tags_later_content_only or with_mix_valid_invalid_tags'
```