### PR TITLE
Update CaseComponent based on recent component grouping

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -44,7 +44,6 @@ CaseComponent:
     - ContentViews
     - Conversionsappliance
     - Dashboard
-    - DHCPDNS
     - DiscoveryImage
     - DiscoveryPlugin
     - Documentation
@@ -57,10 +56,8 @@ CaseComponent:
     - Hammer-Content
     - HTTPProxy
     - HostCollections
-    - HostForm
     - HostGroup
     - Hosts
-    - Hosts-Content
     - Infobloxintegration
     - Installation
     - InterSatelliteSync
@@ -98,7 +95,6 @@ CaseComponent:
     - TasksPlugin
     - TemplatesPlugin
     - TestEnvironment
-    - TFTP
     - Upgrades
     - UsersRoles
     - Virt-whoConfigurePlugin

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1037,7 +1037,7 @@ def test_positive_bootc_api_actions(target_sat, bootc_host, function_ak_with_cv,
 
     :expectedresults: Upon registering a Bootc host, the API returns correct information across multiple endpoints
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :Team: Artemis
 
@@ -1182,7 +1182,7 @@ def test_positive_verify_files_with_pxegrub_uefi_secureboot():
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: TFTP
+    :CaseComponent: Provisioning
 
     :Team: Rocket
     """
@@ -1215,7 +1215,7 @@ def test_positive_verify_files_with_pxegrub2_uefi():
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: TFTP
+    :CaseComponent: Provisioning
 
     :Team: Rocket
     """
@@ -1248,7 +1248,7 @@ def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: TFTP
+    :CaseComponent: Provisioning
 
     :Team: Rocket
     """

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -2,7 +2,7 @@
 
 :Requirement: Content Access
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1937,7 +1937,7 @@ def test_positive_bootc_cli_actions(target_sat, bootc_host, function_ak_with_cv,
 
     :expectedresults: Upon registering a Bootc host, the facts are attached to the host, and are accurate. Hammer host bootc also returns proper info.
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :Team: Artemis
 
@@ -1988,7 +1988,7 @@ def test_negative_multi_cv_registration(
 
     :CaseImportance: Critical
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :team: Proton
 
@@ -2036,7 +2036,7 @@ def test_positive_multi_cv_registration(
 
     :CaseImportance: Critical
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :team: Proton
 
@@ -2110,7 +2110,7 @@ def test_positive_multi_cv_assignment(
 
     :CaseImportance: Critical
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :team: Proton
 
@@ -2179,7 +2179,7 @@ def test_positive_multi_cv_host_repo_availability(
 
     :CaseImportance: Critical
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :team: Proton
 

--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :team: Proton
 
@@ -31,7 +31,7 @@ def test_content_access_after_stopped_foreman(target_sat, rhel7_contenthost):
 
     :CaseImportance: Medium
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :Team: Proton
 

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -2,7 +2,7 @@
 
 :Requirement: Infoblox, Installer
 
-:CaseComponent: DHCPDNS
+:CaseComponent: Provisioning
 
 :Team: Rocket
 

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: DHCPDNS
+:CaseComponent: Provisioning
 
 :Team: Rocket
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :team: Proton
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :team: Proton
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1321,7 +1321,7 @@ def test_all_hosts_manage_columns(target_sat, new_host_ui):
 
     :expectedresults: Through the widget you can change the columns on the All Hosts page
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :Team: Proton
 
@@ -1946,7 +1946,7 @@ def test_all_hosts_delete(target_sat, function_org, function_location, new_host_
 
     :expectedresults: Successful deletion of a host through the table dropdown
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent:Hosts
 
     :Team: Proton
     """
@@ -1975,7 +1975,7 @@ def test_all_hosts_bulk_delete(target_sat, function_org, function_location, new_
 
     :expectedresults: Successful deletion of multiple hosts at once through Bulk Action
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent:Hosts
 
     :Team: Proton
     """
@@ -2001,7 +2001,7 @@ def test_all_hosts_bulk_cve_reassign(
 
     :expectedresults: Both hosts are successfully assigned to a new LCE and CV
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :Team: Proton
     """
@@ -2047,7 +2047,7 @@ def test_all_hosts_redirect_button(target_sat):
 
     :expectedresults: New UI Button redirects to All Hosts page
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :Team: Proton
     """
@@ -2063,7 +2063,7 @@ def test_all_hosts_bulk_build_management(target_sat, function_org, function_loca
 
     :expectedresults: Build Management dropdown in All Hosts UI works properly.
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent:Hosts
 
     :Team: Proton
     """
@@ -2089,7 +2089,7 @@ def test_bootc_booted_container_images(target_sat, bootc_host, function_ak_with_
 
     :expectedresults: Booted Container Images contains the correct information for a given booted image
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent:Hosts
 
     :Verifies:SAT-27163
 
@@ -2121,7 +2121,7 @@ def test_bootc_host_details(target_sat, bootc_host, function_ak_with_cv, functio
 
     :expectedresults: Host Details UI contains the proper information for a bootc host
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent:Hosts
 
     :Verifies:SAT-27171
 
@@ -2159,7 +2159,7 @@ def test_bootc_rex_job(target_sat, bootc_host, function_ak_with_cv, function_org
 
     :expectedresults: Host Details UI links to the proper template, which runs successfully for all templates
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :Verifies:SAT-27154, SAT-27158
 
@@ -2315,7 +2315,7 @@ def test_change_content_source(session, change_content_source_prep, rhel_content
     :expectedresults: Job invocation page should be correctly generated
         by the change content source action, generated script should also be correct
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent:Hosts
 
     :Team: Proton
     """
@@ -2547,7 +2547,7 @@ def test_positive_manage_packages(
 
     :expectedresults: Various package management actions should run successfully on various hosts
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :parametrized: yes
 
@@ -2833,7 +2833,7 @@ def test_all_hosts_manage_errata(
 
     :expectedresults: Errata can be bulk applied to hosts through the All Hosts page.
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent: Hosts
 
     :Team: Proton
     """

--- a/tests/new_upgrades/test_hostcontent.py
+++ b/tests/new_upgrades/test_hostcontent.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :Team: Proton
 

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -7,7 +7,7 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :Team: Proton
 

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :Team: Proton
 


### PR DESCRIPTION
### Problem Statement
We plan to make another round of component grouping. Following is the finalized list.
* `DHCPDNS ` and `TFTP` will merge with the 'Provisioning' component.
* `HostForm` and `Hosts-Content` will merge with `Hosts`.

### Solution
- Update the `testimony`.yaml and `CaseComponent` accordingly.

### Related Issues
- SAT-35642
- SAT-38731


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->