### PR TITLE
Fix CV test with permissions

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2859,18 +2859,19 @@ class TestContentView:
         :CaseImportance: Critical
         """
         password = gen_alphanumeric()
-        no_rights_user = module_target_sat.cli_factory.user({'password': password})
+        no_rights_user = module_target_sat.cli_factory.user(
+            {'organization-id': module_org.id, 'password': password}
+        )
         no_rights_user['password'] = password
-        org_id = module_target_sat.cli_factory.make_org()['id']
         for name in generate_strings_list(exclude_types=['cjk']):
             # test that user can't create
             with pytest.raises(CLIReturnCodeError):
                 module_target_sat.cli.ContentView.with_user(
                     no_rights_user['login'], no_rights_user['password']
-                ).create({'name': name, 'organization-id': org_id})
+                ).create({'name': name, 'organization-id': module_org.id})
             # test that user can't read
             con_view = module_target_sat.cli_factory.make_content_view(
-                {'name': name, 'organization-id': org_id}
+                {'name': name, 'organization-id': module_org.id}
             )
             with pytest.raises(CLIReturnCodeError):
                 module_target_sat.cli.ContentView.with_user(


### PR DESCRIPTION
### Problem Statement
The `test_negative_user_with_read_only_cv_permission` started to fail after the permission approach had been refactored in https://github.com/theforeman/foreman/pull/10701 - now the user (not only Role) needs to be member of the Organization holding the CV.
```
robottelo.exceptions.CLIReturnCodeError: CLIReturnCodeError(status=128, stderr='Could not find content_view resource with id 120. Potential missing permissions: view_content_views\n', msg='Command "content-view info" finished with status 128\nstderr contains:\nCould not find content_view resource with id 120. Potential missing permissions: view_content_views\n'
```

### Solution
Assign the user to the appropriate Org.


 ### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py -k 'test_negative_user_with_read_only_cv_permission or test_negative_user_with_no_create_view_cv_permissions'
```