### PR TITLE
[6.18.z] unbind hussh requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ deepdiff==8.6.1
 dynaconf[vault]==3.2.11
 fastmcp==2.13.1
 fauxfactory==3.1.2
-hussh<0.3.0  # Temporary constraint until tested
 jinja2==3.1.6
 manifester==0.2.14
 navmazing==1.3.0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20362

allow us to update to 0.2.0+