### PR TITLE
Cherry-Pick #20314: Removed legacy host registration mechanism and added global registrat…

### DIFF
--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -279,7 +279,11 @@ def deploy_type_cli(
             {'id': virtwho_config_cli['id']}, output_format='base'
         )
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
+            script,
+            form_data_cli['hypervisor-type'],
+            debug=True,
+            org=org_module.label,
+            target_sat=target_sat,
         )
     elif deploy_type == 'organization-title':
         virtwho_config_cli['organization-title'] = org_module.title
@@ -291,7 +295,11 @@ def deploy_type_cli(
         else:
             command = get_configure_command_option(deploy_type, virtwho_config_cli, org_module.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
+            command,
+            form_data_cli['hypervisor-type'],
+            debug=True,
+            org=org_module.label,
+            target_sat=target_sat,
         )
     return hypervisor_name, guest_name
 
@@ -310,7 +318,11 @@ def deploy_type_api(
     if "id" in deploy_type:
         command = get_configure_command(virtwho_config_api.id, org_module.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data_api['hypervisor_type'], debug=True, org=org_module.label
+            command,
+            form_data_api['hypervisor_type'],
+            debug=True,
+            org=org_module.label,
+            target_sat=target_sat,
         )
     elif "script" in deploy_type:
         script = virtwho_config_api.deploy_script()
@@ -319,6 +331,7 @@ def deploy_type_api(
             form_data_api['hypervisor_type'],
             debug=True,
             org=org_module.label,
+            target_sat=target_sat,
         )
     return hypervisor_name, guest_name
 
@@ -338,12 +351,20 @@ def deploy_type_ui(
     if "id" in deploy_type:
         command = values['deploy']['command']
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data_ui['hypervisor_type'], debug=True, org=org_module.label
+            command,
+            form_data_ui['hypervisor_type'],
+            debug=True,
+            org=org_module.label,
+            target_sat=target_sat,
         )
     elif "script" in deploy_type:
         script = values['deploy']['script']
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data_ui['hypervisor_type'], debug=True, org=org_module.label
+            script,
+            form_data_ui['hypervisor_type'],
+            debug=True,
+            org=org_module.label,
+            target_sat=target_sat,
         )
     return hypervisor_name, guest_name
 

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -15,6 +15,7 @@ from robottelo.cli.host import Host
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
+from robottelo.hosts import ContentHost
 
 ETC_VIRTWHO_CONFIG = "/etc/virt-who.conf"
 
@@ -87,31 +88,41 @@ def runcmd(cmd, system=None, timeout=600000, output_format='base'):
     return result.status, result.stdout.strip()
 
 
-def register_system(system, activation_key=None, org='Default_Organization', env='Library'):
+def register_system(
+    system, activation_key=None, org='Default_Organization', env='Library', target_sat=None
+):
     """Return True if the system is registered to satellite successfully.
 
     :param dict system: system account used by ssh to connect and register.
     :param str activation_key: the activation key will be used to register.
-    :param str org: Which organization will be used to register.
+    :param str org: Which organization will be used to register (org label).
     :param str env: Which environment will be used to register.
+    :param target_sat: Satellite object for registration.
     :raises: VirtWhoError: If failed to register the system.
     """
-    runcmd('subscription-manager unregister', system)
-    runcmd('subscription-manager clean', system)
-    runcmd('rpm -qa | grep katello-ca-consumer | xargs rpm -e |sort', system)
-    runcmd(
-        f'rpm -ihv http://{settings.server.hostname}/pub/katello-ca-consumer-latest.noarch.rpm',
-        system,
+    # Get the guest hostname to check if it's already registered
+    guest_name, _ = runcmd('hostname', system=system)
+
+    if Host.exists(search=('name', guest_name)):
+        Host.delete({'name': guest_name})
+
+    # Create ContentHost object from system dict
+    contenthost = ContentHost(
+        hostname=system['hostname'], auth=(system['username'], system['password'])
     )
-    cmd = f'subscription-manager register --org={org} --environment={env} --force '
-    if activation_key is not None:
-        cmd += f'--activationkey={activation_key}'
-    else:
-        cmd += f'--username={settings.server.admin_username} --password={settings.server.admin_password}'
-    ret, stdout = runcmd(cmd, system)
-    if ret == 0 or "system has been registered" in stdout:
-        return True
-    raise VirtWhoError(f'Failed to register system: {system}')
+
+    # Use the ContentHost's register() method with global registration
+    if isinstance(org, str):
+        org = target_sat.api.Organization().search(query={'search': f'label={org}'})[0]
+
+    result = contenthost.register(
+        org=org,
+        loc=None,
+        activation_keys=activation_key,
+        target=target_sat,
+        force=True,
+    )
+    assert result.status == 0, f'Failed to register system: {system}\n {result}'
 
 
 def virtwho_cleanup():
@@ -306,7 +317,7 @@ def deploy_validation(hypervisor_type):
     """
     status = get_virtwho_status()
     if status != 'running':
-        raise VirtWhoError("Failed to start virt-who service")
+        raise VirtWhoError(f"Failed to start virt-who service. Status: {status}")
     hypervisor_name, guest_name = _get_hypervisor_mapping(hypervisor_type)
     for host in Host.list({'search': hypervisor_name}):
         Host.delete({'id': host['id']})
@@ -314,7 +325,40 @@ def deploy_validation(hypervisor_type):
     return hypervisor_name, guest_name
 
 
-def deploy_configure_by_command(command, hypervisor_type, debug=False, org='Default_Organization'):
+def get_activation_key(org, target_sat):
+    """Create a virt-who activation key for the given organization.
+    :param str org: The label of the organization for which the activation key is created.
+    :param target_sat: Satellite object for activation key
+    :return str: The name of the newly created activation key.
+    """
+    # Get the organization object from label
+    org_obj = target_sat.api.Organization().search(query={'search': f'label={org}'})[0]
+    # Get the Library lifecycle environment for this organization
+    library_env = target_sat.api.LifecycleEnvironment().search(
+        query={'search': f'name=Library AND organization_id={org_obj.id}'}
+    )[0]
+    # Get the default content view for this organization
+    default_cv = target_sat.api.ContentView().search(
+        query={'search': f'name="Default Organization View" AND organization_id={org_obj.id}'}
+    )[0]
+    # Create activation key with lifecycle environment and content view
+    ak = target_sat.api.ActivationKey(
+        organization=org_obj,
+        environment=library_env,
+        content_view=default_cv,
+        name=f'virtwho_ak_{gen_string("alpha", 6)}',
+    ).create()
+    return ak.name
+
+
+def deploy_configure_by_command(
+    command,
+    hypervisor_type,
+    debug=False,
+    org='Default_Organization',
+    activation_key=None,
+    target_sat=None,
+):
     """Deploy and run virt-who service by the hammer command.
 
     :param str command: get the command by UI/CLI/API, it should be like:
@@ -322,12 +366,20 @@ def deploy_configure_by_command(command, hypervisor_type, debug=False, org='Defa
     :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt, ahv
     :param bool debug: if VIRTWHO_DEBUG=1, this option should be True.
     :param str org: Organization Label
+    :param str activation_key: Activation key for system registration (optional)
+    :param target_sat: Satellite object for registration (optional)
     """
     virtwho_cleanup()
     guest_name, guest_uuid = get_guest_info(hypervisor_type)
     if Host.list({'search': guest_name}):
         Host.delete({'name': guest_name})
-    register_system(get_system(hypervisor_type), org=org)
+
+    # If target_sat is provided but activation_key is not, create one for global registration
+    if target_sat and not activation_key:
+        activation_key = get_activation_key(org, target_sat)
+    register_system(
+        get_system(hypervisor_type), activation_key=activation_key, org=org, target_sat=target_sat
+    )
     ret, stdout = runcmd(command)
     if ret != 0 or 'Finished successfully' not in stdout:
         raise VirtWhoError(f"Failed to deploy configure by {command}")
@@ -337,18 +389,34 @@ def deploy_configure_by_command(command, hypervisor_type, debug=False, org='Defa
 
 
 def deploy_configure_by_script(
-    script_content, hypervisor_type, debug=False, org='Default_Organization'
+    script_content,
+    hypervisor_type,
+    debug=False,
+    org='Default_Organization',
+    activation_key=None,
+    target_sat=None,
 ):
     """Deploy and run virt-who service by the shell script.
     :param str script_content: get the script by UI or API.
     :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt, ahv
     :param bool debug: if VIRTWHO_DEBUG=1, this option should be True.
     :param str org: Organization Label
+    :param str activation_key: Activation key for system registration (optional)
+    :param target_sat: Satellite object for registration (optional)
     """
     script_filename = "/tmp/deploy_script.sh"
     script_content = script_content.replace('&amp;', '&').replace('&gt;', '>').replace('&lt;', '<')
     virtwho_cleanup()
-    register_system(get_system(hypervisor_type), org=org)
+    guest_name, guest_uuid = get_guest_info(hypervisor_type)
+    if Host.list({'search': guest_name}):
+        Host.delete({'name': guest_name})
+    # If target_sat is provided but activation_key is not, create one for global registration
+    if target_sat and not activation_key:
+        activation_key = get_activation_key(org, target_sat)
+
+    register_system(
+        get_system(hypervisor_type), activation_key=activation_key, org=org, target_sat=target_sat
+    )
     with open(script_filename, 'w') as fp:
         fp.write(script_content)
     ssh.get_client().put(script_filename, script_filename)
@@ -644,7 +712,7 @@ def hypervisor_guest_mapping_newcontent_ui(
     # Check guest overview
     guest_new_overview = org_session.host_new.get_details(guest_name, 'overview')
 
-    assert guest_new_overview['overview']['host_status']['status_success'] == '1'
+    assert guest_new_overview['overview']['host_status']['status_success'] == '2'
     # Check guest details
     virtualguest_new_detais = org_session.host_new.get_details(guest_name, 'details')
     assert (

--- a/tests/foreman/virtwho/api/test_esx_sca.py
+++ b/tests/foreman/virtwho/api/test_esx_sca.py
@@ -69,7 +69,10 @@ class TestVirtWhoConfigforEsx:
             virtwho_config_api.update(['debug'])
             command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
 
@@ -101,7 +104,10 @@ class TestVirtWhoConfigforEsx:
             virtwho_config_api.update(['interval'])
             command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
 
@@ -124,7 +130,10 @@ class TestVirtWhoConfigforEsx:
             config_file = get_configure_file(virtwho_config_api.id)
             command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
@@ -164,7 +173,10 @@ class TestVirtWhoConfigforEsx:
                 virtwho_config.update(blacklist.keys())
             command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             config_file = get_configure_file(virtwho_config.id)
             result = target_sat.api.VirtWhoConfig().search(
@@ -202,7 +214,10 @@ class TestVirtWhoConfigforEsx:
             virtwho_config = target_sat.api.VirtWhoConfig(**form_data_api).create()
             command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             config_file = get_configure_file(virtwho_config.id)
             result = target_sat.api.VirtWhoConfig().search(
@@ -246,7 +261,10 @@ class TestVirtWhoConfigforEsx:
         virtwho_config = target_sat.api.VirtWhoConfig(**form_data_api).create()
         command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+            command,
+            form_data_api['hypervisor_type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         # Check HTTTP Proxy and No_PROXY option
         http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(
@@ -258,7 +276,10 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.update(['http_proxy_id', 'no_proxy'])
         command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+            command,
+            form_data_api['hypervisor_type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
@@ -273,7 +294,10 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.http_proxy_id = https_proxy_id
         virtwho_config.update(['http_proxy_id'])
         deploy_configure_by_command(
-            command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+            command,
+            form_data_api['hypervisor_type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
         virtwho_config.delete()
@@ -287,7 +311,10 @@ class TestVirtWhoConfigforEsx:
         virtwho_config = target_sat.api.VirtWhoConfig(**form_data_api).create()
         command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+            command,
+            form_data_api['hypervisor_type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
@@ -315,7 +342,10 @@ class TestVirtWhoConfigforEsx:
         """
         command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+            command,
+            form_data_api['hypervisor_type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         search_result = virtwho_config_api.get_organization_configs(data={'per_page': '1000'})
         assert [item for item in search_result['results'] if item['name'] == form_data_api['name']]
@@ -390,7 +420,11 @@ class TestVirtWhoConfigforEsx:
         """
         command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_api['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
+            command,
+            form_data_api['hypervisor_type'],
+            debug=True,
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -66,6 +66,9 @@ class TestVirtWhoConfigforHyperv:
             config_file = get_configure_file(virtwho_config_api.id)
             command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -61,6 +61,9 @@ class TestVirtWhoConfigforKubevirt:
             config_file = get_configure_file(virtwho_config_api.id)
             command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -62,6 +62,9 @@ class TestVirtWhoConfigforLibvirt:
             config_file = get_configure_file(virtwho_config_api.id)
             command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -63,7 +63,10 @@ class TestVirtWhoConfigforNutanix:
             config_file = get_configure_file(virtwho_config_api.id)
             command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
@@ -91,6 +94,7 @@ class TestVirtWhoConfigforNutanix:
                 form_data_api['hypervisor_type'],
                 debug=True,
                 org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
         elif deploy_type == "script":
             script = virtwho_config.deploy_script()
@@ -99,6 +103,7 @@ class TestVirtWhoConfigforNutanix:
                 form_data_api['hypervisor_type'],
                 debug=True,
                 org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
         # Check the option "prism_central=true" should be set in etc/virt-who.d/virt-who.conf
         config_file = get_configure_file(virtwho_config.id)
@@ -129,6 +134,9 @@ class TestVirtWhoConfigforNutanix:
         config_file = get_configure_file(virtwho_config_api.id)
         command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
+            command,
+            form_data_api['hypervisor_type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option("prism_central", config_file) == 'true'

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -88,7 +88,10 @@ class TestVirtWhoConfigforEsx:
             config_file = get_configure_file(virtwho_config_cli['id'])
             command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
@@ -109,7 +112,10 @@ class TestVirtWhoConfigforEsx:
             target_sat.cli.VirtWhoConfig.update({'id': virtwho_config_cli['id'], 'debug': key})
             command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
 
@@ -160,7 +166,10 @@ class TestVirtWhoConfigforEsx:
             target_sat.cli.VirtWhoConfig.update({'id': virtwho_config_cli['id'], 'interval': key})
             command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
 
@@ -209,7 +218,10 @@ class TestVirtWhoConfigforEsx:
             config_file = get_configure_file(virtwho_config_cli['id'])
             command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             if filter_type == "whitelist":
                 assert result['connection']['filtering'] == 'Whitelist'
@@ -245,7 +257,10 @@ class TestVirtWhoConfigforEsx:
                 assert result['connection']['exclude-host-parents'] == regex
             command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             config_file = get_configure_file(virtwho_config_cli['id'])
             if filter_type == "whitelist":
@@ -288,7 +303,10 @@ class TestVirtWhoConfigforEsx:
         assert result['connection']['ignore-proxy'] == no_proxy
         command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
@@ -301,7 +319,10 @@ class TestVirtWhoConfigforEsx:
             {'id': virtwho_config_cli['id'], 'http-proxy-id': http_proxy_id}
         )
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
 
@@ -315,7 +336,10 @@ class TestVirtWhoConfigforEsx:
         ]
         command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
         target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config_cli['name']})
@@ -333,7 +357,10 @@ class TestVirtWhoConfigforEsx:
         assert result['connection']['ignore-proxy'] == no_proxy
         command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         get_configure_file(virtwho_config_cli['id'])
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
@@ -355,7 +382,10 @@ class TestVirtWhoConfigforEsx:
         config_file = get_configure_file(virtwho_config_cli['id'])
         command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         rhsm_username = get_configure_option('rhsm_username', config_file)
         assert not target_sat.cli.User.exists(search=('login', rhsm_username))
@@ -407,7 +437,10 @@ class TestVirtWhoConfigforEsx:
         virtwho_package_locked()
         command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
@@ -484,7 +517,11 @@ class TestVirtWhoConfigforEsx:
         """
         command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            debug=True,
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
@@ -531,7 +568,10 @@ class TestVirtWhoConfigforEsx:
             ]
             command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             vc_id.append(virtwho_config_cli['id'])
             config_file = get_configure_file(virtwho_config_cli['id'])
@@ -551,7 +591,11 @@ class TestVirtWhoConfigforEsx:
         ]
         command = get_configure_command(virtwho_config_cli['id'], org.name)
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], debug=True, org=org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            debug=True,
+            org=org.label,
+            target_sat=target_sat,
         )
         config_file = get_configure_file(virtwho_config_cli['id'])
         rhsm_username.append(get_configure_option('rhsm_username', config_file))
