### PR TITLE
[6.18.z] Destructive Cockpit Test Fix

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2423,6 +2423,7 @@ class Satellite(Capsule, SatelliteMixins):
             organization=module_org, name=f'rhel{rhelver}_{gen_string("alpha")}'
         ).create()
         tasks = []
+        repos = []
         for url in repo_urls:
             repo = self.api.Repository(
                 organization=module_org,
@@ -2430,6 +2431,7 @@ class Satellite(Capsule, SatelliteMixins):
                 content_type='yum',
                 url=url,
             ).create()
+            repos.append(repo)
             task = repo.sync(synchronous=False)
             tasks.append(task)
         for task in tasks:
@@ -2471,8 +2473,13 @@ class Satellite(Capsule, SatelliteMixins):
             # refresh repository metadata on the host
             rhel_contenthost.execute('subscription-manager repos --list')
 
-        # Override the repos to enabled
-        rhel_contenthost.execute(r'subscription-manager repos --enable \*')
+        # Enable only the specific repos created for this product to avoid repo contamination
+        # when multiple products with different RHEL versions exist in the same org
+        for repo in repos:
+            repo = repo.read()
+            repo_label = f'{module_org.label}_{prod.label}_{repo.label}'
+            result = rhel_contenthost.execute(f'subscription-manager repos --enable {repo_label}')
+            assert result.status == 0, f'Failed to enable repository {repo_label}: {result.stderr}'
 
     def enroll_ad_and_configure_external_auth(self, ad_data):
         """Enroll Satellite Server to an AD Server.


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20490

### Problem Statement
Fix broken `destructive/test_host.py:test_positive_cockpit` test.
Within the `register_host_custom_repo` function (in robottelo its only used via `class_cockpit_sat` used only in `test_positive_cockpit`), repos enablement is handled by enabling all available repos in the org.
This causes failures due to repository contamination within the parametrized test case.

- Each test created RHEL version-specific repos in the module_org
- `subscription-manager repos --enable \*` enabled all available repos --> thus cockpit was being installed from the RHEL10 repo on non RHEL10 hosts.

### Solution
Instead of enabling ALL repositories, let's enable only the specific repositories that were created for that exact RHEL version.

### PRT test Case example
<img width="168" height="227" alt="image" src="https://github.com/user-attachments/assets/24fea992-6334-4208-b8ac-19835671ed1c" />

```
trigger: test-robottelo
pytest: tests/foreman/destructive/test_host.py::TestHostCockpit::test_positive_cockpit
```