### PR TITLE
Fix test_positive_verify_updated_fdi_image for 6.17.z

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -480,10 +480,8 @@ def test_positive_verify_updated_fdi_image(target_sat):
     target_sat.register_to_cdn()
     target_sat.execute('yum -y --disableplugin=foreman-protector install foreman-discovery-image')
 
-    if target_sat.os_version.major == 9:
-        version = '9.5' if is_open('SAT-34778') else str(target_sat.os_version)
-    elif target_sat.os_version.major == 8:
-        version = str(target_sat.os_version)
+    # For older zstreams, we still have this version of foreman-discovery-image
+    version = '9.5'
 
     result = target_sat.execute(f'grep "url=" {discovery_ks_path}')
     assert version in result.stdout


### PR DESCRIPTION
### Problem Statement
SAT-34778 is fixed for 6.18+, which is causing tests to fail for older zstream as we shipping same old FDI image

### Solution
For 6.17.z/older zstreams we hardcode FDI versions, same hardcoding it for 6.17.z

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->