### PR TITLE
Skip RHSSO login test if the issue with never ending javascript has not been fixed

### DIFF
--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -295,6 +295,8 @@ def test_external_logout_rhsso(rhsso_setting_setup, enable_external_auth_rhsso, 
         3. Logout from Satellite and Verify the external_logout page displayed
 
     :expectedresults: After logout from Satellite navigate should be external_loout page
+
+    :BlockedBy: SAT-41562
     """
     with module_target_sat.ui_session(login=False) as session:
         login_details = {


### PR DESCRIPTION
### Problem Statement
https://issues.redhat.com/browse/SAT-41562

### Solution
Skip the test until it's fixed

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->
