### PR TITLE
Fix 3 tests providing users with Location scopes

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -2323,7 +2323,7 @@ def test_negative_readonly_user_actions(
 
 
 def test_negative_non_readonly_user_actions(
-    target_sat, content_view, module_org, function_role_with_org
+    target_sat, content_view, module_org, function_role_with_org, default_location
 ):
     """Attempt to view content views
 
@@ -2356,6 +2356,7 @@ def test_negative_non_readonly_user_actions(
     # create a user and assign the above created role
     target_sat.api.User(
         organization=[module_org],
+        location=[default_location],
         role=[function_role_with_org],
         login=user_login,
         password=user_password,

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2952,7 +2952,9 @@ class TestContentView:
                 {'organization-id': module_org.id}
             )
 
-    def test_positive_user_with_all_cv_permissions(self, module_org, module_target_sat):
+    def test_positive_user_with_all_cv_permissions(
+        self, module_org, default_location, module_target_sat
+    ):
         """A user with all content view permissions is able to create,
         read, modify, promote, publish content views
 
@@ -2973,7 +2975,11 @@ class TestContentView:
         )
         password = gen_string('alphanumeric')
         user = module_target_sat.cli_factory.user(
-            {'password': password, 'organization-ids': module_org.id}
+            {
+                'password': password,
+                'organization-ids': module_org.id,
+                'location-ids': default_location.id,
+            }
         )
         role = module_target_sat.cli_factory.make_role({'organization-ids': module_org.id})
         # note: the filters inherit role organizations

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -37,7 +37,7 @@ def function_role(target_sat):
 
 
 @pytest.fixture
-def function_user(target_sat, function_role, function_org):
+def function_user(target_sat, function_role, function_org, default_location):
     """Non-admin user with an empty role assigned."""
     password = gen_string('alphanumeric')
     user = target_sat.api.User(
@@ -45,6 +45,7 @@ def function_user(target_sat, function_role, function_org):
         password=password,
         role=[function_role],
         organization=[function_org],
+        location=[default_location],
     ).create()
     user.password = password
     yield user


### PR DESCRIPTION
### Problem Statement
https://github.com/theforeman/foreman/pull/10701 introduced change in access to the Foreman Tasks by non-admin users - they are required to be members of the task-specific location, or the Default one.

Additionally, if there are more Locations on the Satellite (quite common in CI), and no Location is assigned to a user during his creation, the user ends up without any Location assigned.

And finally, if such a user executes some actions like CV.publish, delete or FR.scan synchronously, nailgun or hammer tries to poll the particular task to wait for its completion. As result such an action fails, although the underlying task succeeds.

```
requests.exceptions.HTTPError: ('404 Client Error: Not Found for url: https://satellite.redhat.com:443/foreman_tasks/api/tasks/65e3aa9d-91ba-4b43-a884-9f44431189c6', {'error': {'message': "Resource task not found by id '65e3aa9d-91ba-4b43-a884-9f44431189c6'"}})
```
```
robottelo.exceptions.CLIReturnCodeError: CLIReturnCodeError(status=128, stderr="Could not publish the content view:\n  Resource task not found by id 'a2544035-2f7c-45ba-8359-3f1135e89864'\n", msg='Command "content-view publish" finished with status 128\nstderr contains:\nCould not publish the content view:\n  Resource task not found by id \'a2544035-2f7c-45ba-8359-3f1135e89864\'\n'
```


### Solution
Assign the non-admin user to the action-scoped or Default location.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py::TestContentView::test_positive_sub_host_with_restricted_user_perm_at_custom_loc tests/foreman/api/test_contentview.py::test_negative_non_readonly_user_actions tests/foreman/cli/test_contentview.py::TestContentView::test_positive_user_with_all_cv_permissions tests/foreman/cli/test_flatpak.py::test_CRUD_and_sync_flatpak_remote_with_permissions
```