### PR TITLE
Update the Hammer host information naming

### DIFF
--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -252,13 +252,15 @@ def test_positive_cli_end_to_end(function_sca_manifest, target_sat, rhel_content
 
     # check that content view matches what we passed
     assert (
-        content_host['content-information']['content-view-environments']['1']['cv-name']
+        content_host['content-information']['content-view-environments']['1']['content-view-name']
         == content_view['name']
     )
 
     # check that lifecycle environment matches
     assert (
-        content_host['content-information']['content-view-environments']['1']['le-name']
+        content_host['content-information']['content-view-environments']['1'][
+            'lifecycle-environment-name'
+        ]
         == lifecycle_environment['name']
     )
 


### PR DESCRIPTION
### Problem Statement
The test was failing because of recent changes in [hammer-cli-katello](https://github.com/Katello/hammer-cli-katello/pull/1008).

### Solution
Updating the changes with the most recent modification.