### PR TITLE
[6.17.z] Fix VMware UI e2e test

### DIFF
--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -592,7 +592,7 @@ def test_positive_provision_end_to_end(
     vmwareclient,
     target_sat,
     module_provisioning_rhel_content,
-    get_vmware_storagepod_summary_string,
+    get_vmware_datastore_summary_string,
 ):
     """Assign Ansible role to a Hostgroup and verify ansible role execution job is scheduled after a host is provisioned
 
@@ -616,7 +616,17 @@ def test_positive_provision_end_to_end(
     SELECTED_ROLE = 'theforeman.foreman_scap_client'
     host_name = gen_string('alpha').lower()
     guest_os_names = 'Red Hat Enterprise Linux 8 (64 bit)'
-    storage_data = {'storage': {'disks': [{'storage_pod': get_vmware_storagepod_summary_string}]}}
+    storage_data = {
+        'storage': {
+            'controller': VMWARE_CONSTANTS['scsicontroller'],
+            'disks': [
+                {
+                    'data_store': get_vmware_datastore_summary_string,
+                    'thin_provision': True,
+                }
+            ],
+        }
+    }
     network_data = {
         'network_interfaces': {
             'nic_type': VMWARE_CONSTANTS['network_interface_name'],
@@ -662,7 +672,8 @@ def test_positive_provision_end_to_end(
         request.addfinalizer(lambda: target_sat.provisioning_cleanup(host_fqdn))
         wait_for(
             lambda: session.host_new.get_host_statuses(host_fqdn)['Build']['Status']
-            != 'Pending installation',
+            != 'Pending installation'
+            and session.host_new.get_host_statuses(host_fqdn)['Execution']['Status'] != 'N/A',
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,
@@ -671,8 +682,7 @@ def test_positive_provision_end_to_end(
         )
         values = session.host_new.get_host_statuses(host_fqdn)
         assert values['Build']['Status'] == 'Installed'
-        if not is_open('SAT-34088'):
-            assert values['Execution']['Status'] == 'Last execution succeeded'
+        assert values['Execution']['Status'] == 'Last execution succeeded'
 
         # Verify SecureBoot is enabled on host after provisioning is completed successfully
         if pxe_loader.vm_firmware == 'uefi_secure_boot':
@@ -682,7 +692,6 @@ def test_positive_provision_end_to_end(
             provisioning_host.wait_for_connection()
             assert 'SecureBoot enabled' in provisioning_host.execute('mokutil --sb-state').stdout
 
-        if not is_open('SAT-34088'):
-            # Verify if assigned role is executed on the host, and correct host passwd is set
-            host = ContentHost(target_sat.api.Host().search(query={'host': host_name})[0].read().ip)
-            assert host.execute('yum list installed rubygem-foreman_scap_client').status == 0
+        # Verify if assigned role is executed on the host, and correct host passwd is set
+        host = ContentHost(target_sat.api.Host().search(query={'host': host_name})[0].read().ip)
+        assert host.execute('yum list installed foreman_scap_client_bash').status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20217

### Problem Statement
VMware UI end to end test is failing while asserting the job execution status which at time is either running or scheduled.

### Solution
Add wait_for or sleep and wait till the job is completed.