### PR TITLE
Update HostCol Management test Functionality

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -3263,7 +3263,7 @@ def test_positive_all_hosts_manage_host_collections(target_sat, function_org, fu
             host_collections_to_select=host_col_limit_1_name,
             option='Add',
         )
-        assert 'Validation failed' in result
+        assert 'Failed to add host to host collection.' in result
         hosts_in_host_col = read_host_collections_hosts(
             target_sat, host_col_limit_1_name, function_org
         )


### PR DESCRIPTION
Follow up to https://github.com/SatelliteQE/robottelo/pull/20006 as new commits were added to the upstream PRs.
Needs: 
https://github.com/theforeman/foreman/pull/10721
https://github.com/Katello/katello/pull/11528
https://github.com/SatelliteQE/airgun/pull/2173

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_positive_all_hosts_manage_host_collections "
airgun: 2173
theforeman:
    foreman: 10721
Katello:
    katello: 11528
```