### PR TITLE
[6.18.z] Fix urlparse property

### DIFF
--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -64,7 +64,7 @@ def setup_http_proxy_global(request, target_sat):
     if request.param:
         parsed_url = urlparse(settings.http_proxy.un_auth_proxy_url)
         protocol = parsed_url.scheme
-        hostname = parsed_url.hostname
+        hostname = parsed_url.netloc
         general_proxy = (
             f'{protocol}://{settings.http_proxy.username}:{settings.http_proxy.password}@{hostname}'
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19970

### Problem Statement
parsed_url.hostname doesn't include port

### Solution
using parsed_url.netloc instead


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->