### PR TITLE
Fix sftp_write in upload_sso_entity

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2765,12 +2765,7 @@ class SSOHost(Host):
         """
         with open(entity_name, "w") as file:
             json.dump(json_content, file)
-        # Before uploading a file, remove the file of the same name. In sftp_write,
-        # if uploading a file of length n when there was already uploaded a file with
-        # the same name of length m, for n<m, only first n characters are replaced by
-        # the characters in new file and the rest is left as it is.
-        self.execute(f'rm {entity_name}')
-        self.session.sftp_write(entity_name)
+        self.session.sftp_write(entity_name, entity_name)
 
     def create_mapper(self, json_content, client_id):
         """Helper method to create the RH-SSO Client Mapper"""


### PR DESCRIPTION
This PR should fix tests of Authentication component which failed on AssetionError in  "update_client_configuration". The function failed due to missing configuration file. The file is missing because of following problem.

Calling function upload_sso_entity results in creating file named "None" instead of the name specified by entity_name parameter. This is probably caused by recent changes in broker.

Providing both source and destination parameter fixes the issue.
see sftp_write function:
https://github.com/SatelliteQE/broker/blob/932ad8e23f5d23dfbe0bb29a7e0b695e9d87cbeb/broker/session.py#L152

Removing the original file before upload is no longer needed thanks to this fix: https://github.com/SatelliteQE/broker/pull/269
