### PR TITLE
[6.18.z] More stable updateDeletePackage test

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1434,7 +1434,7 @@ def test_positive_update_delete_package(
 
         # this should reload page to update packages table
         session.host_new.get_details(client.hostname, widget_names='overview')
-
+        session.browser.refresh()
         # filter packages
         packages = session.host_new.get_packages(client.hostname, FAKE_8_CUSTOM_PACKAGE_NAME)
         assert len(packages) == 1
@@ -1454,6 +1454,7 @@ def test_positive_update_delete_package(
         assert task_status['result'] == 'success'
         # this should reload page to update packages table
         session.host_new.get_details(client.hostname, widget_names='overview')
+        session.browser.refresh()
         packages = session.host_new.get_packages(client.hostname, FAKE_8_CUSTOM_PACKAGE_NAME)
         assert 'Up-to date' in packages[0]['Status']
         # remove package
@@ -1467,6 +1468,7 @@ def test_positive_update_delete_package(
         assert task_status['result'] == 'success'
         # this should reload page to update packages table
         session.host_new.get_details(client.hostname, widget_names='overview')
+        session.browser.refresh()
         packages = session.host_new.get_packages(client.hostname, FAKE_8_CUSTOM_PACKAGE_NAME)
         assert not packages
         result = client.run(f'rpm -q {FAKE_8_CUSTOM_PACKAGE}')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19788

Make `test_positive_update_delete_package` more stable.
Needs https://github.com/SatelliteQE/airgun/pull/2116

### PRT Example
<img width="568" height="132" alt="image" src="https://github.com/user-attachments/assets/79af9d80-3746-4aa4-8069-19255738a1f9" />

``` 
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_positive_update_delete_package"
airgun: 2116
```

