### PR TITLE
fix grep commmand

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -542,7 +542,7 @@ class TestRepository:
 
         result = target_sat.execute(
             "cat /var/log/foreman/production.log | "
-            "grep \"undefined method `id' for nil:NilClass (NoMethodError)\""
+            "grep \"undefined method \\`id\\' for nil:NilClass (NoMethodError)\""
         )
         assert result.status == 1
 


### PR DESCRIPTION
### Problem Statement
Searching error `nil:NilClass (NoMethodError)` using grep command from production.log was failing
**Error**
```
AssertionError: assert 2 == 1
 +  where 2 = stdout:\n\nstderr:\nbash: -c: line 1: unexpected EOF while looking for matching ``'\nbash: -c: line 2: syntax error: unexpected end of file\n\nstatus: 2.status
```

### Solution
Added escape charactor will fix this issue

### Related Issues


PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_repository.py -k 'test_positive_create_repo_with_new_organization_and_location'
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->