### PR TITLE
[6.17.z] Remove RHEL version parametrization of HA proxy fixture

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -399,3 +399,16 @@ def custom_host(request):
     deploy_args['workflow'] = 'deploy-rhel'
     with Broker(**deploy_args, host_class=Satellite) as host:
         yield host
+
+
+@pytest.fixture(scope="module")
+def module_haproxy():
+    """A module-level fixture that provides a RHEL content host for HAProxy loadbalancer,
+    matching the RHEL version of the Capsule deployment."""
+    with Broker(
+        host_class=ContentHost,
+        workflow=settings.capsule.deploy_workflows.os,
+        deploy_rhel_version=settings.capsule.version.rhel_version,
+        deploy_network_type=settings.capsule.network_type,
+    ) as host:
+        yield host

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -233,7 +233,7 @@ def module_capsule_configured_mqtt(request, module_capsule_configured_ansible):
 
 
 @pytest.fixture(scope='module')
-def module_lb_capsule(retry_limit=3, delay=300, **broker_args):
+def module_lb_capsules(retry_limit=3, delay=300, **broker_args):
     """A fixture that spins 2 capsule for loadbalancer
     :return: List of capsules
     """


### PR DESCRIPTION
Manual cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20332
(cherry picked from commit 14c8bf741d6fb6b5ea467b111200a4c15d5376be)

### Problem Statement
LB setup fixture `setup_haproxy`is derived from `module_rhel_contenthost` fixture so it automatically follows the parametrization of client which is not desired.

### Solution
Base the fixture `setup_haproxy` on a new custom fixture `module_haproxy` which deploys RHEL machine matching RHEL version to Capsule(s):
* RHEL9 pipeline -> RHEL9 HA proxy
* RHEL8 pipeline -> RHEL8 HA proxy

Also lets mark these tests non-destructive in order to share this very costly setup. They indeed do nothing harmful to session scoped SAT instance. 

Suggest me please new location for the module then :wink:
I consider `tests/foreman/installer`  (complex installation) or `tests/foreman/sys` (if installer is strictly installer tests only)

### Related Issues
[SAT-39940](https://issues.redhat.com/browse/SAT-39940)



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->