### PR TITLE
Add check for 502 responses from forwarding URLs with pipe character

### DIFF
--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -92,7 +92,7 @@ def test_iop_recommendations_e2e(
         result = module_target_sat_insights.execute(
             'grep "502 Bad Gateway" /var/log/foreman/production.log'
         )
-        assert result.status != 1
+        assert result.status != 0
 
         # Verify that the recommendation is not listed anymore.
         assert (


### PR DESCRIPTION
This PR adds a check to the IOP end-to-end test verifying that no 502 Bad Gateway errors are present in production.log after clicking a URL containing an encoded pipe character. Prior to the fix for SAT-35946, the `foreman_rh_cloud` plugin, clicking a URL that contained a `|` (such as an rule name on the Red Hat Lightspeed > Recommendations page of the Satellite webUI, which is clicked during `test_iop_recommendations_e2e`) would result in an HTTP 502 response on an IOP-enabled Satellite.