### PR TITLE
HC Assigned Content Test Fix & Block HostCol tests

### DIFF
--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -224,6 +224,8 @@ def test_positive_end_to_end(module_target_sat, module_org_with_parameter, smart
     :expectedresults: All expected CRUD actions finished successfully
 
     :CaseImportance: High
+
+    :BlockedBy: SAT-41383
     """
     hc_name = gen_string('alpha')
     new_name = gen_string('alpha')
@@ -273,6 +275,8 @@ def test_negative_install_via_remote_execution(
 
     :expectedresults: The package is not installed, and the job invocation
         status contains some expected values: hosts information, jos status.
+
+    :BlockedBy: SAT-41383
     """
     hosts = []
     for _ in range(2):
@@ -311,6 +315,8 @@ def test_negative_install_via_custom_remote_execution(
 
     :expectedresults: The package is not installed, and the job invocation
         status contains some expected values: hosts information, jos status.
+
+    :BlockedBy: SAT-41383
     """
     hosts = []
     for _ in range(2):
@@ -344,6 +350,8 @@ def test_positive_add_host(session, module_target_sat):
     :id: 80824c9f-15a1-4f76-b7ac-7d9ca9f6ed9e
 
     :expectedresults: Host is added to Host Collection successfully
+
+    :BlockedBy: SAT-41383
     """
     hc_name = gen_string('alpha')
     org = module_target_sat.api.Organization().create()
@@ -377,6 +385,8 @@ def test_positive_install_package(
 
     :expectedresults: Package was successfully installed on all the hosts
         in host collection
+
+    :BlockedBy: SAT-41383
     """
     with session:
         session.organization.select(org_name=module_org_with_parameter.name)
@@ -400,6 +410,8 @@ def test_positive_remove_package(
 
     :expectedresults: Package was successfully removed from all the hosts
         in host collection
+
+    :BlockedBy: SAT-41383
     """
     _install_package_with_assertion(vm_content_hosts, constants.FAKE_0_CUSTOM_PACKAGE)
     with session:
@@ -425,6 +437,8 @@ def test_positive_upgrade_package(
 
     :expectedresults: Package was successfully upgraded on all the hosts in
         host collection
+
+    :BlockedBy: SAT-41383
     """
     _install_package_with_assertion(vm_content_hosts, constants.FAKE_1_CUSTOM_PACKAGE)
     with session:
@@ -449,6 +463,8 @@ def test_positive_install_package_group(
 
     :expectedresults: Package group was successfully installed on all the
         hosts in host collection
+
+    :BlockedBy: SAT-41383
     """
     with session:
         session.organization.select(org_name=module_org_with_parameter.name)
@@ -473,6 +489,8 @@ def test_positive_remove_package_group(
 
     :expectedresults: Package group was successfully removed  on all the
         hosts in host collection
+
+    :BlockedBy: SAT-41383
     """
     for client in vm_content_hosts:
         result = client.run(f'yum groups install -y {constants.FAKE_0_CUSTOM_PACKAGE_GROUP_NAME}')
@@ -503,6 +521,8 @@ def test_positive_install_errata(
 
     :expectedresults: Errata was successfully installed in all the hosts in
         host collection
+
+    :BlockedBy: SAT-41383
     """
     _install_package_with_assertion(vm_content_hosts, constants.FAKE_1_CUSTOM_PACKAGE)
     with session:
@@ -566,6 +586,8 @@ def test_positive_change_assigned_content(
            names
 
     :BZ: 1315280
+
+    :BlockedBy: SAT-41383
     """
     new_lce_name = gen_string('alpha')
     new_cv_name = gen_string('alpha')
@@ -640,6 +662,8 @@ def test_negative_hosts_limit(module_target_sat, module_org_with_parameter, smar
 
     :expectedresults: Second host is not added to Host Collection and
         appropriate error is shown
+
+    :BlockedBy: SAT-41383
     """
     hc_name = gen_string('alpha')
     org = module_target_sat.api.Organization().create()
@@ -707,6 +731,8 @@ def test_positive_install_module_stream(
 
     :expectedresults: Module-Stream should get installed on all the hosts
         in host collection
+
+    :BlockedBy: SAT-41383
     """
     _run_remote_command_on_content_hosts('dnf -y upload-profile', vm_content_hosts_module_stream)
     with session:
@@ -758,6 +784,8 @@ def test_positive_install_modular_errata(
 
     :expectedresults: Modular Errata should get installed on all hosts in host
         collection.
+
+    :BlockedBy: SAT-41383
     """
     stream = "0"
     version = "20180704111719"


### PR DESCRIPTION
### Problem Statement
Fix the host collection content assignment test. The task details page was changed in stream 154.
Also block the tests as the navigation to `Host Collections` is broken (SAT-41383)


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostcollection.py
airgun: 2255
```