### PR TITLE
SAT-34258 Coverage

### DIFF
--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -585,7 +585,7 @@ def test_negative_register_host_when_sat_has_port_80_blocked(
     function_activation_key,
 ):
     """
-    Verify host registration fails when there is port 80 block on Satellite.
+    Verify host registration fails when there is port 80 blocked on Satellite.
 
     :id: 3c3e1a8e-7b4c-4d5e-9a6d-8f2e1b3c4d5e
 


### PR DESCRIPTION
### Problem Statement
Coverage for https://issues.redhat.com/browse/SAT-34258

### Solution
Test (`test_negative_register_host_when_sat_has_port_80_blocked`) that registration fails with non 0 RC when there is port 80 blocked on Satellite.


### PRT test Cases example
<img width="868" height="178" alt="image" src="https://github.com/user-attachments/assets/0c9fc599-b912-426c-b852-454698f5874d" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_registration.py -k 'test_negative_register_host_when_sat_has_port_80_blocked'
```