### PR TITLE
[6.17.z] Update behavior of "is_open" helper 

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2000,7 +2000,15 @@ JIRA_OPEN_STATUSES = (
 )
 JIRA_ONQA_STATUS = "Testing"
 JIRA_CLOSED_STATUSES = ("Release Pending", "Closed")
-JIRA_WONTFIX_RESOLUTIONS = "Obsolete"
+JIRA_WONTFIX_RESOLUTIONS = (
+    "Obsolete",
+    "Won't Do",
+    "Cannot Reproduce",
+    "Can't Do",
+    "Duplicate",
+    "Not a Bug",
+    "MirrorOrphan",
+)
 
 GROUP_MEMBERSHIP_MAPPER = {
     "config": {

--- a/robottelo/utils/issue_handlers/__init__.py
+++ b/robottelo/utils/issue_handlers/__init__.py
@@ -1,4 +1,5 @@
 # Methods related to issue handlers in general
+from robottelo.logging import logger
 from robottelo.utils.issue_handlers import jira
 
 
@@ -22,4 +23,8 @@ def is_open(issue, data=None):
         issue {str} -- A string containing Jira issue id e.g: SAT-12345
         data {dict} -- Issue data indexed by issue id or None
     """
-    return jira.is_open_jira(issue.strip(), data)
+    status = jira.is_open_jira(issue.strip(), data)
+    logger.debug(
+        f"Is {issue} Jira open? - {'Nope! It is fixed!' if status else 'Yeah. It is still not fixed :('}"
+    )
+    return status

--- a/robottelo/utils/issue_handlers/jira.py
+++ b/robottelo/utils/issue_handlers/jira.py
@@ -125,13 +125,9 @@ def is_open_jira(issue_id, data=None):
     jira = follow_duplicates(jira)
     status = jira.get('status', '')
     resolution = jira.get('resolution', '')
-
+    logger.debug(f"{issue_id} Jira status is '{status}' and resolution is '{resolution}'")
     # Jira is explicitly in OPEN status
     if status in JIRA_OPEN_STATUSES:
-        return True
-
-    # Jira is Closed/Obsolete so considered not fixed yet, Jira is open
-    if status in JIRA_CLOSED_STATUSES and resolution in JIRA_WONTFIX_RESOLUTIONS:
         return True
 
     # Jira is Closed with a resolution in (Done, Done-Errata, ...)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19921

### Problem Statement
Currently, `is_open` returns “True” if the issue is closed as “Won’t fix” or similar resolution, but without an actual fix.
This is misleading and is causing unnecessary code build up and false code block execution.
We’ll be changing this behavior and returning the true status of Jira. 


### Solution
Doesn’t matter with what resolution the issue was closed; it’ll be considered as closed and the test owner should do necessary updates to the test accordingly.

### Related Issues
- SAT-39095

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->