### PR TITLE
Fix and improve libvirt image CRUD test

### DIFF
--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -486,10 +486,10 @@ def test_negative_create_libvirt_with_url(module_location, module_org, module_ta
         )
 
 
-def test_positive_create_delete_image_libvirt_with_name(
-    module_location, module_org, module_target_sat, module_os
+def test_positive_crud_image_libvirt_with_name(
+    request, module_location, module_org, module_target_sat, module_os
 ):
-    """Create/Delete images on the libvirt compute resource
+    """Create, Read, Update and Delete images on the libvirt compute resource
 
     :id: 2da84165-a56f-4282-9343-94828fa69c13
 
@@ -497,10 +497,14 @@ def test_positive_create_delete_image_libvirt_with_name(
         1. Create a compute resource of type libvirt.
         2. Create a image for the compute resource with valid parameter,
            compute-resource image create
+        3. List/info the created image
+        4. Update image name and username
+        5. Delete created image
 
-    :expectedresults: The image is created and deleted on the CR successfully
+    :expectedresults: Image should be created, list, updated and deleted in Libvirt CR
     """
     cr_name = gen_string('alpha')
+    module_target_sat.configure_libvirt_cr()
     comp_res = module_target_sat.cli_factory.compute_resource(
         {
             'name': cr_name,
@@ -525,14 +529,34 @@ def test_positive_create_delete_image_libvirt_with_name(
             'uuid': img_path,
         }
     )
+    request.addfinalizer(lambda: module_target_sat.cli.ComputeResource.delete({'name': cr_name}))
     result = module_target_sat.cli.ComputeResource.image_list(
         {'compute-resource': comp_res['name']}
     )
     assert result[0]['uuid'] == img_path
 
+    # Update image
+    new_img_name = gen_string('alpha')
+    new_username = gen_string('alpha')
+    result = module_target_sat.cli.ComputeResource.image_update(
+        {
+            'name': img_name,
+            'compute-resource': cr_name,
+            'new-name': new_img_name,
+            'username': new_username,
+        }
+    )[0]
+    assert result['message'] == 'Image updated.'
+    assert result['name'] == new_img_name
+
+    img_info = module_target_sat.cli.ComputeResource.image_info(
+        {'name': new_img_name, 'compute-resource': cr_name}
+    )[0]
+    assert img_info['username'] == new_username
+
     # Delete Image
     result = module_target_sat.cli.ComputeResource.image_delete(
-        {'name': img_name, 'compute-resource': cr_name}
+        {'name': new_img_name, 'compute-resource': cr_name}
     )
     assert result[0]['message'] == 'Image deleted.'
 

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -553,6 +553,7 @@ def test_positive_crud_image_libvirt_with_name(
         {'name': new_img_name, 'compute-resource': cr_name}
     )[0]
     assert img_info['username'] == new_username
+    assert img_info['uuid'] == img_path
 
     # Delete Image
     result = module_target_sat.cli.ComputeResource.image_delete(


### PR DESCRIPTION
### Problem Statement
Libvirt image create test failing with `Error making a connection to libvirt URI qemu+ssh://root@env-libvirt.redhat.com/system:\n  Call to virConnectOpen failed: Cannot recv data: Host key verification failed.: Connection reset by peer`  after upstream fix for v6.18+

### Solution

1. Use configure_libvirt_cr() helper to fix above error
2. Improve existing test to extend for CRUD operations on image
3. Use teardown to delete CR with finalizer


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->