### PR TITLE
Fix Registration API E2E test

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -30,6 +30,11 @@ from robottelo.config import (
 @pytest.mark.pit_client
 @pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
 @pytest.mark.no_containers
+@pytest.mark.parametrize(
+    'setting_update',
+    ['validate_host_lce_content_source_coherence=false'],
+    indirect=True,
+)
 def test_host_registration_end_to_end(
     module_sca_manifest_org,
     module_location,
@@ -37,6 +42,7 @@ def test_host_registration_end_to_end(
     module_target_sat,
     module_capsule_configured,
     rhel_contenthost,
+    setting_update,
 ):
     """Verify content host registration with global registration
 
@@ -51,9 +57,6 @@ def test_host_registration_end_to_end(
 
     :customerscenario: true
     """
-    module_target_sat.cli.Settings.set(
-        {'name': 'validate_host_lce_content_source_coherence', 'value': 'false'}
-    )
     org = module_sca_manifest_org
     result = rhel_contenthost.api_register(
         module_target_sat,

--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -51,12 +51,16 @@ def test_host_registration_end_to_end(
 
     :customerscenario: true
     """
+    module_target_sat.cli.Settings.set(
+        {'name': 'validate_host_lce_content_source_coherence', 'value': 'false'}
+    )
     org = module_sca_manifest_org
     result = rhel_contenthost.api_register(
         module_target_sat,
         organization=org,
         activation_keys=[module_activation_key.name],
     )
+    assert rhel_contenthost.subscribed, 'Host is not subscribed after registration!'
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # Verify server.hostname and server.port from subscription-manager config
@@ -76,6 +80,7 @@ def test_host_registration_end_to_end(
         location=module_location,
         force=True,
     )
+    assert rhel_contenthost.subscribed, 'Host is not subscribed after registration!'
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # Verify server.hostname and server.port from subscription-manager config


### PR DESCRIPTION
### Problem statement
Similar changes to https://github.com/SatelliteQE/robottelo/pull/19850 and 
https://github.com/SatelliteQE/robottelo/pull/19870.
The Validation error is exposed in new stream snaps 
``` 
Validation failed: Content view environment content facets invalid: The content source must sync the lifecycle environment assigned to the host. See the logs for more information. (HTTP error code 422: Unprocessable Entity) 
```
This error was previously hidden.
It is expected when `validate_host_lce_content_source_coherence` setting is set to true (default).

### Solution
Add  
```
@pytest.mark.parametrize(
    'setting_update',
    ['validate_host_lce_content_source_coherence=false'],
    indirect=True,
)
```
to the test and add assertions checking the subscription state of the host.
 
### PRT Example
 
<img width="542" height="178" alt="image" src="https://github.com/user-attachments/assets/160cd9f1-64e4-4a09-be80-77b46369de61" />

``` 
trigger: test-robottelo
pytest: tests/foreman/api/test_registration.py -k "test_host_registration_end_to_end" 
```
