### PR TITLE
Extend the wait time for CV removal after f-m restart

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -2026,8 +2026,9 @@ class TestContentViewSync:
         # Wait for the CV creation on import and make the import fail
         wait_for(
             lambda: target_sat.cli.ContentView.info(
-                {'name': cv_name, 'organization-id': function_import_org_with_manifest.id}
-            )
+                {'name': cv_name, 'organization-id': function_import_org_with_manifest.id},
+            ),
+            delay=0.2,
         )
         timestamp = datetime.now(UTC)
         target_sat.cli.Service.restart()
@@ -2044,7 +2045,7 @@ class TestContentViewSync:
         target_sat.wait_for_tasks(
             search_query=f'label = Actions::Katello::ContentView::Remove and started_at >= "{timestamp}"',
             search_rate=10,
-            max_tries=6,
+            max_tries=12,
         )
         importing_cvv = target_sat.cli.ContentView.info(
             {'name': cv_name, 'organization-id': function_import_org_with_manifest.id}


### PR DESCRIPTION
### Problem Statement
The `test_positive_export_rerun_failed_import` is failing flakily with this error:
```
tests/foreman/cli/test_satellitesync.py:2044: in test_positive_export_rerun_failed_import
    target_sat.wait_for_tasks(
robottelo/host_helpers/capsule_mixins.py:70: in wait_for_tasks
    raise AssertionError(f"No task was found using query '{search_query}'")
E   AssertionError: No task was found using query 'label = Actions::Katello::ContentView::Remove and started_at >= "2025-10-09 00:09:24.884147+00:00"'
```


### Solution
Let's try to extend the wait a bit (more re-tries) to provide more time for the task to be executed after restart.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py -k test_positive_export_rerun_failed_import
```