### PR TITLE
[6.18.z] Fix AK Upgrade scenario test

### DIFF
--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -37,10 +37,13 @@ class TestActivationKey:
             organization=org, repository=[custom_repo.id], name=f"{request.param}_cv"
         ).create()
         cv.publish()
+        lce = target_sat.api.LifecycleEnvironment(organization=org).search(
+            query={'search': 'name=Library'}
+        )[0]
         ak = target_sat.api.ActivationKey(
-            content_view=cv, organization=org, name=f"{request.param}_ak"
+            content_view=cv, environment=lce, organization=org, name=f"{request.param}_ak"
         ).create()
-        return {'org': org, "cv": cv, 'ak': ak, 'custom_repo': custom_repo}
+        return {'org': org, 'cv': cv, 'ak': ak, 'custom_repo': custom_repo}
 
     @pytest.mark.pre_upgrade
     @pytest.mark.parametrize(
@@ -67,11 +70,6 @@ class TestActivationKey:
         :BlockedBy: SAT-28048
         """
         ak = activation_key_setup['ak']
-        org_subscriptions = target_sat.api.Subscription(
-            organization=activation_key_setup['org']
-        ).search()
-        for subscription in org_subscriptions:
-            ak.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
         ak_subscriptions = ak.product_content()['results']
         subscr_id = {subscr['product']['id'] for subscr in ak_subscriptions}
         assert subscr_id == {activation_key_setup['custom_repo'].product.id}
@@ -115,11 +113,6 @@ class TestActivationKey:
         custom_repo2.sync()
         cv2 = target_sat.api.ContentView(organization=org[0], repository=[custom_repo2.id]).create()
         cv2.publish()
-        org_subscriptions = target_sat.api.Subscription(organization=org[0]).search()
-        for subscription in org_subscriptions:
-            provided_products_ids = [prod.id for prod in subscription.read().provided_product]
-            if custom_repo2.product.id in provided_products_ids:
-                ak[0].add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
         ak_subscriptions = ak[0].product_content()['results']
         assert custom_repo2.product.id in {subscr['product']['id'] for subscr in ak_subscriptions}
         ak[0].delete()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19964

## Problem statement
Fix failing AK upgrade scenario tests.
1. Missing LCE while creating AK - API returned 400 error: "Environment ID and content view ID must be provided together"
2. Subscription addition logic was incompatible with SCA only - causing 400 Bad Request errors when SCA is enabled


## Solution
1. Update AK creation fixture by adding LCE to AK creation
2. Removed subscription attachment related code from both pre-upgrade and post-upgrade tests, as [product_content()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) API already returns the products associated with the activation key's content view, regardless of SCA mode

## Additional info
New upgrades for AK are here https://github.com/SatelliteQE/robottelo/blob/master/tests/new_upgrades/test_activation_key.py



## Test results 
Can't run these scenarios in PRT

### PRE UPGRADE
``` 
pytest tests/upgrades/test_activation_key.py::TestActivationKey::test_pre_create_activation_key -m pre_upgrade -v
============================================================== test session starts ===============================================================
platform darwin -- Python 3.12.11, pytest-8.4.1, pluggy-1.5.0 -- /Users/lvasina/.virtualenvs/workEnv/bin/python3.12
Mandatory Requirements are up to date.
Optional Requirements Mismatch: pre-commit==4.3.0
To update requirements, run the pytest with '--update-required-reqs' OR '--update-all-reqs' option.
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/lvasina/Documents/robottelo
configfile: pyproject.toml
plugins: fixturecollection-0.1.2, reportportal-5.5.2, mock-3.15.1, asyncio-1.2.0, anyio-4.9.0, services-2.2.2, order-1.3.0, ibutsu-3.1.2, xdist-3.6.1, cov-7.0.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                 

tests/upgrades/test_activation_key.py::TestActivationKey::test_pre_create_activation_key[test_pre_create_activation_key] PASSED            [100%]

=============================================================== 1 passed in 39.32s ============================================== 
```


### POST UPGRADE
``` 
pytest tests/upgrades/test_activation_key.py -m post_upgrade -v
=========================================== test session starts ============================================
platform darwin -- Python 3.12.11, pytest-8.4.2, pluggy-1.5.0 -- /Users/lvasina/.virtualenvs/workEnv/bin/python3.12
Mandatory Requirements are up to date.
Optional Requirements Mismatch: pre-commit==4.3.0
To update requirements, run the pytest with '--update-required-reqs' OR '--update-all-reqs' option.
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/lvasina/Documents/robottelo
configfile: pyproject.toml
plugins: fixturecollection-0.1.2, reportportal-5.5.2, mock-3.15.1, asyncio-1.2.0, anyio-4.9.0, services-2.2.2, order-1.3.0, ibutsu-3.1.2, xdist-3.6.1, cov-7.0.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 2 items / 1 deselected / 1 selected                                                              

tests/upgrades/test_activation_key.py::TestActivationKey::test_post_crud_activation_key PASSED       [100%]

===================================== 1 passed, 1 deselected in 55.95s ===================================== 
```