### PR TITLE
only add location if it is not already present

### DIFF
--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -220,8 +220,9 @@ def test_positive_run_custom_job_template(
     """
 
     hostname = rex_contenthost.hostname
-    ui_user.location.append(target_sat.api.Location(id=default_location.id))
-    ui_user.update(['location'])
+    if not any(loc.id == default_location.id for loc in ui_user.location):
+        ui_user.location.append(target_sat.api.Location(id=default_location.id))
+        ui_user.update(['location'])
     job_template_name = gen_string('alpha')
     with target_sat.ui_session() as session:
         session.organization.select(module_org.name)


### PR DESCRIPTION
### Problem Statement
In dualstack runs this caused Validation failed: Taxonomy has already been taken

### Solution
Prt probably won't pass due to some other work being in progress on the ui part of the test, will try though

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->