### PR TITLE
[6.18.z] Fix test case to read from new host UI page

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1216,7 +1216,7 @@ def test_positive_validate_inherited_cv_lce_ansiblerole(session, target_sat, mod
         }
     )
     with session:
-        values = session.host.read(host['name'], ['host.lce', 'host.content_view'])
+        values = session.host_new.read(host['name'], ['host.lce', 'host.content_view'])
         assert values['host']['lce'] == lce.name
         assert values['host']['content_view'] == cv.name
         matching_hosts = target_sat.api.Host().search(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19712

### Problem Statement
1. Test case was redirecting to old UI

### Solution
1.  Corrected to read from new all host UI page
 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k  "test_positive_validate_inherited_cv_lce_ansiblerole"

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->