### PR TITLE
[6.17.z] Pin astroid to <4.0.0 to fix sphinx-autoapi compatibility

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -7,6 +7,9 @@ ruff==0.13.3
 # For generating documentation.
 sphinx==8.2.3
 sphinx-autoapi==3.6.0
+# Pin to <4 due to breaking changes in 4.0.0 incompatible with sphinx-autoapi
+# https://github.com/readthedocs/sphinx-autoapi/issues/536
+astroid<4.0.0
 
 # For 'manage' interactive shell
 manage==0.1.15


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19858

Astroid 4.0.0 introduced breaking API changes that cause sphinx-autoapi to crash with:
```
TypeError: AstroidBuilder.__init__() missing 1 required positional argument: 'manager'
```

This pins astroid to versions below 4.0.0 until sphinx-autoapi releases a compatible version.

Related:
- https://github.com/readthedocs/sphinx-autoapi/issues/536
- https://github.com/readthedocs/sphinx-autoapi/pull/538
- https://issues.redhat.com/browse/SAT-38967