### PR TITLE
[6.18.z] Fix flatpak UI test for partial search match

### DIFF
--- a/tests/foreman/ui/test_flatpak.py
+++ b/tests/foreman/ui/test_flatpak.py
@@ -59,10 +59,14 @@ def test_view_flatpak_remotes(target_sat, function_org, function_flatpak_remote)
         details = session.flatpak_remotes.read_remote_details(
             name=remote['Name'], repo_search=random_repo.name
         )
-        assert len(details['table']) == 1
-        assert details['table'][0]['Name'] == random_repo.name
-        assert details['table'][0]['ID'] == random_repo.id
-        assert details['table'][0]['Last mirrored'] == 'Never'
+        # Search can return multiple results due to partial matching (e.g., searching "kicad"
+        # returns both "org.kicad.kicad" and "org.kicad.kicad.Library")
+        assert len(details['table']) > 0
+        matching_rows = [row for row in details['table'] if row['Name'] == random_repo.name]
+        assert len(matching_rows) == 1
+        assert matching_rows[0]['Name'] == random_repo.name
+        assert matching_rows[0]['ID'] == random_repo.id
+        assert matching_rows[0]['Last mirrored'] == 'Never'
 
 
 def test_CRUD_scan_and_mirror_flatpak_remote(target_sat, function_org, function_product):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20472

### Problem Statement

The UI test `test_view_flatpak_remotes` was failing due to a regression. When searching for a flatpak repository by name (e.g., "org.kicad.kicad"), the UI search performs partial/substring matching and returns multiple results including repos with similar names (e.g., "org.kicad.kicad.Library"). The test was asserting `len(details['table']) == 1`, which failed when multiple partial matches were returned.

### Solution

Updated the test to handle partial search matches:
  - Changed assertion from `len(details['table']) == 1` to `len(details['table']) > 0` to accept multiple search results
  - Added filtering logic to find the exact matching repository from the search results
  - Assert that exactly one exact match exists and validate its attributes (Name, ID, Last mirrored status)

### Related Issues


### PRT test Cases
trigger: test-robottelo
pytest: tests/foreman/ui/test_flatpak.py -k 'test_view_flatpak_remotes'

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->