### PR TITLE
New All Hosts Features - Manage SystemPurpose, Manage Traces

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -3699,6 +3699,8 @@ def test_positive_all_hosts_manage_system_purpose(
                 task_status = module_target_sat.api.ForemanTask(id=task_result[0].id).poll()
                 assert task_status['result'] == 'success', f'Task failed for {host.hostname}'
 
+        wait_for_system_purpose_update_tasks()
+
         # Verify system purpose attributes were set correctly
         verify_system_purpose_via_api(
             module_target_sat,


### PR DESCRIPTION
### Problem statement
Provide coverage for new 6.19 features that are part of EPIC `[Part 4] - New All Hosts page - Complete the top actions and eliminate some AngularJS pages`
 - https://issues.redhat.com/browse/SAT-35464 (`As a user I want to be able to change the system purpose of multiple hosts`)
- https://issues.redhat.com/browse/SAT-35465 (`As a user I want to be able to manage host tracer of multiple hosts`)


### Solution
New tests `test_positive_all_hosts_manage_system_purpose` and `test_positive_all_hosts_manage_traces`.

### Additional info
New fixture providing 2 tracer hosts is added too.

Both Need:
https://github.com/SatelliteQE/airgun/pull/2214

`test_positive_all_hosts_manage_system_purpose`  needs https://github.com/Katello/katello/pull/11549

`test_positive_all_hosts_manage_system_purpose` needs https://github.com/Katello/katello/pull/11547 

### PRT Examples
SystemPurpose
<img width="293" height="43" alt="image" src="https://github.com/user-attachments/assets/faea8568-77a6-4a2a-afa4-3e3609954575" />
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_positive_all_hosts_manage_system_purpose"
airgun: 2214
Katello:
    katello: 11549
```

Tracer
<img width="236" height="80" alt="image" src="https://github.com/user-attachments/assets/cd8bb1d0-68e4-4e21-bb02-ef99bac6561f" />
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_positive_all_hosts_manage_traces"
airgun: 2214
Katello:
    katello: 11547
```