### PR TITLE
conversion to pull provider not for rhel10

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1208,6 +1208,7 @@ class TestPullProviderRex:
         ids=["no_global_proxy"],
         indirect=True,
     )
+    @pytest.mark.rhel_ver_match('[^10].*')
     def test_positive_run_job_on_host_converted_to_pull_provider(
         self,
         module_org,


### PR DESCRIPTION
### Problem Statement
since katello-agent is not shipped in rhel10 client repo, there is nothing to convert from

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->