### PR TITLE
[6.16.z] Remove OS selection from interop global registration form

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -182,7 +182,6 @@ def test_positive_global_registration_end_to_end(
         session.location.select(loc_name=smart_proxy_location.name)
         cmd = session.host.get_register_command(
             {
-                'general.operating_system': default_os.title,
                 'general.activation_keys': module_activation_key.name,
                 'advanced.update_packages': True,
                 'advanced.rex_interface': iface,
@@ -193,7 +192,6 @@ def test_positive_global_registration_end_to_end(
         f'organization_id={module_org.id}',
         f'activation_keys={module_activation_key.name}',
         f'location_id={smart_proxy_location.id}',
-        f'operatingsystem_id={default_os.id}',
         f'{default_smart_proxy.name}',
         'insecure',
         'update_packages=true',

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -352,7 +352,6 @@ def test_insights_registration_with_capsule(
         # Generate host registration command
         cmd = session.host_new.get_register_command(
             {
-                'general.operating_system': default_os.title,
                 'general.organization': org.name,
                 'general.capsule': rhcloud_capsule.hostname,
                 'general.activation_keys': ak.name,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19649

### Problem Statement
We are seeing interop failures in two tests due to a mismatch between the operating system of RHEL compose versions and the available operating systems that can be selected when generating a global registration command. For example:
```
widgetastic_patternfly4.formselect.FormSelectOptionNotFound: Option "RedHat 9.7" not found in FormSelect('.//*[contains(@data-ouia-component-type,"PF4/FormSelect") and @data-ouia-component-id="os-select"]'). Available options: ['', 'RHEL 9.6', 'RHEL 9.7 Beta']
```

### Solution
Remove the `general.operating_system` option from the dictionary of options passed to the global registration form. This option is still present on other registration tests that are not marked for inclusion in our interop pipelines.