### PR TITLE
Modifications in CLI and UI Libvirt CR to resolve key error

### DIFF
--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -40,6 +40,7 @@ from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import parametrized
+from robottelo.utils.issue_handlers import is_open
 
 
 def valid_name_desc_data():
@@ -363,7 +364,7 @@ def test_positive_update_console_password(set_console_password, module_target_sa
 @pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
 @pytest.mark.rhel_ver_match('[7]')
-@pytest.mark.parametrize('pxe_loader', ['uefi', 'secureboot'], indirect=True)
+@pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 @pytest.mark.parametrize('libvirt', ['libvirt9', 'libvirt10'], indirect=True)
 def test_positive_provision_end_to_end(
@@ -400,6 +401,10 @@ def test_positive_provision_end_to_end(
 
     :customerscenario: true
     """
+    # Skip test for UEFI and SecureBoot loaders
+    if is_open('SAT-41340') and pxe_loader.vm_firmware in ['uefi', 'uefi_secure_boot']:
+        pytest.skip(f"Test not supported for {pxe_loader.vm_firmware} firmware")
+
     sat = module_libvirt_provisioning_sat.sat
     cr_name = gen_string('alpha')
     hostname = gen_string('alpha').lower()
@@ -442,12 +447,16 @@ def test_positive_provision_end_to_end(
         f'su foreman -s /bin/bash -c "virsh -c {libvirt.url} list --state-running"'
     )
     assert hostname in result.stdout
-
     wait_for(
-        lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
-        != 'Pending installation',
+        lambda: (
+            sat.cli.Host.info({'name': hostname})
+            .get('status', {})
+            .get('build-status', 'Pending installation')
+            != 'Pending installation'
+        ),
         timeout=1800,
         delay=30,
+        handle_exception=True,
     )
     host_info = sat.cli.Host.info({'id': host['id']})
     assert host_info['status']['build-status'] == 'Installed'

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -181,8 +181,8 @@ def test_positive_provision_end_to_end(
         )
         name = f'{hostname}.{module_libvirt_provisioning_sat.domain.name}'
         request.addfinalizer(lambda: sat.provisioning_cleanup(name))
-        assert session.host_new.search(name)[0]['Name'] == name
-
+        result = session.host_new.search(name)[0]
+        assert result['Name'] == name
         # Check on Libvirt, if VM exists
         result = sat.execute(
             f'su foreman -s /bin/bash -c "virsh -c {libvirt.url} list --state-running"'


### PR DESCRIPTION
### Problem Statement

The test test_positive_provision_end_to_end is failing intermittently with a KeyError during execution of the lambda function used in the `wait_for` call. This happens when the `status` or `build-status` keys are temporarily unavailable in the Satellite API response, causing the test to break before the timeout is reached.

### Solution

Updated the lambda function inside the `wait_for` call to safely handle missing keys and potential transient exceptions by using `.get()` methods and `handle_exception=True`.
This ensures the polling logic continues gracefully until the host build is complete, thereby preventing continue flow of code even after the timeout happens.

Restarting DHCP as dhcpd service does not recover from (Network is down) state on its own.
Removing `UEFI`  and `secure-boot` for RHEL 7 because `RHEL 7 is not supported with UEFI on VMware and libvirt hypervisors.` mentioned in `SAT-41340` for CLI testcase.

Adding `BIOS` back as it is working while Restarting of DHCPD

Added Restart of DHCPD for booting of RHEL 8  host on libvirt.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->