### PR TITLE
Virt-Who: Remove legacy UI check for host details

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -617,7 +617,9 @@ def hypervisor_guest_mapping_check_legacy_ui(
     assert virtualguest['details']['virtual_host'] == hypervisor_display_name
 
 
-def hypervisor_guest_mapping_newcontent_ui(org_session, default_location, hypervisor_name, guest_name):
+def hypervisor_guest_mapping_newcontent_ui(
+    org_session, default_location, hypervisor_name, guest_name
+):
     org_session.location.select(default_location.name)
     hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
     hypervisorhost_new_overview = org_session.host_new.get_details(

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -68,7 +68,9 @@ class TestVirtwhoConfigforEsx:
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
-        hypervisor_guest_mapping_newcontent_ui(org_session, default_location, hypervisor_name, guest_name)
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
 
     def test_positive_debug_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -51,7 +51,9 @@ class TestVirtwhoConfigforHyperv:
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
-        hypervisor_guest_mapping_newcontent_ui(org_session, default_location, hypervisor_name, guest_name)
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
 
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -47,7 +47,9 @@ class TestVirtwhoConfigforKubevirt:
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
-        hypervisor_guest_mapping_newcontent_ui(org_session, default_location, hypervisor_name, guest_name)
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
 
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -51,7 +51,9 @@ class TestVirtwhoConfigforLibvirt:
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
-        hypervisor_guest_mapping_newcontent_ui(org_session, default_location, hypervisor_name, guest_name)
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
 
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -50,7 +50,9 @@ class TestVirtwhoConfigforNutanix:
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
-        hypervisor_guest_mapping_newcontent_ui(org_session, default_location, hypervisor_name, guest_name)
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
 
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui


### PR DESCRIPTION
### Problem Statement
Few details are not available on legacy UI page related to virt who.

### Solution
Remove legacy UI check for host details

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_deploy_configure_by_id_script

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->