### PR TITLE
[6.18.z] Fix template sync over SSH on IPv6

### DIFF
--- a/pytest_fixtures/component/templatesync.py
+++ b/pytest_fixtures/component/templatesync.py
@@ -66,7 +66,7 @@ def git_pub_key(session_target_sat, git_port):
     id = res.json()['id']
     # add ssh key to known host
     session_target_sat.execute(
-        f'ssh-keyscan -4 -t rsa -p {git.ssh_port} {git.hostname} > {key_path}/known_hosts'
+        f"sudo -u foreman sh -c 'ssh-keyscan -t rsa -p {git.ssh_port} {git.hostname} >> {key_path}/known_hosts'"
     )
     yield
     res = requests.delete(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20552

### Problem Statement
Template sync tests that use SSH for transport are failing on IPv6 while on IPv4 they pass:
```
    Could not export:
      git '--git-dir=/tmp/d20251201-23437-yapn4p/.git' '--work-tree=/tmp/d20251201-23437-yapn4p' '-c' 'core.quotePath=true' '-c' 'color.ui=false' 'fetch' '--' 'origin'  2>&1
      status: pid 33515 exit 128
      output: "Host key verification failed.\r\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.\n"
```
Further investigation showed that `ssh-keyscan` is used with wrong parameter `-4`:
```
[D 251218 12:12:36 hosts:198] <SAT_FQDN> executing command: ssh-keyscan -4 -t rsa -p 50126 infra-podman-ipv6.infra > /usr/share/foreman/.ssh/known_hosts
[D 251218 12:12:36 hosts:200] <SAT_FQDN> command result:
    stdout:
    
    stderr:
    getaddrinfo infra-podman-ipv6.infra: Name or service not known
    
    status: 1
```

### Solution
Sanitize `ssh-keyscan` command: 
* ~~`-4`~~ - don't always use ipv4, especially on ipv6
* `sudo -u foreman ...` - `.ssh/known_hosts` file should be owned by user `foreman` not `root`
* `>> {key_path}/known_hosts` - `.ssh/known_hosts` file may contain multiple entries, append new entry

### Related Issues
[SAT-41275](https://issues.redhat.com/browse/SAT-41275)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->