### PR TITLE
Fix test_positive_host_with_rolling_content_source

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1110,10 +1110,9 @@ class TestRollingContentView:
     def test_positive_host_with_rolling_content_source(
         self,
         target_sat,
-        module_rhel_contenthost,
+        rhel_contenthost,
         function_sca_manifest_org,
         function_product,
-        request,
     ):
         """Can use the rolling content view as a content source for a registered host.
         We can use the custom and RedHat repositories available to the content host.
@@ -1125,9 +1124,8 @@ class TestRollingContentView:
             1) Several custom and RedHat repositories added to new rolling cv.
             2) Assign the rolling cv to an activation key.
             3) Override the repos to Enabled for activation key (Hammer).
-            4) Add finalizer, cleanup: unregister the host.
-            5) Register a RHEL host to the activation key.
-            6) SCA enabled, host auto-enabled repos that were overridden for AK.
+            4) Register a RHEL host with the activation key.
+            5) SCA enabled, host auto-enabled repos that were overridden for AK.
 
         :steps:
             1) Remove a repository from the rolling cv. (expectedresults: 3)
@@ -1148,9 +1146,11 @@ class TestRollingContentView:
 
         :customerscenario: true
 
+        :BlockedBy: SAT-30580
+
         """
         org = function_sca_manifest_org
-        client = module_rhel_contenthost
+        client = rhel_contenthost
         custom_repo = target_sat.api.Repository(
             product=function_product, url=settings.repos.yum_9.url
         ).create()
@@ -1164,7 +1164,9 @@ class TestRollingContentView:
         )
         rh_repo = target_sat.api.Repository(id=rh_repo_id, organization=org).read()
         # Create empty rolling cv, add both repos, update it
-        rolling_cv = target_sat.api.ContentView(organization=org, rolling=True).create()
+        rolling_cv = target_sat.api.ContentView(
+            organization=org, rolling=True, environment=[org.library]
+        ).create()
         rolling_cv.repository = [custom_repo.read(), rh_repo.read()]
         rolling_cv.update(['repository'])
         rolling_cv = rolling_cv.read()
@@ -1181,14 +1183,6 @@ class TestRollingContentView:
             value=True,
         )
         assert override['result'] == 'success'
-
-        # Cleanup for in-between parametrized sessions,
-        # unregister the host if it still exists
-        @request.addfinalizer
-        def cleanup():
-            nonlocal client
-            if client:
-                client.unregister()
 
         result = client.register(
             target=target_sat,
@@ -1215,10 +1209,6 @@ class TestRollingContentView:
         rh_repo_content_label = target_sat.cli.Repository.info({'id': rh_repo.id})['content-label']
         assert rh_repo_content_label in sub_man_repos
         time.sleep(30)
-        # rh repo's package (python) is installed and up to date
-        assert 'x86_64' in client.execute('rpm -q python3').stdout
-        result = client.execute('yum install -y python3')
-        assert 'is already installed' in result.stdout
         # custom repo's outdated package can be installed
         assert client.execute(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}').status == 0
         # outdated package makes errata installable, count increased


### PR DESCRIPTION
### Problem Statement
The `test_positive_host_with_rolling_content_source` has been failing since the very beginning (see https://github.com/SatelliteQE/robottelo/pull/19262#issuecomment-3254039761) because of a [bug](https://issues.redhat.com/browse/SAT-30580).
It also uses `module_rhel_contenhost` which doesn't seem appropriate since we are parametrizing through different RHEL versions, and it expects `python3` to be pre-installed for some reason (which is not the case of RHEL8) and I can't see any reason behind testing it.

Additionally for `stream` we need to add an LCE to the Rolling CV so it delivers the content. This needs to be removed from the `6.18.z` cherry-pick since it's present there by default.


### Solution
* Use rhel_contenthost since we parametrize by RHEL version anyway; no finalizer needed
* Add Library LCE to the Rolling CV (stream only)
* Do NOT expect python3 to be pre-installed (case of RHEL8)
* Block the case by SAT-30580 since it affects the errata counts (should have been blocked in #19262)


### Related Issues
https://issues.redhat.com/browse/SAT-39209
https://issues.redhat.com/browse/SAT-30580


### PRT test Cases example
Not applicable (we block the case)