### PR TITLE
[6.17.5] Fix job invocation status and change it to no container as its not working in container host

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -71,7 +71,7 @@ def vm(module_repos_collection_with_manifest, rhel7_contenthost, target_sat):
 @pytest.fixture
 def vm_module_streams(module_repos_collection_with_manifest, rhel8_contenthost, target_sat):
     """Virtual machine registered in satellite"""
-    module_repos_collection_with_manifest.setup_virtual_machine(rhel8_contenthost)
+    module_repos_collection_with_manifest.setup_virtual_machine(rhel8_contenthost, enable_custom_repos=True)
     rhel8_contenthost.add_rex_key(satellite=target_sat)
     return rhel8_contenthost
 
@@ -630,6 +630,7 @@ def test_positive_ensure_errata_applicability_with_host_reregistered(session, de
     ],
     indirect=True,
 )
+@pytest.mark.no_containers
 def test_positive_host_re_registration_with_host_rename(
     session, default_location, module_org, module_repos_collection_with_manifest, vm
 ):
@@ -658,9 +659,9 @@ def test_positive_host_re_registration_with_host_rename(
     assert result.status == 0
     vm.unregister()
     updated_hostname = f'{gen_string("alpha")}.{vm.hostname}'.lower()
-    vm.run(f'hostnamectl set-hostname {updated_hostname}')
+    result = vm.run(f'hostnamectl set-hostname {updated_hostname}')
     assert result.status == 0
-    vm.register_contenthost(
+    result = vm.register_contenthost(
         module_org.name,
         activation_key=module_repos_collection_with_manifest.setup_content_data['activation_key'][
             'name'
@@ -779,6 +780,7 @@ def test_positive_check_ignore_facts_os_setting(
     ],
     indirect=True,
 )
+@pytest.mark.no_containers
 def test_module_stream_actions_on_content_host(
     session, default_location, vm_module_streams, module_target_sat
 ):
@@ -809,7 +811,7 @@ def test_module_stream_actions_on_content_host(
             module_name=FAKE_2_CUSTOM_PACKAGE_NAME,
             stream_version=stream_version,
         )
-        assert result['overview']['hosts_table'][0]['Status'] == 'success'
+        assert result['overview']['hosts_table'][0]['Status'] == 'Succeeded'
         module_stream = session.contenthost.search_module_stream(
             vm_module_streams.hostname,
             FAKE_2_CUSTOM_PACKAGE_NAME,
@@ -828,7 +830,7 @@ def test_module_stream_actions_on_content_host(
             module_name=FAKE_2_CUSTOM_PACKAGE_NAME,
             stream_version=stream_version,
         )
-        assert result['overview']['hosts_table'][0]['Status'] == 'success'
+        assert result['overview']['hosts_table'][0]['Status'] == 'Succeeded'
         assert not session.contenthost.search_module_stream(
             vm_module_streams.hostname,
             FAKE_2_CUSTOM_PACKAGE_NAME,
@@ -852,7 +854,7 @@ def test_module_stream_actions_on_content_host(
             module_name=FAKE_2_CUSTOM_PACKAGE_NAME,
             stream_version=stream_version,
         )
-        assert result['overview']['hosts_table'][0]['Status'] == 'success'
+        assert result['overview']['hosts_table'][0]['Status'] == 'Succeeded'
         module_stream = session.contenthost.search_module_stream(
             vm_module_streams.hostname,
             FAKE_2_CUSTOM_PACKAGE_NAME,
@@ -870,7 +872,7 @@ def test_module_stream_actions_on_content_host(
             module_name=FAKE_2_CUSTOM_PACKAGE_NAME,
             stream_version=stream_version,
         )
-        assert result['overview']['hosts_table'][0]['Status'] == 'success'
+        assert result['overview']['hosts_table'][0]['Status'] == 'Succeeded'
         assert not session.contenthost.search_module_stream(
             vm_module_streams.hostname,
             FAKE_2_CUSTOM_PACKAGE_NAME,
@@ -903,6 +905,7 @@ def test_module_stream_actions_on_content_host(
     ],
     indirect=True,
 )
+@pytest.mark.no_containers
 def test_module_streams_customize_action(session, default_location, vm_module_streams):
     """Check remote execution for customized module action is working on content host.
 
@@ -940,7 +943,7 @@ def test_module_streams_customize_action(session, default_location, vm_module_st
             customize=True,
             customize_values=customize_values,
         )
-        assert result['overview']['hosts_table'][0]['Status'] == 'success'
+        assert result['overview']['hosts_table'][0]['Status'] == 'Succeeded'
         module_stream = session.contenthost.search_module_stream(
             vm_module_streams.hostname,
             FAKE_2_CUSTOM_PACKAGE_NAME,
@@ -967,6 +970,7 @@ def test_module_streams_customize_action(session, default_location, vm_module_st
     ],
     indirect=True,
 )
+@pytest.mark.no_containers
 def test_install_modular_errata(session, default_location, vm_module_streams):
     """Populate, Search and Install Modular Errata generated from module streams.
 
@@ -987,7 +991,7 @@ def test_install_modular_errata(session, default_location, vm_module_streams):
             module_name=module_name,
             stream_version=stream_version,
         )
-        assert result['overview']['hosts_table'][0]['Status'] == 'success'
+        assert result['overview']['hosts_table'][0]['Status'] == 'Succeeded'
 
         # downgrade rpm package to generate errata.
         run_remote_command_on_content_host(f'dnf downgrade {module_name} -y', vm_module_streams)
@@ -1009,7 +1013,7 @@ def test_install_modular_errata(session, default_location, vm_module_streams):
         result = session.contenthost.install_errata(
             vm_module_streams.hostname, settings.repos.module_stream_0.errata[2], install_via='rex'
         )
-        assert result['overview']['hosts_table'][0]['Status'] == 'success'
+        assert result['overview']['hosts_table'][0]['Status'] == 'Succeeded'
 
         # ensure errata installed
         assert not session.contenthost.search_module_stream(
@@ -1190,6 +1194,7 @@ def test_module_status_update_without_force_upload_package_profile(
     ],
     indirect=True,
 )
+@pytest.mark.no_containers
 def test_module_stream_update_from_satellite(session, default_location, vm_module_streams):
     """Verify module stream enable, update actions works and update the module stream
 
@@ -1213,7 +1218,7 @@ def test_module_stream_update_from_satellite(session, default_location, vm_modul
             module_name=module_name,
             stream_version=stream_version,
         )
-        assert result['overview']['hosts_table'][0]['Status'] == 'success'
+        assert result['overview']['hosts_table'][0]['Status'] == 'Succeeded'
         module_stream = session.contenthost.search_module_stream(
             vm_module_streams.hostname,
             module_name,
@@ -1237,7 +1242,7 @@ def test_module_stream_update_from_satellite(session, default_location, vm_modul
             module_name=module_name,
             stream_version=stream_version,
         )
-        assert result['overview']['hosts_table'][0]['Status'] == 'success'
+        assert result['overview']['hosts_table'][0]['Status'] == 'Succeeded'
 
         # ensure module stream get updated
         assert not session.contenthost.search_module_stream(


### PR DESCRIPTION
### Problem Statement
Fix job invocation status and change it to no container as  job invocation  not working in container host from content_host UI

### Solution
This change is same as https://github.com/SatelliteQE/robottelo/pull/19348 but we couldnt cherry pick as Job invocation UI is different  for 6.17.5

### Related Issues


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k "test_positive_host_re_registration_with_host_rename or test_module_streams_customize_action or test_install_modular_errata or test_module_status_update_from_content_host_to_satellite or test_module_status_update_without_force_upload_package_profile or test_module_stream_update_from_satellite"

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->