@@ -617,7 +661,10 @@ class TestVirtWhoConfigforEsx:
         ]
         command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         config_file_1 = get_configure_file(virtwho_config_cli['id'])
         owner_1 = get_configure_option('owner', config_file_1)
@@ -634,7 +681,11 @@ class TestVirtWhoConfigforEsx:
         ]
         command = get_configure_command(virtwho_config_cli['id'], org.name)
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], debug=True, org=org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            debug=True,
+            org=org.label,
+            target_sat=target_sat,
         )
         config_file_2 = get_configure_file(virtwho_config_cli['id'])
         owner_2 = get_configure_option('owner', config_file_2)

--- a/tests/foreman/virtwho/cli/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/cli/test_hyperv_sca.py
@@ -67,6 +67,9 @@ class TestVirtWhoConfigforHyperv:
             config_file = get_configure_file(virtwho_config_cli['id'])
             command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/cli/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt_sca.py
@@ -61,6 +61,9 @@ class TestVirtWhoConfigforKubevirt:
             config_file = get_configure_file(virtwho_config_cli['id'])
             command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/cli/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_libvirt_sca.py
@@ -65,6 +65,9 @@ class TestVirtWhoConfigforLibvirt:
             config_file = get_configure_file(virtwho_config_cli['id'])
             command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/cli/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/cli/test_nutanix_sca.py
