### PR TITLE
docs links now link only to generic pages

### DIFF
--- a/tests/foreman/ui/test_documentation_links.py
+++ b/tests/foreman/ui/test_documentation_links.py
@@ -114,19 +114,10 @@ def test_positive_upgrade_links(target_sat):
 
     :expectedresults: All the Upgrade links present on Satellite are working
 
-    :Verifies: SAT-20700
+    :Verifies: SAT-20700, SAT-35235
     """
     with target_sat.ui_session() as session:
         links = session.upgrade.documentation_links()
-        # in the future, this should link to a higher version than the current Satellite
-        if settings.server.version.release == 'stream':
-            x, y, _ = str(target_sat.version).split('.')
-            version = f'{x}.{int(y) - 1}'
-        else:
-            version = '.'.join(str(settings.server.version.release).split('.')[0:2])
-        assert (
-            f"https://docs.redhat.com/en/documentation/red_hat_satellite/{version}#Upgrade" in links
-        )
         assert (
             'https://access.redhat.com/login?redirectTo=https%3A%2F%2Faccess.redhat.com%2Flabs%2Fsatelliteupgradehelper%2F'
             in links


### PR DESCRIPTION
### Problem Statement
as a result of SAT-35235

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->