### PR TITLE
Add test case verifying duplicate tag removal

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -775,7 +775,7 @@ class TestPodman:
         :Verifies: SAT-38954
         """
         image_name = 'fedora'
-        image_tag = f"{image_name}:test_tag"
+        image_tag = 'test_tag'
         image_1 = f'{image_name}:latest'
         image_2 = f'{image_name}:41'
         assert (
@@ -791,7 +791,9 @@ class TestPodman:
         image_2_id = module_target_sat.execute(f'podman images {image_2} -q')
         assert image_2_id
         # Podman pushes require lowercase org and product labels
-        distribution_path = f'{(module_org.label)}/{(module_product.label)}/{image_tag}'.lower()
+        distribution_path = (
+            f'{(module_org.label)}/{(module_product.label)}/{image_name}:{image_tag}'.lower()
+        )
         # Push both repos
         creds = f'{settings.server.admin_username}:{settings.server.admin_password}'
         result = module_target_sat.execute(


### PR DESCRIPTION
### Problem Statement
When podman containers were pushed to the same repo, with the same tag, duplicate tags weren't removed, leading to multiple containers with the same tag.

### Solution
This adds a test to verify the new deduplication behavior. This also moves this test, and others in the "TestPodman" class within test_docker.py into the ContainerImageManagement component, instead of the Repositories component, which should encompass these type of tests.

### Related Issues
https://issues.redhat.com/browse/SAT-38954

### PRT
```
trigger: test-robottelo
pytest: tests/foreman/api/test_docker.py -k 'test_podman_push_existing_tag'
```
