### PR TITLE
[6.18.z] auditlog test fixes

### DIFF
--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -49,12 +49,6 @@ def test_positive_create_by_type(target_sat):
         {'entity': target_sat.api.Domain(), 'entity_type': 'domain'},
         {'entity': target_sat.api.Host(), 'entity_type': 'host'},
         {'entity': target_sat.api.HostGroup(), 'entity_type': 'hostgroup'},
-        {
-            'entity': target_sat.api.Image(
-                compute_resource=target_sat.api.LibvirtComputeResource().create()
-            ),
-            'entity_type': 'image',
-        },
         {'entity': target_sat.api.Location(), 'entity_type': 'location'},
         {'entity': target_sat.api.Media(), 'entity_type': 'medium'},
         {

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -535,6 +535,10 @@ def test_positive_crud_image_libvirt_with_name(
     )
     assert result[0]['uuid'] == img_path
 
+    # check audit log
+    audit_logs = module_target_sat.api.Audit().search(query={'search': 'type=image'})
+    assert img_name in [entry.auditable_name for entry in audit_logs]
+
     # Update image
     new_img_name = gen_string('alpha')
     new_username = gen_string('alpha')

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -86,7 +86,7 @@ def test_positive_audit_comment(session, module_org):
         session.partitiontable.create(
             {
                 'template.name': name,
-                'template.template_editor': gen_string('alpha'),
+                'template.template_editor.editor': gen_string('alpha'),
                 'template.audit_comment': audit_comment,
             }
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19699

### Problem Statement
Automation fixes for audit log test

### Solution
in the api test: cause -- dummy LibvirtComputeResource can no longer be used to create image, the real compute resource is needed. Dropped the entity from test_audit and added an audit assertion to the specialized cr test that uses the correct setup already

in the ui test: do the same as in https://github.com/SatelliteQE/robottelo/pull/19256

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->