### PR TITLE
[6.17.z] Block kubevirt tests on SAT-36027

### DIFF
--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -8,6 +8,7 @@
 
 :team: Proton
 
+:BlockedBy: SAT-36027
 """
 
 import pytest

--- a/tests/foreman/virtwho/cli/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt_sca.py
@@ -8,6 +8,7 @@
 
 :team: Proton
 
+:BlockedBy: SAT-36027
 """
 
 import pytest

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -8,6 +8,7 @@
 
 :team: Proton
 
+:BlockedBy: SAT-36027
 """
 
 import pytest


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19996

Kubevirt as a compute resource is a tech preview feature, and we do not currently have the infrastructure to test it reliably. However, SAT-36027 tracks work on adding a compute resource for OCP-V (which is downstream of Kubevirt) to Satellite. This PR blocks our Kubevirt tests from running until this feature has been delivered, at which time we should rewrite those tests for OCP-V.