### PR TITLE
[6.18.z] Fix status code while Validation failed with content host registration

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2663,24 +2663,28 @@ def test_host_registration_with_capsule_using_content_coherence(
     module_target_sat.cli.Settings.set(
         {'name': 'validate_host_lce_content_source_coherence', 'value': 'true'}
     )
-    result = rhel_contenthost.register(
-        module_sca_manifest_org,
-        None,
-        module_activation_key.name,
-        module_capsule_configured,
-        force=True,
-    )
-    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    try:
+        result = rhel_contenthost.register(
+            module_sca_manifest_org,
+            None,
+            module_activation_key.name,
+            module_capsule_configured,
+            force=True,
+        )
+        # We expect the initial registration attempt to fail with
+        # HTTP error code 422, and that's why we're looking for an exit code of 1
+        assert result.status == 1, f'Failed to register host: {result.stderr}'
 
-    # Check output for "HTTP error code 422: Validation failed: Content view environment content facets is invalid"
-    assert 'Validation failed' in result.stderr, f'Error is: {result.stderr}'
-    if rhel_contenthost.os_version.major != 7:
-        assert 'HTTP error code 422' in result.stderr, f'Error is: {result.stderr}'
+        # Check output for HTTP error code 422: Validation failed: Content view environment content facets is invalid
+        assert 'Validation failed' in result.stderr, f'Error is: {result.stderr}'
+        if rhel_contenthost.os_version.major != 7:
+            assert 'HTTP error code 422' in result.stderr, f'Error is: {result.stderr}'
+    finally:
+        # Re-register client with settings "validate_host_lce_content_source_coherence" is set to No
+        module_target_sat.cli.Settings.set(
+            {'name': 'validate_host_lce_content_source_coherence', 'value': 'false'}
+        )
 
-    # Re-register client with settings "validate_host_lce_content_source_coherence" is set to No
-    module_target_sat.cli.Settings.set(
-        {'name': 'validate_host_lce_content_source_coherence', 'value': 'false'}
-    )
     result = rhel_contenthost.register(
         module_sca_manifest_org,
         None,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19850

### Problem Statement
Due to change about exposing true error code of the registration we are getting status code as 1 in case of **Validation failed.**
Added try-finally block to reset setting in case of failure
### Solution
Change status code to 1 in case we are getting **Validation failed.**

### Related Issues


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k  test_host_registration_with_capsule_using_content_coherence
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->