### PR TITLE
[6.18.z] Make sure IoP VMaas sync is complete before running satellite-maintain backup

### DIFF
--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -459,6 +459,11 @@ def test_positive_backup_restore_satellite_iop(
     """
     instance = get_instance_name(sat_maintain)
     assert sat_maintain.satellite.local_advisor_enabled
+
+    # Make sure that the vmaas db has been synced successfully
+    result = sat_maintain.execute('systemctl start iop-cvemap-download')
+    assert result.status == 0
+
     subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
     result = sat_maintain.cli.Backup.run_backup(
         backup_dir=subdir,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19973

### Problem Statement

IoP might not have successfully created VMaaS database before we test creating backups with `satellite-maintain`. We want the backup to contain this vmaas configuration.

### Solution

Make sure that `iop-cvemap-download` (which triggers a VMaaS reposcan and db update) has completed successfully, before creating the backup.

### Related Issues

SAT-39193

### PRT test Cases example
```
trigger: test-robottelo
pytest:  tests/foreman/maintain/test_backup_restore.py::test_positive_backup_restore_satellite_iop[satellite_iop-online]
```
The PRT failure is expected, because of the known issue in SAT-39193. From robottelo.log:

```
    Restore configs from backup: 
    
    Resetting
    Restoring configs                                                     [FAIL]
    Failed executing tar --selinux --no-check-device --extract --file=/tmp/backup-LtdbBFwfiI/satellite-backup-2025-10-14-15-03-35/config_files.tar.gz --overwrite --gzip --listed-incremental=/dev/null --directory=/, exit status 2:
     tar: var/lib/containers/storage/volumes/iop-service-vmaas-data/_data/vmaas.db-2025-10-14T19\:03\:50.325216+00\:00: Cannot open: Permission denied
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->