### PR TITLE
IoP test framework updates

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -232,28 +232,14 @@ def get_iop_deploy_args():
 
 
 @pytest.fixture(scope='module')
-def module_satellite_iop():
-    """Deploy and configure Red Hat Lightspeed in Satellite
+def module_satellite_iop(module_target_sat):
+    """Configure Red Hat Lightspeed in Satellite"""
+    satellite = module_target_sat
+    satellite.configure_iop()
 
-    Use the IoP workflow which deploys Satellite + IoP
-    """
-    deploy_args = get_iop_deploy_args()
+    yield satellite
 
-    with Broker(
-        workflow=settings.server.deploy_workflows.iop, **deploy_args, host_class=Satellite
-    ) as satellite:
-        yield satellite
-
-
-@pytest.fixture
-def satellite_iop():
-    """Deploy and configure Red Hat Lightspeed in Satellite"""
-    deploy_args = get_iop_deploy_args()
-
-    with Broker(
-        workflow=settings.server.deploy_workflows.iop, **deploy_args, host_class=Satellite
-    ) as satellite:
-        yield satellite
+    satellite.uninstall_iop()
 
 
 @pytest.fixture(scope='module')

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -22,7 +22,7 @@ from robottelo.constants import (
     PUPPET_SATELLITE_INSTALLER,
 )
 from robottelo.enums import NetworkType
-from robottelo.exceptions import CLIReturnCodeError, NoManifestProvidedError
+from robottelo.exceptions import CLIReturnCodeError, NoManifestProvidedError, SatelliteHostError
 from robottelo.host_helpers.api_factory import APIFactory
 from robottelo.host_helpers.cli_factory import CLIFactory
 from robottelo.host_helpers.ui_factory import UIFactory
@@ -456,19 +456,21 @@ class IoPSetup:
             for service, path in settings.rh_cloud.iop_advisor_engine.image_paths.items()
         }
 
-    def configure_insights_on_prem(self, username=None, password=None, registry=None):
+    def configure_iop(self):
         """Configure on prem Advisor engine on Satellite"""
         logger.info('Configuring Satellite with local Red Hat Lightspeed')
-        iop_settings = settings.rh_cloud.iop_advisor_engine
-        username = username or iop_settings.username
-        password = password or iop_settings.token
-        registry = registry or iop_settings.registry
 
         self.register_to_cdn()
         self.setup_rhel_repos()
         self.setup_satellite_repos()
+
         self.ensure_podman_installed()
-        self.podman_login(username, password, registry)
+
+        iop_settings = settings.rh_cloud.iop_advisor_engine
+        self.podman_login(iop_settings.username, iop_settings.token, iop_settings.registry)
+        self.podman_login(
+            iop_settings.stage_username, iop_settings.stage_token, iop_settings.stage_registry
+        )
 
         # Set IPv6 podman proxy on Satellite, to pull from container registry
         self.enable_ipv6_podman_proxy()
@@ -488,10 +490,28 @@ class IoPSetup:
 
         command = InstallerCommand(
             'enable-iop',
+            iop_ensure='present',
             scenario='satellite',
             foreman_initial_admin_password=settings.server.admin_password,
         ).get_command()
 
         result = self.execute(command, timeout='30m')
-        assert result.status == 0, f'Failed to configure IoP: {result.stdout}'
-        assert self.iop_enabled
+        if result.status != 0:
+            raise SatelliteHostError(f'Failed to configure IoP: {result.stdout}')
+        if not self.iop_enabled:
+            raise SatelliteHostError('IoP is not enabled')
+
+    def uninstall_iop(self):
+        if not self.iop_enabled:
+            logger.info('IoP is already disabled. Skipping uninstallation.')
+            return
+
+        command = InstallerCommand(
+            iop_ensure='absent',
+        ).get_command()
+
+        result = self.execute(command, timeout='30m')
+        if result.status != 0:
+            raise SatelliteHostError(f'Failed to disable IoP: {result.stdout}')
+        if self.iop_enabled:
+            raise SatelliteHostError('IoP is not disabled')

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -172,8 +172,8 @@ def test_positive_install_iop_custom_certs(
 
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('N-0')
-def test_disable_enable_iop(satellite_iop, module_sca_manifest, rhel_contenthost):
-    """Install Satellite + IoP, disable, re-enable.
+def test_disable_enable_iop(module_satellite_iop, module_sca_manifest, rhel_contenthost):
+    """Disable and re-enable IoP on Satellite.
 
     :id: abe165e1-a3a4-413d-b6aa-5cb51acfeb2e
 
@@ -190,7 +190,7 @@ def test_disable_enable_iop(satellite_iop, module_sca_manifest, rhel_contenthost
 
     :CaseAutomation: Automated
     """
-    satellite = satellite_iop
+    satellite = module_satellite_iop
     host = rhel_contenthost
 
     # Register the Insights client


### PR DESCRIPTION
### Problem Statement

IoP fixtures deploy a new host, separate from the default Satellite host deployed by the Satellite fixture factory. This causes problems with upstream PRT, RHEL interop, and other test pipelines that deploy the Satellite from other sources: the default Satellite has the expected packages installed, but the IoP Satellite under test does not.

### Solution

Update the IoP fixtures to use the default Satellite host. The fixture will enable IoP, and then disable it again during teardown.


### Related Issues

SAT-41499

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

### PRT

```
trigger: test-robottelo
pytest: tests/foreman/ui --component Insights-Advisor,Insights-Vulnerability
```

This will run two pytest modules, with a setup / teardown between each.


To verify that PRT + upstream PR works:

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_e2e[rhel10-ipv4-local]
theforeman:
  foreman_rh_cloud: 1144
robottelo: 20521
```

## Summary by Sourcery

Update IoP test fixtures and Satellite helpers to configure IoP on the existing Satellite host instead of deploying a separate IoP-specific Satellite instance.

Enhancements:
- Rename and extend the Satellite helper to configure IoP with explicit enablement checks and add an uninstall helper to disable IoP via the installer.
- Adjust the IoP module fixture to reuse the default module_target_sat host, enabling IoP for tests and cleaning it up during teardown.
- Update the CLI IoP test to consume the new module-level IoP fixture rather than deploying a dedicated IoP Satellite.