### PR TITLE
SAT-28731 - Do not assign taxonomies to filters

### DIFF
--- a/pytest_fixtures/component/user_role.py
+++ b/pytest_fixtures/component/user_role.py
@@ -13,6 +13,11 @@ def function_role(target_sat):
     return target_sat.api.Role().create()
 
 
+@pytest.fixture
+def function_role_with_org(module_target_sat, module_org):
+    return module_target_sat.api.Role(organization=[module_org]).create()
+
+
 @pytest.fixture(scope='module')
 def module_user(module_target_sat, module_org, module_location):
     return module_target_sat.api.User(

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -2242,7 +2242,7 @@ def test_repository_rpms_id_type(target_sat):
 
 
 def test_negative_readonly_user_actions(
-    target_sat, function_role, content_view, module_org, module_lce
+    target_sat, content_view, module_org, module_lce, function_role_with_org
 ):
     """Attempt to manage content views
 
@@ -2264,27 +2264,26 @@ def test_negative_readonly_user_actions(
     """
     user_login = gen_string('alpha')
     user_password = gen_string('alphanumeric')
+
     # create a role with content views read only permissions
     target_sat.api.Filter(
-        organization=[module_org],
         permission=target_sat.api.Permission().search(
             filters={'name': 'view_content_views'},
             query={'search': 'resource_type="Katello::ContentView"'},
         ),
-        role=function_role,
+        role=function_role_with_org,
     ).create()
     # create environment permissions and assign it to our role
     target_sat.api.Filter(
-        organization=[module_org],
         permission=target_sat.api.Permission().search(
             query={'search': 'resource_type="Katello::KTEnvironment"'}
         ),
-        role=function_role,
+        role=function_role_with_org,
     ).create()
     # create a user and assign the above created role
     target_sat.api.User(
         organization=[module_org],
-        role=[function_role],
+        role=[function_role_with_org],
         login=user_login,
         password=user_password,
     ).create()
@@ -2323,7 +2322,9 @@ def test_negative_readonly_user_actions(
         target_sat.api.HostCollection(server_config=cfg).create()
 
 
-def test_negative_non_readonly_user_actions(target_sat, content_view, function_role, module_org):
+def test_negative_non_readonly_user_actions(
+    target_sat, content_view, module_org, function_role_with_org
+):
     """Attempt to view content views
 
     :id: b0a53c38-72f1-4731-881e-192134df6ef3
@@ -2349,14 +2350,13 @@ def test_negative_non_readonly_user_actions(target_sat, content_view, function_r
         entity for entity in cv_permissions_entities if entity.name in user_cv_permissions
     ]
     target_sat.api.Filter(
-        organization=[module_org],
         permission=user_cv_permissions_entities,
-        role=function_role,
+        role=function_role_with_org,
     ).create()
     # create a user and assign the above created role
     target_sat.api.User(
         organization=[module_org],
-        role=[function_role],
+        role=[function_role_with_org],
         login=user_login,
         password=user_password,
     ).create()

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2898,13 +2898,11 @@ class TestContentView:
         )
         password = gen_string('alphanumeric')
         user = module_target_sat.cli_factory.user({'password': password})
-        role = module_target_sat.cli_factory.make_role()
+        role = module_target_sat.cli_factory.make_role({'organization-id': module_org.id})
         module_target_sat.cli_factory.make_filter(
             {
-                'organization-ids': module_org.id,
                 'permissions': 'view_content_views',
                 'role-id': role['id'],
-                'override': 1,
             }
         )
         module_target_sat.cli.User.add_role({'id': user['id'], 'role-id': role['id']})

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -50,56 +50,6 @@ def test_positive_create_with_permission(module_perms, function_role, target_sat
     assert set(filter_['permissions'].split(", ")) == set(module_perms)
 
 
-def test_positive_create_with_org(module_perms, function_role, target_sat):
-    """Create a filter and assign it some permissions.
-
-    :id: f6308192-0e1f-427b-a296-b285f6684691
-
-    :expectedresults: The created filter has the assigned permissions.
-
-    :BZ: 1401469
-
-    :CaseImportance: Critical
-    """
-    org = target_sat.cli_factory.make_org()
-    # Assign filter to created role
-    filter_ = target_sat.cli_factory.make_filter(
-        {
-            'role-id': function_role['id'],
-            'permissions': module_perms,
-            'organization-ids': org['id'],
-            'override': 1,
-        }
-    )
-    # we expect here only only one organization, i.e. first element
-    assert filter_['organizations'][0] == org['name']
-
-
-def test_positive_create_with_loc(module_perms, function_role, module_target_sat):
-    """Create a filter and assign it some permissions.
-
-    :id: d7d1969a-cb30-4e97-a9a3-3a4aaf608795
-
-    :expectedresults: The created filter has the assigned permissions.
-
-    :BZ: 1401469
-
-    :CaseImportance: Critical
-    """
-    loc = module_target_sat.cli_factory.make_location()
-    # Assign filter to created role
-    filter_ = module_target_sat.cli_factory.make_filter(
-        {
-            'role-id': function_role['id'],
-            'permissions': module_perms,
-            'location-ids': loc['id'],
-            'override': 1,
-        }
-    )
-    # we expect here only only one location, i.e. first element
-    assert filter_['locations'][0] == loc['name']
-
-
 def test_positive_delete(module_perms, function_role, module_target_sat):
     """Create a filter and delete it afterwards.
 
@@ -180,43 +130,3 @@ def test_positive_update_role(module_perms, function_role, target_sat):
     target_sat.cli.Filter.update({'id': filter_['id'], 'role-id': new_role['id']})
     filter_ = target_sat.cli.Filter.info({'id': filter_['id']})
     assert filter_['role'] == new_role['name']
-
-
-def test_positive_update_org_loc(module_perms, function_role, target_sat):
-    """Create a filter and assign it to another organization and location.
-
-    :id: 9bb59109-9701-4ef3-95c6-81f387d372da
-
-    :expectedresults: Filter is created and assigned to new org and loc.
-
-    :BZ: 1401469
-
-    :CaseImportance: Critical
-    """
-    org = target_sat.cli_factory.make_org()
-    loc = target_sat.cli_factory.make_location()
-    filter_ = target_sat.cli_factory.make_filter(
-        {
-            'role-id': function_role['id'],
-            'permissions': module_perms,
-            'organization-ids': org['id'],
-            'location-ids': loc['id'],
-            'override': 1,
-        }
-    )
-    # Update org and loc
-    new_org = target_sat.cli_factory.make_org()
-    new_loc = target_sat.cli_factory.make_location()
-    target_sat.cli.Filter.update(
-        {
-            'id': filter_['id'],
-            'permissions': module_perms,
-            'organization-ids': new_org['id'],
-            'location-ids': new_loc['id'],
-            'override': 1,
-        }
-    )
-    filter_ = target_sat.cli.Filter.info({'id': filter_['id']})
-    # We expect here only one organization and location
-    assert filter_['organizations'][0] == new_org['name']
-    assert filter_['locations'][0] == new_loc['name']

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -662,11 +662,10 @@ def test_positive_access_non_admin_user(session, test_name, target_sat):
         }
     )
     # Create new role
