### PR TITLE
added missing token in flatpak tests

### DIFF
--- a/tests/foreman/ui/test_flatpak.py
+++ b/tests/foreman/ui/test_flatpak.py
@@ -182,6 +182,7 @@ def test_rh_flatpak_remote_info_alert(target_sat, function_org):
         2. The shortcut button provides correct link to Red Hat flatpak registry.
         3. No info alert is displayed when RH Flatpak Remote already exists.
 
+    :verifies: SAT-36751
     """
     with target_sat.ui_session() as session:
         session.organization.select(function_org.name)
@@ -229,6 +230,7 @@ def test_rh_flatpak_mirror_repo_dependancy_alert(
         2. Mirroring starts with dependencies included.
         3. Selected repositories are mirrored into the chosen product.
 
+    :verifies: SAT-28473
     """
     candidate_repos = [
         repo


### PR DESCRIPTION
### Problem Statement
Two test does't have require testimony token in it.
`test_rh_flatpak_remote_info_alert` and `test_rh_flatpak_mirror_repo_dependancy_alert`
Test automation coverage have been added for below Jira.
https://issues.redhat.com/browse/SAT-36751
https://issues.redhat.com/browse/SAT-28473

### Solution
Add `:verifies:` token in both the test

### Related Issues
N/A

### Note:
PRT comment not needed.

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Enhancements:
- Annotate Red Hat flatpak remote info and mirror dependency alert tests with :verifies: markers linking them to their Jira issues.