### PR TITLE
[6.18.z] update the page old to new UI

### DIFF
--- a/pytest_fixtures/component/provision_azure.py
+++ b/pytest_fixtures/component/provision_azure.py
@@ -9,7 +9,7 @@ from robottelo.constants import (
     AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
     AZURERM_RHEL7_FT_GALLERY_IMG_URN,
     AZURERM_RHEL7_FT_IMG_URN,
-    AZURERM_RHEL7_UD_IMG_URN,
+    AZURERM_RHEL9_UD_IMG_URN,
     DEFAULT_ARCHITECTURE,
     DEFAULT_OS_SEARCH_QUERY,
 )
@@ -153,7 +153,7 @@ def module_azurerm_cloudimg(
         name=gen_string('alpha'),
         operatingsystem=sat_azure_default_os,
         username=settings.azurerm.username,
-        uuid=AZURERM_RHEL7_UD_IMG_URN,
+        uuid=AZURERM_RHEL9_UD_IMG_URN,
         user_data=True,
     ).create()
 

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -151,7 +151,7 @@ AZURERM_VALID_REGIONS = [
     'Norway East',
 ]
 AZURERM_RHEL7_FT_IMG_URN = 'marketplace://RedHat:RHEL:7-RAW:latest'
-AZURERM_RHEL7_UD_IMG_URN = 'marketplace://RedHat:rhel-byos:rhel-raw-ci76:7.6.20190814'
+AZURERM_RHEL9_UD_IMG_URN = 'marketplace://RedHat:rhel-byos:rhel-lvm97:9.7.2026012716'
 AZURERM_RHEL7_FT_BYOS_IMG_URN = 'marketplace://RedHat:rhel-byos:rhel-lvm78:7.8.20200410'
 AZURERM_RHEL7_FT_CUSTOM_IMG_URN = 'custom://imageVM1-RHEL7-image-20220617150105'
 AZURERM_RHEL7_FT_GALLERY_IMG_URN = 'gallery://RHSG_1/RHEL77img'

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -20,7 +20,7 @@ from robottelo.constants import (
     AZURERM_FILE_URI,
     AZURERM_PLATFORM_DEFAULT,
     AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
-    AZURERM_RHEL7_UD_IMG_URN,
+    AZURERM_RHEL9_UD_IMG_URN,
     AZURERM_VM_SIZE_DEFAULT,
     AZURERM_PREMIUM_OS_Disk,
 )
@@ -106,7 +106,7 @@ class TestAzureRMComputeResourceTestCase:
         assert module_azurerm_cloudimg.architecture.id == sat_azure_default_architecture.id
         assert module_azurerm_cloudimg.compute_resource.id == module_azurerm_cr.id
         assert module_azurerm_cloudimg.username == settings.azurerm.username
