### PR TITLE
Fixed virt-who test cases as per details appear on UI

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -623,11 +623,15 @@ def hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_n
         hypervisor_display_name, 'overview'
     )
 
-    assert hypervisorhost_new_overview['overview']['host_status']['status'] == 'All statuses cleared'
+    assert (
+        hypervisorhost_new_overview['overview']['host_status']['status'] == 'All statuses cleared'
+    )
     # hypervisor host Check details
     hypervisorhost_new_detais = org_session.host_new.get_details(hypervisor_display_name, 'details')
     assert (
-        hypervisorhost_new_detais['details']['system_properties']['sys_properties']['virtual_guests']
+        hypervisorhost_new_detais['details']['system_properties']['sys_properties'][
+            'virtual_guests'
+        ]
         == '1 guests'
     )
     assert (


### PR DESCRIPTION
### Problem Statement
For guest VM we can see `"virtual host"` under system properties and host status but for virtwho vm(virt-who-env-vmware) we are  seeing status as `"All status cleared"`  and under system properties we are seeing `virtual_guests`

### Solution
Updated assert statement 

### Related Issues


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_deploy_configure_by_id_script

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->