### PR TITLE
[6.18.z] Fix generating of hostname prefix

### DIFF
--- a/tests/foreman/api/test_settings.py
+++ b/tests/foreman/api/test_settings.py
@@ -18,7 +18,7 @@ from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.constants import SUPPORTED_MIRRORING_POLICIES
+from robottelo.constants import STRING_TYPES, SUPPORTED_MIRRORING_POLICIES
 from robottelo.utils.datafactory import (
     filtered_datapoint,
     generate_strings_list,
@@ -133,8 +133,11 @@ def test_positive_update_hostname_default_prefix(setting_update):
 
     :expectedresults: Default set prefix should be updated with new value
     """
-    discovery_prefix = random.choice(
-        list(generate_strings_list(exclude_types=['alphanumeric', 'numeric']))
+    # Value must start with a letter. Allowed characters: `a-z`, `A-Z`, `0-9` and `-`. Max length is 62 characters.
+    discovery_prefix = gen_string('alpha', 1) + random.choice(
+        generate_strings_list(
+            exclude_types=list(set(STRING_TYPES) - {'alphanumeric', 'alpha', 'numeric'})
+        )
     )
     setting_update.value = discovery_prefix
     setting_update = setting_update.update({'value'})


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20007

Test test_positive_update_hostname_default_prefix failed (semi)randomly. The failures were caused by invalid characters in the hostname prefix that is generated by generate_strings_list.
Allowed characters are following:
_Value must start with a letter. Allowed characters: `a-z`, `A-Z`, `0-9` and `-`. Max length is 62 characters._
This fix generates string that meets this requirement.