### PR TITLE
Fix flaky UI updateDeletePackage Test

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1420,6 +1420,7 @@ def test_positive_update_delete_package(
         )
         task_status = target_sat.api.ForemanTask(id=task_result[0].id).poll()
         assert task_status['result'] == 'success'
+        session.browser.refresh()
         packages = session.host_new.get_packages(client.hostname, FAKE_8_CUSTOM_PACKAGE_NAME)
         assert len(packages) == 1
         assert packages[0]['Package'] == FAKE_8_CUSTOM_PACKAGE_NAME


### PR DESCRIPTION
### Problem statement
`test_positive_update_delete_package` is flaky in the automation.

### Solution
Try to add a page refresh to the test.

### PRT Example
<img width="588" height="222" alt="image" src="https://github.com/user-attachments/assets/76547e09-7f63-4f45-bfa8-cee42109fe4c" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_positive_update_delete_package"
```
