### PR TITLE
Rename local_advisor_enabled to iop_enabled

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -13,7 +13,7 @@ def enable_insights(host, satellite, org, activation_key):
         rhel_distro=f"rhel{host.os_version.major}",
     )
     # Sync inventory if using hosted Insights
-    if not satellite.local_advisor_enabled:
+    if not satellite.iop_enabled:
         satellite.generate_inventory_report(org)
         satellite.sync_inventory_status(org)
 

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -494,4 +494,4 @@ class IoPSetup:
 
         result = self.execute(command, timeout='30m')
         assert result.status == 0, f'Failed to configure IoP: {result.stdout}'
-        assert self.local_advisor_enabled
+        assert self.iop_enabled

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2712,8 +2712,8 @@ class Satellite(Capsule, SatelliteMixins):
         self.execute(f'sed -i "s/dry_run.*/dry_run = {str(safe).lower()}/g" /etc/pulp/cli.toml')
 
     @property
-    def local_advisor_enabled(self):
-        """Return boolean indicating whether local Insights advisor engine is enabled."""
+    def iop_enabled(self):
+        """Return boolean indicating whether IoP (local Red Hat Lightspeed) is enabled."""
         return self.api.RHCloud().advisor_engine_config()['use_iop_mode']
 
 

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -78,9 +78,7 @@ def get_exp_files(sat_maintain, skip_pulp=False):
     if not skip_pulp:
         expected_files = expected_files | CONTENT_FILES
     if type(sat_maintain) is Satellite:
-        expected_files = (
-            expected_files | IOP_FILES if sat_maintain.local_advisor_enabled else expected_files
-        )
+        expected_files = expected_files | IOP_FILES if sat_maintain.iop_enabled else expected_files
     return expected_files
 
 
@@ -458,7 +456,7 @@ def test_positive_backup_restore_satellite_iop(
     :Verifies: SAT-34508
     """
     instance = get_instance_name(sat_maintain)
-    assert sat_maintain.satellite.local_advisor_enabled
+    assert sat_maintain.satellite.iop_enabled
 
     # Make sure that the vmaas db has been synced successfully
 

--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -72,7 +72,7 @@ def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
         'sync plans: disabled',
         'cron jobs: not running',
     ]
-    local_advisor_enabled = sat_maintain.local_advisor_enabled
+    iop_enabled = sat_maintain.iop_enabled
 
     # Verify maintenance-mode status
     mm_status = sat_maintain.cli.MaintenanceMode.status()
@@ -87,7 +87,7 @@ def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
     assert mm_is_enabled.status == 1
     assert 'Maintenance mode is Off' in mm_is_enabled.stdout
 
-    if local_advisor_enabled:
+    if iop_enabled:
         timer_status = sat_maintain.cli.Service.status(
             options={'only': 'iop-service-vuln-vmaas-sync.timer'}
         )
@@ -107,7 +107,7 @@ def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
         data_yml = yaml.safe_load(f)
     assert len(enable_sync_ids) == len(data_yml[':default'][':sync_plans'][':disabled'])
 
-    if local_advisor_enabled:
+    if iop_enabled:
         assert 'All timers stopped' in mm_start.stdout
         timer_status = sat_maintain.cli.Service.status(
             options={'only': 'iop-service-vuln-vmaas-sync.timer'}
@@ -148,7 +148,7 @@ def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
         data_yml = yaml.safe_load(f)
     assert len(enable_sync_ids) == len(data_yml[':default'][':sync_plans'][':enabled'])
 
-    if local_advisor_enabled:
+    if iop_enabled:
         assert 'All timers started' in mm_stop.stdout
         timer_status = sat_maintain.cli.Service.status(
             options={'only': 'iop-service-vuln-vmaas-sync.timer'}

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -114,9 +114,7 @@ def test_positive_service_list(sat_maintain):
     assert result.status == 0
     if isinstance(sat_maintain, Satellite):
         services = (
-            SATELLITE_SERVICES + IOP_SERVICES
-            if sat_maintain.local_advisor_enabled
-            else SATELLITE_SERVICES
+            SATELLITE_SERVICES + IOP_SERVICES if sat_maintain.iop_enabled else SATELLITE_SERVICES
         )
     else:
         services = CAPSULE_SERVICES

--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -249,10 +249,10 @@ def test_iop_recommendations_host_details_e2e(
         )
 
 
-@pytest.mark.parametrize("module_target_sat_insights", [False], ids=["local"], indirect=True)
+# @pytest.mark.parametrize("module_target_sat_insights", [False], ids=["local"], indirect=True)
 def test_rhcloud_inventory_disabled_local_insights(module_target_sat_insights):
-    """Verify that the 'Insights > Inventory Upload' navigation item is not available
-    when the Satellite is configured to use a local advisor engine.
+    """Verify that the 'Red Hat Lightspeed > Inventory Upload' navigation item is not available
+    when the Satellite is configured to use IoP.
 
     :id: 84023ae9-7bc4-4332-9aaf-749d6c48c2d2
 


### PR DESCRIPTION
### Problem Statement

In Satellite 6.18 and later, IoP includes more than advisor, and `local_advisor_enabled` is a misleading name for the method that checks whether IoP is enabled.

### Solution

Rename `local_advisor_enabled` to `iop_enabled`.

### Related Issues

SAT-36167

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->