### PR TITLE
[6.17.z] Resolve ipv6 container connection failures

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -243,7 +243,6 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
         "rhel_version": "8",
         "distro": "rhel",
         "no_containers": True,
-        "network": "ipv6" if module_target_sat.network_type == NetworkType.IPV6 else "ipv4",
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()


### PR DESCRIPTION
### Problem Statement
in 6.17.z IPV6 only, some containers using this fixture are failing to connect, or failing to register to CDN due to the connection issue. In Stream and 6.18.z , we do not see this failure.

### Related Issues
`ContainerImageManagement` 6 failures in setup related to cases using this fixture 
(socket: connection unreachable, or fails to reg to CDN)


### PRT Case
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_container_management.py --uses-fixtures module_container_contenthost
network_type: ipv6
```