### PR TITLE
Fix loadbalancer config for IPv6

### DIFF
--- a/tests/foreman/data/haproxy.cfg
+++ b/tests/foreman/data/haproxy.cfg
@@ -10,7 +10,7 @@ global
     stats socket /var/lib/haproxy/stats
 
 listen stats
-bind :5566
+bind :::5566
 stats enable
 stats hide-version
 stats refresh 20s
@@ -31,7 +31,7 @@ defaults
 
 #https + rhsm
 frontend https
-   bind *:443
+   bind :::443
    mode tcp
    option              	tcplog
    default_backend f-proxy-https
@@ -45,7 +45,7 @@ backend f-proxy-https
 
 #http
 frontend http
-   bind *:80
+   bind :::80
    mode tcp
    option              	tcplog
    default_backend f-proxy-http
@@ -59,7 +59,7 @@ backend f-proxy-http
 
 #amqp
 frontend amqp
-   bind *:5647
+   bind :::5647
    mode tcp
    option              	tcplog
    default_backend f-proxy-amqp
@@ -73,7 +73,7 @@ backend f-proxy-amqp
 
 #anaconda
 frontend anaconda
-   bind *:8000
+   bind :::8000
    mode tcp
    option              	tcplog
    default_backend f-proxy-anaconda
@@ -87,7 +87,7 @@ backend f-proxy-anaconda
 
 #scap
 frontend scap
-   bind *:9090
+   bind :::9090
    mode tcp
    option              	tcplog
    default_backend f-proxy-scap
@@ -101,7 +101,7 @@ backend f-proxy-scap
 
 #docker
 frontend docker
-   bind *:5000
+   bind :::5000
    mode tcp
    option              	tcplog
    default_backend f-proxy-docker

--- a/tests/foreman/sys/test_capsule_loadbalancer.py
+++ b/tests/foreman/sys/test_capsule_loadbalancer.py
@@ -139,25 +139,28 @@ def setup_haproxy(
     module_haproxy.execute('firewall-cmd --add-service RH-Satellite-6-capsule')
     module_haproxy.execute('firewall-cmd --runtime-to-permanent')
     module_haproxy.register(module_org, None, haproxy_ak.name, module_target_sat)
-    result = module_haproxy.execute('yum install haproxy policycoreutils-python-utils -y')
+    result = module_haproxy.execute('yum install -y haproxy policycoreutils-python-utils')
     assert result.status == 0
-    module_haproxy.execute('rm -f /etc/haproxy/haproxy.cfg')
+    config_file = '/etc/haproxy/haproxy.cfg'
+    module_haproxy.execute(f'mv {config_file} {config_file}.bak')
     module_haproxy.session.sftp_write(
         source=DataFile.DATA_DIR.joinpath('haproxy.cfg'),
-        destination='/etc/haproxy/haproxy.cfg',
+        destination=config_file,
     )
     module_haproxy.execute(
         f'sed -i -e s/CAPSULE_1/{setup_capsules[0].hostname}/g '
-        f' --e s/CAPSULE_2/{setup_capsules[1].hostname}/g '
-        f' /etc/haproxy/haproxy.cfg'
+        f'-e s/CAPSULE_2/{setup_capsules[1].hostname}/g '
+        f'{config_file}'
     )
-    module_haproxy.execute('systemctl restart haproxy.service')
+    module_haproxy.execute('systemctl enable haproxy.service')
+    module_haproxy.execute('semanage boolean -m --on haproxy_connect_any')
+    # HAProxy logging setup
     module_haproxy.execute('mkdir /var/lib/haproxy/dev')
     module_haproxy.session.sftp_write(
         source=DataFile.DATA_DIR.joinpath('99-haproxy.conf'),
         destination='/etc/rsyslog.d/99-haproxy.conf',
     )
-    module_haproxy.execute('setenforce permissive')
+    module_haproxy.execute('setenforce permissive')  # logging setup requires permissive mode
     assert module_haproxy.execute('systemctl restart haproxy.service rsyslog.service').status == 0
 
     haproxy_url = f'https://{module_haproxy.hostname}:9090'
@@ -179,6 +182,7 @@ def setup_haproxy(
 @pytest.mark.e2e
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_loadbalancer_install_package(
+    setup_haproxy,
     setup_capsules,
     content_for_client,
     module_target_sat,


### PR DESCRIPTION
### Problem Statement
Loadbalancer configuration in `haproxy.cfg` configures to listen only on IPv4 addresses.
```
2025-12-02 02:00:40 - gw1 - broker - DEBUG - <CONTENT_HOST_FQDN> command result:
    stdout:
    
    stderr:
    curl: (7) Failed to connect to <LOADBALANCER_FQDN> port 9090: Connection refused
```    

### Solution
Change configuration in `haproxy.cfg` so that loadbalancer works in both IPv4 and IPv6.

### Related Issues
[SAT-41242](https://issues.redhat.com/browse/SAT-41242)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->