### PR TITLE
Fix test case to read from new host UI page

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -965,7 +965,7 @@ def test_positive_search_by_reported_data(
             api_hosts = target_sat.api.Host().search(query={'search': search_string})
             ui_hosts = session.host.search(search_string)
             assert set([host.name for host in api_hosts]) == set(
-                [host['Name'] for host in ui_hosts]
+                [host['Name'] for host in ui_hosts if host['Name'] != 'No Results']
             )
 
 
@@ -1216,7 +1216,7 @@ def test_positive_validate_inherited_cv_lce_ansiblerole(session, target_sat, mod
         }
     )
     with session:
-        values = session.host.read(host['name'], ['host.lce', 'host.content_view'])
+        values = session.host_new.read(host['name'], ['host.lce', 'host.content_view'])
         assert values['host']['lce'] == lce.name
         assert values['host']['content_view'] == cv.name
         matching_hosts = target_sat.api.Host().search(


### PR DESCRIPTION
### Problem Statement
1. If there are no result in host search then we get "No Results" 
2. Test case was redirecting to old UI

### Solution
1. Eliminating item if we we get "No Results" 
2. Corrected to read from new all host UI page

### Related Issues


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k  "test_positive_validate_inherited_cv_lce_ansiblerole or test_positive_search_by_reported_data"

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->