### PR TITLE
[6.15.z] update operating system Root Password Hash as per fips enabled/disabled

### DIFF
--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -35,7 +35,7 @@ def test_positive_end_to_end(session, module_org, module_location, target_sat):
     minor_version = gen_string('numeric', 2)
     description = gen_string('alpha')
     family = 'Red Hat'
-    hash = HASH_TYPE['md5']
+    hash = HASH_TYPE['sha256'] if target_sat.is_fips_enabled() else HASH_TYPE['md5']
     architecture = target_sat.api.Architecture().create()
     ptable = target_sat.api.PartitionTable(
         organization=[module_org], location=[module_location], os_family='Redhat'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20169

### Problem Statement
The Root Password hash type MD5 is not allowed when FIPS mode is enabled while creating an operating system.

### Solution
Updating the automation to ensure it selects the appropriate Root Password Hash based on whether FIPS mode is enabled or disabled.