### PR TITLE
[6.18.z] IoP Vulnerability test fixes

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -1,4 +1,4 @@
-"""Tests for RH Cloud - Vulnerability
+"""Tests for IoP Vulnerability service
 
 :Requirement: RHCloud
 
@@ -17,29 +17,15 @@ import pytest
 from robottelo import constants
 
 
-def create_insights_vulnerability(host):
-    """Function to create vulnerabilities for IoP Vulnerability Engine"""
-    # Upload insights data to Satellite
-    assert host.execute('insights-client').status == 0
-
-    # Add vulnerability for glibc package - CVE-2025-8058
-    assert host.execute('dnf downgrade -y glibc').status == 0
-
-
 @pytest.fixture(scope='module')
-def setup_content_for_iop(
-    module_target_sat_insights, rhcloud_manifest_org, module_rhel_contenthost
-):
-    """Fixture to setup an AK with a RHEL content repos, which is used for registering a host."""
-    sat = module_target_sat_insights
-    rhel_ver = module_rhel_contenthost.os_version.major
-    content_view = sat.api.ContentView(organization=rhcloud_manifest_org).create()
+def setup_content_for_iop(module_target_sat_insights, rhcloud_manifest_org):
+    """Fixture to sync RHEL content repos"""
+    satellite = module_target_sat_insights
 
