### PR TITLE
Host API Image Test Fix

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -23,7 +23,7 @@ from nailgun import client
 import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.config import get_credentials
+from robottelo.config import get_credentials, settings
 from robottelo.constants import (
     DEFAULT_CV,
     ENVIRONMENT,
@@ -662,7 +662,13 @@ def test_positive_end_to_end_with_host_parameters(module_org, module_location, m
 
 @pytest.mark.e2e
 def test_positive_end_to_end_with_image(
-    module_org, module_location, module_cr_libvirt, module_libvirt_image, module_target_sat
+    module_org,
+    module_location,
+    module_cr_libvirt,
+    libvirt,
+    default_architecture,
+    module_os,
+    module_target_sat,
 ):
     """Create a host with an image specified then remove it
     and update the host with the same image afterwards
@@ -671,9 +677,20 @@ def test_positive_end_to_end_with_image(
 
     :expectedresults: A host is created with expected image, image is removed and
         host is updated with expected image
-
-    :BlockedBy: SAT-32733
     """
+    # Configure SSH authentication for libvirt connection before creating image
+    module_target_sat.configure_libvirt_cr(server_fqdn=libvirt.fqdn)
+
+    module_libvirt_image = module_target_sat.api.Image(
+        compute_resource=module_cr_libvirt,
+        name=gen_string('alpha'),
+        operatingsystem=module_os,
+        architecture=default_architecture,
+        username=settings.libvirt.image_username,
+        password=settings.libvirt.image_password,
+        uuid=settings.libvirt.libvirt_image_path,
+    ).create()
+
     host = module_target_sat.api.Host(
         organization=module_org,
         location=module_location,


### PR DESCRIPTION
Add image creation and libvirt SSH setup to the test.


### PRT test Cases example
<img width="293" height="44" alt="image" src="https://github.com/user-attachments/assets/01a48982-c53e-4b16-9df2-e7f04cabc6e5" />

```
trigger: test-robottelo
pytest: tests/foreman/api/test_host.py -k "test_positive_end_to_end_with_image"
```