### PR TITLE
Add ansible verbosity to the FAM tests

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -351,6 +351,7 @@ def common_test_positive_run_modules_and_roles(satellite, ansible_module, extra_
         'NO_COLOR=1',
         'PYTEST_DISABLE_PLUGIN_AUTOLOAD=1',
         'ANSIBLE_HOST_PATTERN_MISMATCH=ignore',
+        'FAM_TEST_ANSIBLE_VERBOSITY=1',
     ]
     if extra_env is not None:
         env.extend(extra_env)
@@ -378,8 +379,14 @@ def test_positive_run_inventory(module_target_sat, setup_fam, ansible_module):
 
     :expectedresults: All inventories run successfully
     """
+    env = [
+        'NO_COLOR=1',
+        'PYTEST_DISABLE_PLUGIN_AUTOLOAD=1',
+        'ANSIBLE_HOST_PATTERN_MISMATCH=ignore',
+        'FAM_TEST_ANSIBLE_VERBOSITY=1',
+    ]
     # Execute test_playbook
     result = module_target_sat.execute(
-        f'cd {FAM_ROOT_DIR} && NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest-3.12 tests/test_crud.py::test_inventory[{ansible_module}]'
+        f'cd {FAM_ROOT_DIR} && {" ".join(env)} pytest-3.12 tests/test_crud.py::test_inventory[{ansible_module}]'
     )
     assert result.status == 0, f"{result.status=}\n{result.stdout=}\n{result.stderr=}"


### PR DESCRIPTION
### Problem Statement
Right now the default ansible verbosity is 4 which outputs too much logs which is sometimes difficult to debug in case of test failures.

### Solution
Add FAM_TEST_ANSIBLE_VERBOSITY=1 to the env to limit the log output.

ref: https://github.com/theforeman/foreman-ansible-modules/pull/1941