### PR TITLE
changed search repository with accurate way

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -433,7 +433,7 @@ def test_positive_end_to_end_custom_yum_crud(session, module_org, module_prod, m
                 'repo_content.download_policy': DOWNLOAD_POLICIES['immediate'],
             },
         )
-        assert not session.repository.search(module_prod.name, repo_name)
+        assert not session.repository.search(module_prod.name, value=f'name = "{repo_name}"')
         repo_values = session.repository.read(module_prod.name, new_repo_name)
         assert repo_values['name'] == new_repo_name
         assert repo_values['repo_content']['upstream_url'] == settings.repos.yum_2.url


### PR DESCRIPTION
### Problem Statement
Updated repository name still able to search using old name, as label name didn't updated

### Solution
Changing the way of searching with 'name = old_repo_name' solved this issue.
Repository update from airgun entities need to be updated.

Airgun PR: https://github.com/SatelliteQE/airgun/pull/2238
### Related Issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_repository.py -k 'test_positive_end_to_end_custom_yum_crud'
airgun: 2238
```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->