### PR TITLE
Fix host reregister rest

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2595,7 +2595,7 @@ def test_positive_reregister_rhel(
     # remove local consumer certs
     rhel_contenthost.execute('rm -rf /etc/pki/consumer/*')
     status = rhel_contenthost.execute("subscription-manager status")
-    assert "Overall Status: Unknown" in status.stdout
+    assert "Overall Status: Not registered" in status.stdout
     # reregister host with force
     reregister = rhel_contenthost.register(
         function_org, None, function_ak_with_cv.name, target_sat, force=True


### PR DESCRIPTION
Fix the re-registration test as the submit message has changed.

### PRT Examples
<img width="190" height="36" alt="image" src="https://github.com/user-attachments/assets/9d142126-6c62-4397-aad4-c217e98d9623" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k "test_positive_reregister_rhel"
```


