### PR TITLE
[PIT]Corrected subscription-manager repos --enable command as \ was missing

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -257,7 +257,7 @@ def test_sca_end_to_end(
         'lifecycle_environment_id': module_ak.environment.id,
     }
     host.update(['content_facet_attributes'])
-    rhel_contenthost.run('subscription-manager repos --enable \*')
+    rhel_contenthost.run(r'subscription-manager repos --enable \*')
     repos = rhel_contenthost.run('subscription-manager refresh && yum repolist')
     assert content_view.repository[1].name in repos.stdout
     # install package and verify it succeeds or is already installed


### PR DESCRIPTION
### Problem Statement

Corrected subscription-manager repos --enable command as \ was missing

### Solution


### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_subscription.py -k test_sca_end_to_end

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->