### PR TITLE
[6.18.z] removed is_open from ansible import variables test

### DIFF
--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -22,7 +22,6 @@ from robottelo.config import (
     settings,
 )
 from robottelo.exceptions import CLIFactoryError
-from robottelo.utils.issue_handlers import is_open
 
 
 def assert_job_invocation_result(
@@ -692,7 +691,7 @@ class TestAnsibleREX:
         vars = f'{robottelo_tmp_dir}/vars.yml'
         target_sat.execute(f'ansible-galaxy init --init-path /etc/ansible/roles/ {SELECTED_ROLE}')
         tasks_file = f'/etc/ansible/roles/{SELECTED_ROLE}/tasks/main.yml'
-        vars_file = f'/etc/ansible/roles/{SELECTED_ROLE}/{"defaults" if is_open("SAT-28198") else "vars"}/main.yml'
+        vars_file = f'/etc/ansible/roles/{SELECTED_ROLE}/defaults/main.yml'
         tasks_main = [
             {
                 'name': 'Copy SSH keys',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20460

### Problem Statement
as SAT-28198 got closed as wontfix, the is_open condition here got flipped, hence test failures

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->