### PR TITLE
[6.18.z] Catch and report OpenSSL data extraction errors

### DIFF
--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -219,12 +219,17 @@ def test_positive_validate_capsule_certificate(capsule_certs_teardown):
     )
     assert result.status == 0, 'Extraction to working directory failed.'
 
-    # Extract the cert data from file cert-raw-data and write to cert-data
-    target_sat.execute(
-        'openssl x509 -noout -text -in {0}/ssl-build/{1}/{1}-apache.crt'
-        '>> {0}/ssl-build/{1}/cert-data'.format(
-            file_setup['tmp_dir'], file_setup['capsule_hostname']
-        )
+    cert_file = (
+        f'{file_setup["tmp_dir"]}/ssl-build/{file_setup["capsule_hostname"]}/'
+        f'{file_setup["capsule_hostname"]}-apache.crt'
+    )
+
+    # Extract the cert data from apache cert and write to cert-data
+    result = target_sat.execute(
+        f'openssl x509 -noout -text -in {cert_file} > {file_setup["caps_cert_file"]}'
+    )
+    assert result.status == 0, (
+        f'Failed to extract certificate data from {cert_file}\nError: {result.stderr}'
     )
 
     # use same location on remote and local for cert_file


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20446

### Problem Statement
The `test_positive_validate_capsule_certificate` was failing on Satellite stream 143.0 with FileNotFoundError when trying to read cert-data file, because the test didn’t verify that the `openssl x509` command actually succeeded in generating that file.

### Solution
- Use the existing `ssl-build/{capsule_hostname}/{capsule_hostname}-apache.crt` as the source cert.
- Write the `openssl x509` output directly to `file_setup["caps_cert_file"]`.
- Assert the `openssl` command’s return code and include `stderr` on failure, then download and parse `cert-data` as before.

### Related Issues

[SAT-40296](https://issues.redhat.com/browse/SAT-40296)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->