-    role = target_sat.api.Role().create()
+    role = target_sat.api.Role(organization=[org]).create()
     # Create filter with predefined activation keys search criteria
     envs_condition = ' or '.join(['environment = ' + s for s in envs_list])
     target_sat.api.Filter(
-        organization=[org],
         permission=target_sat.api.Permission().search(
             filters={'name': 'view_activation_keys'},
             query={'search': 'resource_type="Katello::ActivationKey"'},

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -796,9 +796,8 @@ def test_positive_list_permission(
     ).create()
     custom_repo.sync()
     # create role with access only to 'RHEL8' RedHat product
-    role = module_target_sat.api.Role().create()
+    role = module_target_sat.api.Role(organization=[function_sca_manifest_org]).create()
     module_target_sat.api.Filter(
-        organization=[function_sca_manifest_org],
         permission=module_target_sat.api.Permission().search(
             query={'search': 'resource_type="Katello::Product"'}
         ),

--- a/tests/new_upgrades/test_role.py
+++ b/tests/new_upgrades/test_role.py
@@ -62,7 +62,6 @@ def default_role_permission_with_filter_setup(search_upgrade_shared_satellite, u
             permission=target_sat.api.Permission().search(
                 filters={'name': 'view_domains'}, query={'search': 'resource_type="Domain"'}
             ),
-            unlimited=False,
             role=default_role,
             search='name ~ a',
         ).create()
@@ -111,63 +110,6 @@ def test_default_role_added_permission_with_filter(default_role_permission_with_
     assert domain_filter[0].search == 'name ~ a'
     # Teardown
     domain_filter[0].delete()
-
-
-@pytest.mark.stubbed
-class TestOverriddenFilter:
-    """Filter associated with taxonomies becomes overridden filter post upgrade
-
-    :steps:
-
-        1. In Preupgrade Satellite, Create a role
-        2. Add filter in a role to which taxonomies can be assigned
-        3. Assign taxonomies to above filter
-        4. Upgrade the satellite to next/latest version
-        5. Postupgrade, View the above role filter
-
-    :expectedresults:
-
-        1. The Filter should be have set override flag postupgrade
-        2. The locations and organizations of filter should be unchanged
-            postupgrade
-
-    :CaseAutomation: NotAutomated
-    """
-
-    @pytest.mark.pre_upgrade
-    def test_pre_existing_overriden_filter(self):
-        """Role with taxonomies associated filter can be created
-
-        :id: preupgrade-e8ecf446-375e-45fa-8e2c-558a40a7d8d0
-
-        :steps:
-
-            1. In Preupgrade Satellite, Create a role
-            2. Add filter in a role to which taxonomies can be assigned
-            3. Assign taxonomies to above filter
-
-        :expectedresults: The role with taxonomies associated to them should
-            be created
-        """
-
-    @pytest.mark.post_upgrade
-    def test_post_existing_overriden_filter(self):
-        """Filter associated with taxonomies becomes overridden filter post
-        upgrade
-
-        :id: postupgrade-e8ecf446-375e-45fa-8e2c-558a40a7d8d0
-
-        :steps:
-
-            1. Postupgrade, view the role filter created in preupgraded
-                satellite
-
-        :expectedresults:
-
-            1. The Filter should be have set override flag postupgrade
-            2. The locations and organizations of filter should be unchanged
-                postupgrade
-        """
 
 
 @pytest.mark.stubbed

--- a/tests/upgrades/test_role.py
+++ b/tests/upgrades/test_role.py
@@ -16,63 +16,6 @@ import pytest
 
 
 @pytest.mark.stubbed
-class TestOverriddenFilter:
-    """Filter associated with taxonomies becomes overridden filter post upgrade
-
-    :steps:
-
-        1. In Preupgrade Satellite, Create a role
-        2. Add filter in a role to which taxonomies can be assigned
-        3. Assign taxonomies to above filter
-        4. Upgrade the satellite to next/latest version
-        5. Postupgrade, View the above role filter
-
-    :expectedresults:
-
-        1. The Filter should be have set override flag postupgrade
-        2. The locations and organizations of filter should be unchanged
-            postupgrade
-
-    :CaseAutomation: NotAutomated
-    """
-
-    @pytest.mark.pre_upgrade
-    def test_pre_existing_overriden_filter(self):
-        """Role with taxonomies associated filter can be created
-
-        :id: preupgrade-e8ecf446-375e-45fa-8e2c-558a40a7d8d0
-
-        :steps:
-
-            1. In Preupgrade Satellite, Create a role
-            2. Add filter in a role to which taxonomies can be assigned
-            3. Assign taxonomies to above filter
-
-        :expectedresults: The role with taxonomies associated to them should
-            be created
-        """
-
-    @pytest.mark.post_upgrade
-    def test_post_existing_overriden_filter(self):
-        """Filter associated with taxonomies becomes overridden filter post
-        upgrade
-
-        :id: postupgrade-e8ecf446-375e-45fa-8e2c-558a40a7d8d0
-
-        :steps:
-
-            1. Postupgrade, view the role filter created in preupgraded
-                satellite
-
-        :expectedresults:
-
-            1. The Filter should be have set override flag postupgrade
-            2. The locations and organizations of filter should be unchanged
-                postupgrade
-        """
-
-
-@pytest.mark.stubbed
 class TestBuiltInRolesLocked:
     """Builtin roles in satellite gets locked post upgrade
 
@@ -231,7 +174,6 @@ class TestRoleAddPermissionWithFilter:
             permission=target_sat.api.Permission().search(
                 filters={'name': 'view_domains'}, query={'search': 'resource_type="Domain"'}
             ),
-            unlimited=False,
             role=default_role,
             search='name ~ a',
         ).create()


### PR DESCRIPTION
A recent change in Foreman dropped the option to assign (and override) organizations and locations on filters as well as the unlimited and override fields from api responses.

### Problem Statement
Some tests use no-longer-available code paths, some tests don't make sense anymore.

### Solution
Change the tests that make sense to the new way (aka orgs/locs on roles only), drop the ones that aren't relevant anymore.

### Related Issues
https://issues.redhat.com/browse/SAT-28731
https://github.com/theforeman/foreman/pull/10370
https://github.com/theforeman/hammer-cli-foreman/pull/645

Requires https://github.com/SatelliteQE/nailgun/pull/1363 and https://github.com/SatelliteQE/airgun/pull/2141

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->