### PR TITLE
Add a general + scenario tests for pulp href-to-prn mapping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ tests/foreman/cli/test_imagemode.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_lifecycleenvironment.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_ostreebranch.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_product.py @SatelliteQE/team-artemis
+tests/foreman/cli/test_pulp.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_repositories.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_repository.py @SatelliteQE/team-artemis
 tests/foreman/cli/test_repository_set.py @SatelliteQE/team-artemis
@@ -75,6 +76,7 @@ tests/foreman/ui/test_syncplan.py @SatelliteQE/team-artemis
 tests/new_upgrades/test_contentview.py @SatelliteQE/team-artemis
 tests/new_upgrades/test_capsulecontent.py @SatelliteQE/team-artemis
 tests/new_upgrades/test_errata.py @SatelliteQE/team-artemis
+tests/new_upgrades/test_pulp.py @SatelliteQE/team-artemis
 tests/new_upgrades/test_repository.py @SatelliteQE/team-artemis
 tests/new_upgrades/test_satellitesync.py @SatelliteQE/team-artemis
 tests/new_upgrades/test_syncplan.py @SatelliteQE/team-artemis

--- a/conftest.py
+++ b/conftest.py
@@ -64,6 +64,7 @@ pytest_plugins = [
     'pytest_fixtures.component.provision_capsule_pxe',
     'pytest_fixtures.component.provision_vmware',
     'pytest_fixtures.component.provisioning_template',
+    'pytest_fixtures.component.pulp',
     'pytest_fixtures.component.puppet',
     'pytest_fixtures.component.repository',
     'pytest_fixtures.component.rh_cloud',

--- a/pytest_fixtures/component/pulp.py
+++ b/pytest_fixtures/component/pulp.py
@@ -1,0 +1,156 @@
+"""Fixtures and helpers for Pulp-related tests
+
+:Requirement: Pulp
+
+:CaseAutomation: Automated
+
+:CaseComponent: Pulp
+
+:Team: Artemis
+
+"""
+
+from box import Box
+from fauxfactory import gen_string
+import pytest
+
+from robottelo import constants
+from robottelo.config import settings
+
+
+def _setup_prn_content(sat, manifest, test_name=None):
+    """Helper to set up content entities to properly test pulp HREF to PRN mapping.
+
+    Creates:
+        1. Organization with manifest uploaded.
+        2. Product with multiple repository types.
+        3. Yum repositories (with streams and srpms).
+        4. Red Hat repository (rhsclient10).
+        5. File repository.
+        6. Docker repository with manifest list.
+        7. Ansible Collection repository.
+        8. Alternate Content Sources (yum and file).
+
+    Args:
+        sat: Satellite instance
+        manifest: SCA manifest object with .content attribute
+
+    Returns:
+        Box containing created entities (sat, org, product, repositories, etc.)
+    """
+    # Create an Organization and upload manifest
+    org = sat.api.Organization(
+        name=f'{test_name}_{gen_string("alpha")}' if test_name else gen_string('alpha')
+    ).create()
+    sat.upload_manifest(org.id, manifest.content)
+
+    # Create a Product for custom repos
+    product = sat.api.Product(
+        organization=org,
+        name=f'{test_name}_{gen_string("alpha")}' if test_name else gen_string('alpha'),
+    ).create()
+
+    # Create and sync yum repository with streams
+    yum_repository = sat.api.Repository(
+        product=product,
+        url=settings.repos.module_stream_0.url,
+        content_type='yum',
+        name=f'{test_name}_{gen_string("alpha")}' if test_name else gen_string('alpha'),
+    ).create()
+    yum_repository.sync()
+
+    # Create and sync yum repository with srpms
+    srpm_repository = sat.api.Repository(
+        product=product,
+        url=constants.repos.FAKE_YUM_SRPM_REPO,
+        content_type='yum',
+        name=f'{test_name}_{gen_string("alpha")}' if test_name else gen_string('alpha'),
+    ).create()
+    srpm_repository.sync()
+
+    # Create ULN repository with ULN remote
+    uln_repository = sat.api.Repository(
+        product=product,
+        url='uln://fake.unbreakable.linux.netw.org',
+        content_type='yum',
+        upstream_username=gen_string('alpha'),
+        upstream_password=gen_string('alpha'),
+        name=f'{test_name}_{gen_string("alpha")}' if test_name else gen_string('alpha'),
+    ).create()
+
+    # Enable and sync Red Hat repository
+    rh_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
+        basearch=constants.DEFAULT_ARCHITECTURE,
+        org_id=org.id,
+        product=constants.PRDS['rhel10'],
+        repo=constants.REPOS['rhsclient10']['name'],
+        reposet=constants.REPOSET['rhsclient10'],
+        releasever=constants.REPOS['rhsclient10']['releasever'],
+    )
+    rh_repo = sat.api.Repository(id=rh_repo_id).read()
+    rh_repo.sync()
+
+    # Create and sync file repository
+    file_repository = sat.api.Repository(
+        product=product,
+        content_type='file',
+        url=settings.repos.file_type_repo.url,
+        name=f'{test_name}_{gen_string("alpha")}' if test_name else gen_string('alpha'),
+    ).create()
+    file_repository.sync()
+
+    # Create and sync docker repository
+    docker_repository = sat.api.Repository(
+        product=product,
+        content_type='docker',
+        docker_upstream_name=settings.container.upstream_name,
+        url=settings.container.registry_hub,
+        name=f'{test_name}_{gen_string("alpha")}' if test_name else gen_string('alpha'),
+    ).create()
+    docker_repository.sync()
+
+    # Create and sync Ansible Collection repository
+    ac_repository = sat.api.Repository(
+        product=product,
+        content_type='ansible_collection',
+        ansible_collection_requirements='{collections: [{ name: theforeman.foreman, version: "2.1.0"}]}',
+        url=constants.repos.ANSIBLE_GALAXY,
+        name=f'{test_name}_{gen_string("alpha")}' if test_name else gen_string('alpha'),
+    ).create()
+    ac_repository.sync()
+
+    # Create ACS of each content type
+    ACSes = []
+    for content_type in ['yum', 'file']:
+        acs = sat.api.AlternateContentSource(
+            alternate_content_source_type='custom',
+            content_type=content_type,
+            base_url=constants.repos.PULP_FIXTURE_ROOT,
+            subpaths=constants.repos.PULP_SUBPATHS_COMBINED[content_type],
+            smart_proxy_ids=[sat.nailgun_capsule.id],
+            verify_ssl=False,
+            name=f'{test_name}_{gen_string("alpha")}' if test_name else gen_string('alpha'),
+        ).create()
+        ACSes.append(acs)
+
+    return Box(
+        {
+            'target_sat': sat,
+            'org': org,
+            'product': product,
+            'yum_repo': yum_repository,
+            'srpm_repo': srpm_repository,
+            'uln_repo': uln_repository,
+            'rh_repo': rh_repo,
+            'file_repo': file_repository,
+            'docker_repo': docker_repository,
+            'ac_repo': ac_repository,
+            'ACSes': ACSes,
+        }
+    )
+
+
+@pytest.fixture(scope='module')
+def module_prn_content_setup(module_target_sat, module_sca_manifest):
+    """Fixture to set up content entities to properly test pulp HREF to PRN mapping."""
+    return _setup_prn_content(module_target_sat, module_sca_manifest)

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1039,6 +1039,85 @@ SUPPORTED_MIRRORING_POLICIES = {
     'ansible_collection': ['additive', 'mirror_content_only'],
     'file': ['additive', 'mirror_content_only'],
 }
