### PR TITLE
Fix flaky test_positive_candlepin_events_processed_by_stomp

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -17,7 +17,6 @@ https://<sat6.com>/apidoc/v2/subscriptions.html
 """
 
 import re
-import time
 
 from fauxfactory import gen_string
 from nailgun.config import ServerConfig
@@ -292,7 +291,8 @@ def test_positive_candlepin_events_processed_by_stomp(
     wait_for(
         lambda: parse(
             target_sat.api.Ping().search_json()['services']['candlepin_events']['message']
-        )['Processed'] > pre_processed_count,
+        )['Processed']
+        > pre_processed_count,
         timeout=60,
         delay=5,
         handle_exception=True,


### PR DESCRIPTION
### Problem Statement
Flaky test that intermittently failed with assert 36 > 36

### Solution
Replace fixed time.sleep(5) with wait_for() polling to eliminate test flakiness. The test was intermittently failing because 5 seconds was not always enough time for Candlepin to process manifest upload events via STOMP.

Changes:
- Added wait_for import from wait_for library
- Replaced time.sleep(5) with wait_for() that polls for processed event count to increase
- Set 60 second timeout with 5 second polling interval
- Stored pre_processed_count for cleaner comparison

The test now waits up to 60 seconds for Candlepin to process events, returning immediately when the condition is met, eliminating race conditions while improving test execution time when Candlepin processes quickly.

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: pytest -sv tests/foreman/api/test_subscription.py -k test_positive_candlepin_events_processed_by_stomp

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->