### PR TITLE
Fix test_external_new_user_login_and_check_count_rhsso

### DIFF
--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -381,8 +381,12 @@ def test_external_new_user_login_and_check_count_rhsso(
     # checking delete user can't login anymore
     default_sso_host.delete_sso_user(user_details['username'])
     with module_target_sat.ui_session(login=False) as rhsso_session:
-        with pytest.raises(NavigationTriesExceeded) as error:
-            rhsso_session.rhsso_login.login(login_details)
+        result = rhsso_session.rhsso_login.login(login_details)
+        # Verify that login failed and error message is displayed
+        assert result is not None, "Expected login to fail and return error"
+        assert 'error_message' in result
+        assert 'Invalid username or password' in result['error_message']
+        # Also verify that attempting to navigate fails with exception
         with pytest.raises(NavigationTriesExceeded) as error:
             rhsso_session.task.read_all()
         assert error.typename == 'NavigationTriesExceeded'


### PR DESCRIPTION
The test was failing because no exception is thrown when attempting to log in with a deleted RHSSO user. Instead, the login form submits credentials but displays an error message.

Changed the test to check for the error message returned by the login() method, while still verifying that attempting to navigate after failed login raises NavigationTriesExceeded exception.

Requires https://github.com/SatelliteQE/airgun/pull/2174