### PR TITLE
verification of container content page synced tab

### DIFF
--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -287,11 +287,7 @@ def test_positive_verify_synced_container_image_tags(
         if hasattr(matching_api_tag, 'manifest') and 'digest' in matching_api_tag.manifest:
             api_manifest_digest = matching_api_tag.manifest['digest']
             ui_manifest_digest = manifest_list_row.get('Manifest digest', '')
-            # Normalize digests by removing 'sha256:' prefix if present for comparison
-            # Docker digests may be displayed with or without the 'sha256:' prefix
-            api_digest_normalized = api_manifest_digest.replace('sha256:', '')
-            ui_digest_normalized = ui_manifest_digest.replace('sha256:', '')
-            # Assert exact match after normalization
-            assert api_digest_normalized == ui_digest_normalized, (
+            # Assert exact match - digests should be in the same format
+            assert api_manifest_digest == ui_manifest_digest, (
                 f'Manifest digest from API ({api_manifest_digest}) should match UI ({ui_manifest_digest})'
             )


### PR DESCRIPTION
### Problem Statement
6.19.0 Feature Story https://issues.redhat.com/browse/SAT-38202
Verify expandable table for Synced image tags in the Synced images tab.

### Solution
Added airgun support along with newly written test case 
https://github.com/SatelliteQE/airgun/pull/2215

### Related Issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_containerimagetag.py -k 'test_positive_verify_synced_container_image_tags'
airgun: 2215
Katello:
    katello: 11538
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->