### PR TITLE
[6.17.z] Fix obtaining proxy hostname and protocol

### DIFF
--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import pytest
 
 from robottelo.config import settings
@@ -60,9 +62,11 @@ def setup_http_proxy_without_global_settings(request, module_sca_manifest_org, t
 def setup_http_proxy_global(request, target_sat):
     """Create a new HTTP proxy and set related settings based on proxy"""
     if request.param:
-        hostname = settings.http_proxy.auth_proxy_url[7:]
+        parsed_url = urlparse(settings.http_proxy.un_auth_proxy_url)
+        protocol = parsed_url.scheme
+        hostname = parsed_url.hostname
         general_proxy = (
-            f'http://{settings.http_proxy.username}:{settings.http_proxy.password}@{hostname}'
+            f'{protocol}://{settings.http_proxy.username}:{settings.http_proxy.password}@{hostname}'
         )
     else:
         general_proxy = settings.http_proxy.un_auth_proxy_url


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19782

### Problem Statement

1. Hostname not correctly detected for https proxy URL
2. No way to specify protocol 

### Solution

Use regexp to define correct hostname and protocol

### Related Issues

tests to run:

```
tests/foreman/cli/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_dir_filtered
```

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->