### PR TITLE
Add test for package file install command with more than 20 packages, the default pagination amount.

### DIFF
--- a/tests/foreman/api/test_imagemode.py
+++ b/tests/foreman/api/test_imagemode.py
@@ -838,13 +838,13 @@ def test_positive_transient_packages_containerfile_command_with_search(target_sa
 
 
 def test_positive_transient_packages_search_with_many_packages(target_sat):
-    """Test the transient_packages containerfile_install_command endpoint with more than 20 transient_packages
+    """Test the transient_packages containerfile_install_command endpoint with more than 20 transient_packages.
 
     :id: 1f133a31-2be0-4677-bcc5-0d023ba08cc9
 
     :steps:
         1. Create a host
-        2. Add more than 20 transient packages to the host
+        2. Add more than 20 transient packages to the host, so the total is above the default pagination amount.
         3. Call containerfile_install_command endpoint
         4. Verify all transient packages are included in the install command.
 


### PR DESCRIPTION
### Problem Statement
Containerfile Install command was having issues with pagination, causing it to possibly not return the full list of transient packages. 

### Related Issues
https://issues.redhat.com/browse/SAT-41161

```
trigger: test-robottelo
pytest: tests/foreman/api/test_imagemode.py -k 'test_positive_transient_packages_search_with_many_packages'
```