### PR TITLE
[6.15.z] Fixing remaining changes of PR-19543

### DIFF
--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -76,6 +76,7 @@ def shared_cap_checkout(shared_name):
     cap_inst = Broker(
         workflow=settings.CAPSULE.deploy_workflows.product,
         deploy_sat_version=settings.UPGRADE.FROM_VERSION,
+        deploy_network_type=settings.CAPSULE.network_type,
         host_class=Capsule,
         upgrade_group=f'{shared_name}_shared_checkout',
     )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19671

### Problem Statement

Missed to update network parameter in https://github.com/SatelliteQE/robottelo/pull/19543 for capsule, which causes the capsule checkout only to happens with default network

### Solution

Added missing network parameter in the new upgrade's capsule checkout module.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->