### PR TITLE
[6.17.z] skipping timeout-to-kill test

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -196,6 +196,8 @@ class TestRemoteExecution:
 
         :Verifies: SAT-25243
 
+        :BlockedBy: SAT-36025
+
         :customerscenario: true
         """
         client = rex_contenthost


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19729

### Problem Statement
now that the jira got triaged we can use it to prevent hopeless test runs

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->