### PR TITLE
[6.16.z] Add deploy_network_type to broker nicks

### DIFF
--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -16,6 +16,7 @@ from broker import Broker
 from fauxfactory import gen_string
 import pytest
 
+from robottelo.config import settings
 from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.hosts import ContentHost
@@ -308,7 +309,9 @@ def test_positive_register_host_ak_with_host_collection(module_org, module_ak_wi
         {'id': hc['id'], 'organization-id': module_org.id, 'host-ids': host_info['id']}
     )
 
-    with Broker(nick='rhel7', host_class=ContentHost) as client:
+    with Broker(
+        nick='rhel7', deploy_network_type=settings.content_host.network_type, host_class=ContentHost
+    ) as client:
         # register the client host with the current activation key
         client.register(module_org, None, module_ak_with_cv.name, target_sat)
         assert client.subscribed

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -812,7 +812,12 @@ def test_positive_generate_hostpkgcompare(
     )
 
     clients = []
-    with Broker(nick='rhel7', host_class=ContentHost, _count=2) as hosts:
+    with Broker(
+        nick='rhel7',
+        deploy_network_type=settings.content_host.network_type,
+        host_class=ContentHost,
+        _count=2,
+    ) as hosts:
         for client in hosts:
             # Create RHEL hosts via broker and register content host
             result = client.register(

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -979,7 +979,12 @@ def test_positive_host_associations(session, target_sat):
         environment=org_entities['lifecycle-environment-id'],
         organization=org.id,
     ).create()
-    with Broker(nick='rhel7', host_class=ContentHost, _count=2) as hosts:
+    with Broker(
+        nick='rhel7',
+        deploy_network_type=settings.content_host.network_type,
+        host_class=ContentHost,
+        _count=2,
+    ) as hosts:
         vm1, vm2 = hosts
         result = vm1.register(org, None, ak1.name, target_sat)
         assert result.status == 0, f'Failed to register host: {result.stderr}'

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -68,7 +68,12 @@ def module_repos_collection(module_org_with_parameter, module_lce, module_target
 @pytest.fixture
 def vm_content_hosts(smart_proxy_location, module_repos_collection, module_target_sat):
     distro = module_repos_collection.distro
-    with Broker(nick=distro, host_class=ContentHost, _count=2) as clients:
+    with Broker(
+        nick=distro,
+        deploy_network_type=settings.content_host.network_type,
+        host_class=ContentHost,
+        _count=2,
+    ) as clients:
         for client in clients:
             module_repos_collection.setup_virtual_machine(client)
             client.add_rex_key(satellite=module_target_sat)
@@ -80,7 +85,12 @@ def vm_content_hosts(smart_proxy_location, module_repos_collection, module_targe
 def vm_content_hosts_module_stream(
     smart_proxy_location, module_repos_collection_with_manifest, module_target_sat
 ):
-    with Broker(nick='rhel8', host_class=ContentHost, _count=2) as clients:
+    with Broker(
+        nick='rhel8',
+        deploy_network_type=settings.content_host.network_type,
+        host_class=ContentHost,
+        _count=2,
+    ) as clients:
         for client in clients:
             module_repos_collection_with_manifest.setup_virtual_machine(client)
             client.add_rex_key(satellite=module_target_sat)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20038

### Problem Statement
Nicks are nicks so we have to tell Jake about it:
```
socket.gaierror: [Errno -5] No address associated with hostname
```
Broker nicks w/o `deploy_network_type` spin out IPv4 hosts for IPv6 testing :(


### Solution
Add `deploy_network_type` to broker nicks so that content hosts with correct network type (`ipv4` vs. `ipv6`) are deployed

### Related Issues
[SAT-37379](https://issues.redhat.com/browse/SAT-37379)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->