### PR TITLE
Fix AzureRM UI test host deletion assertion

### DIFF
--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -143,7 +143,7 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
                 with sat_azure.api_factory.satellite_setting('destroy_vm_on_host_delete=True'):
                     session.host_new.delete(fqdn)
                 wait_for(
-                    lambda: session.host.search(fqdn)[0].get('Name') == 'No Results',
+                    lambda: session.host_new.search(fqdn)[0].get('Name') == 'No Results',
                     timeout=300,
                     delay=10,
                 )


### PR DESCRIPTION
### Problem Statement
The `session.host.search(fqdn)` method returns a list with a 'No Results'placeholder
``` 
 [{0: 'No Results', 'Name': 'No Results', 'Host group': 'No Results', 'OS': 'No Results', ...}]
```
 dictionary when no hosts are found, rather than an emptylist. This caused the assertion `assert not session.host.search(fqdn)`to fail even when the host was successfully deleted.
### Solution
Updated the assertion to properly check for the "No Results" response

### Related Issues

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_computeresource_azurerm.py -k 'test_positive_end_to_end_azurerm_ft_host_provision'
provisioning: true

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->