### PR TITLE
[6.17.z] small fixes in org tests

### DIFF
--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -178,7 +178,7 @@ class TestOrganization:
         with pytest.raises(HTTPError) as err:
             org.create()
         assert err.value.response.status_code == 404
-        assert 'Route overridden by Katello' in err.value.response.text
+        assert 'use the /katello API endpoint instead' in err.value.response.text
 
     def test_default_org_id_check(self, target_sat):
         """test to check the default_organization id

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -122,9 +122,6 @@ def test_positive_end_to_end(session, module_target_sat):
         assert hostgroup.name in org_values['host_groups']['resources']['assigned']
         assert location.name in org_values['locations']['resources']['assigned']
 
-        ptables_before_remove = len(org_values['partition_tables']['resources']['assigned'])
-        templates_before_remove = len(org_values['provisioning_templates']['resources']['assigned'])
-
         # remove attributes
         session.organization.update(
             new_name,
@@ -144,11 +141,8 @@ def test_positive_end_to_end(session, module_target_sat):
         assert user.login in org_values['users']['resources']['unassigned']
         assert len(org_values['media']['resources']['assigned']) == 0
         assert media.name in org_values['media']['resources']['unassigned']
-        assert len(org_values['partition_tables']['resources']['assigned']) < ptables_before_remove
-        assert (
-            len(org_values['provisioning_templates']['resources']['assigned'])
-            < templates_before_remove
-        )
+        assert ptable.name not in org_values['partition_tables']['resources']['assigned']
+        assert template.name not in org_values['provisioning_templates']['resources']['assigned']
         assert len(org_values['domains']['resources']['assigned']) == 0
         assert domain.name in org_values['domains']['resources']['unassigned']
         assert len(org_values['host_groups']['resources']['assigned']) == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19703

### Problem Statement
avoid checking the part of string with product msg typo (pr open upstream for that)

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->