### PR TITLE
Add test case for nested manifests in manifests lists in docker tags

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1913,7 +1913,7 @@ class TestDockerRepository:
         repo.sync()
         all_tags = target_sat.api.DockerTag().search(query={'per_page': '999'})
         manifest_lists = [t for t in all_tags if t.manifest['manifest_type'] == 'list']
-        assert len(manifest_lists) > 0, 'No manifests of "list" type found'
+        assert manifest_lists, 'No manifests of "list" type found'
         assert all('manifests' in lst.manifest for lst in manifest_lists)
         assert all(len(lst.manifest['manifests']) > 0 for lst in manifest_lists)
 


### PR DESCRIPTION
### Problem Statement
The docker_tags endpoint has been extended with `manifests` listed under manifests of "list" type in the response.
This PR adds a simple test for that as a companion PR for https://github.com/SatelliteQE/nailgun/pull/1397 


### Related Issues
https://issues.redhat.com/browse/SAT-38188


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k test_positive_manifests_lists_in_docker_tags
nailgun: 1397
```