### PR TITLE
Extend test_pulp_href_prn_mapping with environment repos

### DIFF
--- a/tests/foreman/cli/test_pulp.py
+++ b/tests/foreman/cli/test_pulp.py
@@ -37,6 +37,10 @@ def test_pulp_href_prn_mapping(table, target_sat, module_prn_content_setup):
 
     :expectedresults:
         All pulp_prn values match the expected format based on pulp_href.
+
+    :Verifies: SAT-37807, SAT-40415
+
+    :BlockedBy: SAT-40415
     """
     records = target_sat.query_db(
         f'SELECT {table["href_key"]}, {table["prn_key"]} FROM {table["name"]} '


### PR DESCRIPTION
### Problem Statement
When a repository is published in a CV, new cloned "pulp repository" entities (environment repos) are created for each lifecycle environment, as well as some other entities like errata. They need to have their PRNs filled too and it should be tested. We already have a test case for PRNs check, we just need to extend it with the CV bits.

Currently there is a bug opened for the CV bits specifically (see the related issue bellow).


### Solution
This PR proposes such an extension.


### Related Issues
https://issues.redhat.com/browse/SAT-40415 


### PRT test Cases example
Not applicable (`:BlockedBy: 40415`) until the issue is resolved