### PR TITLE
[6.18.z] Fix LEAPP upgrade tests not handling locations

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -757,8 +757,8 @@ REPOS = {
 # RHEL versions for LEAPP testing
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
-RHEL9_VER = '9.6'
-RHEL10_VER = '10.0'
+RHEL9_VER = '9.7'
+RHEL10_VER = '10.1'
 
 BULK_REPO_LIST = [
     REPOS['rhel7_optional'],

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -16,7 +16,7 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import RHEL8_VER, RHEL9_VER, RHEL10_VER
+from robottelo.constants import DEFAULT_LOC, RHEL8_VER, RHEL9_VER, RHEL10_VER
 from robottelo.utils import ohsnap
 
 
@@ -70,6 +70,7 @@ def test_positive_leapp_upgrade_rhel(
                 'login': login,
                 'password': password,
                 'organization-ids': org.id,
+                'location': DEFAULT_LOC,
             }
         )
         request.addfinalizer(lambda: module_target_sat.cli.User.delete({'login': user.login}))


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20373

### Problem Statement
Non-admin LEAPP upgrade tests:

* `tests/foreman/cli/test_leapp_client.py::test_positive_leapp_upgrade_rhel[non-admin-8.10_to_9.6]`
* `tests/foreman/cli/test_leapp_client.py::test_positive_leapp_upgrade_rhel[non-admin-9.6_to_10.0]`

are failing in larger test-collections (like FIPS and fapolicyd). In these test-collection LEAPP upgrade tests are preceded by a test `tests/foreman/api/test_parameters.py::test_positive_parameter_precedence_impact` that just creates location w/o tearing it down and all LEAPP upgrade tests were written w/o handling a location and then create entities w/ no location. (When there are two or more locations none is assigned to newly created organizations))

### Solution
Allow non-admin user to access Default Location.


### Related Issues
[SAT-39930](https://issues.redhat.com/browse/SAT-39930)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->