-        assert module_azurerm_cloudimg.uuid == AZURERM_RHEL7_UD_IMG_URN
+        assert module_azurerm_cloudimg.uuid == AZURERM_RHEL9_UD_IMG_URN
 
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
@@ -318,7 +318,7 @@ class TestAzureRMUserDataProvisioning:
         """
 
         request.cls.region = settings.azurerm.azure_region
-        request.cls.rhel7_ud_img = AZURERM_RHEL7_UD_IMG_URN
+        request.cls.rhel9_ud_img = AZURERM_RHEL9_UD_IMG_URN
         request.cls.rg_default = settings.azurerm.resource_group
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -20,7 +20,7 @@ from robottelo.constants import (
     AZURERM_FILE_URI,
     AZURERM_PLATFORM_DEFAULT,
     AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
-    AZURERM_RHEL7_UD_IMG_URN,
+    AZURERM_RHEL9_UD_IMG_URN,
     AZURERM_VM_SIZE_DEFAULT,
     AZURERM_PREMIUM_OS_Disk,
 )
@@ -117,7 +117,7 @@ class TestAzureRMComputeResourceTestCase:
     @pytest.mark.parametrize(
         "image",
         [
-            AZURERM_RHEL7_UD_IMG_URN,
+            AZURERM_RHEL9_UD_IMG_URN,
             AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
         ],
     )
@@ -434,7 +434,7 @@ class TestAzureRMUserDataProvisioning:
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
         request.cls.region = settings.azurerm.azure_region
-        request.cls.rhel7_ft_img = AZURERM_RHEL7_UD_IMG_URN
+        request.cls.rhel9_ft_img = AZURERM_RHEL9_UD_IMG_URN
         request.cls.rg_default = settings.azurerm.resource_group
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -119,10 +119,11 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
                     }
                 )
 
-                host_info = session.host.get_details(fqdn)
-                assert 'Installed' in host_info['properties']['properties_table']['Build']
+                host_info = session.host_new.get_host_statuses(fqdn)
+                assert 'Installed' in host_info['Build']['Status']
+                host_page = session.host_new.get_details(fqdn, widget_names='overview')
                 assert (
-                    host_info['properties']['properties_table']['Host group']
+                    host_page['overview']['details']['details']['host_group']
                     == module_azure_hg.name
                 )
 
@@ -131,7 +132,12 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
                 assert azurecloud_vm
                 assert azurecloud_vm.is_running
                 assert azurecloud_vm.name == hostname.lower()
-                assert azurecloud_vm.ip == host_info['properties']['properties_table']['IP Address']
+                assert (
+                    azurecloud_vm.ip
+                    == host_page['overview']['details']['details'][
+                        f'{settings.server.NETWORK_TYPE}_address'
+                    ]
+                )
                 assert azurecloud_vm.type == AZURERM_VM_SIZE_DEFAULT
 
                 # Host Delete
@@ -208,12 +214,11 @@ def test_positive_azurerm_host_provision_ud(
                     }
                 )
 
-                host_info = session.host.get_details(fqdn)
+                host_info = session.host_new.get_host_statuses(fqdn)
+                assert 'Pending installation' in host_info['Build']['Status']
+                host_page = session.host_new.get_details(fqdn, widget_names='overview')
                 assert (
-                    'Pending installation' in host_info['properties']['properties_table']['Build']
-                )
-                assert (
-                    host_info['properties']['properties_table']['Host group']
+                    host_page['overview']['details']['details']['host_group']
                     == module_azure_hg.name
                 )
 
@@ -222,7 +227,12 @@ def test_positive_azurerm_host_provision_ud(
                 assert azurecloud_vm
                 assert azurecloud_vm.is_running
                 assert azurecloud_vm.name == hostname.lower()
-                assert azurecloud_vm.ip == host_info['properties']['properties_table']['IP Address']
+                assert (
+                    azurecloud_vm.ip
+                    == host_page['overview']['details']['details'][
+                        f'{settings.server.NETWORK_TYPE}_address'
+                    ]
+                )
                 assert azurecloud_vm.type == AZURERM_VM_SIZE_DEFAULT
 
         finally:

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -181,8 +181,12 @@ def test_positive_provision_end_to_end(
         )
         name = f'{hostname}.{module_libvirt_provisioning_sat.domain.name}'
         request.addfinalizer(lambda: sat.provisioning_cleanup(name))
+
         result = session.host_new.search(name)[0]
         assert result['Name'] == name
+
+        assert session.host_new.search(name)[0]['Name'] == name
+
         # Check on Libvirt, if VM exists
         result = sat.execute(
             f'su foreman -s /bin/bash -c "virsh -c {LIBVIRT_URL} list --state-running"'
@@ -209,7 +213,12 @@ def test_positive_provision_end_to_end(
             provisioning_host.wait_for_connection()
             assert 'SecureBoot enabled' in provisioning_host.execute('mokutil --sb-state').stdout
 
-        session.host.delete(name)
+        session.host_new.delete(name)
+        wait_for(
+            lambda: session.host_new.search(name)[0].get('Name') == 'No Results',
+            timeout=300,
+            delay=10,
+        )
         assert not sat.api.Host().search(query={'search': f'name="{name}"'})
 
 

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -277,16 +277,16 @@ def test_positive_update_name(
             quick=False,
             host_values={'host.name': new_name},
         )
-        assert session.host.search(new_host_name)[0]['Name'] == new_host_name
-        values = session.host.get_details(new_host_name)
-        assert values['properties']['properties_table']['Status'] == 'OK'
+        assert session.host_new.search(new_host_name)[0]['Name'] == new_host_name
+        values = session.host_new.get_details(new_host_name)
+        assert values['overview']['host_status']['status'] == 'All statuses OK'
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')
 
 
 @pytest.mark.upgrade
 @pytest.mark.on_premises_provisioning
 @pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
-@pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
+@pytest.mark.parametrize('pxe_loader', ['bios'], indirect=True)
 @pytest.mark.rhel_ver_match('9')
 def test_positive_auto_provision_host_with_rule(
     request,
@@ -346,11 +346,11 @@ def test_positive_auto_provision_host_with_rule(
         session.organization.select(org_name=module_org.name)
         session.location.select(loc_name=module_location.name)
         session.discoveredhosts.apply_action('Auto Provision', [discovered_host_name])
-        assert session.host.search(host_name)[0]['Name'] == host_name
-        host_values = session.host.get_details(host_name)
-        assert host_values['properties']['properties_table']['Status'] == 'OK'
+        assert session.host_new.search(host_name)[0]['Name'] == host_name
+        host_values = session.host_new.get_details(host_name)
+        assert host_values['overview']['host_status']['status'] == 'All statuses OK'
         assert (
-            host_values['properties']['properties_table']['Comment']
+            host_values['overview']['details']['details']['comment']
             == f"Auto-discovered and provisioned via rule '{discovery_rule.name}'"
         )
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20370

Updated the code in some places so that it now loads the new UI page instead of the old UI for Rocket-based components.
