### PR TITLE
[6.18.z] Fixed virt-who test cases as per details appear on UI

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -622,19 +622,25 @@ def hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_n
     hypervisorhost_new_overview = org_session.host_new.get_details(
         hypervisor_display_name, 'overview'
     )
-    assert hypervisorhost_new_overview['overview']['host_status']['status_success'] == '1'
+
+    assert (
+        hypervisorhost_new_overview['overview']['host_status']['status'] == 'All statuses cleared'
+    )
     # hypervisor host Check details
     hypervisorhost_new_detais = org_session.host_new.get_details(hypervisor_display_name, 'details')
     assert (
-        hypervisorhost_new_detais['details']['system_properties']['sys_properties']['virtual_host']
-        == hypervisor_display_name
+        hypervisorhost_new_detais['details']['system_properties']['sys_properties'][
+            'virtual_guests'
+        ]
+        == '1 guests'
     )
     assert (
         hypervisorhost_new_detais['details']['system_properties']['sys_properties']['name']
-        == guest_name
+        == hypervisor_display_name
     )
     # Check guest overview
     guest_new_overview = org_session.host_new.get_details(guest_name, 'overview')
+
     assert guest_new_overview['overview']['host_status']['status_success'] == '1'
     # Check guest details
     virtualguest_new_detais = org_session.host_new.get_details(guest_name, 'details')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20113

### Problem Statement
For guest VM we can see `"virtual host"` under system properties and host status but for virtwho vm(virt-who-env-vmware) we are  seeing status as `"All status cleared"`  and under system properties we are seeing `virtual_guests`

### Solution
Updated assert statement 

### Related Issues


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_deploy_configure_by_id_script

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->