### PR TITLE
async ssh capsule now with lce

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1174,6 +1174,9 @@ class TestAsyncSSHProviderRex:
                 'location-ids': smart_proxy_location.id,
             }
         )
+        ensure_capsule_has_lifecycle_environment(
+            module_capsule_configured_async_ssh, module_ak_with_cv
+        )
         result = rhel_contenthost.register(
             module_org,
             smart_proxy_location,


### PR DESCRIPTION
### Problem Statement
same as here https://github.com/SatelliteQE/robottelo/pull/19424 

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->