### PR TITLE
[6.17.z] Fix discovery rule test failing due to no hostgroup available

### DIFF
--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -81,10 +81,13 @@ def test_positive_crud_with_non_admin_user(
     priority = str(gen_integer(1, 20))
     new_rule_name = gen_string('alpha')
     new_search = gen_string('alpha')
-    new_hg_name = gen_string('alpha')
     new_priority = str(gen_integer(101, 200))
-    hg = module_target_sat.api.HostGroup(organization=[module_org]).create()
-    new_hg_name = module_target_sat.api.HostGroup(organization=[module_org]).create()
+    hg = module_target_sat.api.HostGroup(
+        organization=[module_org], location=[module_location]
+    ).create()
+    new_hg_name = module_target_sat.api.HostGroup(
+        organization=[module_org], location=[module_location]
+    ).create()
     with module_target_sat.ui_session(
         user=manager_user.login, password=manager_user.password
     ) as session:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20482

### Problem Statement
test_positive_crud_with_non_admin_user is failing as the hostgroup is not created with the location and when the discovery rule is being created it errors out on missing hostgroup

### Solution
Create hostgroup with proper location assigned