+PULP_HREF_PRN_MAP = {
+    '/pulp/api/v3/contentguards/certguard/rhsm': 'prn:certguard.rhsmcertguard:',
+    '/pulp/api/v3/remotes/ansible/collection': 'prn:ansible.collectionremote:',
+    '/pulp/api/v3/remotes/file/file': 'prn:file.fileremote:',
+    '/pulp/api/v3/remotes/rpm/rpm': 'prn:rpm.rpmremote:',
+    '/pulp/api/v3/remotes/rpm/uln': 'prn:rpm.ulnremote:',
+    '/pulp/api/v3/remotes/container/container': 'prn:container.containerremote:',
+    '/pulp/api/v3/distributions/rpm/rpm': 'prn:rpm.rpmdistribution:',
+    '/pulp/api/v3/distributions/container/container': 'prn:container.containerdistribution:',
+    '/pulp/api/v3/distributions/ansible/ansible': 'prn:ansible.ansibledistribution:',
+    '/pulp/api/v3/distributions/file/file': 'prn:file.filedistribution:',
+    '/pulp/api/v3/publications/file/file': 'prn:file.filepublication:',
+    '/pulp/api/v3/publications/rpm/rpm': 'prn:rpm.rpmpublication:',
+    '/pulp/api/v3/content/ansible/collection_versions': 'prn:ansible.collectionversion:',
+    '/pulp/api/v3/content/rpm/modulemds': 'prn:rpm.modulemd:',
+    '/pulp/api/v3/content/container/manifests': 'prn:container.manifest:',
+    '/pulp/api/v3/content/container/tags': 'prn:container.tag:',
+    '/pulp/api/v3/content/rpm/packages': 'prn:rpm.package:',
+    '/pulp/api/v3/content/file/files': 'prn:file.filecontent:',
+    '/pulp/api/v3/content/rpm/packagegroups': 'prn:rpm.packagegroup:',
+    '/pulp/api/v3/repositories/ansible/ansible': 'prn:ansible.ansiblerepository:',
+    '/pulp/api/v3/repositories/rpm/rpm': 'prn:rpm.rpmrepository:',
+    '/pulp/api/v3/repositories/container/container': 'prn:container.containerrepository:',
+    '/pulp/api/v3/repositories/file/file': 'prn:file.filerepository:',
+    '/pulp/api/v3/content/rpm/advisories': 'prn:rpm.updaterecord:',
+    '/pulp/api/v3/acs/rpm/rpm': 'prn:rpm.rpmalternatecontentsource:',
+    '/pulp/api/v3/acs/file/file': 'prn:file.filealternatecontentsource:',
+}
+
+PULP_PRN_TABLES = [
+    {'name': 'katello_content_guards', 'href_key': 'pulp_href', 'prn_key': 'pulp_prn'},
+    {'name': 'katello_repositories', 'href_key': 'remote_href', 'prn_key': 'remote_prn'},
+    {
+        'name': 'katello_repositories',
+        'href_key': 'publication_href',
+        'prn_key': 'publication_prn',
+    },  # Only for rpm and file types, otherwise NULL
+    {'name': 'katello_ansible_collections', 'href_key': 'pulp_id', 'prn_key': 'pulp_prn'},
+    # {'name': 'katello_generic_content_units', 'href_key': 'pulp_id', 'prn_key': 'pulp_prn'},  # Unsupported downstream
+    {'name': 'katello_module_streams', 'href_key': 'pulp_id', 'prn_key': 'pulp_prn'},
+    {
+        'name': 'katello_docker_manifest_lists',
+        'href_key': 'pulp_id',
+        'prn_key': 'pulp_prn',
+    },
+    {'name': 'katello_docker_manifests', 'href_key': 'pulp_id', 'prn_key': 'pulp_prn'},
+    {'name': 'katello_docker_tags', 'href_key': 'pulp_id', 'prn_key': 'pulp_prn'},
+    {'name': 'katello_rpms', 'href_key': 'pulp_id', 'prn_key': 'pulp_prn'},
+    {'name': 'katello_srpms', 'href_key': 'pulp_id', 'prn_key': 'pulp_prn'},
+    {'name': 'katello_files', 'href_key': 'pulp_id', 'prn_key': 'pulp_prn'},
+    {'name': 'katello_package_groups', 'href_key': 'pulp_id', 'prn_key': 'pulp_prn'},
+    # {'name': 'katello_debs', 'href_key': 'pulp_id', 'prn_key': 'pulp_prn'},  # Unsupported downstream
+    {'name': 'katello_distribution_references', 'href_key': 'href', 'prn_key': 'prn'},
+    {
+        'name': 'katello_distribution_references',
+        'href_key': 'content_guard_href',
+        'prn_key': 'content_guard_prn',
+    },  # Only for RH repos, otherwise NULL
+    {
+        'name': 'katello_repository_references',
+        'href_key': 'repository_href',
+        'prn_key': 'repository_prn',
+    },
+    {
+        'name': 'katello_repository_errata',
+        'href_key': 'erratum_pulp3_href',
+        'prn_key': 'erratum_prn',
+    },
+    {
+        'name': 'katello_smart_proxy_alternate_content_sources',
+        'href_key': 'remote_href',
+        'prn_key': 'remote_prn',
+    },
+    {
+        'name': 'katello_smart_proxy_alternate_content_sources',
+        'href_key': 'alternate_content_source_href',
+        'prn_key': 'alternate_content_source_prn',
+    },
+]
 
 PUPPET_COMMON_INSTALLER_OPTS = {
     'foreman-proxy-puppetca': 'true',

--- a/tests/foreman/cli/test_pulp.py
+++ b/tests/foreman/cli/test_pulp.py
@@ -1,0 +1,73 @@
+"""Module for tests related to the Pulp backend
+
+:Requirement: Pulp
+
+:CaseAutomation: Automated
+
+:CaseComponent: Pulp
+
+:Team: Artemis
+
+:CaseImportance: High
+
+"""
+
+import json
+
+import pytest
+
+from robottelo.constants import PULP_HREF_PRN_MAP, PULP_PRN_TABLES
+
+
+@pytest.mark.parametrize('table', PULP_PRN_TABLES, ids=lambda t: f"{t['name']}:{t['prn_key']}")
+def test_pulp_href_prn_mapping(table, target_sat, module_prn_content_setup):
+    """Verify Pulp HREF to PRN mapping for all relevant Katello tables, except for repo versions.
+
+    :id: c840688e-9a80-491e-bc26-a4636d691662
+
+    :parametrized: yes
+
+    :setup:
+        1. Specific content entities created to populate all relevant tables.
+
+    :steps:
+        1. Query database table for records with pulp_href.
+        2. Extract UUID from pulp_href path.
+        3. Verify pulp_prn matches expected format from PULP_HREF_PRN_MAP.
+
+    :expectedresults:
+        All pulp_prn values match the expected format based on pulp_href.
+    """
+    records = target_sat.query_db(
+        f'SELECT {table["href_key"]}, {table["prn_key"]} FROM {table["name"]} '
+        f'WHERE {table["href_key"]} IS NOT NULL'
+    )
+    assert len(records), 'No records found in table, probably insufficient content setup'
+    for row in records:
+        base_path, uuid = row[table['href_key']].rstrip('/').rsplit('/', 1)
+        assert row[table['prn_key']] == PULP_HREF_PRN_MAP.get(base_path, '') + uuid
+
+
+def test_pulp_repoversion_href_prn_mapping(target_sat, module_prn_content_setup):
+    """Verify Pulp HREF to PRN mapping for repository versions in katello_repositories table.
+
+    :id: dc555f29-9218-4c7d-8f10-c46e0213baa6
+
+    :setup:
+        1. Specific content entities created to populate all relevant tables.
+
+    :steps:
+        1. Query katello_repositories table for records with version_href and version_prn.
+        2. Get version details for each version_href via pulp cli.
+        3. Verify the version_prn from the table matches the prn from pulp cli.
+
+    :expectedresults:
+        All version_prn values match the expected PRN from pulp cli.
+    """
+    records = target_sat.query_db(
+        'SELECT version_href,version_prn FROM katello_repositories WHERE version_href IS NOT NULL'
+    )
+    assert len(records), 'No records found in table, probably insufficient content setup'
+    for row in records:
+        version = json.loads(target_sat.execute(f'pulp show --href {row["version_href"]}').stdout)
+        assert row['version_prn'] == version['prn']

--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -129,6 +129,17 @@ def content_upgrade_shared_satellite():
         test_duration.ready()
 
 
+@pytest.fixture(scope='module')
+def pulp_upgrade_shared_satellite():
+    """Mark tests using this fixture with pytest.mark.pulp_upgrades."""
+    sat_instance = shared_checkout("pulp_upgrade")
+    with SharedResource(
+        "pulp_upgrade_tests", shared_checkin, sat_instance=sat_instance
+    ) as test_duration:
+        yield sat_instance
+        test_duration.ready()
+
+
 @pytest.fixture
 def search_upgrade_shared_satellite():
     """Mark tests using this fixture with pytest.mark.search_upgrades."""

--- a/tests/new_upgrades/test_pulp.py
+++ b/tests/new_upgrades/test_pulp.py
@@ -1,0 +1,101 @@
+"""Test for Pulp related Upgrade Scenarios
+
+:Requirement: UpgradedSatellite
+
+:CaseAutomation: Automated
+
+:CaseComponent: Pulp
+
+:Team: Artemis
+
+:CaseImportance: High
+
+"""
+
+import json
+
+from manifester import Manifester
+import pytest
+
+from pytest_fixtures.component.pulp import _setup_prn_content
+from robottelo.config import settings
+from robottelo.constants import PULP_HREF_PRN_MAP, PULP_PRN_TABLES
+from robottelo.utils.shared_resource import SharedResource
+
+
+@pytest.fixture(scope='module')
+def pulp_upgrade_manifest():
+    with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='module')
+def pulp_upgrade_setup(pulp_upgrade_shared_satellite, upgrade_action, pulp_upgrade_manifest):
+    """Fixture to set up content entities to properly test pulp HREF to PRN mapping."""
+    target_sat = pulp_upgrade_shared_satellite
+    with SharedResource(target_sat.hostname, upgrade_action, target_sat=target_sat) as sat_upgrade:
+        test_data = _setup_prn_content(
+            target_sat, pulp_upgrade_manifest, test_name='pulp_href_prn_migration'
+        )
+        sat_upgrade.ready()
+        target_sat._session = None
+        yield test_data
+
+
+@pytest.mark.pulp_upgrades
+@pytest.mark.parametrize('table', PULP_PRN_TABLES, ids=lambda t: f"{t['name']}:{t['prn_key']}")
+def test_pulp_href_prn_migration_scenario(pulp_upgrade_setup, table):
+    """Verify Pulp HREF to PRN migration for all relevant Katello tables, except for repo versions.
+
+    :id: postupgrade-8306165e-7666-43c7-911f-75c803c20e45
+
+    :parametrized: yes
+
+    :setup:
+        1. Specific content entities created before upgrade to populate all relevant tables.
+
+    :steps:
+        1. Query database table for records with pulp_href.
+        2. Extract UUID from pulp_href path.
+        3. Verify pulp_prn matches expected format from PULP_HREF_PRN_MAP.
+
+    :expectedresults:
+        All pulp_prn values match the expected format based on pulp_href after upgrade.
+    """
+    target_sat = pulp_upgrade_setup.target_sat
+
+    records = target_sat.query_db(
+        f'SELECT {table["href_key"]}, {table["prn_key"]} FROM {table["name"]} '
+        f'WHERE {table["href_key"]} IS NOT NULL'
+    )
+    assert len(records), 'No records found in table, probably insufficient content setup'
+    for row in records:
+        base_path, uuid = row[table['href_key']].rstrip('/').rsplit('/', 1)
+        assert row[table['prn_key']] == PULP_HREF_PRN_MAP.get(base_path, '') + uuid
+
+
+def test_pulp_repoversion_href_prn_migration_scenario(pulp_upgrade_setup):
+    """Verify Pulp HREF to PRN migration for repository versions in katello_repositories table.
+
+    :id: 0cc9ebf7-dff5-4fa0-892b-90a46ad1e800
+
+    :setup:
+        1. Specific content entities created to populate all relevant tables.
+
+    :steps:
+        1. Query katello_repositories table for records with version_href and version_prn.
+        2. Get version details for each version_href via pulp cli.
+        3. Verify the version_prn from the table matches the prn from pulp cli.
+
+    :expectedresults:
+        All version_prn values match the expected PRN from pulp cli.
+    """
+    target_sat = pulp_upgrade_setup.target_sat
+
+    records = target_sat.query_db(
+        'SELECT version_href,version_prn FROM katello_repositories WHERE version_href IS NOT NULL'
+    )
+    assert len(records), 'No records found in table, probably insufficient content setup'
+    for row in records:
+        version = json.loads(target_sat.execute(f'pulp show --href {row["version_href"]}').stdout)
+        assert row['version_prn'] == version['prn']


