### PR TITLE
Exclude requirements from spellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,6 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --skip=*hammer_commands.json,*.xml
+          - --skip=*hammer_commands.json,*.xml,requirements*.txt
           - -L=Thirdparty,ACSes,checkin,cockateel
           - -w


### PR DESCRIPTION
### Problem Statement
Spellcheck reports a spelling error when we specify `astroid` as a dependency.

### Solution
exclude requirements from spellchecking as it has close to 0 value there

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->
