### PR TITLE
[6.18.z] Convert Lightspeed inventory sync from CLI to UI

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -141,57 +141,6 @@ def test_positive_inventory_recommendation_sync(
     assert 'Synchronized Insights hosts hits data' in result.stdout
 
 
-@pytest.mark.e2e
-@pytest.mark.pit_server
-@pytest.mark.pit_client
-def test_positive_sync_inventory_status(
-    rhcloud_manifest_org,
-    rhcloud_registered_hosts,
-    module_target_sat,
-):
-    """Sync inventory status via foreman-rake commands:
-    https://github.com/theforeman/foreman_rh_cloud/blob/master/README.md
-
-    :id: 915ffbfd-c2e6-4296-9d69-f3f9a0e79b32
-
-    :steps:
-
-        0. Create a VM and register to insights within org having manifest.
-        1. Sync inventory status for specific organization.
-            # export organization_id=1
-            # /usr/sbin/foreman-rake rh_cloud_inventory:sync
-
-    :expectedresults: Inventory status is successfully synced for satellite hosts.
-
-    :BZ: 1957186
-
-    :CaseAutomation: Automated
-    """
-    org = rhcloud_manifest_org
-    cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:sync'
-    success_msg = f"Synchronized inventory for organization '{org.name}'"
-    timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
-    result = module_target_sat.execute(cmd)
-    assert result.status == 0
-    assert success_msg in result.stdout
-    # Check task details
-    wait_for(
-        lambda: module_target_sat.api.ForemanTask()
-        .search(query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'})[0]
-        .result
-        == 'success',
-        timeout=400,
-        delay=15,
-        silent_failure=True,
-        handle_exception=True,
-    )
-    task_output = module_target_sat.api.ForemanTask().search(
-        query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'}
-    )
-    assert task_output[0].output['host_statuses']['sync'] == 2
-    assert task_output[0].output['host_statuses']['disconnect'] == 0
-
-
 def test_positive_sync_inventory_status_missing_host_ip(
     rhcloud_manifest_org,
     rhcloud_registered_hosts,

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -671,3 +671,47 @@ def test_rh_cloud_minimal_report(
         assert all(all(key in item for key in required_fields) for item in host_data), (
             "Not all required keys are present in every dictionary"
         )
+
+
+@pytest.mark.e2e
+@pytest.mark.pit_server
+@pytest.mark.pit_client
+@pytest.mark.rhel_ver_list([7, 8, 9, 10])
+def test_sync_inventory_status(rhcloud_manifest_org, rhcloud_registered_hosts, module_target_sat):
+    """Test syncing Lightspeed inventory status
+
+    :id: 1fe47111-8831-4168-b79e-ca7c1f6aa343
+
+    :steps:
+        1. Register 2 hosts to Satellite to an org with a manifest imported and set up Lightspeed.
+        2. Sync the Lightspeed inventory for the org.
+
+    :expectedresults: Inventory status is successfully synced for the hosts.
+
+    :BZ: 1957186
+
+    :CaseAutomation: Automated
+    """
+    org = rhcloud_manifest_org
+    inventory_sync_task = 'InventorySync::Async::InventoryFullSync'
+    timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
+
+    with module_target_sat.ui_session() as session:
+        session.organization.select(org_name=org.name)
+        session.location.select(loc_name=DEFAULT_LOC)
+        session.cloudinventory.sync_inventory_status()
+        wait_for(
+            lambda: module_target_sat.api.ForemanTask()
+            .search(query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'})[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
+        )
+        task_output = module_target_sat.api.ForemanTask().search(
+            query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'}
+        )
+        assert task_output[0].output['host_statuses']['sync'] == 2
+        assert task_output[0].output['host_statuses']['disconnect'] == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20028

### Problem Statement

The CLI test for syncing Lightpseed inventory status is failing due to its reliance on the `foreman-rake rh_cloud_inventory:sync` rake task. This command syncs the inventory for all organization on a Satellite and does not respect options passed in to restrict the scope of the command to a single org. As a result, in CI, when the test searches for an inventory sync task on which to make assertions, it often erroneously finds a sync task for an organization other than the one being tested.

Additionally, syncing the inventory via the `foreman-rake` CLI is not a documented approach, and the `foreman-rake` CLI is typically not a supported customer use case.

### Solution

Convert the CLI inventory sync test to a UI test, which uses a supported workflow and restricts the sync to the selected org by default.