### PR TITLE
[6.18.z] Fix host search API query used for searching provisioned host

### DIFF
--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -203,7 +203,7 @@ def test_positive_provision_end_to_end(
 
         # Verify SecureBoot is enabled on host after provisioning is completed successfully
         if pxe_loader.vm_firmware == 'uefi_secure_boot':
-            host = sat.api.Host().search(query={'host': hostname})[0].read()
+            host = sat.api.Host().search(query={'search': f'name={name}'})[0].read()
             provisioning_host = ContentHost(host.ip)
             # Wait for the host to be rebooted and SSH daemon to be started.
             provisioning_host.wait_for_connection()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20463

### Problem Statement
The host search API calls in `test_positive_provision_end_to_end` ui tests for libvirt and vmware were using
incorrect search parameters(host) that was fetching the satellite instance in `host`  variable instead of the provisioned host which ended up running `mokutil --sb-state` on satellite instead of provisioned host


### Solution
Update search parameter to search instead of host in host search API calls

credits: @Gauravtalreja1 thanks for help  
### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_computeresource_libvirt.py -k test_positive_provision_end_to_end
provisioning: true

