### PR TITLE
Fixed host component failures

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2363,7 +2363,7 @@ def test_positive_host_with_puppet(
         }
     )
     host = session_puppet_enabled_sat.cli.Host.info({'id': host['id']})
-    assert host['puppet-environment'] == module_puppet_environment.name
+    assert host['puppet-environment']['name'] == module_puppet_environment.name
     session_puppet_enabled_sat.cli.Host.delete({'id': host['id']})
 
 


### PR DESCRIPTION
### Problem Statement
test_positive_host_with_puppet
- Picked value from correct field
test_positive_view_hosts_with_non_admin_user
- Changed setting to read from old content host UI page.
test_positive_remove_parameter_non_admin_user
- Corrected test case to read from new all host details UI page.

### Solution


### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_positive_view_hosts_with_non_admin_user or  test_positive_remove_parameter_non_admin_user"

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->