### PR TITLE
Narrow down test_selinux_status for pulp services only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -200,7 +200,6 @@ tests/foreman/maintain/test_service.py @SatelliteQE/team-rocket
 tests/foreman/maintain/test_upgrade.py @SatelliteQE/team-rocket
 tests/foreman/sys/test_fam.py @SatelliteQE/team-rocket
 tests/foreman/sys/test_katello_certs_check.py @SatelliteQE/team-rocket
-tests/foreman/sys/test_pulp3_filesystem.py @SatelliteQE/team-rocket
 tests/foreman/ui/test_computeprofiles.py @SatelliteQE/team-rocket
 tests/foreman/ui/test_computeresource.py @SatelliteQE/team-rocket
 tests/foreman/ui/test_computeresource_azurerm.py @SatelliteQE/team-rocket

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -20,7 +20,6 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.mark.upgrade
@@ -29,17 +28,16 @@ def test_selinux_status(target_sat):
 
     :id: 43218070-ac5e-4679-b74a-3e2bcb497a0a
 
-    :expectedresults: SELinux is enabled and there are no denials
+    :expectedresults: SELinux is enabled and there are no denials for pulp services
 
-    :BZ: 2263294
+    :Verifies: SAT-23121
     """
     # check SELinux is enabled
     result = target_sat.execute('getenforce')
     assert 'Enforcing' in result.stdout
     # check there are no SELinux denials
-    if not is_open('SAT-23121'):
-        result = target_sat.execute('ausearch --input-logs -m avc -ts today --raw')
-        assert result.status == 1, 'Some SELinux denials were found in journal.'
+    result = target_sat.execute('ausearch --input-logs -m avc -ts today --comm pulp --raw')
+    assert result.status == 1, 'Some SELinux denials were found in journal.'
 
 
 @pytest.mark.upgrade


### PR DESCRIPTION
### Problem Statement
The `test_selinux_status` is occasionally failing with avc denials unrelated to pulp.
Since this test should be ensuring correct context of pulp, we should narrow down the test case.
Also, it seems the test file is mentioned twice in the `.CODEOWNERS` file.


### Solution
This PR proposes a fix for both problems.


### Related Issues
https://issues.redhat.com/browse/SAT-23121


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/sys/test_pulp3_filesystem.py -k test_selinux_status
```