### PR TITLE
[6.17.z] Fix test_ccv_inc_update_autopublish

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -16,6 +16,7 @@ import random
 
 from fauxfactory import gen_alphanumeric, gen_string
 import pytest
+from wait_for import wait_for
 from wrapanapi.entities.vm import VmState
 
 from robottelo import constants
@@ -3133,14 +3134,19 @@ class TestContentView:
                 'errata-ids': settings.repos.yum_1.errata[1],
             }
         )
-        task_status = module_target_sat.wait_for_tasks(
-            search_query=(
-                f'Actions::Katello::ContentView::Publish and organization_id = {module_org.id}'
+        wait_for(
+            lambda: all(
+                t.result == 'success'
+                for t in module_target_sat.api.ForemanTask().search(
+                    query={
+                        'search': f'Actions::Katello::ContentView::Publish and organization_id = {module_org.id}'
+                    }
+                )
             ),
-            max_tries=50,
-            search_rate=5,
+            timeout=20,
+            delay=3,
         )
-        assert task_status[0].result == 'success'
+
         composite_view = module_target_sat.cli.ContentView.info({'id': composite_view['id']})
         assert len(composite_view['versions']) == 1
         # Also check that the description of the version contains Auto Publish


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19831

### Problem Statement
The `test_ccv_inc_update_autopublish` is failing flakily with this result on line L3159:
```
AssertionError: assert 'pending' == 'success'
```

It seems like the `wait_for_tasks` sometimes returns task which is still pending. In this case, two tasks are returned: `[0]` is the latest publish we are waiting for, `[1]` is the original publish.


### Solution
Use `wait_for` until both of the tasks are finished. 
The second task usually takes ~2 seconds, so I set `delay=3, timeout=20`.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py -k test_ccv_inc_update_autopublish
```