### PR TITLE
[6.15.z] Update CaseComponent based on recent component grouping

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -44,7 +44,6 @@ CaseComponent:
     - ContentViews
     - Conversionsappliance
     - Dashboard
-    - DHCPDNS
     - DiscoveryImage
     - DiscoveryPlugin
     - Documentation
@@ -57,10 +56,8 @@ CaseComponent:
     - Hammer-Content
     - HTTPProxy
     - HostCollections
-    - HostForm
     - HostGroup
     - Hosts
-    - Hosts-Content
     - Infobloxintegration
     - Installation
     - InterSatelliteSync
@@ -98,7 +95,6 @@ CaseComponent:
     - TasksPlugin
     - TemplatesPlugin
     - TestEnvironment
-    - TFTP
     - Upgrades
     - UsersRoles
     - Virt-whoConfigurePlugin

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1217,7 +1217,7 @@ def test_positive_verify_files_with_pxegrub_uefi_secureboot():
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: TFTP
+    :CaseComponent: Provisioning
 
     :Team: Rocket
     """
@@ -1251,7 +1251,7 @@ def test_positive_verify_files_with_pxegrub2_uefi():
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: TFTP
+    :CaseComponent: Provisioning
 
     :Team: Rocket
     """
@@ -1285,7 +1285,7 @@ def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: TFTP
+    :CaseComponent: Provisioning
 
     :Team: Rocket
     """

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -2,7 +2,7 @@
 
 :Requirement: Content Access
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :CaseAutomation: Automated
 

--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :team: Proton
 

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -2,7 +2,7 @@
 
 :Requirement: Infoblox, Installer
 
-:CaseComponent: DHCPDNS
+:CaseComponent: Provisioning
 
 :Team: Rocket
 

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: DHCPDNS
+:CaseComponent: Provisioning
 
 :Team: Rocket
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :team: Proton
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :team: Proton
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1286,7 +1286,6 @@ def test_positive_manage_table_columns(
             assert (column in displayed_columns) is is_displayed
 
 
-@pytest.mark.tier4
 def test_positive_host_details_read_templates(
     session, target_sat, current_sat_org, current_sat_location
 ):
@@ -1902,7 +1901,7 @@ def test_all_hosts_delete(target_sat, function_org, function_location, new_host_
 
     :expectedresults: Successful deletion of a host through the table dropdown
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent:Hosts
 
     :Team: Proton
     """
@@ -1921,7 +1920,7 @@ def test_all_hosts_bulk_delete(target_sat, function_org, function_location, new_
 
     :expectedresults: Successful deletion of multiple hosts at once through Bulk Action
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent:Hosts
 
     :Team: Proton
     """
@@ -2020,7 +2019,7 @@ def test_change_content_source(session, change_content_source_prep, rhel_content
     :expectedresults: Job invocation page should be correctly generated
         by the change content source action, generated script should also be correct
 
-    :CaseComponent:Hosts-Content
+    :CaseComponent:Hosts
 
     :Team: Proton
     """

--- a/tests/new_upgrades/test_hostcontent.py
+++ b/tests/new_upgrades/test_hostcontent.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :Team: Proton
 

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -7,7 +7,7 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :Team: Proton
 

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts-Content
+:CaseComponent: Hosts
 
 :Team: Proton
 


### PR DESCRIPTION
### Problem Statement
We plan to make another round of component grouping. Following is the finalized list.
* `DHCPDNS ` and `TFTP` will merge with the 'Provisioning' component.
* `HostForm` and `Hosts-Content` will merge with `Hosts`.

### Solution
- Update the `testimony.yaml` and `CaseComponent` accordingly.

### Related Issues
- SAT-35642
- SAT-38731


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->