### PR TITLE
update test for enable/disable recommendations (IoP)

### DIFF
--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -280,7 +280,7 @@ def test_rhcloud_inventory_disabled_local_insights(module_target_sat_insights):
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('N-1')
+@pytest.mark.rhel_ver_match('10')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_iop_recommendations_remediation_type_and_status(
     rhel_insights_vm,


### PR DESCRIPTION
Test for disabling/enabling recommendations on IOP. 
SAT-38139
https://github.com/SatelliteQE/airgun/pull/2247

## Summary by Sourcery

Update IOP recommendations UI test to validate disabling and re-enabling a specific recommendation on supported RHEL versions.

Enhancements:
- Adjust RHEL version matching for the IOP recommendations test to use the N-1 selector.

Tests:
- Change the IOP recommendations test to disable and re-enable a specific recommendation instead of only checking enabled/disabled counts.
- Update test metadata and verification tags to include the new SAT requirement.