### PR TITLE
[6.18.z] Change test case to use rhel_contenthost instead of hard-coded nick

### DIFF
--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -12,14 +12,12 @@
 
 """
 
-from broker import Broker
 from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
-from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import (
     invalid_values_list,
     parametrized,
@@ -285,7 +283,10 @@ def test_positive_copy_by_id(module_org, module_target_sat):
 
 
 @pytest.mark.upgrade
-def test_positive_register_host_ak_with_host_collection(module_org, module_ak_with_cv, target_sat):
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+def test_positive_register_host_ak_with_host_collection(
+    module_org, module_ak_with_cv, target_sat, rhel_contenthost
+):
     """Attempt to register a host using activation key with host collection
 
     :id: 62459e8a-0cfa-44ff-b70c-7f55b4757d66
@@ -309,18 +310,12 @@ def test_positive_register_host_ak_with_host_collection(module_org, module_ak_wi
         {'id': hc['id'], 'organization-id': module_org.id, 'host-ids': host_info['id']}
     )
 
-    with Broker(
-        nick='rhel7', deploy_network_type=settings.content_host.network_type, host_class=ContentHost
-    ) as client:
-        # register the client host with the current activation key
-        client.register(module_org, None, module_ak_with_cv.name, target_sat)
-        assert client.subscribed
-        # note: when registering the host, it should be automatically added to the host-collection
-        client_host = target_sat.cli.Host.info({'name': client.hostname})
-        hosts = target_sat.cli.HostCollection.hosts(
-            {'id': hc['id'], 'organization-id': module_org.id}
-        )
-        assert len(hosts) == 2
-        expected_hosts_ids = {host_info['id'], client_host['id']}
-        hosts_ids = {host['id'] for host in hosts}
-        assert hosts_ids == expected_hosts_ids
+    rhel_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
+    assert rhel_contenthost.subscribed
+    # note: when registering the host, it should be automatically added to the host-collection
+    client_host = target_sat.cli.Host.info({'name': rhel_contenthost.hostname})
+    hosts = target_sat.cli.HostCollection.hosts({'id': hc['id'], 'organization-id': module_org.id})
+    assert len(hosts) == 2
+    expected_hosts_ids = {host_info['id'], client_host['id']}
+    hosts_ids = {host['id'] for host in hosts}
+    assert hosts_ids == expected_hosts_ids


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20440

### Problem Statement
Test case failing since long time due to harcoded nick `rhel7` 

### Solution
Change test case to use `rhel_contenthost`

### Related Issues


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_hostcollection.py -k 'test_positive_register_host_ak_with_host_collection'

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->