### PR TITLE
[6.18.z] Used function_org instead of module_org

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2194,7 +2194,8 @@ def test_host_status_honors_taxonomies(
     target_sat,
     test_name,
     rhel_contenthost,
-    setup_content,
+    function_ak_with_cv,
+    function_org,
     default_location,
     default_org,
     default_org_lce,
@@ -2210,8 +2211,6 @@ def test_host_status_honors_taxonomies(
 
     :expectedresults: First, the user can't see any host, then they can see one host
     """
-    ak, org, _ = setup_content
-
     lce = default_org_lce
     # Create content view environment for the default org
     content_view = target_sat.api.ContentView(organization=default_org).create()
@@ -2220,7 +2219,7 @@ def test_host_status_honors_taxonomies(
     content_view_version = published_cv.version[0]
     content_view_version.promote(data={'environment_ids': lce.id})
 
-    # default_org != org (== module_org)
+    # default_org != function_org
     default_org_ak_name = gen_string('alpha')
     target_sat.cli_factory.make_activation_key(
         {
@@ -2240,10 +2239,10 @@ def test_host_status_honors_taxonomies(
     host_id = target_sat.cli.Host.info({'name': rhel_contenthost.hostname})['id']
     password = gen_string('alpha')
     login = gen_string('alpha')
-    # the user is in org
+    # the user is in function_org
     target_sat.cli.User.create(
         {
-            'organization-id': org.id,
+            'organization-id': function_org.id,
             'location-id': default_location.id,
             'auth-source': 'Internal',
             'password': password,
@@ -2255,10 +2254,15 @@ def test_host_status_honors_taxonomies(
     with target_sat.ui_session(test_name, user=login, password=password) as session:
         statuses = session.host.host_statuses()
     assert all(int(status['count'].split(': ')[1]) == 0 for status in statuses)
-    # register the host to org
+    # register the host to function_org
     assert rhel_contenthost.unregister().status == 0
     target_sat.cli.Host.delete({'id': host_id})
-    assert rhel_contenthost.register(org, default_location, ak.name, target_sat).status == 0
+    assert (
+        rhel_contenthost.register(
+            function_org, default_location, function_ak_with_cv.name, target_sat
+        ).status
+        == 0
+    )
     with target_sat.ui_session(test_name, user=login, password=password) as session:
         statuses = session.host.host_statuses()
     assert len([status for status in statuses if int(status['count'].split(': ')[1]) != 0]) == 1


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20498

### Problem Statement
Test was failing in jenkins pipeline due to isolation problems with module-scoped fixtures. Multiple tests were sharing the same organization (module_org), and when previous tests left hosts in that org without proper cleanup, this test would fail in Jenkins.

### Solution
  By switching to function-scoped fixtures (function_org and function_ak_with_cv), each test run gets a fresh organization and activation key, ensuring proper isolation between test executions. This should resolve the Jenkins failure where the test was seeing hosts from previous tests.

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k test_host_status_honors_taxonomies

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->