### PR TITLE
[6.18.z] block HWmodel test bcs of SAT-38893

### DIFF
--- a/tests/foreman/ui/test_hardwaremodel.py
+++ b/tests/foreman/ui/test_hardwaremodel.py
@@ -26,6 +26,8 @@ def test_positive_end_to_end(session, host_ui_options, module_target_sat):
     :CaseImportance: Medium
 
     :BZ:1758260
+
+    :BlockedBy: SAT-38893
     """
     name = gen_string('alpha')
     model = gen_string('alphanumeric')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19799

Test `ui/test_hardwaremodel.py/test_positive_end_to_end` is failing because of SAT-38893. 
Let's not run it until it is resolved.