### PR TITLE
Fix failing rhcloud generating assertion

### DIFF
--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -62,7 +62,10 @@ def common_assertion(
     )
     upload_error_messages = ['NSS error', 'Permission denied']
 
-    assert 'Check the Uploading tab for report uploading status' in inventory_data['generating']['terminal']
+    assert (
+        'Check the Uploading tab for report uploading status'
+        in inventory_data['generating']['terminal']
+    )
     if subscription_connection_enabled:
         assert upload_success_msg in inventory_data['uploading']['terminal']
         assert 'x-rh-insights-request-id' in inventory_data['uploading']['terminal'].lower()


### PR DESCRIPTION
Several tests are failing in rhcloud 6.18 and stream on the assertion below:
`assert 'Successfully generated' in inventory_data['generating']['terminal']`
This message was removed and replaced with 
`Check the Uploading tab for report uploading status`
This failure is due to this change here https://github.com/theforeman/foreman_rh_cloud/pull/1102

