### PR TITLE
Modify Libvirt tests to run on Libvirt-CR deployed on RHEL10

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -15,7 +15,6 @@
 from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.utils.datafactory import (
@@ -261,7 +260,7 @@ def test_positive_add_and_remove_hostgroups(module_org, module_target_sat):
 
 @pytest.mark.skip_if_not_set('libvirt')
 @pytest.mark.upgrade
-def test_positive_add_and_remove_compute_resources(module_org, module_target_sat):
+def test_positive_add_and_remove_compute_resources(module_org, module_target_sat, libvirt):
     """Add and remove a compute resource from organization
 
     :id: 415c14ab-f879-4ed8-9ba7-8af4ada2e277
@@ -278,7 +277,7 @@ def test_positive_add_and_remove_compute_resources(module_org, module_target_sat
         module_target_sat.cli_factory.compute_resource(
             {
                 'provider': FOREMAN_PROVIDERS['libvirt'],
-                'url': f'qemu+ssh://root@{settings.libvirt.libvirt_hostname}/system',
+                'url': libvirt.url,
             },
         )
         for _ in range(0, 2)

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1053,7 +1053,9 @@ class TestEndToEnd:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    def test_positive_end_to_end(self, function_sca_manifest, target_sat, rhel_contenthost):
+    def test_positive_end_to_end(
+        self, function_sca_manifest, target_sat, rhel_contenthost, libvirt
+    ):
         """Perform end to end smoke tests using RH and custom repos.
 
         1. Create a new user with admin permissions
@@ -1190,7 +1192,7 @@ class TestEndToEnd:
         # step 2.14: Create a new libvirt compute resource
         target_sat.api.LibvirtComputeResource(
             server_config=user_cfg,
-            url=f'qemu+ssh://root@{settings.libvirt.libvirt_hostname}/system',
+            url=libvirt.url,
         ).create()
 
         # step 2.15: Create a new subnet

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -62,7 +62,7 @@ def test_positive_cli_find_admin_user(module_target_sat):
 @pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_cli_end_to_end(function_sca_manifest, target_sat, rhel_contenthost):
+def test_positive_cli_end_to_end(function_sca_manifest, target_sat, rhel_contenthost, libvirt):
     """Perform end to end smoke tests using RH and custom repos.
 
     1. Create a new user with admin permissions
@@ -271,7 +271,7 @@ def test_positive_cli_end_to_end(function_sca_manifest, target_sat, rhel_content
         {
             'name': gen_alphanumeric(),
             'provider': 'Libvirt',
-            'url': f'qemu+ssh://root@{settings.libvirt.libvirt_hostname}/system',
+            'url': libvirt.url,
         },
     )
 

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -15,8 +15,7 @@
 from fauxfactory import gen_ipaddr, gen_string
 import pytest
 
-from robottelo.config import settings
-from robottelo.constants import ANY_CONTEXT, INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
+from robottelo.constants import ANY_CONTEXT, INSTALL_MEDIUM_URL
 
 
 @pytest.mark.e2e
@@ -172,15 +171,14 @@ def test_positive_add_org_hostgroup_template(session, target_sat):
 
 
 @pytest.mark.skip_if_not_set('libvirt')
-def test_positive_update_compresource(session, target_sat):
+def test_positive_update_compresource(session, target_sat, libvirt):
     """Add/Remove compute resource from/to location
 
     :id: 1d24414a-666d-490d-89b9-cd0704684cdd
 
     :expectedresults: compute resource is added and removed from the location
     """
-    url = LIBVIRT_RESOURCE_URL % settings.libvirt.libvirt_hostname
-    resource = target_sat.api.LibvirtComputeResource(url=url).create()
+    resource = target_sat.api.LibvirtComputeResource(url=libvirt.url).create()
     resource_name = resource.name + ' (Libvirt)'
     loc = target_sat.api.Location().create()
     with session:

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -16,7 +16,7 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import ANY_CONTEXT, DEFAULT_ORG, INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
+from robottelo.constants import ANY_CONTEXT, DEFAULT_ORG, INSTALL_MEDIUM_URL
 from robottelo.logging import logger
 
 CUSTOM_REPO_ERRATA_ID = settings.repos.yum_0.errata[0]
@@ -216,15 +216,14 @@ def test_positive_create_with_all_users(session, module_target_sat):
 
 
 @pytest.mark.skip_if_not_set('libvirt')
-def test_positive_update_compresource(session, module_target_sat):
+def test_positive_update_compresource(session, module_target_sat, libvirt):
     """Add/Remove compute resource from/to organization.
 
     :id: a49349b9-4637-4ef6-b65b-bd3eccb5a12a
 
     :expectedresults: Compute resource is added and then removed.
     """
-    url = f'{LIBVIRT_RESOURCE_URL}{settings.libvirt.libvirt_hostname}'
-    resource = module_target_sat.api.LibvirtComputeResource(url=url).create()
+    resource = module_target_sat.api.LibvirtComputeResource(url=libvirt.url).create()
     resource_name = resource.name + ' (Libvirt)'
     org = module_target_sat.api.Organization().create()
     with session:


### PR DESCRIPTION
### Problem Statement
we got a few bugs where customer is running Libvirt CR on RHEL10 hypervisor, and its currently incompatible with existing Satellite release, so in Satellite 6.19 we introducing the support Libvirt CR on RHEL10 hypervisor in SAT-40266

### Solution
Modify Libvirt tests to run on Libvirt-CR deployed on RHEL10 along with existing RHEL9 deployment.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->