### PR TITLE
Hosts UI e2e finalizer fix

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -210,7 +210,9 @@ def tracer_hosts(rex_contenthosts, target_sat):
 
 
 @pytest.mark.e2e
-def test_positive_end_to_end(session, module_global_params, target_sat, host_ui_options, request):
+def test_positive_end_to_end(
+    session, module_global_params, target_sat, host_ui_options, request, ui_user
+):
     """Create a new Host with parameters, config group. Check host presence on
         the dashboard. Update name with 'new' prefix and delete.
 
@@ -248,9 +250,7 @@ def test_positive_end_to_end(session, module_global_params, target_sat, host_ui_
     @request.addfinalizer
     def _finalize():
         # Get table to original state
-        # with session:
-        # TODO TADY z nejakeho duvodu to kdyz se pouzije ui_session ma navic sloupec comment idfk
-        with target_sat.ui_session() as session:
+        with target_sat.ui_session(user=ui_user.login, password=ui_user.password) as session:
             session.organization.select(api_values['host.organization'])
             session.location.select(api_values['host.location'])
             session.all_hosts.manage_table_columns({header: True for header in stripped_headers})


### PR DESCRIPTION
Update the finalizer so it actually restores the columns to their original state.
Now it was not actually adding the columns back to the user who is being used within the test session.

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_positive_end_to_end or test_positive_read_from_edit_page or test_positive_create_with_inherited_params or test_negative_delete_primary_interface"
```