### PR TITLE
Bump Broker from 0.6.12 to 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Version updates managed by dependabot
 
 apypie==0.7.1
-broker[docker,podman,hussh]==0.6.12
+broker[satlab,docker,ssh2_python]==0.7.0
 cryptography==43.0.3
 deepdiff==8.6.1
 dynaconf[vault]==3.2.12


### PR DESCRIPTION
This also changes the dependency groups a bit.
We should be able to drop ssh2_python soon and I'm not sure how much we really need docker..