@@ -64,7 +64,10 @@ class TestVirtWhoConfigforNutanix:
             config_file = get_configure_file(virtwho_config_cli['id'])
             command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
@@ -135,6 +138,9 @@ class TestVirtWhoConfigforNutanix:
         config_file = get_configure_file(virtwho_config_cli['id'])
         command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+            command,
+            form_data_cli['hypervisor-type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option("prism_central", config_file) == 'true'

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -73,7 +73,7 @@ class TestVirtwhoConfigforEsx:
         )
 
     def test_positive_debug_option(
-        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui, target_sat
     ):
         """Verify debug checkbox and the value changes of VIRTWHO_DEBUG
 
@@ -89,19 +89,25 @@ class TestVirtwhoConfigforEsx:
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, module_sca_manifest_org.name)
         deploy_configure_by_command(
-            config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+            config_command,
+            form_data_ui['hypervisor_type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '1'
         org_session.virtwho_configure.edit(name, {'debug': False})
         results = org_session.virtwho_configure.read(name)
         assert results['overview']['debug'] is False
         deploy_configure_by_command(
-            config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+            config_command,
+            form_data_ui['hypervisor_type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '0'
 
     def test_positive_interval_option(
-        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui, target_sat
     ):
         """Verify interval dropdown options and the value changes of VIRTWHO_INTERVAL.
 
