### PR TITLE
[6.18.z] different task description parsing

### DIFF
--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -238,7 +238,7 @@ def test_positive_logging_from_pulp3(module_org, target_sat):
     target_sat.cli.Repository.synchronize({'id': repo['id']})
     # Get the id of repository sync from task
     task_out = target_sat.execute(
-        "hammer task list | grep -F 'Synchronize repository {\"text\"=>\"repository'"
+        f"hammer task list | grep -F 'Synchronize repository' | grep -F {product_name}"
     ).stdout.splitlines()[0][:8]
     prod_log_out = target_sat.execute(f'grep  {task_out} {source_log}').stdout.splitlines()[0]
     # Get correlation id of pulp from production logs


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19701

### Problem Statement
grepping yielded no results due to format change in cli task output

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->