### PR TITLE
assertion fix on dashboard test

### DIFF
--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -84,7 +84,7 @@ def test_positive_host_configuration_status(session, target_sat):
                 session.dashboard.action({'HostConfigurationStatus': {'status_list': criteria}})
                 values = session.host.read_all()
                 assert values['searchbox'] == search
-                assert len(values['table']) == 0
+                assert values['table'][0][0] in ('No Results', 'Loading Loading...')
 
 
 def test_positive_host_configuration_chart(session, target_sat):


### PR DESCRIPTION
### Problem Statement
empty table looks differently now

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->