### PR TITLE
Removing resources file if main process is failed

### DIFF
--- a/robottelo/utils/shared_resource.py
+++ b/robottelo/utils/shared_resource.py
@@ -152,7 +152,7 @@ class SharedResource:
             curr_data = json.loads(self.resource_file.read_text())
             if curr_data["main_status"] == "error":
                 raise Exception(f"Error in main watcher: {curr_data['main_watcher']}")
-            elif curr_data["main_status"] == "action_error":
+            if curr_data["main_status"] == "action_error":
                 self._try_take_over()
             elif curr_data["main_status"] != "done":
                 time.sleep(settings.robottelo.shared_resource_wait)
@@ -219,8 +219,12 @@ class SharedResource:
                 delay=self.delay,
             )
         except Exception as err:
-            self._update_main_status("error")
-            raise SharedResourceError("Main worker failed during action") from err
+            if not self.action_is_recoverable:
+                self._update_main_status("error")
+                self.resource_file.unlink()
+                raise SharedResourceError('Main worker failed during action') from err
+            self._update_main_status('action_error')
+            raise SharedResourceError('Recoverable failures in main worker') from err
 
     def _perform_action_with_validation(self):
         """Helper function to run the action and its validation."""


### PR DESCRIPTION
### Problem Statement

Sometimes the context manager's exit call doesn't clean the resource file due to an error in the `main` process. As a result, the watchers wait for the `main` process  'done' status, which will never happen, and this blocks the rest of the processes.

### Solution

Resource file is now unlinked when the main process fails. This ensures a clean cleanup and prevents other test cases from hanging indefinitely

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->