### PR TITLE
[6.18.z] [IOP] Update pytest rhel version match for fips

### DIFF
--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -24,7 +24,7 @@ from tests.foreman.ui.test_rhcloud_insights import (
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('N-1')
+@pytest.mark.rhel_ver_match(r'^(?![78]).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_iop_recommendations_e2e(
     rhel_insights_vm,
@@ -105,7 +105,7 @@ def test_iop_recommendations_e2e(
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('N-1')
+@pytest.mark.rhel_ver_match(r'^(?![78]).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_iop_recommendations_remediate_multiple_hosts(
     rhel_insights_vms,
@@ -179,7 +179,7 @@ def test_iop_recommendations_remediate_multiple_hosts(
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('N-1')
+@pytest.mark.rhel_ver_match(r'^(?![78]).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_iop_recommendations_host_details_e2e(
     rhel_insights_vm,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20155

Update pytest marker for fips testing