### PR TITLE
Block test_complete_sync_fixes_metadata on SAT-40499

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -1465,6 +1465,8 @@ class TestCapsuleContentManagement:
 
         :Verifies: SAT-28575
 
+        :BlockedBy: SAT-40499
+
         :customerscenario: true
 
         :setup:


### PR DESCRIPTION
### Problem Statement
https://issues.redhat.com/browse/SAT-40499 makes `test_complete_sync_fixes_metadata` fail via interference with docker repo sync (the reproduce condition is one docker repo, one another repo, sync both with `skip_metadata_check`).


### Solution
Block the test until the issue is resolved and use it for verification.


### Related Issues
https://issues.redhat.com/browse/SAT-40499


### PRT test Cases example
not applicable