### PR TITLE
[6.18.z] Register to CDN for test_podman_login_check test

### DIFF
--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -54,6 +54,7 @@ def sat_maintain(request):
         infra_host = request.getfixturevalue('module_capsule_maintain')
     elif host_type == 'satellite_iop':
         infra_host = request.getfixturevalue('module_satellite_iop')
+        infra_host.register_to_cdn()
     else:
         infra_host = _get_satellite_host(request)
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20449

### Problem Statement
When running `test_podman_login_check` test it runs `satellite-maintain health check --label="container-podman-login"` which requires the server to be registered to cdn([reference](https://github.com/theforeman/foreman_maintain/blob/master/definitions/checks/container/podman_login.rb#L6)) otherwise fails with `No scenario matching label [container-podman-login]`

### Solution
Register the satellite to cdn in case of `satellite_iop` so that test passes without any issue.
