### PR TITLE
Fix Other-type Errata case, EPEL repo publish duration

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -1693,7 +1693,7 @@ def test_positive_filter_errata_type_other(
 
     # Create a content view, add the EPEL repo, publish the first version.
     cv = target_sat.api.ContentView(organization=function_org, repository=[epel_repo]).create()
-    cv.read().publish(timeout=240)
+    cv.read().publish(timeout=600)
     cv = cv.read()
     version_1 = cv.version[-1].read()  # unfiltered
     assert '1.0' in version_1.version


### PR DESCRIPTION
### Problem Statement
Error: Publish duration timeout-
EPEL(rhel10) repository, unfiltered, just after syncing, takes a long time to publish the initial Version 1.0 of repo content (over 10,000 items). 
Let's increase the duration timeout from 2 to 10 minutes. 
The filtered Version 2.0 is already given up to 20 minutes to publish.
_^ it seems the Version 2.0 is the one that timed out in CI runs (exceeds 1200 seconds), 
locally v1.0 is the one I get failing, still investigating_

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_errata.py::test_positive_filter_errata_type_other
```