### PR TITLE
[6.16.z] Fix test_positive_sync_kickstart_check_os

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1421,7 +1421,8 @@ class TestRepositorySync:
         rh_repo = target_sat.api.Repository(id=repo_id).read()
         rh_repo.sync()
 
-        major, minor = constants.REPOS['kickstart'][distro]['version'].split('.')
+        major, *rest = constants.REPOS['kickstart'][distro]['version'].split('.')
+        minor = rest[0] if rest else '0'
         os = target_sat.api.OperatingSystem().search(
             query={'search': f'name="RedHat" AND major="{major}" AND minor="{minor}"'}
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19571

### Problem Statement
RHEL10 has been added to the `supportability.yaml` and constants. However, without the [minor version](https://github.com/SatelliteQE/robottelo/blob/master/robottelo/constants/__init__.py#L625), which was unexpected by `test_positive_sync_kickstart_check_os`.


### Solution
Fix the test to handle any version, use `0` when minor is not provided.


### Related Issues
https://issues.redhat.com/browse/SAT-37889


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k test_positive_sync_kickstart_check_os
```