### PR TITLE
Fix test_content_validation_on_download

### DIFF
--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -178,7 +178,7 @@ def test_content_validation_on_download(request, target_sat, function_org, funct
         product=function_product,
         content_type='yum',
         download_policy='on_demand',
-        url=f'http://localhost/pub/{repo_fsname}/',
+        url=f'http://{target_sat.hostname}/pub/{repo_fsname}/',
     ).create()
     repo.sync()
 


### PR DESCRIPTION
### Problem Statement
The `test_content_validation_on_download` is failing on IPv6 network since `localhost` is not recognized.
```
"503, message='Service Unavailable', url='http://localhost/pub/test_YwatxMDDCC'"
```


### Solution
Provide FQDN instead.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/sys/test_pulp3_filesystem.py -k test_content_validation_on_download
network_type: ipv6
```