### PR TITLE
[6.18.z] Fix AzureRM UI test host deletion assertion (#20466)

### DIFF
--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -14,6 +14,7 @@
 
 from fauxfactory import gen_string
 import pytest
+from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import (
@@ -135,8 +136,12 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
 
                 # Host Delete
                 with sat_azure.api_factory.satellite_setting('destroy_vm_on_host_delete=True'):
-                    session.host.delete(fqdn)
-                assert not session.host.search(fqdn)
+                    session.host_new.delete(fqdn)
+                wait_for(
+                    lambda: session.host_new.search(fqdn)[0].get('Name') == 'No Results',
+                    timeout=300,
+                    delay=10,
+                )
 
                 # AzureRm Cloud assertion
                 assert not azurecloud_vm.exists


### PR DESCRIPTION
* Fix AzureRM UI test host deletion assertion

---------


(cherry picked from commit 7532ef391b095f2b52168a685cfeea7d70488644)

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->