### PR TITLE
Add test for dangling transactions in Candlepin DB

### DIFF
--- a/tests/new_upgrades/test_subscription.py
+++ b/tests/new_upgrades/test_subscription.py
@@ -203,7 +203,8 @@ def test_subscription_scenario_auto_attach(subscription_auto_attach_setup):
 
 
 @pytest.mark.subscription_upgrades
-@pytest.mark.rhel_ver_match('N-0')
+@pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
+@pytest.mark.no_containers
 @pytest.mark.manifester
 def test_candlepin_hung_transaction(subscription_auto_attach_setup):
     """Check that no open Candlepin transactions are present after upgrading


### PR DESCRIPTION
This PR adds a test for SAT-36234, a bug in which hung transactions in Candlepin could eventually lead to a Postgres outage. This test is being added to the subscription upgrade scenario, as starting Candlepin after a database migration is one of the expected conditions for creating a hung transaction prior to the fix for SAT-36234 being merged.