### PR TITLE
[6.16.z] Fix loadbalancer config for IPv6

### DIFF
--- a/tests/foreman/data/haproxy.cfg
+++ b/tests/foreman/data/haproxy.cfg
@@ -10,7 +10,7 @@ global
     stats socket /var/lib/haproxy/stats
 
 listen stats
-bind :5566
+bind :::5566
 stats enable
 stats hide-version
 stats refresh 20s
@@ -31,7 +31,7 @@ defaults
 
 #https
 frontend https
-   bind *:443
+   bind :::443
    mode tcp
    option              	tcplog
    default_backend f-proxy-https
@@ -45,7 +45,7 @@ backend f-proxy-https
 
 #http
 frontend http
-   bind *:80
+   bind :::80
    mode tcp
    option              	tcplog
    default_backend f-proxy-http
@@ -59,7 +59,7 @@ backend f-proxy-http
 
 #amqp
 frontend amqp
-   bind *:5647
+   bind :::5647
    mode tcp
    option              	tcplog
    default_backend f-proxy-amqp
@@ -73,7 +73,7 @@ backend f-proxy-amqp
 
 #anaconda
 frontend anaconda
-   bind *:8000
+   bind :::8000
    mode tcp
    option              	tcplog
    default_backend f-proxy-anaconda
@@ -101,7 +101,7 @@ backend f-proxy-rhsm
 
 #scap
 frontend scap
-   bind *:9090
+   bind :::9090
    mode tcp
    option              	tcplog
    default_backend f-proxy-scap
@@ -115,7 +115,7 @@ backend f-proxy-scap
 
 #docker
 frontend docker
-   bind *:5000
+   bind :::5000
    mode tcp
    option              	tcplog
    default_backend f-proxy-docker


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20634

### Problem Statement
Loadbalancer configuration in `haproxy.cfg` configures to listen only on IPv4 addresses.
```
2025-12-02 02:00:40 - gw1 - broker - DEBUG - <CONTENT_HOST_FQDN> command result:
    stdout:
    
    stderr:
    curl: (7) Failed to connect to <LOADBALANCER_FQDN> port 9090: Connection refused
```    

### Solution
Change configuration in `haproxy.cfg` so that loadbalancer works in both IPv4 and IPv6.

### Related Issues
[SAT-41242](https://issues.redhat.com/browse/SAT-41242)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->