### PR TITLE
Added poll_timeout for repository sync as in parallel run(Jenkins) it takes longer than usual

### DIFF
--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -269,7 +269,7 @@ def test_positive_incremental_update_time(module_target_sat, module_sca_manifest
             f'label = Actions::Katello::Repository::Sync and started_at >= "{repo_sync_timestamp}"'
         ),
         search_rate=10,
-        max_tries=200,
+        max_tries=100,
         poll_timeout=2000,
     )
     assert all(task.poll()['result'] == 'success' for task in sync_tasks)


### PR DESCRIPTION
### Problem Statement
 repository sync were getting timeout in Jenkins pipeline

### Solution
Added poll_timeout for repository sync as in Jenkins it takes longer than usual

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/longrun/test_inc_updates.py -k test_positive_incremental_update_time

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->