### PR TITLE
[6.16.z] cherry-pick-19660 : Corrected subscription-manager repos --enable command as \ was missing (#19660)

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -257,7 +257,7 @@ def test_sca_end_to_end(
         'lifecycle_environment_id': module_ak.environment.id,
     }
     host.update(['content_facet_attributes'])
-    rhel_contenthost.run('subscription-manager repos --enable *')
+    rhel_contenthost.run(r'subscription-manager repos --enable \*')
     repos = rhel_contenthost.run('subscription-manager refresh && yum repolist')
     assert content_view.repository[1].name in repos.stdout
     # install package and verify it succeeds or is already installed


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20417

There are some PIT failure that need this fix in 6.17.z and 6.16.z
Cherry pick of #19660
* Corrected subscription-manager repos --enable command as \ was missing

* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

---------

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->