### PR TITLE
[6.18.z] applyErratum Fix

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1563,6 +1563,7 @@ def test_positive_apply_erratum(
         task_status = target_sat.api.ForemanTask(id=task_result[0].id).poll()
         assert task_status['result'] == 'success'
         # verify
+        session.browser.refresh()
         values = session.host_new.get_details(client.hostname, widget_names='content.errata')
         assert 'table' not in values['content']['errata']
         result = client.run(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19693

Make `test_positive_apply_erratum` more stable.

### PRT Example
<img width="442" height="140" alt="image" src="https://github.com/user-attachments/assets/93972979-7dc4-4576-963d-5d21781214f1" />

``` 
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_positive_apply_erratum" 
```

