### PR TITLE
[6.18.z] Updated assertion for cli rhcloud test case

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -596,7 +596,7 @@ def generate_report(rhcloud_manifest_org, module_target_sat, disconnected=False)
     assert task_output[0].result == "success"
 
     report_log = module_target_sat.api.Organization(id=org.id).rh_cloud_fetch_last_report_log()
-    expected = f'Successfully generated /var/lib/foreman/red_hat_inventory/generated_reports/report_for_{org.id}.tar.xz for organization id {org.id}'
+    expected = 'Check the Uploading tab for report uploading status'
     assert expected in report_log['output']
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19984

Several tests are failing in rhcloud 6.18 and stream on the assertion below:
`assert 'Successfully generated' in inventory_data['generating']['terminal']
`This message was removed and replaced with
`Check the Uploading tab for report uploading status
`
Ref UI change https://github.com/SatelliteQE/robottelo/pull/19954

 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_rhcloud_inventory.py -k "test_positive_generate_reports_job_cli or test_positive_download_reports_job_cli_disconnected"

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->