### PR TITLE
Block test_positive_generate_reports_job_cli_disconnected from running bcs of BZ

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -463,6 +463,8 @@ def test_positive_generate_reports_job_cli_disconnected(
         1. Execute hammer insights inventory generate-report.
 
     :expectedresults: Reports generation works as expected.
+
+    :BlockedBy: SAT-38836
     """
     org = rhcloud_manifest_org
     generate_report(org, module_target_sat, disconnected=True)


### PR DESCRIPTION
### Problem Statement
The test `test_positive_generate_reports_job_cli_disconnected` is failing because of [SAT-38836](https://issues.redhat.com/browse/SAT-38836)

### Solution
Block the test from running until the issue is resolved

