### PR TITLE
[6.18.z] SAT-34258 Coverage

### DIFF
--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -574,3 +574,66 @@ def test_negative_users_permission_for_invalidating_tokens(
             options={'search': f"id ^ ({admin_user.id}, {non_admin_user.id})"}
         )
     assert "Missing one of the required permissions: edit_users" in str(context.value)
+
+
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+def test_negative_register_host_when_sat_has_port_80_blocked(
+    target_sat,
+    rhel_contenthost,
+    function_org,
+    function_location,
+    function_activation_key,
+):
+    """
+    Verify host registration fails when there is port 80 blocked on Satellite.
+
+    :id: 3c3e1a8e-7b4c-4d5e-9a6d-8f2e1b3c4d5e
+
+    :steps:
+        1. Block port 80 on Satellite
+        2. Generate and execute registration command
+        3. Verify registration fails with non-zero exit code
+        4. Unblock port 80
+        5. Re-register host and verify it succeeds
+
+    :expectedresults:
+        1. Registration fails with non-zero exit code when port 80 is blocked
+        2. Registration succeeds after port 80 is unblocked
+
+    :Verifies: SAT-34258
+
+    :customerscenario: true
+    """
+
+    # Block port 80 on Satellite
+    target_sat.execute('nft add table inet filter')
+    target_sat.execute(
+        r'nft add chain inet filter input { type filter hook input priority 0 \; policy accept \; }'
+    )
+    target_sat.execute('nft add rule inet filter input tcp dport 80 drop')
+
+    try:
+        # Attempt to register with port 80 blocked
+        result = rhel_contenthost.register(
+            function_org, function_location, function_activation_key.name, target_sat
+        )
+
+        # Registration should fail with non-zero exit code
+        assert result.status != 0, (
+            f'Registration should have failed when port 80 is blocked, but got status {result.status}.',
+            f'\n STDOUT: {result.stdout} \n STDERR: {result.stderr}',
+        )
+
+    finally:  # Unblock port 80
+        rule_handle_res = target_sat.execute(
+            'nft -a list chain inet filter input | grep "tcp dport 80 drop # handle"'
+        )
+        handle = rule_handle_res.stdout.split()[-1]
+        target_sat.execute(f'nft delete rule inet filter input handle {handle}')
+
+    # Now registration should succeed
+    result = rhel_contenthost.register(
+        function_org, function_location, function_activation_key.name, target_sat, force=True
+    )
+
+    assert result.status == 0, f'Failed to register host after unblocking port 80: {result.stderr}'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19848

### Problem Statement
Coverage for https://issues.redhat.com/browse/SAT-34258

### Solution
Test (`test_negative_register_host_when_sat_has_port_80_blocked`) that registration fails with non 0 RC when there is port 80 blocked on Satellite.


### PRT test Cases example
<img width="868" height="178" alt="image" src="https://github.com/user-attachments/assets/0c9fc599-b912-426c-b852-454698f5874d" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_registration.py -k 'test_negative_register_host_when_sat_has_port_80_blocked'
```