### PR TITLE
Fix IDs in Hosts CLI tests

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -368,11 +368,13 @@ def test_positive_create_and_delete(target_sat, module_lce_library, module_publi
     assert f'{name}.{host.domain.read().name}' == new_host['name']
     assert new_host['organization']['name'] == host.organization.name
     assert (
-        new_host['content-information']['content-view-environments']['1']['cv-name']
+        new_host['content-information']['content-view-environments']['1']['content-view-name']
         == module_published_cv.name
     )
     assert (
-        new_host['content-information']['content-view-environments']['1']['le-name']
+        new_host['content-information']['content-view-environments']['1'][
+            'lifecycle-environment-name'
+        ]
         == module_lce_library.name
     )
     host_interface = target_sat.cli.HostInterface.info(
@@ -531,11 +533,13 @@ def test_positive_create_with_lce_and_cv(
         }
     )
     assert (
-        new_host['content-information']['content-view-environments']['1']['le-name']
+        new_host['content-information']['content-view-environments']['1'][
+            'lifecycle-environment-name'
+        ]
         == module_lce.name
     )
     assert (
-        new_host['content-information']['content-view-environments']['1']['cv-name']
+        new_host['content-information']['content-view-environments']['1']['content-view-name']
         == module_promoted_cv.name
     )
 
@@ -733,11 +737,15 @@ def test_positive_create_inherit_lce_cv(
         {'hostgroup-id': hostgroup.id, 'organization-id': module_org.id}
     )
     assert (
-        int(host['content-information']['content-view-environments']['1']['le-id'])
+        int(
+            host['content-information']['content-view-environments']['1'][
+                'lifecycle-environment-id'
+            ]
+        )
         == hostgroup.lifecycle_environment.id
     )
     assert (
-        int(host['content-information']['content-view-environments']['1']['cv-id'])
+        int(host['content-information']['content-view-environments']['1']['content-view-id'])
         == hostgroup.content_view.id
     )
 
@@ -851,12 +859,12 @@ def test_positive_list_with_nested_hostgroup(target_sat):
     logger.info(f'Host info: {host}')
     assert host['operating-system']['medium']['name'] == options.medium.name
     assert host['operating-system']['partition-table']['name'] == options.ptable.name  # inherited
-    assert int(host['content-information']['content-view-environments']['1']['le-id']) == int(
-        lce.id
-    )
-    assert int(host['content-information']['content-view-environments']['1']['cv-id']) == int(
-        content_view.id
-    )  # inherited
+    assert int(
+        host['content-information']['content-view-environments']['1']['lifecycle-environment-id']
+    ) == int(lce.id)
+    assert int(
+        host['content-information']['content-view-environments']['1']['content-view-id']
+    ) == int(content_view.id)  # inherited
 
 
 @pytest.mark.cli_host_create


### PR DESCRIPTION
### Problem statement
Some ids were changed, thus failing the tests.

### Solution
Change the ids

`le-id` -> `lifecycle-environment-id`
`cv-id` -> `content-view-id`

`le-name` -> `lifecycle-environment-name`
`cv-name` -> `content-view-name`

### Additional info
Affected tests:
`test_positive_list_with_nested_hostgroup`
`test_positive_create_and_delete`
`test_positive_create_with_lce_and_cv`
`test_positive_create_inherit_lce_cv`


### PRT Examples
<img width="267" height="39" alt="image" src="https://github.com/user-attachments/assets/51f63bcb-1334-4960-9e37-d47b31c7dde2" />

<img width="267" height="39" alt="image" src="https://github.com/user-attachments/assets/efb63a72-0dc1-463f-bb97-800aa3540251" />

<img width="267" height="39" alt="image" src="https://github.com/user-attachments/assets/86f0dede-5302-4fc2-ae92-cd6823de3f23" />

<img width="267" height="39" alt="image" src="https://github.com/user-attachments/assets/93f7155d-525a-4328-a117-bdd601034008" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k "test_positive_list_with_nested_hostgroup or test_positive_create_and_delete or test_positive_create_with_lce_and_cv or test_positive_create_inherit_lce_cv"
```