### PR TITLE
[6.18.z] IoP test updates

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -60,6 +60,8 @@ CaseComponent:
     - Hosts
     - ImageMode
     - Infobloxintegration
+    - Insights-Advisor
+    - Insights-Vulnerability
     - Installation
     - InterSatelliteSync
     - katello-tracer

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -18,12 +18,10 @@ import time
 
 import pytest
 from wait_for import wait_for
-import yaml
 
 from robottelo import constants
-from robottelo.config import robottelo_tmp_dir, settings
+from robottelo.config import robottelo_tmp_dir
 from robottelo.constants import DEFAULT_CV, DEFAULT_ORG, ENVIRONMENT
-from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.io import get_local_file_data, get_remote_report_checksum
 
 inventory_sync_task = 'InventorySync::Async::InventoryFullSync'
@@ -547,127 +545,6 @@ def generate_report(rhcloud_manifest_org, module_target_sat, disconnected=False)
     report_log = module_target_sat.api.Organization(id=org.id).rh_cloud_fetch_last_report_log()
     expected = 'Check the Uploading tab for report uploading status'
     assert expected in report_log['output']
-
-
-@pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('N-0')
-def test_positive_install_iop_custom_certs(
-    certs_data,
-    sat_ready_rhel,
-    module_sca_manifest,
-    rhel_contenthost,
-):
-    """Install Satellite + IoP with custom SSL certs.
-
-    :id: 9528fc93-822d-461e-af84-283dfdc0043f
-
-    :steps:
-
-        1. Generate the custom certs on RHEL machine
-        2. Install Satellite and IoP with custom certs
-        3. Assert success return code from satellite-installer
-        4. Assert all services are running
-        5. Register client to Satellite and upload insights-client data
-        6. Assert success return code from insights-client
-
-    :expectedresults: Satellite should be installed using the custom certs.
-
-    :CaseAutomation: Automated
-    """
-    satellite = sat_ready_rhel
-    host = rhel_contenthost
-    iop_settings = settings.rh_cloud.iop_advisor_engine
-
-    # Set IPv6 system proxy on Satellite, to reach container registry
-    satellite.enable_ipv6_system_proxy()
-
-    # Set IPv6 dnf proxy on Content Host, to install insights-client from non-Satellite source
-    host.enable_ipv6_dnf_proxy()
-
-    # Install satellite packages
-    satellite.download_repofile(
-        product='satellite',
-        release=settings.server.version.release,
-        snap=settings.server.version.snap,
-    )
-    satellite.register_to_cdn()
-    satellite.execute('dnf -y update')
-    satellite.execute('dnf -y install podman')
-    satellite.install_satellite_or_capsule_package()
-
-    # Set up firewall
-    result = satellite.execute(
-        "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
-    )
-    assert result.status == 0, "firewalld is not present and can't be installed"
-
-    result = satellite.execute(
-        'firewall-cmd --add-port="53/udp" --add-port="53/tcp" --add-port="67/udp" '
-        '--add-port="69/udp" --add-port="80/tcp" --add-port="443/tcp" '
-        '--add-port="5647/tcp" --add-port="8000/tcp" --add-port="9090/tcp" '
-        '--add-port="8140/tcp"'
-    )
-    assert result.status == 0
-
-    result = satellite.execute('firewall-cmd --runtime-to-permanent')
-    assert result.status == 0
-
-    # Log in to container registry
-    result = satellite.execute(
-        f'podman login --authfile /etc/foreman/registry-auth.json -u {iop_settings.stage_username!r} -p {iop_settings.stage_token!r} {iop_settings.stage_registry}'
-    )
-    assert result.status == 0, f'Error logging in to container registry: {result.stdout}'
-
-    # Set up container image path overrides
-    custom_hiera_yaml = yaml.dump(
-        {f'iop::{service}::image': path for service, path in iop_settings.image_paths.items()}
-    )
-    satellite.execute(f'echo "{custom_hiera_yaml}" > /etc/foreman-installer/custom-hiera.yaml')
-
-    command = InstallerCommand(
-        'enable-iop',
-        'certs-update-server',
-        'certs-update-server-ca',
-        scenario='satellite',
-        certs_server_cert=f'/root/{certs_data["cert_file_name"]}',
-        certs_server_key=f'/root/{certs_data["key_file_name"]}',
-        certs_server_ca_cert=f'/root/{certs_data["ca_bundle_file_name"]}',
-        foreman_initial_admin_password=settings.server.admin_password,
-    ).get_command()
-
-    result = satellite.execute(command, timeout='30m')
-    assert result.status == 0
-
-    result = satellite.execute('hammer ping')
-    assert result.stdout.count('Status:') == result.stdout.count(' ok')
-
-    # Assert all services are running
-    result = satellite.execute('satellite-maintain health check --label services-up -y')
-    assert result.status == 0, 'Not all services are running'
-
-    org = satellite.api.Organization().create()
-    satellite.upload_manifest(org.id, module_sca_manifest.content)
-
-    activation_key = satellite.api.ActivationKey(
-        content_view=org.default_content_view,
-        organization=org,
-        environment=satellite.api.LifecycleEnvironment(id=org.library.id),
-        service_level='Self-Support',
-        purpose_usage='test-usage',
-        purpose_role='test-role',
-        auto_attach=False,
-    ).create()
-
-    host.configure_rex(satellite=satellite, org=org, register=False)
-    host.configure_insights_client(
-        satellite=satellite,
-        activation_key=activation_key,
-        org=org,
-        rhel_distro=f"rhel{host.os_version.major}",
-    )
-
-    result = host.execute('insights-client')
-    assert result.status == 0, 'insights-client upload failed'
 
 
 def test_positive_config_on_sat_without_network_protocol(module_target_sat, module_sca_manifest):

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -1,0 +1,262 @@
+"""CLI tests for IoP
+
+:Requirement: RHCloud
+
+:CaseAutomation: Automated
+
+:CaseComponent: Insights-Advisor
+
+:Team: Proton
+
+:CaseImportance: High
+
+"""
+
+import pytest
+import yaml
+
+from robottelo.config import settings
+from robottelo.utils.installer import InstallerCommand
+
+IOP_SERVICES = [
+    'iop-core-engine',
+    'iop-core-gateway',
+    'iop-core-host-inventory-api',
+    'iop-core-host-inventory-migrate',
+    'iop-core-host-inventory',
+    'iop-core-ingress',
+    'iop-core-kafka',
+    'iop-core-puptoo',
+    'iop-core-yuptoo',
+    'iop-service-advisor-backend-api',
+    'iop-service-advisor-backend',
+    'iop-service-remediations-api',
+    'iop-service-vmaas-reposcan',
+    'iop-service-vmaas-webapp-go',
+    'iop-service-vuln-dbupgrade',
+    'iop-service-vuln-evaluator-recalc',
+    'iop-service-vuln-evaluator-upload',
+    'iop-service-vuln-grouper',
+    'iop-service-vuln-listener',
+    'iop-service-vuln-manager',
+    'iop-service-vuln-taskomatic',
+]
+
+
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('N-0')
+def test_positive_install_iop_custom_certs(
+    certs_data,
+    sat_ready_rhel,
+    module_sca_manifest,
+    rhel_contenthost,
+):
+    """Install Satellite + IoP with custom SSL certs.
+
+    :id: 9528fc93-822d-461e-af84-283dfdc0043f
+
+    :steps:
+
+        1. Generate the custom certs on RHEL machine
+        2. Install Satellite and IoP with custom certs
+        3. Assert success return code from satellite-installer
+        4. Assert all services are running
+        5. Register client to Satellite and upload insights-client data
+        6. Assert success return code from insights-client
+
+    :expectedresults: Satellite should be installed using the custom certs.
+
+    :CaseAutomation: Automated
+    """
+    satellite = sat_ready_rhel
+    host = rhel_contenthost
+    iop_settings = settings.rh_cloud.iop_advisor_engine
+
+    # Set IPv6 system proxy on Satellite, to reach container registry
+    satellite.enable_ipv6_system_proxy()
+
+    # Set IPv6 dnf proxy on Content Host, to install insights-client from non-Satellite source
+    host.enable_ipv6_dnf_proxy()
+
+    # Install satellite packages
+    satellite.download_repofile(
+        product='satellite',
+        release=settings.server.version.release,
+        snap=settings.server.version.snap,
+    )
+    satellite.register_to_cdn()
+    satellite.execute('dnf -y update')
+    satellite.execute('dnf -y install podman')
+    satellite.install_satellite_or_capsule_package()
+
+    # Set up firewall
+    result = satellite.execute(
+        "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
+    )
+    assert result.status == 0, "firewalld is not present and can't be installed"
+
+    result = satellite.execute(
+        'firewall-cmd --add-port="53/udp" --add-port="53/tcp" --add-port="67/udp" '
+        '--add-port="69/udp" --add-port="80/tcp" --add-port="443/tcp" '
+        '--add-port="5647/tcp" --add-port="8000/tcp" --add-port="9090/tcp" '
+        '--add-port="8140/tcp"'
+    )
+    assert result.status == 0
+
+    result = satellite.execute('firewall-cmd --runtime-to-permanent')
+    assert result.status == 0
+
+    # Log in to container registry
+    result = satellite.execute(
+        f'podman login --authfile /etc/foreman/registry-auth.json -u {iop_settings.stage_username!r} -p {iop_settings.stage_token!r} {iop_settings.stage_registry}'
+    )
+    assert result.status == 0, f'Error logging in to container registry: {result.stdout}'
+
+    # Set up container image path overrides
+    custom_hiera_yaml = yaml.dump(
+        {f'iop::{service}::image': path for service, path in iop_settings.image_paths.items()}
+    )
+    satellite.execute(f'echo "{custom_hiera_yaml}" > /etc/foreman-installer/custom-hiera.yaml')
+
+    command = InstallerCommand(
+        'enable-iop',
+        'certs-update-server',
+        'certs-update-server-ca',
+        scenario='satellite',
+        certs_server_cert=f'/root/{certs_data["cert_file_name"]}',
+        certs_server_key=f'/root/{certs_data["key_file_name"]}',
+        certs_server_ca_cert=f'/root/{certs_data["ca_bundle_file_name"]}',
+        foreman_initial_admin_password=settings.server.admin_password,
+    ).get_command()
+
+    result = satellite.execute(command, timeout='30m')
+    assert result.status == 0
+
+    result = satellite.execute('hammer ping')
+    assert result.stdout.count('Status:') == result.stdout.count(' ok')
+
+    # Assert all services are running
+    result = satellite.execute('satellite-maintain health check --label services-up -y')
+    assert result.status == 0, 'Not all services are running'
+
+    org = satellite.api.Organization().create()
+    satellite.upload_manifest(org.id, module_sca_manifest.content)
+
+    activation_key = satellite.api.ActivationKey(
+        content_view=org.default_content_view,
+        organization=org,
+        environment=satellite.api.LifecycleEnvironment(id=org.library.id),
+        service_level='Self-Support',
+        purpose_usage='test-usage',
+        purpose_role='test-role',
+        auto_attach=False,
+    ).create()
+
+    host.configure_rex(satellite=satellite, org=org, register=False)
+    host.configure_insights_client(
+        satellite=satellite,
+        activation_key=activation_key,
+        org=org,
+        rhel_distro=f"rhel{host.os_version.major}",
+    )
+
+    result = host.execute('insights-client')
+    assert result.status == 0, 'insights-client upload failed'
+
+
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('N-0')
+def test_disable_enable_iop(satellite_iop, module_sca_manifest, rhel_contenthost):
+    """Install Satellite + IoP, disable, re-enable.
+
+    :id: abe165e1-a3a4-413d-b6aa-5cb51acfeb2e
+
+    :steps:
+
+        1. Install Satellite and IoP
+        2. Assert all IoP services are running
+        3. Disable IoP by running satellite-installer with `--iop-ensure absent`
+        4. Assert all IoP services are stopped, and podman containers, networks, secrets, and volumes are removed
+        5. Re-enable IoP with `--iop-ensure present`
+        6. Assert all IoP services are running
+
+    :expectedresults: IoP services should be running or absent as configured by the `iop-ensure` installer option
+
+    :CaseAutomation: Automated
+    """
+    satellite = satellite_iop
+    host = rhel_contenthost
+
+    # Register the Insights client
+    org = satellite.api.Organization().create()
+    satellite.upload_manifest(org.id, module_sca_manifest.content)
+
+    activation_key = satellite.api.ActivationKey(
+        content_view=org.default_content_view,
+        organization=org,
+        environment=satellite.api.LifecycleEnvironment(id=org.library.id),
+        service_level='Self-Support',
+        purpose_usage='test-usage',
+        purpose_role='test-role',
+        auto_attach=False,
+    ).create()
+
+    host.configure_rex(satellite=satellite, org=org, register=False)
+    host.configure_insights_client(
+        satellite=satellite,
+        activation_key=activation_key,
+        org=org,
+        rhel_distro=f"rhel{host.os_version.major}",
+    )
+
+    result = host.execute('insights-client')
+    assert result.status == 0, 'Initial insights-client upload failed'
+
+    # Disable IoP
+    command = InstallerCommand(iop_ensure='absent').get_command()
+    result = satellite.execute(command, timeout='10m')
+    assert result.status == 0, 'Failed to disable IoP'
+
+    result = satellite.execute('podman ps -a --noheading')
+    assert result.stdout == '', 'Podman containers not removed'
+
+    result = satellite.execute('podman volume ls -n')
+    assert result.stdout == '', 'Podman volumes not removed'
+
+    result = satellite.execute('podman secret ls -n')
+    assert result.stdout == '', 'Podman secrets not removed'
+
+    result = satellite.execute('podman network ls -n -f "name=iop"')
+    assert result.stdout == '', 'Podman network not removed'
+
+    result = satellite.execute('satellite-maintain service status -b')
+    assert 'FAIL' not in result.stdout, 'Services not running'
+    assert not any(service in result.stdout for service in IOP_SERVICES), (
+        'IoP services not disabled'
+    )
+
+    # Verify insights-client re-registration
+    result = host.execute('insights-client --status')
+    assert 'Insights API says this machine is NOT registered.' in result.stdout, (
+        'insights-client still registered after disabling IoP'
+    )
+
+    result = host.execute('insights-client --register --force')
+    assert result.status == 0, 'Failed to re-register insights client'
+
+    host.execute('insights-client --unregister')
+
+    # Re-enable IoP
+    command = InstallerCommand(iop_ensure='present').get_command()
+    result = satellite.execute(command, timeout='10m')
+    assert result.status == 0, 'Failed to re-enable IoP'
+
+    result = satellite.execute('satellite-maintain service status -b')
+    assert 'FAIL' not in result.stdout, 'Services not running'
+    assert all(service in result.stdout for service in IOP_SERVICES), 'IoP services not enabled'
+
+    result = host.execute('insights-client --register --force')
+    assert result.status == 0, 'Failed to re-register insights client'
+
+    result = host.execute('insights-client')
+    assert result.status == 0, 'insights-client upload failed'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20122

### Problem Statement

- `test_positive_install_iop_custom_certs` needs to update custom-hiera.yaml when installing IoP.
- Test needed for disabling and re-enabling IoP.

### Solution

- Add `custom-hiera.yaml` setup to `test_positive_install_iop_custom_certs`
- Add new test, `test_disable_enable_iop`
- Create new IoP-only test module `tests/foreman/cli/test_rhcloud_iop.py` for both, moving `test_positive_install_iop_custom_certs` to the new module.

### Related Issues

### PRT example:

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_rhcloud_iop.py
robottelo: 20122
env:
  ROBOTTELO_RH_CLOUD__IOP_ADVISOR_ENGINE__IMAGE_PATHS__core_engine: quay..io/iop/gateway:foreman-3.16
```

Supported keys in `IMAGE_PATHS`:

- core_engine
- core_gateway
- core_host_inventory
- core_host_inventory_frontend
- core_ingress
- core_kafka
- core_puptoo
- core_yuptoo
- service_advisor
- service_advisor_frontend
- service_remediations
- service_vmaas
- service_vulnerability
- service_vulnerability_frontend