@@ -131,12 +137,15 @@ class TestVirtwhoConfigforEsx:
             results = org_session.virtwho_configure.read(name)
             assert results['overview']['interval'] == option
             deploy_configure_by_command(
-                config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                config_command,
+                form_data_ui['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
 
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui, target_sat
     ):
         """Verify Hypervisor ID dropdown options.
 
@@ -158,14 +167,23 @@ class TestVirtwhoConfigforEsx:
             results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                config_command,
+                form_data_ui['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.parametrize('filter_type', ['whitelist', 'blacklist'])
     @pytest.mark.parametrize('option_type', ['edit', 'create'])
     def test_positive_filtering_option(
-        self, module_sca_manifest_org, org_session, form_data_ui, filter_type, option_type
+        self,
+        module_sca_manifest_org,
+        org_session,
+        form_data_ui,
+        filter_type,
+        option_type,
+        target_sat,
     ):
         """Verify Filtering dropdown options.
 
@@ -216,6 +234,7 @@ class TestVirtwhoConfigforEsx:
                     config_command,
                     form_data_ui['hypervisor_type'],
                     org=module_sca_manifest_org.label,
+                    target_sat=target_sat,
                 )
                 if filter_type == "whitelist":
                     assert regex == get_configure_option('filter_hosts', config_file)
