### PR TITLE
[6.17.z] Fix: Update test stdout access for hussh compatibility

### DIFF
--- a/tests/foreman/api/test_webhook.py
+++ b/tests/foreman/api/test_webhook.py
@@ -27,12 +27,13 @@ from robottelo.utils.datafactory import parametrized
 def _read_log(ch, pattern):
     """Read the first line from the given channel buffer and return the matching line"""
     # read lines until the buffer is empty
-    for log_line in ch.stdout().splitlines():
+    # Try hussh-style stdout first (attribute), fall back to ssh2-python style (method)
+    stdout = getattr(ch.result, 'stdout', None) if hasattr(ch, 'result') else ch.stdout()
+    for log_line in (stdout or '').splitlines():
         logger.debug(f'foreman-tail: {log_line}')
         if re.search(pattern, log_line):
             return log_line
-    else:
-        return None
+    return None
 
 
 def _wait_for_log(channel, pattern, timeout=2, delay=0.2):

--- a/tests/foreman/destructive/test_discoveredhost.py
+++ b/tests/foreman/destructive/test_discoveredhost.py
@@ -25,12 +25,13 @@ pytestmark = pytest.mark.destructive
 def _read_log(ch, pattern):
     """Read a first line from the given channel buffer and return the matching line"""
     # read lines until the buffer is empty
-    for log_line in ch.stdout().splitlines():
+    # Try hussh-style stdout first (attribute), fall back to ssh2-python style (method)
+    stdout = getattr(ch.result, 'stdout', None) if hasattr(ch, 'result') else ch.stdout()
+    for log_line in (stdout or '').splitlines():
         logger.debug(f'foreman-tail: {log_line}')
         if re.search(pattern, log_line):
             return log_line
-    else:
-        return None
+    return None
 
 
 def _wait_for_log(channel, pattern, timeout=5, delay=0.2):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20632

Refactoring:
- Improve `_read_log` functions in test utilities to safely handle `stdout` retrieval and processing.
- Replace direct attribute access `ch.result.stdout` with `getattr(ch.result, 'stdout', None)` to prevent `AttributeError` when `ch.result` is present but lacks the `stdout` attribute.
- Ensure `stdout` is a string before calling `splitlines()` by using `(stdout or '')`, which defaults to an empty string if `stdout` is `None`.
- Simplify the control flow by removing the `for...else` construct; `None` is now returned explicitly after the loop if no matching log line is found.
- These changes enhance the resilience of the log parsing helper against variations in channel output, preventing potential runtime errors during test execution.

Tests:
- Modify the `_read_log` helper function in webhook and discovered host tests.
- Implement a conditional check to access the standard output (stdout) from the SSH channel result.
- This change resolves an incompatibility issue now that `hussh` is the default SSH backend, as it exposes stdout as an attribute (`ch.result.stdout`) rather than a method (`ch.stdout()`) used by previous backends.
- Ensure test stability and compatibility across different SSH backend implementations.

## Summary by Sourcery

Update test log-reading helpers to be compatible with the new hussh SSH backend while maintaining fallback to older backends.

Bug Fixes:
- Prevent errors when accessing stdout in tests by supporting hussh's result.stdout attribute alongside the legacy stdout() method.

Tests:
- Adjust webhook and discovered host test helpers to read stdout from either ch.result.stdout or ch.stdout(), ensuring reliable log parsing across SSH backends.