### PR TITLE
[6.17.z] SAT-24175 Support IP address HTTP proxy testing (#19801)

### DIFF
--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -13,7 +13,7 @@ def session_auth_proxy(session_target_sat):
 
 
 @pytest.fixture
-def setup_http_proxy(request, module_org, target_sat):
+def setup_http_proxy(request, use_ip, module_org, target_sat):
     """Create a new HTTP proxy and set related settings based on proxy"""
     proxy_settings = ['content_default_http_proxy', 'http_proxy']
     saved_proxies = list(
@@ -23,7 +23,7 @@ def setup_http_proxy(request, module_org, target_sat):
         )
     )
 
-    http_proxy = target_sat.api_factory.make_http_proxy(module_org, request.param)
+    http_proxy = target_sat.api_factory.make_http_proxy(module_org, request.param, use_ip)
 
     if request.param is None:
         target_sat.update_setting('content_default_http_proxy', '')

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -5,7 +5,9 @@ example: my_satellite.api_factory.api_method()
 
 from contextlib import contextmanager
 from datetime import datetime
+import socket
 import time
+from urllib.parse import urlparse
 
 from fauxfactory import gen_ipaddr, gen_mac, gen_string
 from nailgun.client import request
@@ -28,29 +30,38 @@ class APIFactory:
         self._satellite = satellite
         self.__dict__.update(initiate_repo_helpers(self._satellite))
 
-    def make_http_proxy(self, org, http_proxy_type):
+    def make_http_proxy(self, org, http_proxy_type, use_ip=False):
         """
         Creates HTTP proxy.
         :param str org: Organization
         :param str http_proxy_type: None, False, True
+        :param bool use_ip: Whether to use IP address in the proxy URL or hostname
         """
+        if http_proxy_type is None:
+            return None
         if http_proxy_type is False:
-            return self._satellite.api.HTTPProxy(
-                name=gen_string('alpha', 15),
-                url=settings.http_proxy.un_auth_proxy_url,
-                organization=[org.id],
-                content_default_http_proxy=True,
-            ).create()
-        if http_proxy_type:
-            return self._satellite.api.HTTPProxy(
-                name=gen_string('alpha', 15),
-                url=settings.http_proxy.auth_proxy_url,
-                username=settings.http_proxy.username,
-                password=settings.http_proxy.password,
-                organization=[org.id],
-                content_default_http_proxy=True,
-            ).create()
-        return None
+            auth = {}
+            url = settings.http_proxy.un_auth_proxy_url
+        elif http_proxy_type is True:
+            auth = {
+                'username': settings.http_proxy.username,
+                'password': settings.http_proxy.password,
+            }
+            url = settings.http_proxy.auth_proxy_url
+        if use_ip:
+            family = socket.AF_INET6 if self._satellite.network_type.has_ipv6 else socket.AF_INET
+            ip_addr = socket.getaddrinfo(urlparse(url).hostname, None, family)[0][4][0]
+            url = url.replace(
+                urlparse(url).hostname,
+                f'[{ip_addr}]' if self._satellite.network_type.has_ipv6 else ip_addr,
+            )
+        return self._satellite.api.HTTPProxy(
+            name=gen_string('alpha', 15),
+            url=url,
+            **auth,
+            organization=[org.id],
+            content_default_http_proxy=True,
+        ).create()
 
     def cv_publish_promote(self, name=None, env_name=None, repo_id=None, org_id=None):
         """Create, publish and promote CV to selected environment"""

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -26,10 +26,15 @@ from robottelo.constants.repos import ANSIBLE_GALAXY, CUSTOM_FILE_REPO
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize(
+    'use_ip',
+    [False],
+    ids=['hostname'],
+)
+@pytest.mark.parametrize(
     'setup_http_proxy',
     [True, False],
-    indirect=True,
     ids=['auth_http_proxy', 'unauth_http_proxy'],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
@@ -151,6 +156,11 @@ def test_positive_end_to_end(
 @pytest.mark.upgrade
 @pytest.mark.rhel_ver_match('9')
 @pytest.mark.run_in_one_thread
+@pytest.mark.parametrize(
+    'use_ip',
+    [False],
+    ids=['hostname'],
+)
 @pytest.mark.parametrize(
     'setup_http_proxy',
     [True, False],

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -87,6 +87,11 @@ def test_positive_create_update_delete(module_org, module_location, target_sat):
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('N-2')
 @pytest.mark.parametrize(
+    'use_ip',
+    [False, True],
+    ids=['hostname', 'ip'],
+)
+@pytest.mark.parametrize(
     'setup_http_proxy',
     [True, False],
     indirect=True,

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -466,6 +466,11 @@ def test_http_proxy_containing_special_characters(
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.usefixtures('allow_repo_discovery')
 @pytest.mark.parametrize(
+    'use_ip',
+    [False],
+    ids=['hostname'],
+)
+@pytest.mark.parametrize(
     'setup_http_proxy',
     [True, False],
     indirect=True,


### PR DESCRIPTION
Manual cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19801
(cherry picked from commit c6a9f383f122fd7a2c83f8f76fdd12ef54525bbf)

Fixes #20025

### Problem Statement
We only test HTTP proxy defined by hostname and completely ignore testing HTTP proxy defined by its IP adress and specifically IPv6 address (with square bracket in it)

### Solution
Enhance `make_http_proxy` in API factory and introduce new parameter `use_ip` which set to true creates the same HTTP proxy but it is defined by its IP address derived from simply resolving hostname. This enhanced API factory function then allows to introduce new parametrization `use_ip` for `setup_http_proxy` fixture.

### Related Issues
[SAT-24175](https://issues.redhat.com/browse/SAT-24175)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->