### PR TITLE
[6.18.z] remove pit marker for azure and gce provider

### DIFF
--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -247,7 +247,6 @@ class TestAzureRMHostProvisioningTestCase:
 
     @pytest.mark.e2e
     @pytest.mark.upgrade
-    @pytest.mark.pit_server
     @pytest.mark.parametrize('sat_azure', ['sat'], indirect=True)
     def test_positive_azurerm_host_provisioned(self, class_host_ft, azureclient_host):
         """Host can be provisioned on AzureRM

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -220,7 +220,6 @@ class TestGCEHostProvisioningTestCase:
         return googleclient.get_vm(name='{}'.format(self.fullhostname.replace('.', '-')))
 
     @pytest.mark.e2e
-    @pytest.mark.pit_server
     @pytest.mark.skipif(
         (is_open('SAT-27997')),
         reason='Google CR APIs failing',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20297

Removing the PIT marker for these tests as they do not provide any additional testing benefit on PIT. On the server side, we are not verifying any packages for the el9 client, and these are purely provisioning-related tests, which are already covered in non-PIT scenarios. This has been discussed with the team, and we are removing these tests from PIT accordingly.