### PR TITLE
[6.18.z] Fix test_negative_synchronize_private_registry_wrong_repo

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1706,7 +1706,7 @@ class TestDockerRepository:
         :BZ: 1475121, 1580510
 
         """
-        msg = "404, message='Not Found'"
+        msg = "Pulp task error"
         with pytest.raises(TaskFailedError, match=msg):
             repo.sync()
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19625

### Problem Statement
The `test_negative_synchronize_private_registry_wrong_repo` is failing since as far as I can see in history, most probably since the age of pulp2. With pulp3, however, for any repo sync error we get just a "Pulp task error" without any details. Finer error granularization would mean a new RFE.


### Solution
Just update the expected error message so it matches the reality.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k test_negative_synchronize_private_registry_wrong_repo
```