### PR TITLE
Add tests for rolling CV LCE support

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1329,7 +1329,7 @@ class TestRollingContentView:
                     name=f'LCE-{i}-{j}', organization=function_org, prior=lces[-1].id
                 ).create()
                 lces.append(lce)
-                # gather all environments for this organization
+        # gather all environments for this organization
         all_envs = [
             env.read()
             for env in target_sat.api.LifecycleEnvironment().search(


### PR DESCRIPTION
### Problem Statement
Rolling CVs can now be assigned to different LCEs than Library.

### Solution
Add 2 tests covering these cases.

### Related Issues
https://issues.redhat.com/browse/SAT-37739

PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_contentview.py -k '_lce'
