### PR TITLE
Align hosts owner properly

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,7 +64,6 @@ tests/foreman/ui/test_contentview.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_contentview_old.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_errata.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_flatpak.py @SatelliteQE/team-artemis
-tests/foreman/ui/test_host.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_imagemode.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_lifecycleenvironment.py @SatelliteQE/team-artemis
 tests/foreman/ui/test_modulestreams.py @SatelliteQE/team-artemis
@@ -119,6 +118,7 @@ tests/foreman/destructive/test_host.py @SatelliteQE/team-proton
 tests/foreman/longrun/test_inc_updates.py @SatelliteQE/team-proton
 tests/foreman/ui/test_activationkey.py @SatelliteQE/team-proton
 tests/foreman/ui/test_contenthost.py @SatelliteQE/team-proton
+tests/foreman/ui/test_host.py @SatelliteQE/team-proton
 tests/foreman/ui/test_hostcollection.py @SatelliteQE/team-proton
 tests/foreman/ui/test_rhc.py @SatelliteQE/team-proton
 tests/foreman/ui/test_rhcloud_insights.py @SatelliteQE/team-proton
@@ -161,7 +161,6 @@ tests/foreman/api/test_computeresource_vmware.py @SatelliteQE/team-rocket
 tests/foreman/api/test_convert2rhel.py @SatelliteQE/team-rocket
 tests/foreman/api/test_discoveredhost.py @SatelliteQE/team-rocket
 tests/foreman/api/test_discoveryrule.py @SatelliteQE/team-rocket
-tests/foreman/api/test_host.py @SatelliteQE/team-rocket
 tests/foreman/api/test_operatingsystem.py @SatelliteQE/team-rocket
 tests/foreman/api/test_provisioning.py @SatelliteQE/team-rocket
 tests/foreman/api/test_provisioningtemplate.py @SatelliteQE/team-rocket


### PR DESCRIPTION
### Problem Statement
1. There were two definitions for `tests/foreman/api/test_host.py`, the second (wrong) one took precedence.
2. The `tests/foreman/ui/test_host.py` was incorrectly aligned.

Now both files owner should match with the module meta/docstring (and test majority ownership).

