### PR TITLE
Remove invalid / unnecessary skip decorators for SRPM

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2209,9 +2209,6 @@ class TestSRPMRepositoryIgnoreContent:
     :BZ: 1673215
     """
 
-    @pytest.mark.skipif(
-        (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
-    )
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -2237,9 +2234,6 @@ class TestSRPMRepositoryIgnoreContent:
         repo = repo.read()
         assert repo.content_counts['srpm'] == 0
 
-    @pytest.mark.skipif(
-        (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
-    )
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(
@@ -2261,10 +2255,6 @@ class TestSRPMRepositoryIgnoreContent:
         repo = repo.read()
         assert repo.content_counts['srpm'] == 2
 
-    @pytest.mark.skip('Uses deprecated SRPM repository')
-    @pytest.mark.skipif(
-        (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
-    )
     @pytest.mark.parametrize(
         'repo_options',
         **datafactory.parametrized(


### PR DESCRIPTION
### Problem Statement
There are several invalid skip decorators in the `TestSRPMRepositoryIgnoreContent` class. We are currently using SRPM repos from fixtures.pulpproject.org, not `REPOS_HOSTING_URL`, so it makes no sense to skip them based on the `REPOS_HOSTING_URL` availability. Also, the `test_positive_ignore_srpm_sync` doesn't need to be skipped.


### Solution
Remove the skips.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py::TestSRPMRepositoryIgnoreContent
```