### PR TITLE
[6.18.z] Block Hosts API Image Test

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -671,6 +671,8 @@ def test_positive_end_to_end_with_image(
 
     :expectedresults: A host is created with expected image, image is removed and
         host is updated with expected image
+
+    :BlockedBy: SAT-32733
     """
     host = module_target_sat.api.Host(
         organization=module_org,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20004

Block `test_positive_end_to_end_with_image` because fixtures needed for this test setup are not working.
Fixing of these issues is handled bythe  Rocket team in this issue https://issues.redhat.com/browse/SAT-32733