### PR TITLE
[6.17.z] Enable ipv6 for rhel7_contenthost and rhel8_contenthost

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -20,7 +20,7 @@ def host_conf(request):
     if hasattr(request, 'param'):
         params = request.param
     distro = params.get('distro', 'rhel')
-    network = params.get('network')
+    network = params.get('network') or settings.content_host.network_type
     _rhelver = f"{distro}{params.get('rhel_version', settings.content_host.default_rhel_version)}"
 
     # check to see if no-containers is passed as an argument to pytest

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -29,6 +29,7 @@ from robottelo.constants import (
     FAKE_8_CUSTOM_PACKAGE,
     FAKE_8_CUSTOM_PACKAGE_NAME,
 )
+from robottelo.enums import NetworkType
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.logging import logger
 from robottelo.utils.datafactory import (
@@ -2144,7 +2145,8 @@ def test_positive_dump_enc_yaml(target_sat):
     """
     enc_dump = target_sat.cli.Host.enc_dump({'name': target_sat.hostname})
     assert f'fqdn: {target_sat.hostname}' in enc_dump
-    assert f'ip: {target_sat.ip_addr}' in enc_dump
+    ip_prefix = 'ip6' if target_sat.network_type == NetworkType.IPV6 else 'ip'
+    assert f'{ip_prefix}: {target_sat.ip_addr}' in enc_dump
     assert 'ssh-rsa' in enc_dump
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19950

### Problem Statement
rhel7_contenthost and rhel8_contenthost was not checking out ipv6 content host even we add settings

### Solution
Enable ipv6 for rhel7_contenthost and rhel8_contenthost

### Related Issues
Note: Long term solution will be to remove hardcoded rhel version. 

### PRT test Cases example
trigger: test-robottelo
pytest: pytest -sv tests/foreman/ui/test_contenthost.py -k "test_positive_end_to_end_bulk_update or test_install_modular_errata or test_module_stream_update_from_satellite"

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->