### PR TITLE
[6.18.z] Upgrade Broker to 0.8 and refine logging setup

### DIFF
--- a/pytest_plugins/logging_hooks.py
+++ b/pytest_plugins/logging_hooks.py
@@ -7,9 +7,7 @@ from xdist import is_xdist_worker
 
 from robottelo.logging import (
     DEFAULT_DATE_FORMAT,
-    broker_log_setup,
     logger,
-    logging_yaml,
     robottelo_log_dir,
     robottelo_log_file,
 )
@@ -55,12 +53,6 @@ def configure_logging(request, worker_id):
         worker_handler.setFormatter(worker_formatter)
         worker_handler.setLevel(worker_log_level)
         logger.addHandler(worker_handler)
-        broker_log_setup(
-            level=logging_yaml.broker.level,
-            file_level=logging_yaml.broker.fileLevel,
-            formatter=worker_formatter,
-            path=robottelo_log_dir.joinpath(f'robottelo_{worker_id}.log'),
-        )
 
         if use_rp_logger:
             rp_handler = RPLogHandler(request.node.config.py_test_service)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Version updates managed by dependabot
 
 apypie==0.7.1
-broker[satlab,docker,ssh2_python]==0.7.3
+broker[satlab,docker,ssh2_python]==0.8.0
 cryptography==43.0.3
 deepdiff==8.6.1
 dynaconf[vault]==3.2.11


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20598

Configuration:
- Updated `broker` dependency from `0.7.3` to `0.8.0` in `requirements.txt`.

Refactoring:
- Removed explicit calls to `broker_log_setup` from `robottelo/logging.py` and `pytest_plugins/logging_hooks.py`.
- `broker` version 0.8 now manages its logging configuration internally or through different mechanisms, making the previous explicit setup calls redundant or incompatible.

Features:
- Integrated `broker.logging.RedactingFilter` to automatically redact sensitive information, such as passwords and tokens, from `broker` log output.
- This enhances log security by preventing the accidental leakage of credentials.
- The TRACE log level is now automatically registered upon importing `broker.logging`.
