### PR TITLE
Used function_org instead of module_org

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2292,7 +2292,12 @@ def test_host_status_honors_taxonomies(
     # register the host to function_org
     assert rhel_contenthost.unregister().status == 0
     target_sat.cli.Host.delete({'id': host_id})
-    assert rhel_contenthost.register(function_org, default_location, function_ak_with_cv.name, target_sat).status == 0
+    assert (
+        rhel_contenthost.register(
+            function_org, default_location, function_ak_with_cv.name, target_sat
+        ).status
+        == 0
+    )
     with target_sat.ui_session(test_name, user=login, password=password) as session:
         statuses = session.host.host_statuses()
     assert len([status for status in statuses if int(status['count'].split(': ')[1]) != 0]) == 1


### PR DESCRIPTION
### Problem Statement
Test was failing in jenkins pipeline due to isolation problems with module-scoped fixtures. Multiple tests were sharing the same organization (module_org), and when previous tests left hosts in that org without proper cleanup, this test would fail in Jenkins.

### Solution
  By switching to function-scoped fixtures (function_org and function_ak_with_cv), each test run gets a fresh organization and activation key, ensuring proper isolation between test executions. This should resolve the Jenkins failure where the test was seeing hosts from previous tests.

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k test_host_status_honors_taxonomies

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->