### PR TITLE
[6.17.z] Updated test case to select location/organization

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -301,8 +301,8 @@ def test_read_host_with_ics_domain(
         session.location.select(smart_proxy_location.name)
         values = session.host_new.get_details(host_name, widget_names='details')
         assert (
-                values['details']['system_properties']['sys_properties']['domain']
-                == template.domain.name
+            values['details']['system_properties']['sys_properties']['domain']
+            == template.domain.name
         )
         assert values['details']['system_properties']['sys_properties']['name'] == host_name
 


### PR DESCRIPTION
### Problem Statement
ics domain host was not visible due to improper  location/organization

### Solution
Updated test case to select location/organization

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k test_read_host_with_ics_domain

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->