### PR TITLE
Fix docstring for set_rex_script_mode_provider method

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1876,7 +1876,7 @@ class Capsule(ContentHost, CapsuleMixins):
 
     def set_rex_script_mode_provider(self, mode='ssh'):
         """Set provider for remote execution script mode. One of: ssh(default),
-        pull-mqtt, ssh-async"""
+        pull-mqtt"""
 
         installer_opts = {'foreman-proxy-plugin-remote-execution-script-mode': mode}
 


### PR DESCRIPTION
minor docstring change with regards to https://github.com/SatelliteQE/robottelo/pull/20351 


### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->