### PR TITLE
Add UI test for containerfile command modal

### DIFF
--- a/tests/foreman/ui/test_imagemode.py
+++ b/tests/foreman/ui/test_imagemode.py
@@ -11,12 +11,12 @@
 :CaseImportance: High
 """
 
-from asyncio import wait_for
 import json
 import time
 
 from fauxfactory import gen_alpha, gen_string
 import pytest
+from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import (


### PR DESCRIPTION
### Problem Statement
A modal for generating a Containerfile install command for transient packages was added. This exercises that.

### Related Issues
Requires: https://github.com/SatelliteQE/airgun/pull/2276

```
trigger: test-robottelo
airgun: 2276
pytest: tests/foreman/ui/test_imagemode.py -k 'test_generate_containerfile_command'
```

## Summary by Sourcery

Tests:
- Add a UI test that exercises the Generate Containerfile Command modal for bootc hosts, covering known, unknown, and absent transient package persistence cases.