### PR TITLE
[6.18.z] Virt-Who: Remove legacy UI check for host details

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -617,7 +617,10 @@ def hypervisor_guest_mapping_check_legacy_ui(
     assert virtualguest['details']['virtual_host'] == hypervisor_display_name
 
 
-def hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name):
+def hypervisor_guest_mapping_newcontent_ui(
+    org_session, default_location, hypervisor_name, guest_name
+):
+    org_session.location.select(default_location.name)
     hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
     hypervisorhost_new_overview = org_session.host_new.get_details(
         hypervisor_display_name, 'overview'

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -31,7 +31,6 @@ from robottelo.utils.virtwho import (
     get_configure_id,
     get_configure_option,
     get_virtwho_status,
-    hypervisor_guest_mapping_check_legacy_ui,
     hypervisor_guest_mapping_newcontent_ui,
     restart_virtwho_service,
     update_configure_option,
@@ -68,13 +67,10 @@ class TestVirtwhoConfigforEsx:
         # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
-        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        hypervisor_guest_mapping_check_legacy_ui(
-            org_session, form_data_ui, default_location, hypervisor_name, guest_name
-        )
-
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
-        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
 
     def test_positive_debug_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -18,7 +18,6 @@ from robottelo.utils.virtwho import (
     get_configure_file,
     get_configure_id,
     get_configure_option,
-    hypervisor_guest_mapping_check_legacy_ui,
     hypervisor_guest_mapping_newcontent_ui,
 )
 
@@ -51,13 +50,10 @@ class TestVirtwhoConfigforHyperv:
         # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
-        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        hypervisor_guest_mapping_check_legacy_ui(
-            org_session, form_data_ui, default_location, hypervisor_name, guest_name
-        )
-
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
-        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
 
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -19,7 +19,6 @@ from robottelo.utils.virtwho import (
     get_configure_file,
     get_configure_id,
     get_configure_option,
-    hypervisor_guest_mapping_check_legacy_ui,
     hypervisor_guest_mapping_newcontent_ui,
 )
 
@@ -47,13 +46,10 @@ class TestVirtwhoConfigforKubevirt:
         # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
-        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        hypervisor_guest_mapping_check_legacy_ui(
-            org_session, form_data_ui, default_location, hypervisor_name, guest_name
-        )
-
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
-        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
 
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -18,7 +18,6 @@ from robottelo.utils.virtwho import (
     get_configure_file,
     get_configure_id,
     get_configure_option,
-    hypervisor_guest_mapping_check_legacy_ui,
     hypervisor_guest_mapping_newcontent_ui,
 )
 
@@ -51,13 +50,10 @@ class TestVirtwhoConfigforLibvirt:
         # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
-        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        hypervisor_guest_mapping_check_legacy_ui(
-            org_session, form_data_ui, default_location, hypervisor_name, guest_name
-        )
-
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
-        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
 
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -22,7 +22,6 @@ from robottelo.utils.virtwho import (
     get_configure_id,
     get_configure_option,
     get_hypervisor_ahv_mapping,
-    hypervisor_guest_mapping_check_legacy_ui,
     hypervisor_guest_mapping_newcontent_ui,
 )
 
@@ -50,13 +49,10 @@ class TestVirtwhoConfigforNutanix:
         # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
-        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        hypervisor_guest_mapping_check_legacy_ui(
-            org_session, form_data_ui, default_location, hypervisor_name, guest_name
-        )
-
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
-        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
 
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20165

### Problem Statement
Few details are not available on legacy UI page related to virt who.

### Solution
Remove legacy UI check for host details

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_deploy_configure_by_id_script

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->