### PR TITLE
Manage Traces UI Test Refactor

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -77,15 +77,7 @@ def mock_service_as_rebootable(contenthost, service_name):
     Usage:
         with mock_service_as_rebootable(rhel_contenthost, 'robottelo-mock-service'):
             rhel_contenthost.execute('yum -y downgrade robottelo-mock-service')
-            rhel_contenthost.execute('dnf katello-tracer-upload')
-            # Service now appears as type='static' requiring reboot
 
-    Example:
-        >>> with mock_service_as_rebootable(host, 'test-service'):
-        ...     # Service is now in STATIC_SERVICES list
-        ...     host.execute('yum downgrade test-service')
-        ...     # Tracer will classify it as needing reboot
-        ... # Automatically cleaned up when exiting context
     """
     # Dynamically find the katello tracer dnf.py file (Python version agnostic)
     find_cmd = 'python3 -c "import katello.tracer.dnf; print(katello.tracer.dnf.__file__)"'


### PR DESCRIPTION
### Problem Statement
The `test_positive_all_hosts_manage_traces()` started failing and stopped being reliable in the way it was generating rebootable traces, by upgrading/downgrading systemd or kernel packages.

### Solution
1. Created `mock_service_as_rebootable()` context manager
A reusable helper that temporarily modifies the Katello tracer configuration on the host to classify any service as `type='static'` (reboot-required) instead of `type='daemon'` (restart-required). 
This enables reliable testing of reboot scenarios using only the `robottelo-mock-service` package, which before could be used only for restart scenario.

	Key features:
	 - Dynamically locates katello tracer module (Python version agnostic)
	 - Modifies `STATIC_SERVICES` list to include the specified service
	 - Automatic backup and restoration of original configuration
	 - Comprehensive error handling and logging

2. Refactored `test_positive_all_hosts_manage_traces()`
Simplified the test for better maintainability and clarity.
Simplified parametrization to a single boolean require_reboot parameter.
Better test isolation: Uses only `robottelo-mock-service` package instead of mixing real system packages


### PRT example
<img width="299" height="117" alt="image" src="https://github.com/user-attachments/assets/5f9ad338-53bf-4ae8-8e2c-caa7c0066024" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_positive_all_hosts_manage_traces'
```