### PR TITLE
Manage Traces Test - Improvement of stability

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -3505,7 +3505,11 @@ def test_positive_all_hosts_manage_traces(target_sat, module_org, tracer_hosts, 
         for host in tracer_hosts:
             host_info = target_sat.cli.Host.info({'name': host.hostname})
             traces = target_sat.cli.HostTraces.list({'host-id': host_info['id']})
-            assert traces_to_test not in traces
+            remaining_apps = {t['application'] for t in traces}
+            for app in traces_to_test:
+                assert app not in remaining_apps, (
+                    f'Trace {app} still present on {host.hostname} after restart/reboot'
+                )
 
 
 def verify_system_purpose_via_api(


### PR DESCRIPTION
Change the `kernel` to `systemd` in the test to improve test stability.


### PRT Examples
<img width="283" height="92" alt="image" src="https://github.com/user-attachments/assets/8c908942-69f9-49b5-9e81-d8d1c07bdfc3" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k "test_positive_all_hosts_manage_traces"
```


