### PR TITLE
Block RHC CLI Test

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -390,6 +390,8 @@ def test_positive_generate_reports_job_cli(
         1. Execute hammer insights inventory generate-report.
 
     :expectedresults: Reports generation works as expected.
+
+    :BlockedBy: SAT-38836
     """
     org = rhcloud_manifest_org
     generate_report(org, module_target_sat, disconnected=False)


### PR DESCRIPTION
Block `test_positive_generate_reports_job_cli` because of the SAT-38836

