### PR TITLE
[6.18.z] Fix test_sync_AC_without_deadlock false positive

### DIFF
--- a/tests/foreman/destructive/test_capsulecontent.py
+++ b/tests/foreman/destructive/test_capsulecontent.py
@@ -299,5 +299,5 @@ def test_sync_AC_without_deadlock(
     assert sync_status['result'] == 'success', f'Capsule sync task failed: {sync_status}'
     sharelock_check = capsule_configured.execute('grep -i "ShareLock" /var/log/messages')
     assert sharelock_check.status != 0, 'ShareLock detected in /var/log/messages'
-    deadlock_check = capsule_configured.execute('grep -i "deadlock" /var/log/messages')
+    deadlock_check = capsule_configured.execute('grep -i "deadlock detected" /var/log/messages')
     assert deadlock_check.status != 0, 'Deadlock detected in /var/log/messages'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20670

### Problem Statement

The test test_sync_AC_without_deadlock was incorrectly failing with a false positive. The grep pattern "deadlock" was too broad and matched the test name itself when it appeared in /var/log/messages during loki reporting. This caused the assertion assert deadlock_check.status != 0 to fail even though no actual product deadlock occurred.

### Solution

Updated the grep pattern from "deadlock" to "deadlock detected" to be more specific. This ensures the test only detects actual deadlock errors in the logs while avoiding false positives from the test name being present in log messages.

### Related Issues


trigger: test-robottelo
pytest: tests/foreman/destructive/test_capsulecontent.py