### PR TITLE
Update hammer commands list

### DIFF
--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -20346,6 +20346,12 @@
                   "value": null
                 },
                 {
+                  "help": "Array of dependency repository ids to mirror along with the main repository",
+                  "name": "dependency-ids",
+                  "shortname": null,
+                  "value": "LIST"
+                },
+                {
                   "help": "VALUE/NUMBER             Name/Id of associated flatpak remote",
                   "name": "flatpak-remote",
                   "shortname": null,


### PR DESCRIPTION
### Problem Statement
test_positive_all_options is failing as `dependency-ids` option is added for `hammer flatpak-remote remote-repository mirror`
The change was introduced here -> https://github.com/Katello/katello/pull/11573


### Solution
Update `hammer_commands.json`

