### PR TITLE
Update tests for new inventory upload ui

### DIFF
--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -601,15 +601,17 @@ def test_rh_cloud_minimal_report(
             session.cloudinventory.generate_and_upload_report(org.name)
             # wait_for_tasks report generation task to finish
             wait_for(
-                lambda: module_target_sat.api.ForemanTask()
-                .search(
-                    query={
-                        'search': f'label = ForemanInventoryUpload::Async::HostInventoryReportJob '
-                        f'and started_at >= "{timestamp}"'
-                    }
-                )[0]
-                .result
-                == 'success',
+                lambda: (
+                    module_target_sat.api.ForemanTask()
+                    .search(
+                        query={
+                            'search': f'label = ForemanInventoryUpload::Async::HostInventoryReportJob '
+                            f'and started_at >= "{timestamp}"'
+                        }
+                    )[0]
+                    .result
+                    == 'success'
+                ),
                 timeout=400,
                 delay=15,
                 silent_failure=True,


### PR DESCRIPTION
Updating tests for new Inventory Upload page
SAT-39884
https://github.com/SatelliteQE/airgun/pull/2258

## Summary by Sourcery

Update Red Hat cloud inventory UI tests to align with the new inventory upload workflow, task naming, and settings behavior.

Tests:
- Adjust end-to-end and settings tests to use separate generate-and-upload vs generate-only flows and the new HostInventoryReport background task label.
- Update assertions to validate new task status, report location fields, and revised button/visibility behavior in the inventory upload UI based on subscription connection state.
- Introduce an autouse fixture to reset inventory-related settings before each test and add cleanup logic to restore default data collection and obfuscation settings after minimal-report tests.
- Remove the obsolete test for inventory behavior without an imported manifest and update minimal data collection tests to match the new UI and report field expectations.