@@ -238,7 +257,10 @@ class TestVirtwhoConfigforEsx:
                 config_id = get_configure_id(name)
                 command = get_configure_command(config_id, module_sca_manifest_org.name)
                 deploy_configure_by_command(
-                    command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                    command,
+                    form_data_ui['hypervisor_type'],
+                    org=module_sca_manifest_org.label,
+                    target_sat=target_sat,
                 )
                 config_file = get_configure_file(config_id)
                 results = org_session.virtwho_configure.read(name)
@@ -260,6 +282,7 @@ class TestVirtwhoConfigforEsx:
         form_data_ui,
         org_session,
         default_location,
+        target_sat,
     ):
         """Verify the Last Checkin status on Content Hosts Page.
 
@@ -277,7 +300,11 @@ class TestVirtwhoConfigforEsx:
         values = org_session.virtwho_configure.read(name, widget_names='deploy.command')
         command = values['deploy']['command']
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data_ui['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
+            command,
+            form_data_ui['hypervisor_type'],
+            debug=True,
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         time_now = org_session.browser.get_client_datetime()
         assert org_session.virtwho_configure.search(name)[0]['Status'] == 'ok'
@@ -313,7 +340,11 @@ class TestVirtwhoConfigforEsx:
         values = org_session.virtwho_configure.read(name)
         command = values['deploy']['command']
         deploy_configure_by_command(
-            command, form_data_ui['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
+            command,
+            form_data_ui['hypervisor_type'],
+            debug=True,
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert org_session.virtwho_configure.search(name)[0]['Status'] == 'ok'
         # Check the option "env=" should be removed from etc/virt-who.d/virt-who.conf
@@ -361,7 +392,9 @@ class TestVirtwhoConfigforEsx:
                 assigned_permissions = org_session.filter.read_permissions(role_name)
                 assert sorted(assigned_permissions) == sorted(role_filters)
 
-    def test_positive_delete_configure(self, module_sca_manifest_org, org_session, form_data_ui):
+    def test_positive_delete_configure(
+        self, module_sca_manifest_org, org_session, form_data_ui, target_sat
+    ):
         """Verify when a config is deleted the associated user is deleted.
 
         :id: efc7253d-f455-4dc3-ae03-3ed5e215bd11
