### PR TITLE
Move IoP tests to Insights-Advisor or Insights-Vulnerability components

### DIFF
--- a/tests/foreman/api/test_rhcloud_iop.py
+++ b/tests/foreman/api/test_rhcloud_iop.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: RHCloud
+:CaseComponent: Insights-Advisor
 
 :Team: Proton
 

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -97,12 +97,6 @@ def test_positive_create_update_delete(module_org, module_location, target_sat):
     indirect=True,
     ids=['auth_http_proxy', 'unauth_http_proxy'],
 )
-@pytest.mark.parametrize(
-    'module_target_sat_insights',
-    [True, False],
-    indirect=True,
-    ids=['hosted', 'local'],
-)
 def test_insights_client_registration_with_http_proxy(
     module_target_sat_insights,
     setup_http_proxy,
@@ -120,12 +114,12 @@ def test_insights_client_registration_with_http_proxy(
         1. Satellite with Default HTTP Proxy set.
 
     :steps:
-        1. Register a host with satellite.
-        2. Register host with insights.
-        3. Try insights-client register/unregister/test-connection/status
+        1. Register a Host with Satellite.
+        2. Register host with hosted Red Hat Lightspeed.
+        3. Verify `insights-client --(register|unregister|test-connection|status)`
 
     :expectedresults:
-        1. insights-client register/unregister/test-connection/status works with http proxy set.
+        1. `insights-client` commands work when Satellite has Default HTTP Proxy set.
 
     :BZ: 1959932
 

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -258,3 +258,62 @@ def test_disable_enable_iop(satellite_iop, module_sca_manifest, rhel_contenthost
 
     result = host.execute('insights-client')
     assert result.status == 0, 'insights-client upload failed'
+
+
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('N-2')
+@pytest.mark.parametrize(
+    'use_ip',
+    [False, True],
+    ids=['hostname', 'ip'],
+)
+@pytest.mark.parametrize(
+    'setup_http_proxy',
+    [True, False],
+    indirect=True,
+    ids=['auth_http_proxy', 'unauth_http_proxy'],
+)
+@pytest.mark.parametrize(
+    'module_target_sat_insights',
+    [False],
+    ids=['local'],
+    indirect=True,
+)
+def test_insights_client_registration_with_http_proxy(
+    module_target_sat_insights,
+    setup_http_proxy,
+    rhel_contenthost,
+    rhcloud_activation_key,
+    rhcloud_manifest_org,
+):
+    """Verify that insights-client registration work with HTTP Proxy.
+
+    :id: 6ab0842e-9e8b-4d9e-aed4-b183f7e8f44d
+
+    :parametrized: yes
+
+    :setup:
+        1. Satellite with Default HTTP Proxy set.
+
+    :steps:
+        1. Register a Host with Satellite.
+        2. Register host with IoP.
+        3. Verify `insights-client --(register|unregister|test-connection|status)`
+
+    :expectedresults:
+        1. `insights-client` commands work when Satellite has Default HTTP Proxy set.
+
+    :BZ: 1959932
+
+    :customerscenario: true
+    """
+    rhel_contenthost.configure_insights_client(
+        module_target_sat_insights,
+        rhcloud_activation_key,
+        rhcloud_manifest_org,
+        f"rhel{rhel_contenthost.os_version.major}",
+    )
+    assert rhel_contenthost.execute('insights-client --register').status == 0
+    assert rhel_contenthost.execute('insights-client --test-connection').status == 0
+    assert rhel_contenthost.execute('insights-client --status').status == 0
+    assert rhel_contenthost.execute('insights-client --unregister').status == 0

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: RHCloud
+:CaseComponent: Insights-Vulnerability
 
 :Team: Proton
 

--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: RHCloud
+:CaseComponent: Insights-Advisor
 
 :Team: Proton
 


### PR DESCRIPTION
### Problem Statement

- IoP tests will use the new `Insights-Advisor` and `Insights-Vulnerability` components

### Solution

- Update the `CaseComponent` on existing IoP tests, and move any IoP tests out of mixed-component modules and into separate IoP-only modules.

### Related Issues

SAT-36167

### Test results

Before:

```
$ pytest --co -q --component "Insights-Advisor,Insights-Vulnerability" tests/foreman/
tests/foreman/cli/test_rhcloud_iop.py::test_positive_install_iop_custom_certs[rhel10-ipv6]
tests/foreman/cli/test_rhcloud_iop.py::test_disable_enable_iop[rhel10-ipv6]
```

After:

```
$ pytest --co -q --component "Insights-Advisor,Insights-Vulnerability" tests/foreman/
tests/foreman/api/test_rhcloud_iop.py::test_positive_iop_inventory_tags_present[rhel10-ipv4-local]
tests/foreman/api/test_rhcloud_iop.py::test_positive_iop_inventory_tags_present[rhel10_fips-ipv4-local]
tests/foreman/api/test_rhcloud_iop.py::test_positive_iop_inventory_tags_present[rhel7-ipv4-local]
tests/foreman/api/test_rhcloud_iop.py::test_positive_iop_inventory_tags_present[rhel7_fips-ipv4-local]
tests/foreman/api/test_rhcloud_iop.py::test_positive_iop_inventory_tags_present[rhel8-ipv4-local]
tests/foreman/api/test_rhcloud_iop.py::test_positive_iop_inventory_tags_present[rhel8_fips-ipv4-local]
tests/foreman/api/test_rhcloud_iop.py::test_positive_iop_inventory_tags_present[rhel9-ipv4-local]
tests/foreman/api/test_rhcloud_iop.py::test_positive_iop_inventory_tags_present[rhel9_fips-ipv4-local]

tests/foreman/cli/test_rhcloud_iop.py::test_positive_install_iop_custom_certs[rhel10-ipv4]
tests/foreman/cli/test_rhcloud_iop.py::test_disable_enable_iop[rhel10-ipv4]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel10-ipv4-local-auth_http_proxy-hostname]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel10-ipv4-local-auth_http_proxy-ip]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel10-ipv4-local-unauth_http_proxy-hostname]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel10-ipv4-local-unauth_http_proxy-ip]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel8-ipv4-local-auth_http_proxy-hostname]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel8-ipv4-local-auth_http_proxy-ip]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel8-ipv4-local-unauth_http_proxy-hostname]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel8-ipv4-local-unauth_http_proxy-ip]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel9-ipv4-local-auth_http_proxy-hostname]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel9-ipv4-local-auth_http_proxy-ip]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel9-ipv4-local-unauth_http_proxy-hostname]
tests/foreman/cli/test_rhcloud_iop.py::test_insights_client_registration_with_http_proxy[rhel9-ipv4-local-unauth_http_proxy-ip]

tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_rhcloud_insights_vulnerabilities_e2e[rhel10-ipv4-local]

tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_e2e[rhel10-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_e2e[rhel10_fips-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_e2e[rhel9-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_e2e[rhel9_fips-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_remediate_multiple_hosts[rhel10-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_remediate_multiple_hosts[rhel10_fips-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_remediate_multiple_hosts[rhel9-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_remediate_multiple_hosts[rhel9_fips-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_host_details_e2e[rhel10-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_host_details_e2e[rhel10_fips-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_host_details_e2e[rhel9-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_host_details_e2e[rhel9_fips-ipv4-local]
tests/foreman/ui/test_rhcloud_iop.py::test_rhcloud_inventory_disabled_local_insights[local]
```

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->