### PR TITLE
[6.18.z] Kept few e2e test case for each RH Cloud  functionality as a part of interopt

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -139,8 +139,6 @@ def test_rhcloud_insights_e2e(
 
 
 @pytest.mark.e2e
-@pytest.mark.pit_server
-@pytest.mark.pit_client
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([10])
 def test_rhcloud_insights_remediate_multiple_hosts(

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -398,8 +398,6 @@ def test_rhcloud_inventory_without_manifest(session, module_org, target_sat):
     )
 
 
-@pytest.mark.pit_server
-@pytest.mark.pit_client
 @pytest.mark.run_in_one_thread
 def test_rhcloud_global_parameters(
     inventory_settings,
@@ -649,7 +647,6 @@ def test_rh_cloud_minimal_report(
 
 
 @pytest.mark.e2e
-@pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.rhel_ver_list([7, 8, 9, 10])
 def test_sync_inventory_status(rhcloud_manifest_org, rhcloud_registered_hosts, module_target_sat):

--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -102,8 +102,6 @@ def test_iop_recommendations_e2e(
 
 
 @pytest.mark.e2e
-@pytest.mark.pit_server
-@pytest.mark.pit_client
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match(r'^(?![78]).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
@@ -275,8 +273,6 @@ def test_rhcloud_inventory_disabled_local_insights(module_target_sat_insights):
 
 
 @pytest.mark.e2e
-@pytest.mark.pit_server
-@pytest.mark.pit_client
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match(r'^(?![78]).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20516

### Problem Statement
During each interop test milestone, we experience numerous failures within the RH Cloud test automation.
Card : https://issues.redhat.com/browse/SAT-41010
### Solution
Kept only one e2e test case for each RH Cloud  functionality in interopt

### Related Issues

Note: No PRT needed a this is just removal of markers.
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->