### PR TITLE
Fix flatpak UI CRUD test

### DIFF
--- a/tests/foreman/ui/test_flatpak.py
+++ b/tests/foreman/ui/test_flatpak.py
@@ -155,4 +155,4 @@ def test_CRUD_scan_and_mirror_flatpak_remote(target_sat, function_org, function_
         session.flatpak_remotes.delete(fr_name)
         remotes = session.flatpak_remotes.read()
         assert 'no_results' in remotes
-        assert 'table' not in remotes
+        assert 'No Results' in str(remotes['table'])


### PR DESCRIPTION
### Problem Statement
The FR page has changed. When empty, it shows the table with "No Results" sign. It used to show "No Results" sign without table in 6.18, which was expected by the UI CRUD test.


### Solution
Instead of ensuring the table is missing, ensure the table shows "No Results".


### Related Issues
https://issues.redhat.com/browse/SAT-38790


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_flatpak.py -k test_CRUD_scan_and_mirror_flatpak_remote
```