### PR TITLE
6.17.z cherry pick of 19761

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -12,7 +12,6 @@
 
 """
 
-import json
 from random import choice
 import re
 
@@ -23,19 +22,13 @@ import yaml
 
 from robottelo.config import settings
 from robottelo.constants import (
-    DEFAULT_SUBSCRIPTION_NAME,
-    DUMMY_BOOTC_FACTS,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_1_CUSTOM_PACKAGE_NAME,
     FAKE_2_CUSTOM_PACKAGE,
     FAKE_7_CUSTOM_PACKAGE,
     FAKE_8_CUSTOM_PACKAGE,
     FAKE_8_CUSTOM_PACKAGE_NAME,
-    PRDS,
-    REPOS,
-    REPOSET,
 )
-from robottelo.enums import NetworkType
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.logging import logger
 from robottelo.utils.datafactory import (


### PR DESCRIPTION
### Problem Statement
6.17.z cherry pick of https://github.com/SatelliteQE/robottelo/pull/19761

### Solution


### Related Issues


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k "test_positive_erratum_applicability or test_positive_apply_security_erratum or test_positive_report_package_installed_removed" 

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->