### PR DESCRIPTION
### Problem Statement
Pulp3 introduces Pulp Resource Names (PRN) to potentially replace currently used hrefs as identifiers in the Pulp4 future. For smooth transition we need to get the PRNs correctly populated in the database tables, which is tracked by [SAT-30134](https://issues.redhat.com/browse/SAT-30134).

New content entities (created in stream/6.19) have the PRNs populated on the create time.
Old entities, created earlier, have the PRNs populated during upgrade migration to 6.19.

Both paths need test coverage.


### Solution
This PR introduces solution for both. The approach is to:
1. Setup specific entities via fixtures and reusable helper for both, general and upgrade scenario.
2. Check specific database tables in test bodies to ensure all PRNs match their href representation.

For most of the entities the HREF to PRN mapping is quite straightforward, so I've used a map and parametrized the test with particular table names and the column names to be tested.
The only exception are repo versions, where particular versions map differently. They have their own test.

For DB access I've added the `query_db` method to the Capsule class, so it can be used at both, Satellite (which inherits from Capsule) and Capsule.


### Related Issues
https://issues.redhat.com/browse/SAT-30134


### PRT test Cases example
General (tests PRNs are populated on entity create time):
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_pulp.py
Katello:
    katello: 11522
```
Upgrade scenario (tests PRNs are populated on upgrade):
```
trigger: test-robottelo
pytest: tests/new_upgrades/test_pulp.py -n 2
env:
    ROBOTTELO_server__xdist_behavior: 'run-on-one'
    ROBOTTELO_upgrade__from_version: '6.18'
    ROBOTTELO_upgrade__to_version: 'stream'
```
