### PR TITLE
Reflect team changes in upgrades test ownership (#19573)

### DIFF
--- a/tests/new_upgrades/test_capsulecontent.py
+++ b/tests/new_upgrades/test_capsulecontent.py
@@ -4,9 +4,9 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanProxy
+:CaseComponent: Capsule-Content
 
-:Team: Endeavour
+:Team: Artemis
 
 :CaseImportance: High
 
@@ -105,7 +105,6 @@ def test_post_capsule_features(capsule_sync_setup):
     """Post-upgrade scenario that sync capsule from satellite and then
     verifies if the repo/rpm of pre-upgrade scenario is synced to capsule
 
-
     :id: 1a50f0ec-482e-11ef-a468-98fa9b11ac24
 
     :steps:
@@ -127,7 +126,6 @@ def test_post_capsule_features(capsule_sync_setup):
 def test_post_user_scenario_capsule_sync(capsule_sync_setup):
     """Post-upgrade scenario that sync capsule from satellite and then
     verifies if the repo/rpm of pre-upgrade scenario is synced to capsule
-
 
     :id: postupgrade-eb8970fa-98cc-4a99-99fb-1c12c4e319c9
 

--- a/tests/new_upgrades/test_computeresource_gce.py
+++ b/tests/new_upgrades/test_computeresource_gce.py
@@ -4,9 +4,9 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts
+:CaseComponent: ComputeResources-GCE
 
-:Team: Endeavour
+:Team: Rocket
 
 :CaseImportance: High
 

--- a/tests/new_upgrades/test_hostgroup.py
+++ b/tests/new_upgrades/test_hostgroup.py
@@ -4,7 +4,7 @@
 
 :CaseComponent: HostGroup
 
-:Team: Endeavour
+:Team: Proton
 
 :CaseImportance: High
 

--- a/tests/upgrades/test_capsulecontent.py
+++ b/tests/upgrades/test_capsulecontent.py
@@ -4,9 +4,9 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanProxy
+:CaseComponent: Capsule-Content
 
-:Team: Endeavour
+:Team: Artemis
 
 :CaseImportance: High
 

--- a/tests/upgrades/test_computeresource_gce.py
+++ b/tests/upgrades/test_computeresource_gce.py
@@ -4,9 +4,9 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Hosts
+:CaseComponent: ComputeResources-GCE
 
-:Team: Endeavour
+:Team: Rocket
 
 :CaseImportance: High
 

--- a/tests/upgrades/test_hostgroup.py
+++ b/tests/upgrades/test_hostgroup.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: HostGroup
 
-:Team: Endeavour
+:Team: Proton
 
 :CaseImportance: High
 


### PR DESCRIPTION
* Change ownership of capsule sync upgrades to Artemis

* Change ownership of provisioning upgrades to Rocket

* Change ownership of hostgroup upgrades to Proton

(cherry picked from commit 955750374de872cac968d3f2c6fb18381c4788f6)
