### PR TITLE
Fix for 2 CV tests

### DIFF
--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -674,7 +674,8 @@ class TestContentViewFilterRule:
         target_sat.api.ContentViewFilterRule(content_view_filter=cv_filter, errata=errata).create()
 
         content_view.publish()
-        content_view_version_info = content_view.read().version[1].read()
+        content_view = content_view.read()
+        content_view_version_info = content_view.version[0].read()
 
         # verify the module_stream_count and errata_count for Include Filter
         assert content_view_version_info.module_stream_count == 5

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1479,7 +1479,7 @@ class TestContentView:
         )
         module_target_sat.cli.ContentView.publish({'id': new_cv['id']})
         new_cv_version_2 = module_target_sat.cli.ContentView.info({'id': new_cv['id']})['versions'][
-            1
+            0
         ]
         module_streams = module_target_sat.cli.ModuleStream.list(
             {'content-view-version-id': new_cv_version_2['id']}


### PR DESCRIPTION
### Problem Statement
These 2 CV tests have been failing for a while, and we need to get to 100% pass rate this quarter.

### Solution
I'm assuming sometime inbetween when these tests were written, and now, new versions of content views are returned in reverse order of creation, instead of chronological order, ie: version 1 -> cv_version[0], version 2 -> cv_version[0], as well

trigger: test-robottelo
pytest: tests/foreman/api/test_contentviewfilter.py::test_positive_include_exclude_module_stream_filter, tests/foreman/cli/test_contentview.py::test_positive_publish_custom_content_module_stream
