### PR TITLE
Updated RHC  generate inventory report task name

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2654,7 +2654,7 @@ class Satellite(Capsule, SatelliteMixins):
 
     def generate_inventory_report(self, org, disconnected='false'):
         """Function to perform inventory upload."""
-        generate_report_task = 'ForemanInventoryUpload::Async::GenerateReportJob'
+        generate_report_task = 'ForemanInventoryUpload::Async::HostInventoryReportJob'
         timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         self.api.Organization(id=org.id).rh_cloud_generate_report(
             data={'disconnected': disconnected}


### PR DESCRIPTION
### Problem Statement
Test cases were failing as RHC generate inventory report task name 'ForemanInventoryUpload::Async::GenerateReportJob' changed.

### Solution
Updated RHC  generate inventory report task name to `ForemanInventoryUpload::Async::HostInventoryReportJob`

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_rhcloud_inventory.py -k  'test_rhcloud_scheduled_insights_sync'

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->