-    # add IPv6 proxy for IPv6 communication
-    module_rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
-
-    for name in [f'rhel{rhel_ver}_bos', f'rhel{rhel_ver}_aps']:
-        rh_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
+    # Enable and sync BaseOS and AppStram repos
+    for name in ['rhel10_bos', 'rhel10_aps']:
+        # Enable the repository
+        rh_repo_id = satellite.api_factory.enable_rhrepo_and_fetchid(
             basearch=constants.DEFAULT_ARCHITECTURE,
             org_id=rhcloud_manifest_org.id,
             product=constants.REPOS[name]['product'],
@@ -47,34 +33,20 @@ def setup_content_for_iop(
             reposet=constants.REPOS[name]['reposet'],
             releasever=constants.REPOS[name]['releasever'],
         )
-        # Sync step because repo is not synced by default
-        rh_repo = sat.api.Repository(id=rh_repo_id).read()
+
+        # Sync the repository
+        rh_repo = satellite.api.Repository(id=rh_repo_id).read()
         task = rh_repo.sync(synchronous=False)
-        sat.wait_for_tasks(
+        satellite.wait_for_tasks(
             search_query=(f'id = {task["id"]}'),
             poll_timeout=2500,
         )
-        task_status = sat.api.ForemanTask(id=task['id']).poll()
+        task_status = satellite.api.ForemanTask(id=task['id']).poll()
         assert task_status['result'] == 'success'
-        content_view.repository.append(rh_repo)
-        content_view.update(['repository'])
 
-    publish = content_view.publish()
-    task_status = sat.wait_for_tasks(
-        search_query=(f'Actions::Katello::ContentView::Publish and id = {publish["id"]}'),
-        search_rate=15,
-        max_tries=10,
-    )
-    assert task_status[0].result == 'success'
-    content_view = sat.api.ContentView(
-        organization=rhcloud_manifest_org, name=content_view.name
-    ).search()[0]
-
-    return sat.api.ActivationKey(
-        organization=rhcloud_manifest_org,
-        content_view=content_view,
-        environment=rhcloud_manifest_org.library.id,
-    ).create()
+    # Manually trigger CVE sync
+    assert satellite.execute('systemctl start iop-cvemap-download').status == 0
+    assert satellite.execute('systemctl start iop-service-vuln-vmaas-sync').status == 0
 
 
 @pytest.mark.e2e
@@ -82,8 +54,7 @@ def setup_content_for_iop(
 @pytest.mark.rhel_ver_list([10])
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_rhcloud_insights_vulnerabilities_e2e(
-    request,
-    module_rhel_contenthost,
+    rhel_insights_vm,
     rhcloud_manifest_org,
     module_target_sat_insights,
     setup_content_for_iop,
@@ -95,10 +66,11 @@ def test_rhcloud_insights_vulnerabilities_e2e(
 
     :steps:
         1. Enable local Insights/Red Hat Lightspeed on Satellite.
-        2. Import Manifest, Sync RHEL content and create AK with the content.
-        3. Register a VM using AK created.
-        4. Create vulnerabilities for detection by vulnerability engine and upload its data to Insights.
-        5. In Satellite UI, go to vulnerabilities tab on host details page and validate the data.
+        2. Import Manifest, Sync RHEL content, and create AK with the content.
+        3. Register a host using AK created.
+        4. Downgrade package on host to create vulnerability for detection by vulnerability engine.
+        5. In Satellite UI, go to Vulnerabilities tab on Host Details page and validate the data.
+        6. In Satellite UI, go to Vulnerability page and validate the data.
 
     :expectedresults:
         1. Local insights vulnerability engine detects the new vulnerabilities.
@@ -107,47 +79,39 @@ def test_rhcloud_insights_vulnerabilities_e2e(
     :verifies: SAT-30762
     """
     CVE_ID = 'CVE-2025-8058'
+    GLIBC_RPM = 'glibc-2.39-43.el10_0.x86_64'
 
-    result = module_rhel_contenthost.register(
-        rhcloud_manifest_org,
-        None,
-        setup_content_for_iop.name,
-        module_target_sat_insights,
-        update_packages=True,
-        setup_insights=True,
-    )
-    assert result.status == 0, f'Failed to register host: {result.stderr}'
-    request.addfinalizer(lambda: module_rhel_contenthost.unregister())
+    satellite = module_target_sat_insights
+    client = rhel_insights_vm
+    hostname = client.hostname
 
-    # Verify insights-client can update to latest version available from server
-    assert module_rhel_contenthost.execute('insights-client --version').status == 0
-
-    # Manual VMaaS reposcan sync task
+    # Remove any static repos and update to the latest packages available from the Satellite
     assert (
-        module_target_sat_insights.execute(
-            'curl --fail --cert /etc/foreman/client_cert.pem --key /etc/foreman/client_key.pem --cacert /etc/foreman/proxy_ca.pem -X PUT "https://localhost:24443/api/vmaas-reposcan/v1/sync"'
+        client.execute(
+            "find /etc/yum.repos.d/ -type f | grep -vF redhat.repo | xargs -I '{}' rm '{}'"
         ).status
         == 0
     )
+    assert client.execute('dnf -y update').status == 0
 
-    # Prepare a machine with vulnerability CVE-2025-8058 and upload data to Insights
-    create_insights_vulnerability(module_rhel_contenthost)
+    # Downgrade to vulnerable glibc version
+    assert client.execute(f'dnf downgrade -y {GLIBC_RPM}').status == 0
 
-    with module_target_sat_insights.ui_session() as session:
+    with satellite.ui_session() as session:
         session.organization.select(org_name=rhcloud_manifest_org.name)
 
-        status = session.host_new.get_host_statuses(module_rhel_contenthost.hostname)
+        status = session.host_new.get_host_statuses(hostname)
         assert status['Red Hat Lightspeed']['Status'] == 'Reporting'
 
-        vulnerabilities = session.host_new.get_vulnerabilities(module_rhel_contenthost.hostname)
+        vulnerabilities = session.host_new.get_vulnerabilities(hostname)
         assert vulnerabilities[0]['CVE ID'] == CVE_ID
 
-        # Validate the affected host from vulnerability details and list pages
+        # Validate the affected Host from the Vulnerability details and list pages
         affected_host = session.cloudvulnerability.get_affected_hosts_by_cve(CVE_ID)
-        assert affected_host[0]['Name'] == module_rhel_contenthost.hostname
+        assert affected_host[0]['Name'] == hostname
 
-        # Validate the vulnerabilities tab on host details page from CVE list and CVE details
+        # Validate the Host's Vulnerabilities tab
         vulnerabilities = session.cloudvulnerability.validate_cve_to_host_details_flow(
-            CVE_ID, module_rhel_contenthost.hostname
+            CVE_ID, hostname
         )
         assert vulnerabilities[0]['CVE ID'] == CVE_ID


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20381

### Problem Statement
 
- Newer non-security errata for `glibc` mean that downgrading it once does not introduce a CVE vulnerability on the client
- `module_rhel_contenthost` fixture teardown errors out because the Satellite has already been checked in
- The test assumes the first CVE is the one we're looking for, even though newer CVEs are now applicable to a newly-provisioned RHEL 10 host
-  The test uses an outdated `curl` command to trigger VMaaS sync

### Solution

- Update the client to the latest packages available, then downgrade `glibc` to the specific version that triggers the desired CVE.
- Use the existing (function-scope) `rhel_insights_vm` fixture for the client instead of `module_rhel_contenthost`.
- Use `systemctl` commands to sync CVE metadata.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->