### PR TITLE
[6.18.z] Remove sneaked env assignment to RCV from 6.18.z

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1190,9 +1190,7 @@ class TestRollingContentView:
         )
         rh_repo = target_sat.api.Repository(id=rh_repo_id, organization=org).read()
         # Create empty rolling cv, add both repos, update it
-        rolling_cv = target_sat.api.ContentView(
-            organization=org, rolling=True, environment=[org.library]
-        ).create()
+        rolling_cv = target_sat.api.ContentView(organization=org, rolling=True).create()
         rolling_cv.repository = [custom_repo.read(), rh_repo.read()]
         rolling_cv.update(['repository'])
         rolling_cv = rolling_cv.read()


### PR DESCRIPTION
This particular fix is related to `stream` only. I planned to remove it from the [auto-cherry-picked PR](https://github.com/SatelliteQE/robottelo/pull/20635) before merge, but didn't make it. The rest of the ACP PR is OK.