### PR TITLE
[Do Not Merge] Debug registration failure in virt-who tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ broker[docker,podman,hussh]==0.6.12
 cryptography==43.0.3
 deepdiff==8.6.1
 dynaconf[vault]==3.2.11
+epdb == 0.15.1
 fastmcp==2.12.4
 fauxfactory==3.1.2
 jinja2==3.1.6

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -1,5 +1,6 @@
 """Utility module to handle the virtwho configure UI/CLI/API testing"""
 
+import epdb
 import json
 import re
 import uuid
@@ -107,6 +108,7 @@ def register_system(system, activation_key=None, org='Default_Organization', env
     if activation_key is not None:
         cmd += f'--activationkey={activation_key}'
     else:
+        epdb.serve(port=(8888))
         cmd += f'--username={settings.server.admin_username} --password={settings.server.admin_password}'
     ret, stdout = runcmd(cmd, system)
     if ret == 0 or "system has been registered" in stdout:


### PR DESCRIPTION
We have numerous virt-who tests failing with a registration error, but this error is not reproducible locally. This PR exists solely to enable debugging on a running Robottelo container in CI. It should not be merged.