### PR TITLE
[6.16.z] Add Python 3.14 for PR checks in GHA

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
     env:
       UV_CACHE_DIR: /tmp/.uv-cache
       UV_SYSTEM_PYTHON: 1

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12]
+        python-version: [3.14]
     env:
       UV_CACHE_DIR: /tmp/.uv-cache
       UV_SYSTEM_PYTHON: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
 ]
-requires-python = "~=3.11"
+requires-python = "~=3.12"
 license = {text = "GNU GPL v3.0"}
 
 [project.urls]
@@ -32,7 +32,7 @@ include = ["robottelo*"]
 exclude = ["tests*"]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 # Allow lines to be as long as 100.
 line-length = 100
 exclude = [".git", ".hg", ".mypy_cache", ".venv", "_build", "buck-out", "build", "dist"]

--- a/tests/robottelo/test_func_locker.py
+++ b/tests/robottelo/test_func_locker.py
@@ -198,7 +198,10 @@ class TestFuncLocker:
     def count_and_pool(self):
         global counter_file
         counter_file.write('0')
-        pool = multiprocessing.Pool(POOL_SIZE)
+        # Always use the same start method for all Python versions
+        # 'fork' is consistent with pre-3.14 behavior
+        ctx = multiprocessing.get_context('fork')
+        pool = ctx.Pool(POOL_SIZE)
         yield pool
 
         pool.terminate()

--- a/tests/robottelo/test_func_shared.py
+++ b/tests/robottelo/test_func_shared.py
@@ -171,7 +171,10 @@ class TestFuncShared:
 
     @pytest.fixture
     def pool(self):
-        pool = multiprocessing.Pool(DEFAULT_POOL_SIZE)
+        # Always use the same start method for all Python versions
+        # 'fork' is consistent with pre-3.14 behavior
+        ctx = multiprocessing.get_context('fork')
+        pool = ctx.Pool(DEFAULT_POOL_SIZE)
         yield pool
 
         pool.terminate()


### PR DESCRIPTION
(cherry picked from commit 7d8e4b7df42c88ffa402e0df6adb23c4dfbfb6bf)

Failed Auto-CherryPick for https://github.com/SatelliteQE/robottelo/pull/20082
Fixes #20102

### Problem Statement
Python 3.14 was released on October 7, 2025, and we're not covering this in the PR checks in GHA yet

### Solution
Add Python 3.14 for PR checks in GHA and bump Py3.12 as new required Python version to match CI


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->