### PR TITLE
Add imagemode to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@ tests/foreman/api/test_capsulecontent.py @SatelliteQE/team-artemis
 tests/foreman/api/test_contentcredentials.py @SatelliteQE/team-artemis
 tests/foreman/api/test_contentviewfilter.py @SatelliteQE/team-artemis
 tests/foreman/api/test_docker.py @SatelliteQE/team-artemis
+tests/foreman/api/test_imagemode.py @SatelliteQE/team-artemis
 tests/foreman/api/test_lifecycleenvironment.py @SatelliteQE/team-artemis
 tests/foreman/api/test_product.py @SatelliteQE/team-artemis
 tests/foreman/api/test_repositories.py @SatelliteQE/team-artemis
@@ -41,6 +42,7 @@ tests/foreman/cli/test_contentviewfilter.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_docker.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_errata.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_flatpak.py @SatelliteQE/team-artemis
+tests/foreman/cli/test_imagemode.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_lifecycleenvironment.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_ostreebranch.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_product.py @SatelliteQE/team-artemis
@@ -61,6 +63,7 @@ tests/foreman/ui/test_contentview_old.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_errata.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_flatpak.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_host.py @SatelliteQE/team-artemis
+tests/foreman/ui/test_imagemode.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_lifecycleenvironment.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_modulestreams.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_package.py @SatelliteQE/team-artemis


### PR DESCRIPTION
### Problem Statement
ImageMode test files weren't in CODEOWNERS

### Solution
Add them to CODEOWNERS under Team Artemis

### Related Issues
https://issues.redhat.com/browse/SAT-38781