### PR TITLE
Added component overview refresh to check updated package list

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1480,6 +1480,8 @@ def test_positive_update_delete_package(
         )
         task_status = target_sat.api.ForemanTask(id=task_result[0].id).poll()
         assert task_status['result'] == 'success'
+        # this should reload page to update packages table
+        session.host_new.get_details(client.hostname, widget_names='overview')
         packages = session.host_new.get_packages(client.hostname, FAKE_8_CUSTOM_PACKAGE_NAME)
         assert not packages
         result = client.run(f'rpm -q {FAKE_8_CUSTOM_PACKAGE}')


### PR DESCRIPTION
### Problem Statement
Deleted package details were not getting updated if cursor remain on same UI Page

### Solution

Added component refresh to check updated package 

### Related Issues


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py  -k  "test_positive_update_delete_package"

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->