### PR TITLE
[6.18.z] Add multiple libvirt image UUIDs to fam.yaml template

### DIFF
--- a/conf/fam.yaml.template
+++ b/conf/fam.yaml.template
@@ -48,6 +48,8 @@ FAM:
           - Test Location
         params:
           url: qemu+ssh://libvirtuser@localhost/system
+        image_uuid: /var/lib/libvirt/images/rhel10.qcow2
+        image_uuid_2: /var/lib/libvirt/images/rhel8.qcow2
         compute_profile:
           name: app-small
           attrs:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19592

### Problem Statement
The `conf/fam.yaml.template` did not define `image_uuid` values for libvirt,
causing issues when running compute resource and image-related tests that
expect multiple images.

### Solution
Added `image_uuid` and `image_uuid_2` entries under the libvirt
`compute_resource` section to support multiple image paths

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->