### PR TITLE
[6.16.z] Limit Capsule LB test parametrization to default RHEL only

### DIFF
--- a/tests/foreman/destructive/test_capsule_loadbalancer.py
+++ b/tests/foreman/destructive/test_capsule_loadbalancer.py
@@ -251,7 +251,7 @@ def test_loadbalancer_install_package(
     assert result.status == 0
 
 
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_client_register_through_lb(
     loadbalancer_setup,
     rhel_contenthost,


### PR DESCRIPTION
**Manual** Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20311
(cherry picked from commit 406413a7ec34a6a6af3e4d10dccd6cdf3963b550)

### Problem Statement
There is broken `ForemanProxy` test collection when `xdist` is used.
```
==================================== ERRORS ====================================
_____________________________ ERROR collecting gw0 _____________________________
Different tests were collected between gw1 and gw0. The difference is:
--- gw1

+++ gw0

@@ -6,10 +6,10 @@

 tests/foreman/destructive/test_capsule_loadbalancer.py::test_loadbalancer_install_package[rhel9-ipv4-rhel9-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel10-ipv4-rhel10-ipv4]
+tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel8-ipv4-rhel10-ipv4]
+tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel9-ipv4-rhel10-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel10-ipv4-rhel8-ipv4]
+tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel8-ipv4-rhel8-ipv4]
+tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel9-ipv4-rhel8-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel10-ipv4-rhel9-ipv4]
-tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel8-ipv4-rhel10-ipv4]
-tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel8-ipv4-rhel8-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel8-ipv4-rhel9-ipv4]
-tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel9-ipv4-rhel10-ipv4]
-tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel9-ipv4-rhel8-ipv4]
 tests/foreman/destructive/test_capsule_loadbalancer.py::test_client_register_through_lb[rhel9-ipv4-rhel9-ipv4]
```
Breakage is caused by Capsule LB test `test_client_register_through_lb` that is parametrized over multiple RHEL versions and different xdist workers collects parametrized tests sorted differently.


### Solution
Limit Capsule LB test parametrization to default RHEL only as running this very costly setup for every client  RHEL version is not necessary. Registration of whole client RHEL version matrix is already covered by standard component(s) testing.

### Related Issues
[SAT-39940](https://issues.redhat.com/browse/SAT-39940)
#20328
