### PR TITLE
[6.16.z] [6.17.z] mqtt capsule lce idempotent (#19745)

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -88,6 +88,16 @@ def assert_job_invocation_status(sat, invocation_command_id, client_hostname, st
         ) from err
 
 
+def ensure_capsule_has_lifecycle_environment(capsule, activation_key):
+    """Ensure the capsule has the lifecycle environment from the activation key."""
+    if activation_key.environment.id not in [
+        env['id'] for env in capsule.nailgun_capsule.lifecycle_environments
+    ]:
+        capsule.nailgun_capsule.content_add_lifecycle_environment(
+            data={'environment_id': activation_key.environment.id}
+        )
+
+
 class TestRemoteExecution:
     """Implements job execution tests in CLI."""
 
@@ -408,15 +418,12 @@ class TestRemoteExecution:
             }
         )
         assert_job_invocation_result(module_target_sat, invocation_command['id'], client.hostname)
+
         # check the file owner
         result = client.execute(
             f'''stat -c '%U' /home/{username}/{filename}''',
         )
-        # assert the file is owned by the effective user
         assert username == result.stdout.strip('\n')
-        result = client.execute(
-            f'''stat -c '%G' /home/{username}/{filename}''',
-        )
 
     @pytest.mark.parametrize(
         'multi_setting_update',
@@ -1181,6 +1188,7 @@ class TestPullProviderRex:
                 'location-ids': smart_proxy_location.id,
             }
         )
+        ensure_capsule_has_lifecycle_environment(module_capsule_configured_mqtt, module_ak_with_cv)
         # register host with rex, enable client repo, install katello-agent
         result = client.register(
             module_org,
@@ -1276,6 +1284,7 @@ class TestPullProviderRex:
                 'location-ids': smart_proxy_location.id,
             }
         )
+        ensure_capsule_has_lifecycle_environment(module_capsule_configured_mqtt, module_ak_with_cv)
         # register host with pull provider rex
         result = client.register(
             module_org,
@@ -1384,6 +1393,7 @@ class TestPullProviderRex:
                 'location-ids': smart_proxy_location.id,
             }
         )
+        ensure_capsule_has_lifecycle_environment(module_capsule_configured_mqtt, module_ak_with_cv)
         # register host with pull provider rex (SAT-1677)
         result = client.register(
             module_org,
@@ -1504,6 +1514,7 @@ class TestPullProviderRex:
                 'location-ids': smart_proxy_location.id,
             }
         )
+        ensure_capsule_has_lifecycle_environment(module_capsule_configured_mqtt, module_ak_with_cv)
         result = client.register(
             module_org,
             smart_proxy_location,
@@ -1592,6 +1603,7 @@ class TestPullProviderRex:
                 'location-ids': smart_proxy_location.id,
             }
         )
+        ensure_capsule_has_lifecycle_environment(module_capsule_configured_mqtt, module_ak_with_cv)
         # register host with pull provider rex (SAT-1677)
         result = client.register(
             module_org,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20227

Cherry pick of #19745 into 6..17.z

The fix was originally merged only into master and 6.18.z. Same failure appeared in Interop test results in 6.17 and 6.16, so it needs to be fixed in both