### PR TITLE
[6.18.z] Fix test_positive_check_permissions_affect_create_procedure by adding location to hostgroups

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -764,8 +764,12 @@ def test_positive_check_permissions_affect_create_procedure(
         content_view = content_view.read()
         content_view.version[0].promote(data={'environment_ids': filter_lc_env.id})
     # Create two host groups
-    hg = target_sat.api.HostGroup(organization=[function_org]).create()
-    filter_hg = target_sat.api.HostGroup(organization=[function_org]).create()
+    hg = target_sat.api.HostGroup(
+        organization=[function_org], location=[smart_proxy_location]
+    ).create()
+    filter_hg = target_sat.api.HostGroup(
+        organization=[function_org], location=[smart_proxy_location]
+    ).create()
     # Create lifecycle environment permissions and select one specific
     # environment user will have access to
     target_sat.api_factory.create_role_permissions(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20645

### Problem Statement

The test was failing because hostgroups were created without a location assigned, making them invisible to users with a specific location. This fix ensures that both hostgroups are created with smart_proxy_location so they appear in the dropdown when the user attempts to create a host.

### Solution

The hostgroups now include location=[smart_proxy_location] in their creation, matching the location assigned to the test user.

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k test_positive_check_permissions_affect_create_procedure

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->