### PR TITLE
Replace library/busybox with lighter container repo

### DIFF
--- a/conf/container.yaml.template
+++ b/conf/container.yaml.template
@@ -4,7 +4,7 @@ CONTAINER:
     - docker
     - podman
   REGISTRY_HUB: https://mirror.gcr.io
-  UPSTREAM_NAME: 'library/busybox'
+  UPSTREAM_NAME: jmalloc/echo-server
   ALTERNATIVE_UPSTREAM_NAMES:
     - hello-world
     - alpine

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -119,7 +119,7 @@ VALIDATORS = dict(
             'container.upstream_name',
             must_exist=True,
             is_type_of=str,
-            default='library/busybox',
+            default='jmalloc/echo-server',
         ),
         Validator(
             'container.alternative_upstream_names',

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -11,6 +11,7 @@
 """
 
 from datetime import UTC, datetime
+import re
 
 from box import Box
 from fauxfactory import gen_string
@@ -94,16 +95,18 @@ class TestDockerClient:
             )
             assert result.status == 0
             try:
-                result = module_container_contenthost.execute(f'docker run {repo["published-at"]}')
+                result = module_container_contenthost.execute(
+                    f'docker run -d {repo["published-at"]}'
+                )
                 assert result.status == 0
+                match = re.match(r'^[0-9a-f]+$', result.stdout)
+                if match:
+                    container_id = match.group(0)
             finally:
                 # Stop and remove the container
-                result = module_container_contenthost.execute(
-                    f'docker ps -a | grep {repo["published-at"]}'
-                )
-                container_id = result.stdout[0].split()[0]
-                module_container_contenthost.execute(f'docker stop {container_id}')
-                module_container_contenthost.execute(f'docker rm {container_id}')
+                if container_id:
+                    module_container_contenthost.execute(f'docker stop {container_id}')
+                    module_container_contenthost.execute(f'docker rm {container_id}')
         finally:
             # Remove docker image
             module_container_contenthost.execute(f'docker rmi {repo["published-at"]}')


### PR DESCRIPTION
### Problem Statement
Gradually over time the `library/busybox` repo is becoming more and more huge.
The problem with repo sync arises especially in IPv6 environment where the traffic goes over IPv6-to-4 proxy.

Testing revealed that syncing over IPv4 takes approx. 10 min while syncing over IPv6 takes 25 min and tends to time out quite often.

### Solution 
Find more suitable replacement for testing container repo target


### Related Issues
[SAT-41831](https://issues.redhat.com/browse/SAT-41831)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update container test configuration to use a lighter upstream image and adjust test execution accordingly.

Enhancements:
- Change the default container upstream image from library/busybox to jmalloc/echo-server in configuration validators.
- Adjust container management CLI test to run the pulled image in detached mode and simplify container ID extraction from command output.

Tests:
- Adapt the container pull-and-run test to work with the new upstream image behavior while maintaining container cleanup.