### PR TITLE
Ensure hosts can continue reporting after enabling IOP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ broker[satlab,docker,ssh2_python]==0.8.0
 cryptography==43.0.3
 deepdiff==8.6.1
 dynaconf[vault]==3.2.12
+epdb==0.15.1
 fastmcp==2.14.3
 fauxfactory==4.2.0
 jinja2==3.1.6

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -362,10 +362,14 @@ def test_host_insights_registration_status_when_enabling_iop(
     :Verifies: SAT-40987
 
     """
+    import epdb
+    epdb.serve(port=6000)
+
     enable_insights(
         rhel_contenthost, target_sat, function_sca_manifest_org, function_activation_key
     )
     assert rhel_contenthost.execute('insights-client --version').status == 0
+    assert rhel_contenthost.execute('insights-client').status == 0
 
     result = target_sat.execute(
         f'podman login --authfile /etc/foreman/registry-auth.json -u {settings.subscription.rhn_username} -p {settings.subscription.rhn_password} registry.redhat.io'


### PR DESCRIPTION
This PR automates testing for SAT-40987, which fixes a bug in which hosts needed to re-register to Insights after enabling IOP on a Satellite if the hosts were previously registered to hosted Insights through the Satellite. It adds a new CLI test to verify that this behavior is no longer present.