### PR TITLE
[6.16.z] recommendation sync CLI test fix

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -133,7 +133,7 @@ def test_positive_inventory_recommendation_sync(
         handle_exception=True,
     )
     assert result.status == 0
-    assert result.stdout == 'Synchronized Insights hosts hits data\n'
+    assert 'Synchronized Insights hosts hits data' in result.stdout
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Manual cherrypick of https://github.com/SatelliteQE/robottelo/pull/19066

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_rhcloud_inventory.py -k "test_positive_inventory_recommendation_sync[rhel9-ipv4]"
```