@@ -384,7 +417,10 @@ class TestVirtwhoConfigforEsx:
             config_id = get_configure_id(name)
             config_command = get_configure_command(config_id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                config_command,
+                form_data_ui['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert org_session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             org_session.virtwho_configure.delete(name)
@@ -393,7 +429,7 @@ class TestVirtwhoConfigforEsx:
             assert get_virtwho_status() == 'logerror'
 
     def test_positive_virtwho_reporter_role(
-        self, module_sca_manifest_org, org_session, test_name, form_data_ui
+        self, module_sca_manifest_org, org_session, test_name, form_data_ui, target_sat
     ):
         """Verify the virt-who reporter role can TRULY work.
 
@@ -426,7 +462,10 @@ class TestVirtwhoConfigforEsx:
             values = org_session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
             deploy_configure_by_command(
-                command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_ui['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert org_session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Update the virt-who config file
@@ -450,7 +489,7 @@ class TestVirtwhoConfigforEsx:
             assert not org_session.user.search(username)
 
     def test_positive_virtwho_viewer_role(
-        self, module_sca_manifest_org, org_session, test_name, form_data_ui
+        self, module_sca_manifest_org, org_session, test_name, form_data_ui, target_sat
     ):
         """Verify the virt-who viewer role can TRULY work.
 
@@ -483,7 +522,10 @@ class TestVirtwhoConfigforEsx:
             values = org_session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
             deploy_configure_by_command(
-                command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_ui['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert org_session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Check the permissioin of Virt-who Viewer
@@ -513,7 +555,7 @@ class TestVirtwhoConfigforEsx:
             assert not org_session.user.search(username)
 
     def test_positive_virtwho_manager_role(
-        self, module_sca_manifest_org, org_session, test_name, form_data_ui
+        self, module_sca_manifest_org, org_session, test_name, form_data_ui, target_sat
     ):
         """Verify the virt-who manager role can TRULY work.
 
@@ -545,7 +587,10 @@ class TestVirtwhoConfigforEsx:
             values = org_session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
             deploy_configure_by_command(
-                command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                command,
+                form_data_ui['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert org_session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Check the permissioin of Virt-who Manager
@@ -561,7 +606,10 @@ class TestVirtwhoConfigforEsx:
                 values = newsession.virtwho_configure.read(new_virt_who_name)
                 command = values['deploy']['command']
                 deploy_configure_by_command(
-                    command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                    command,
+                    form_data_ui['hypervisor_type'],
+                    org=module_sca_manifest_org.label,
+                    target_sat=target_sat,
                 )
                 assert newsession.virtwho_configure.search(new_virt_who_name)[0]['Status'] == 'ok'
                 # edit_virt_who_config
@@ -627,7 +675,7 @@ class TestVirtwhoConfigforEsx:
             assert not org_session.virtwho_configure.search(name)
 
     def test_positive_hypervisor_password_option(
-        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui, target_sat
     ):
         """Verify Hypervisor password.
 
@@ -646,7 +694,10 @@ class TestVirtwhoConfigforEsx:
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, module_sca_manifest_org.name)
         deploy_configure_by_command(
-            config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+            config_command,
+            form_data_ui['hypervisor_type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         config_file = get_configure_file(config_id)
         assert get_configure_option('encrypted_password', config_file)

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -56,7 +56,7 @@ class TestVirtwhoConfigforHyperv:
         )
 
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui, target_sat
     ):
         """Verify Hypervisor ID dropdown options.
 
@@ -78,6 +78,9 @@ class TestVirtwhoConfigforHyperv:
             results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                config_command,
+                form_data_ui['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -52,7 +52,7 @@ class TestVirtwhoConfigforKubevirt:
         )
 
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui, target_sat
     ):
         """Verify Hypervisor ID dropdown options.
 
@@ -74,6 +74,9 @@ class TestVirtwhoConfigforKubevirt:
             results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                config_command,
+                form_data_ui['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -56,7 +56,7 @@ class TestVirtwhoConfigforLibvirt:
         )
 
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui, target_sat
     ):
         """Verify Hypervisor ID dropdown options.
 
@@ -78,6 +78,9 @@ class TestVirtwhoConfigforLibvirt:
             results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+                config_command,
+                form_data_ui['hypervisor_type'],
+                org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -55,7 +55,7 @@ class TestVirtwhoConfigforNutanix:
         )
 
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui, target_sat
     ):
         """Verify Hypervisor ID dropdown options.
 
@@ -81,12 +81,13 @@ class TestVirtwhoConfigforNutanix:
                 form_data_ui['hypervisor_type'],
                 debug=True,
                 org=module_sca_manifest_org.label,
+                target_sat=target_sat,
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
     def test_positive_prism_central_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type
+        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type, target_sat
     ):
         """Verify configure created and deployed with id on nutanix prism central mode
 
@@ -115,6 +116,7 @@ class TestVirtwhoConfigforNutanix:
                     form_data_ui['hypervisor_type'],
                     debug=True,
                     org=module_sca_manifest_org.label,
+                    target_sat=target_sat,
                 )
             elif deploy_type == "script":
                 script = values['deploy']['script']
@@ -123,6 +125,7 @@ class TestVirtwhoConfigforNutanix:
                     form_data_ui['hypervisor_type'],
                     debug=True,
                     org=module_sca_manifest_org.label,
+                    target_sat=target_sat,
                 )
             # Check the option "prism_central=true" should be set in etc/virt-who.d/virt-who.conf
             config_id = get_configure_id(name)
@@ -133,7 +136,7 @@ class TestVirtwhoConfigforNutanix:
             assert not org_session.virtwho_configure.search(name)
 
     def test_positive_prism_central_prism_flavor_option(
-        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui, target_sat
     ):
         """Verify prism_flavor dropdown options.
 
@@ -157,12 +160,15 @@ class TestVirtwhoConfigforNutanix:
         results = org_session.virtwho_configure.read(name)
         assert results['overview']['prism_flavor'] == "central"
         deploy_configure_by_command(
-            config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
+            config_command,
+            form_data_ui['hypervisor_type'],
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert get_configure_option('prism_central', config_file) == 'true'
 
     def test_positive_ahv_internal_debug_option(
-        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui, target_sat
     ):
         """Verify ahv_internal_debug option by hammer virt-who-config"
 
@@ -189,7 +195,11 @@ class TestVirtwhoConfigforNutanix:
         command = values['deploy']['command']
         config_file = get_configure_file(config_id)
         deploy_configure_by_command(
-            command, form_data_ui['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
+            command,
+            form_data_ui['hypervisor_type'],
+            debug=True,
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         results = org_session.virtwho_configure.read(name)
         assert str(results['overview']['ahv_internal_debug']) == 'False'
@@ -209,7 +219,11 @@ class TestVirtwhoConfigforNutanix:
         command = results['deploy']['command']
         assert str(results['overview']['ahv_internal_debug']) == 'True'
         deploy_configure_by_command(
-            command, form_data_ui['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
+            command,
+            form_data_ui['hypervisor_type'],
+            debug=True,
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         assert (
             get_hypervisor_ahv_mapping(form_data_ui['hypervisor_type']) == 'Host UUID found for VM'

--- a/tests/new_upgrades/test_virtwho.py
+++ b/tests/new_upgrades/test_virtwho.py
@@ -1,0 +1,174 @@
+"""Test for Virt-who related Upgrade Scenario's
+
+:Requirement: UpgradedSatellite
+
+:CaseAutomation: Automated
+
+:CaseComponent: Virt-whoConfigurePlugin
+
+:Team: Phoenix-subscriptions
+
+:CaseImportance: High
+
+"""
+
+from box import Box
+from fauxfactory import gen_alpha, gen_string
+from manifester import Manifester
+import pytest
+
+from robottelo.config import settings
+from robottelo.utils.shared_resource import SharedResource
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
+
+
+@pytest.fixture
+def form_data(virt_who_upgrade_shared_satellite):
+    esx = settings.virtwho.esx
+    return {
+        'debug': 1,
+        'interval': '60',
+        'hypervisor_id': 'hostname',
+        'hypervisor_type': esx.hypervisor_type,
+        'hypervisor_server': esx.hypervisor_server,
+        'filtering_mode': 'none',
+        'satellite_url': virt_who_upgrade_shared_satellite.hostname,
+        'hypervisor_username': esx.hypervisor_username,
+        'hypervisor_password': esx.hypervisor_password,
+        'name': f'preupgrade_virt_who_{gen_alpha()}',
+    }
+
+
+@pytest.fixture
+def virt_who_upgrade_manifest():
+    with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
+        yield manifest
+
+
+ORG_DATA = {'name': f'virtwho_upgrade_{gen_alpha()}'}
+
+
+@pytest.fixture
+def create_virt_who_configuration_setup(
+    virt_who_upgrade_shared_satellite,
+    form_data,
+    virt_who_upgrade_manifest,
+    upgrade_action,
+):
+    """Create and deploy virt-who configuration.
+
+    :steps: In Preupgrade Satellite, Create and deploy virt-who configuration.
+
+    :expectedresults:
+        1. Config can be created and deployed by command.
+        2. No error msg in /var/log/rhsm/rhsm.log.
+        3. Report is sent to satellite.
+    """
+    target_sat = virt_who_upgrade_shared_satellite
+    settings.server.hostname = target_sat.hostname
+    manifest = virt_who_upgrade_manifest
+    with SharedResource(target_sat.hostname, upgrade_action, target_sat=target_sat) as sat_upgrade:
+        test_name = f'virt_who_upgrade_{gen_alpha()}'
+        org = target_sat.api.Organization(name=f'{test_name}_org').create()
+        test_data = Box(
+            {
+                'hypervisor_name': None,
+                'guest_name': None,
+                'org': org,
+                'satellite': target_sat,
+                'vhd': None,
+            }
+        )
+        target_sat.upload_manifest(org.id, manifest.content)
+        form_data.update({'organization_id': org.id})
+        vhd = target_sat.api.VirtWhoConfig(**form_data).create()
+        assert vhd.status == 'unknown'
+        configure_command = get_configure_command(vhd.id, org=org.name)
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            configure_command, form_data['hypervisor_type'], debug=True, org=org.label
+        )
+        test_data.hypervisor_name = hypervisor_name
+        test_data.guest_name = guest_name
+        test_data.vhd = vhd.read()
+        assert test_data.vhd.status == 'ok'
+        sat_upgrade.ready()
+        target_sat._session = None
+        yield test_data
+
+
+@pytest.mark.virt_who_upgrades
+def test_post_crud_virt_who_configuration(create_virt_who_configuration_setup, form_data):
+    """Virt-who config is intact post upgrade and verify the config can be updated and deleted.
+
+    :id: d7ae7b2b-3291-48c8-b412-cb54e444c7a4
+
+    :steps:
+        1. Post upgrade, Verify virt-who exists and has same status.
+        2. Verify the connection of the guest on Content host.
+        3. Verify the virt-who config-file exists.
+        4. Verify Report is sent to satellite.
+        5. Update virt-who config with new name.
+        6. Delete virt-who config.
+
+    :expectedresults:
+        1. virt-who config is intact post upgrade.
+        2. the config and guest connection have the same status.
+        3. Report is sent to satellite.
+        4. virt-who config should update and delete successfully.
+    """
+    target_sat = create_virt_who_configuration_setup.satellite
+    org = create_virt_who_configuration_setup.org
+    vhd = create_virt_who_configuration_setup.vhd
+
+    # Post upgrade, Verify virt-who exists and has same status.
+    assert vhd.status == 'ok'
+    # Verify virt-who status via CLI as we cannot check it via API now
+    vhd_cli = target_sat.cli.VirtWhoConfig.exists(search=('name', vhd.name))
+    assert (
+        target_sat.cli.VirtWhoConfig.info({'id': vhd_cli['id']})['general-information']['status']
+        == 'OK'
+    )
+
+    # Vefify the connection of the guest on Content host
+    hypervisor_name = create_virt_who_configuration_setup.hypervisor_name
+    guest_name = create_virt_who_configuration_setup.guest_name
+    result = (
+        target_sat.api.Host(organization=org.id)
+        .search(query={'search': hypervisor_name})[0]
+        .read_json()
+    )
+    assert result['subscription_facet_attributes']['virtual_guests'][0]['name'] == guest_name
+    result = (
+        target_sat.api.Host(organization=org.id).search(query={'search': guest_name})[0].read_json()
+    )
+    assert hypervisor_name in result['subscription_facet_attributes']['virtual_host']['name']
+
+    # Verify the virt-who config-file exists.
+    config_file = get_configure_file(vhd.id)
+    get_configure_option('hypervisor_id', config_file)
+
+    # Verify Report is sent to satellite.
+    command = get_configure_command(vhd.id, org=org.name)
+    deploy_configure_by_command(command, form_data['hypervisor_type'], debug=True, org=org.label)
+    virt_who_instance = (
+        target_sat.api.VirtWhoConfig(organization_id=org.id)
+        .search(query={'search': f'name={vhd.name}'})[0]
+        .status
+    )
+    assert virt_who_instance == 'ok'
+
+    # Update virt-who config
+    modify_name = gen_string('alpha')
+    vhd.name = modify_name
+    vhd.update(['name'])
+
+    # Delete virt-who config
+    vhd.delete()
+    assert not target_sat.api.VirtWhoConfig(organization_id=org.id).search(
+        query={'search': f'name={modify_name}'}
+    )

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -75,7 +75,11 @@ class TestScenarioPositiveVirtWho:
         assert vhd.status == 'unknown'
         command = get_configure_command(vhd.id, org=module_sca_manifest_org.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
+            command,
+            form_data['hypervisor_type'],
+            debug=True,
+            org=module_sca_manifest_org.label,
+            target_sat=target_sat,
         )
         virt_who_instance = (
             target_sat.api.VirtWhoConfig(organization_id=module_sca_manifest_org.id)
@@ -156,7 +160,7 @@ class TestScenarioPositiveVirtWho:
         # Verify Report is sent to satellite.
         command = get_configure_command(vhd.id, org=org_name)
         deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=org_label
+            command, form_data['hypervisor_type'], debug=True, org=org_label, target_sat=target_sat
         )
         virt_who_instance = (
             target_sat.api.VirtWhoConfig(organization_id=org_id)


### PR DESCRIPTION
…ion template for virt-who (#20314)

* Removed legacy host registration mechanism and added global registration template

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* Update robottelo/utils/virtwho.py



* Added seperate def for activation key

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* Added fix to delete host from satellite

* Added registration result to exeption

* Update robottelo/utils/virtwho.py



* Updated as per review comment

* Updated as per review comment

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* Updated target to target_sat for better reading

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

* Update terget to target_sat for better redability

---------

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->