### PR TITLE
[6.18.z] skip leapp preupgrade test

### DIFF
--- a/tests/foreman/ui/test_leapp_client.py
+++ b/tests/foreman/ui/test_leapp_client.py
@@ -15,8 +15,13 @@
 import pytest
 
 from robottelo.constants import RHEL8_VER, RHEL9_VER
+from robottelo.utils.issue_handlers import is_open
 
 
+@pytest.mark.skipif(
+    is_open('SAT-36237'),
+    reason='Missing "Leapp Preupgrade report" tab on new job invocation details page (SAT-38786)',
+)
 @pytest.mark.parametrize(
     'upgrade_path',
     [


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19951

### Problem Statement

Skipt test `tests/foreman/ui/test_leapp_client.py::test_leapp_preupgrade_report`
until the missing section "Leapp Preupgrade report" is added to the new job invocation details page.

### Solution

Relevat task tracked as SAT-38786

### Related Issues

Epic link: SAT-36237

### PRT test Cases example

trigger: test-robottelo
pytest: tests/foreman/ui/test_leapp_client.py::test_leapp_preupgrade_report
