### PR TITLE
[6.18.z] Limit Capsule LB test parametrization to default RHEL only

### DIFF
--- a/tests/foreman/destructive/test_capsule_loadbalancer.py
+++ b/tests/foreman/destructive/test_capsule_loadbalancer.py
@@ -337,7 +337,7 @@ def test_loadbalancer_container(
     assert rhel_contenthost.execute('podman rmi -a').status == 0
 
 
-@pytest.mark.rhel_ver_match('N-2')
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_client_register_through_lb(
     loadbalancer_setup,
     rhel_contenthost,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20311

### Problem Statement
There is broken `ForemanProxy` test collection when `xdist` is used.
```
==================================== ERRORS ====================================
_____________________________ ERROR collecting gw0 _____________________________
Different tests were collected between gw1 and gw0. The difference is:
--- gw1

+++ gw0

@@ -6,11 +6,11 @@

 tests/foreman/destructive/test_capsule_loadbalancer.py::test_loadbalancer_install_package[rhel9-ipv4-rhel9-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_loadbalancer_container[rhel9-ipv4-rhel9-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel10-ipv4-rhel10-ipv4]
+tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel8-ipv4-rhel10-ipv4]
+tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel9-ipv4-rhel10-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel10-ipv4-rhel8-ipv4]
+tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel8-ipv4-rhel8-ipv4]
+tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel9-ipv4-rhel8-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel10-ipv4-rhel9-ipv4]
-tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel8-ipv4-rhel10-ipv4]
-tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel8-ipv4-rhel8-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel8-ipv4-rhel9-ipv4]
-tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel9-ipv4-rhel10-ipv4]
-tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel9-ipv4-rhel8-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel9-ipv4-rhel9-ipv4]
```
Breakage is caused by Capsule LB test `test_client_register_through_lb` that is parametrized over multiple RHEL versions and different xdist workers collects parametrized tests sorted differently.


### Solution
Limit Capsule LB test parametrization to default RHEL only as running this very costly setup for every client  RHEL version is not necessary. Registration of whole client RHEL version matrix is already covered by standard component(s) testing.

### Related Issues
[SAT-39940](https://issues.redhat.com/browse/SAT-39940)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->