### PR TITLE
[6.18.z] Fixed host component failures

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2363,7 +2363,7 @@ def test_positive_host_with_puppet(
         }
     )
     host = session_puppet_enabled_sat.cli.Host.info({'id': host['id']})
-    assert host['puppet-environment'] == module_puppet_environment.name
+    assert host['puppet-environment']['name'] == module_puppet_environment.name
     session_puppet_enabled_sat.cli.Host.delete({'id': host['id']})
 
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -81,6 +81,16 @@ def ui_admin_user(target_sat):
 
 
 @pytest.fixture
+def host_ui_default(target_sat):
+    settings_object = target_sat.api.Setting().search(query={'search': 'name=host_details_ui'})[0]
+    settings_object.value = 'No'
+    settings_object.update({'value'})
+    yield
+    settings_object.value = 'Yes'
+    settings_object.update({'value'})
+
+
+@pytest.fixture
 def ui_view_hosts_user(target_sat, current_sat_org, current_sat_location):
     """User with View hosts role."""
     role = target_sat.api.Role().search(query={'search': 'name="View hosts"'})[0]
@@ -612,7 +622,7 @@ def test_negative_delete_primary_interface(session, host_ui_options):
 
 
 def test_positive_view_hosts_with_non_admin_user(
-    test_name, module_org, smart_proxy_location, target_sat
+    test_name, module_org, smart_proxy_location, target_sat, host_ui_default
 ):
     """View hosts and content hosts as a non-admin user with only view_hosts, edit_hosts
     and view_organization permissions
@@ -644,7 +654,7 @@ def test_positive_view_hosts_with_non_admin_user(
         location=smart_proxy_location, organization=module_org
     ).create()
     with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
-        host = session.host.get_details(created_host.name, widget_names='breadcrumb')
+        host = session.host_new.get_details(created_host.name, widget_names='breadcrumb')
         assert host['breadcrumb'] == created_host.name
         content_host = session.contenthost.read(created_host.name, widget_names='breadcrumb')
         assert content_host['breadcrumb'] == created_host.name
@@ -692,10 +702,10 @@ def test_positive_remove_parameter_non_admin_user(
         host_parameters_attributes=[parameter],
     ).create()
     with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
-        values = session.host.read(host.name, 'parameters')
+        values = session.host_new.read(host.name, 'parameters')
         assert values['parameters']['host_params'][0] == parameter
-        session.host.update(host.name, {'parameters.host_params': []})
-        values = session.host.read(host.name, 'parameters')
+        session.host_new.update(host.name, {'parameters.host_params': []})
+        values = session.host_new.read(host.name, 'parameters')
         assert not values['parameters']['host_params']
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19588

### Problem Statement
test_positive_host_with_puppet
- Picked value from correct field
test_positive_view_hosts_with_non_admin_user
- Changed setting to read from old content host UI page.
test_positive_remove_parameter_non_admin_user
- Corrected test case to read from new all host details UI page.

### Solution


### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_positive_view_hosts_with_non_admin_user or  test_positive_remove_parameter_non_admin_user"

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->