### PR TITLE
Add validator and default value for IoP image_paths setting

### DIFF
--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -330,7 +330,12 @@ VALIDATORS = dict(
         ),
         Validator('report_portal.fail_threshold', default=20),
     ],
-    rh_cloud=[Validator('rh_cloud.token', required=True)],
+    rh_cloud=[
+        Validator('rh_cloud.token', required=True),
+        Validator(
+            'rh_cloud.iop_advisor_engine.image_paths', default={}, apply_default_on_none=True
+        ),
+    ],
     repos=[
         Validator(
             'repos.rhel6_os',


### PR DESCRIPTION
### Problem Statement

Error when `rh_cloud.iop_advisor_engine.image_paths` is present but empty:

```
pytest_fixtures/component/rh_cloud.py:31: in module_target_sat_insights
    return module_target_sat if hosted_insights else request.getfixturevalue('module_satellite_iop')
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../lib64/python3.12/site-packages/pytest_asyncio/plugin.py:733: in pytest_fixture_setup
    return (yield)
            ^^^^^
pytest_fixtures/core/sat_cap_factory.py:240: in module_satellite_iop
    deploy_args = get_iop_deploy_args()
                  ^^^^^^^^^^^^^^^^^^^^^
pytest_fixtures/core/sat_cap_factory.py:229: in get_iop_deploy_args
    for service, path in settings.rh_cloud.iop_advisor_engine.image_paths.items()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: 'NoneType' object has no attribute 'items'
```

### Solution

Add validator to set default value for `image_paths` to be an empty dictionary.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->