### PR TITLE
[6.17.z] Remove iop setup_script setting

### DIFF
--- a/conf/rh_cloud.yaml.template
+++ b/conf/rh_cloud.yaml.template
@@ -9,4 +9,3 @@ RH_CLOUD:
     REGISTRY:
     USERNAME:
     TOKEN:
-    SETUP_SCRIPT:

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -34,7 +34,6 @@ def module_target_sat_insights(request, module_target_sat, satellite_factory):
 
     if not hosted_insights:
         iop_settings = settings.rh_cloud.iop_advisor_engine
-        script = (iop_settings.setup_script or '').splitlines()
 
         # Use HTTPS_PROXY to reach container registry for IPv6
         satellite.enable_ipv6_system_proxy()
@@ -62,14 +61,6 @@ def module_target_sat_insights(request, module_target_sat, satellite_factory):
         )
         if cmd_result.status != 0:
             raise SatelliteHostError(f'Error installing advisor engine: {cmd_result.stdout}')
-
-        # Perform any post-install steps, such as custom rule content generation
-        for cmd in script:
-            cmd_result = satellite.execute(cmd)
-            if cmd_result.status != 0:
-                raise SatelliteHostError(
-                    f'Error during post-install setup of advisor engine: {cmd_result.stdout}'
-                )
 
     yield satellite
 


### PR DESCRIPTION
### Problem Statement

IoP setup on 6.17 fails because the `setup_script` field is no longer present:

```
pytest_fixtures/component/rh_cloud.py:37: in module_target_sat_insights
    script = (iop_settings.setup_script or '').splitlines()
              ^^^^^^^^^^^^^^^^^^^^^^^^^
[...]
../../lib64/python3.12/site-packages/dynaconf/vendor/box/box.py:176: in __getattr__
    raise BoxKeyError(str(E))from _A
E   dynaconf.vendor.box.exceptions.BoxKeyError: "'DynaBox' object has no attribute 'setup_script'"
```

### Solution

Remove any reference to `rh_cloud.iop_advisor_engine.setup_script`.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->