### PR TITLE
Add initial tests to validate foremanctl

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from robottelo.config import settings
+
 pytest_plugins = [
     # Plugins
     'pytest_plugins.auto_vault',
@@ -94,3 +96,14 @@ def pytest_runtest_makereport(item, call):
     # be "setup", "call", "teardown"
 
     setattr(item, "report_" + report.when, report)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, nextitem):
+    """Set version source to upstream for tests marked with foremanctl."""
+    if item.get_closest_marker('foremanctl'):
+        settings.set('server.version.source', 'upstream')
+        yield
+        settings.set('server.version.source', 'internal')
+    else:
+        yield

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -25,6 +25,7 @@ def pytest_configure(config):
         "ldap: Tests related to ldap authentication",
         "no_compose : Skip the marked sanity test for nightly compose",
         "network: Restrict test to specific network environments",
+        "foremanctl: Tests that require foremanctl",
     ]
     markers.extend(module_markers())
     for marker in markers:

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -14,7 +14,11 @@ VALIDATORS = dict(
         Validator('server.hostname', is_type_of=str),
         Validator('server.hostnames', must_exist=True, is_type_of=list),
         Validator('server.version.release', must_exist=True),
-        Validator('server.version.source', default='internal', is_in=['internal', 'ga', 'nightly']),
+        Validator(
+            'server.version.source',
+            default='internal',
+            is_in=['internal', 'ga', 'nightly', 'upstream'],
+        ),
         Validator('server.version.rhel_version', must_exist=True, cast=str),
         Validator(
             'server.xdist_behavior', must_exist=True, is_in=['run-on-one', 'balance', 'on-demand']

--- a/tests/foreman/installer/test_install_foremanctl.py
+++ b/tests/foreman/installer/test_install_foremanctl.py
@@ -1,0 +1,124 @@
+"""Smoke tests to check installation health
+
+:Requirement: Installation
+
+:CaseAutomation: Automated
+
+:CaseComponent: Installation
+
+:Team: Rocket
+
+:CaseImportance: Critical
+
+"""
+
+from broker import Broker
+import pytest
+
+from robottelo.config import settings
+from robottelo.hosts import Satellite
+from robottelo.utils.issue_handlers import is_open
+
+pytestmark = [pytest.mark.foremanctl, pytest.mark.build_sanity, pytest.mark.upgrade]
+
+SATELLITE_SERVICES = [
+    'candlepin',
+    'dynflow-sidekiq@orchestrator',
+    'dynflow-sidekiq@worker',
+    'dynflow-sidekiq@worker-hosts-queue',
+    'foreman-proxy',
+    'foreman',
+    'httpd',
+    'postgresql',
+    'pulp-api',
+    'pulp-content',
+    'pulp-worker@*',
+    'redis',
+]
+
+
+def common_sat_install_assertions(satellite):
+    # no errors/failures in journald
+    result = satellite.execute(
+        r'journalctl --quiet --no-pager --boot --grep ERROR -u "dynflow-sidekiq*" -u "foreman-proxy" -u "foreman" -u "httpd" -u "postgresql" -u "pulp-api" -u "pulp-content" -u "pulp-worker*" -u "redis" -u "candlepin"'
+    )
+    if is_open('SAT-21086'):
+        assert not list(filter(lambda x: 'PG::' not in x, result.stdout.splitlines()))
+    else:
+        assert not result.stdout
+    # no errors/failures in /var/log/httpd/*
+    result = satellite.execute(r'grep -iR "error" /var/log/httpd/*')
+    assert not result.stdout
+    httpd_log = satellite.execute('journalctl --unit=httpd')
+    assert 'WARNING' not in httpd_log.stdout
+
+
+@pytest.fixture(scope='module')
+def module_sat_ready_rhel(request):
+    with Broker(
+        workflow=settings.server.deploy_workflows.os,
+        deploy_rhel_version=settings.server.version.rhel_version,
+        deploy_flavor=settings.flavors.default,
+        deploy_network_type=settings.server.network_type,
+        host_class=Satellite,
+    ) as sat:
+        sat.install_satellite_foremanctl(
+            enable_fapolicyd=(request.param == 'fapolicyd'), enable_fips=(request.param == 'fips')
+        )
+        yield sat
+
+
+@pytest.mark.first_sanity
+@pytest.mark.parametrize('module_sat_ready_rhel', ['default'], indirect=True)
+def test_satellite_installation_with_foremanctl(module_sat_ready_rhel):
+    """Run a basic Satellite installation
+
+    :id: 661206f3-2eec-403c-af26-3c5cadcd5769
+
+    :steps:
+        1. Get RHEL Host
+        2. Configure satellite repos
+        3. Install satellite using foremanctl
+        4. Run foremanctl deploy
+
+    :expectedresults:
+        1. foremanctl deploy runs successfully
+        2. no unexpected errors in logs
+    """
+    common_sat_install_assertions(module_sat_ready_rhel)
+
+
+@pytest.mark.parametrize('module_sat_ready_rhel', ['default'], indirect=True)
+@pytest.mark.parametrize('service', SATELLITE_SERVICES)
+def test_positive_check_installer_service_running(service, module_sat_ready_rhel):
+    """Check if all Satellite services is running
+
+    :id: 5389c174-7ab1-4e9d-b2aa-66d80fd6dc5h
+
+    :steps:
+        1. Verify a service is active with systemctl is-active
+
+    :expectedresults: All Satellite services are active
+    """
+    is_active = module_sat_ready_rhel.execute(f'systemctl is-active {service}')
+    status = module_sat_ready_rhel.execute(f'systemctl status {service}')
+    assert is_active.status == 0, status.stdout
+
+
+@pytest.mark.parametrize('module_sat_ready_rhel', ['default'], indirect=True)
+def test_positive_check_installer_hammer_ping(module_sat_ready_rhel):
+    """Check if hammer ping reports all services as ok
+
+    :id: 85fd4388-6d94-42f5-bed2-24be38e9f111
+
+    :steps:
+        1. Run the 'hammer ping' command on satellite.
+
+    :expectedresults: All services are active (running)
+    """
+    # check status reported by hammer ping command
+    result = module_sat_ready_rhel.execute('hammer ping')
+    assert result.status == 0
+    for line in result.stdout.split('\n'):
+        if 'Status' in line:
+            assert 'ok' in line


### PR DESCRIPTION
### Problem Statement
Missing coverage for new installer or foremanctl 

### Solution
Adding initial tests to validate foremanctl

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->