### PR TITLE
[6.16.z] docker repository name doesn't support html tags

### DIFF
--- a/robottelo/utils/datafactory.py
+++ b/robottelo/utils/datafactory.py
@@ -281,7 +281,6 @@ def valid_docker_repository_names():
         gen_string('latin1', random.randint(1, 255)),
         gen_string('numeric', random.randint(1, 255)),
         gen_string('utf8', random.randint(1, 85)),
-        gen_string('html', random.randint(1, 85)),
     ]
 
 

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -66,7 +66,7 @@ class TestFilteredDataPoint:
             assert len(datafactory.valid_org_names_list()) == 7
             assert len(datafactory.valid_usernames_list()) == 5
             assert len(datafactory.valid_cron_expressions()) == 4
-            assert len(datafactory.valid_docker_repository_names()) == 7
+            assert len(datafactory.valid_docker_repository_names()) == 6
 
     @mock.patch('robottelo.utils.datafactory.gen_string')
     def test_generate_strings_list_remove_str(self, gen_string, run_one_datapoint):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20150

### Problem Statement
Docker repository creation with html tags is not supported, test failing with error 
```
Could not create the repository:
  Validation failed: Container repository name invalid container image name"
```

### Solution
removed html name generation from robottelo>utils>datafactory.py

### Related Issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_repository.py -k 'test_positive_create_docker_repo_with_name'

```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->