### PR TITLE
Add cli containerfile install cmd

### DIFF
--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -179,6 +179,13 @@ class Host(Base):
         )
 
     @classmethod
+    def package_containerfile_install_command(cls, options):
+        """Generate a Containerfile RUN command from transiently
+        installed packages on image mode hosts"""
+        cls.command_sub = 'package containerfile-install-command'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
     def package_install(cls, options):
         """Install packages remotely."""
         cls.command_sub = 'package install'

--- a/tests/foreman/cli/test_imagemode.py
+++ b/tests/foreman/cli/test_imagemode.py
@@ -16,6 +16,7 @@ import json
 import pytest
 
 from robottelo.constants import DUMMY_BOOTC_FACTS
+from tests.foreman.api.test_host import _create_transient_packages
 
 
 @pytest.mark.e2e
@@ -53,4 +54,77 @@ def test_positive_bootc_cli_actions(
     ), (
         f'Expected bootc image {bootc_dummy_info["bootc.booted.image"]} not found in booted bootc images list. '
         f'Available images: {[img.get("running-image") for img in all_bootc_images]}'
+    )
+
+
+def test_containerfile_install_command(target_sat):
+    """Ensure the containerfile install command returns correct output.
+
+    :id: a1879eed-5dc3-4f96-bd9e-edad7ca4801d
+
+    :steps:
+        1. Create a host
+        2. Add packages with different persistence values via SQL (2x transient, persistent, None)
+        3. Retrieve the containerfile install command via hammer.
+        4. Verify the command format and content.
+
+    :expectedresults:
+        1. Packages with persistence='transient' are returned with correct value.
+        2. Packages with persistence='persistent' or None are not returned.
+
+    :Verifies: SAT-36792
+    """
+    # Create a host
+    host = target_sat.api.Host().create()
+
+    # Add packages with different persistence values via SQL (2x transient, persistent, None)
+    package_data = [
+        {
+            'name': 'transient-pkg-1',
+            'version': '1.2.3',
+            'release': '1.el9',
+            'arch': 'x86_64',
+            'persistence': 'transient',
+        },
+        {
+            'name': 'transient-pkg-2',
+            'version': '4.5.6',
+            'release': '1.el10',
+            'arch': 'x86_64',
+            'persistence': 'transient',
+        },
+        {
+            'name': 'persistent-pkg',
+            'version': '1.1.1',
+            'release': '1.el10',
+            'arch': 'x86_64',
+            'persistence': 'persistent',
+        },
+        {
+            'name': 'unknown-pkg',
+            'version': '2.2.2',
+            'release': '1.el10',
+            'arch': 'x86_64',
+            'persistence': None,
+        },
+    ]
+    _create_transient_packages(target_sat, host, package_data)
+
+    # Retrieve the containerfile install command via hammer.
+    cmd = target_sat.cli.Host.package_containerfile_install_command({'host-id': host.id})
+
+    # Verify the command format and content.
+    assert cmd.startswith('RUN dnf install -y')
+
+    transient_packages = [p for p in package_data if p['persistence'] == 'transient']
+    packages_in_cmd = cmd.replace('RUN dnf install -y', '').split()
+    assert len(packages_in_cmd) == len(transient_packages)
+
+    assert all(
+        f'{p["name"]}-{p["version"]}-{p["release"]}.{p["arch"]}' in cmd for p in transient_packages
+    )
+    assert all(
+        f'{p["name"]}-{p["version"]}-{p["release"]}.{p["arch"]}' not in cmd
+        for p in package_data
+        if p['persistence'] != 'transient'
     )


### PR DESCRIPTION
### Problem Statement
We have added hammer command for the containerfile install command and we should test it.


### Solution
This PR adds a function and test case for that.


### Related Issues
https://issues.redhat.com/browse/SAT-36792


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_imagemode.py -k test_containerfile_install_command
```