### PR TITLE
[6.17.z] Remove is_open from api/test_capsulecontent

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -49,7 +49,6 @@ from robottelo.content_info import (
     get_repomd_revision,
 )
 from robottelo.utils.datafactory import gen_string
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture
@@ -979,8 +978,7 @@ class TestCapsuleContentManagement:
                     f'{con_client} search {module_capsule_configured.hostname}/{path}'
                 )
                 assert result.status == 0
-                if not is_open('SAT-25813'):
-                    assert f'{module_capsule_configured.hostname}/{path}' in result.stdout
+                assert f'{module_capsule_configured.hostname}/{path}' in result.stdout
 
                 result = module_container_contenthost.execute(
                     f'{con_client} pull {module_capsule_configured.hostname}/{path}'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19665

### Problem Statement
We should avoid `is_open` conditions in build_sanity tests (there is an offline/email thread).


### Solution
Remove it since the issue has been resolved.


### Related Issues
https://issues.redhat.com/browse/SAT-25813


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k test_positive_sync_container_repo_end_to_end
```