### PR TITLE
[6.18.z] Bump fastmcp from 2.13.0.2 to 2.13.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ broker[satlab,docker,ssh2_python]==0.7.0
 cryptography==43.0.3
 deepdiff==8.6.1
 dynaconf[vault]==3.2.11
-fastmcp==2.13.0.1
+fastmcp==2.13.1
 fauxfactory==3.1.2
 jinja2==3.1.6
 manifester==0.2.13


### PR DESCRIPTION
### Problem Statement
fastmcp dependancy isn't updated 

### Solution
Fixes https://github.com/SatelliteQE/robottelo/issues/20269

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->