### PR TITLE
[6.18.z] CLI IoP test fixes

### DIFF
--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -72,11 +72,10 @@ def test_positive_install_iop_custom_certs(
     host = rhel_contenthost
     iop_settings = settings.rh_cloud.iop_advisor_engine
 
-    # Set IPv6 system proxy on Satellite, to reach container registry
-    satellite.enable_ipv6_system_proxy()
+    # Satellite + IoP installation
 
-    # Set IPv6 dnf proxy on Content Host, to install insights-client from non-Satellite source
-    host.enable_ipv6_dnf_proxy()
+    # Set IPv6 proxy for shell commands
+    satellite.enable_ipv6_system_proxy()
 
     # Install satellite packages
     satellite.download_repofile(
@@ -86,7 +85,6 @@ def test_positive_install_iop_custom_certs(
     )
     satellite.register_to_cdn()
     satellite.execute('dnf -y update')
-    satellite.execute('dnf -y install podman')
     satellite.install_satellite_or_capsule_package()
 
     # Set up firewall
@@ -105,6 +103,9 @@ def test_positive_install_iop_custom_certs(
 
     result = satellite.execute('firewall-cmd --runtime-to-permanent')
     assert result.status == 0
+
+    # Set IPv6 proxy for podman to pull images
+    satellite.enable_ipv6_podman_proxy()
 
     # Log in to container registry
     result = satellite.execute(
@@ -152,6 +153,11 @@ def test_positive_install_iop_custom_certs(
         auto_attach=False,
     ).create()
 
+    # Host setup
+
+    # Set IPv6 proxy on Content Host for (non-Satellite) dnf repos
+    host.enable_ipv6_dnf_proxy()
+
     host.configure_rex(satellite=satellite, org=org, register=False)
     host.configure_insights_client(
         satellite=satellite,
@@ -160,6 +166,7 @@ def test_positive_install_iop_custom_certs(
         rhel_distro=f"rhel{host.os_version.major}",
     )
 
+    # Verify insights-client upload
     result = host.execute('insights-client')
     assert result.status == 0, 'insights-client upload failed'
 
@@ -217,6 +224,9 @@ def test_disable_enable_iop(satellite_iop, module_sca_manifest, rhel_contenthost
     result = satellite.execute(command, timeout='10m')
     assert result.status == 0, 'Failed to disable IoP'
 
+    result = satellite.execute('satellite-maintain service restart')
+    assert result.status == 0, 'Failed to restart Satellite services'
+
     result = satellite.execute('podman ps -a --noheading')
     assert result.stdout == '', 'Podman containers not removed'
 
@@ -238,25 +248,30 @@ def test_disable_enable_iop(satellite_iop, module_sca_manifest, rhel_contenthost
     # Verify insights-client re-registration
     result = host.execute('insights-client --status')
     assert 'Insights API says this machine is NOT registered.' in result.stdout, (
-        'insights-client still registered after disabling IoP'
+        'insights-client status check failed'
     )
 
-    result = host.execute('insights-client --register --force')
-    assert result.status == 0, 'Failed to re-register insights client'
+    result = host.execute('rm -f /etc/insights-client/machine-id; insights-client --register')
+    assert result.status == 0, 'Failed to register to Red Hat Lightspeed'
 
-    host.execute('insights-client --unregister')
+    result = host.execute('insights-client --unregister')
+    assert result.status == 0, 'Failed to unregister from Red Hat Lightspeed'
 
     # Re-enable IoP
     command = InstallerCommand(iop_ensure='present').get_command()
     result = satellite.execute(command, timeout='10m')
     assert result.status == 0, 'Failed to re-enable IoP'
 
+    result = satellite.execute('satellite-maintain service restart')
+    assert result.status == 0, 'Failed to restart Satellite services'
+
     result = satellite.execute('satellite-maintain service status -b')
     assert 'FAIL' not in result.stdout, 'Services not running'
     assert all(service in result.stdout for service in IOP_SERVICES), 'IoP services not enabled'
 
-    result = host.execute('insights-client --register --force')
-    assert result.status == 0, 'Failed to re-register insights client'
+    # Verify insights-client re-registration again
+    result = host.execute('rm -f /etc/insights-client/machine-id; insights-client --register')
+    assert result.status == 0, 'Failed to register to IoP'
 
     result = host.execute('insights-client')
     assert result.status == 0, 'insights-client upload failed'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20290

### Problem Statement

- `test_positive_install_iop_custom_certs` for IPv6 fails
- `insights-client` sometimes errors out after disabling / re-enabling IoP in `test_disable_enable_iop`

### Solution

- Add `satellite-maintain service restart` calls after disabling or re-enabling IoP
- Fix `test_positive_install_iop_custom_certs` for IPv6

### Related Issues

### PRT results

PRT job 13532:

```
14:09:17  tests/foreman/cli/test_rhcloud_iop.py ..                                 [100%]
[...]
14:09:17  ================= 2 passed, 22 warnings in 4102.40s (1:08:22) ==================
```

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->