### PR TITLE
[6.18.z] Update jira issue in test_positive_verify_updated_fdi_image

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -470,7 +470,7 @@ def test_positive_verify_updated_fdi_image(target_sat):
 
     :expectedresults: Installed foreman-discovery-image is built on latest up-to-date RHEL
 
-    Verifies: SAT-24197, SAT-27541, SAT-34778
+    Verifies: SAT-24197, SAT-27541, SAT-34778, SAT-40503
 
     :customerscenario: true
 
@@ -481,7 +481,7 @@ def test_positive_verify_updated_fdi_image(target_sat):
     target_sat.execute('yum -y --disableplugin=foreman-protector install foreman-discovery-image')
 
     if target_sat.os_version.major == 9:
-        version = '9.5' if is_open('SAT-34778') else str(target_sat.os_version)
+        version = '9.6' if is_open('SAT-40503') else str(target_sat.os_version)
     elif target_sat.os_version.major == 8:
         version = str(target_sat.os_version)
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20340

### Problem Statement
SAT-34778 is fixed already and FDI is now based on RHEL 9.6, but SAT is on 9.7, so `test_positive_verify_updated_fdi_image` started to fail

### Solution
Update jira issue in test_positive_verify_updated_fdi_image to pass until SAT-40503 is fixed

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->