### PR TITLE
[6.18.z] Add check for 502 responses from forwarding URLs with pipe character

### DIFF
--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -88,6 +88,12 @@ def test_iop_recommendations_e2e(
         assert result['status']['Succeeded'] != 0
         assert result['overall_status']['is_success']
 
+        # Verify that the Satellite is not affected by SAT-35946
+        result = module_target_sat_insights.execute(
+            'grep "502 Bad Gateway" /var/log/foreman/production.log'
+        )
+        assert result.status != 0
+
         # Verify that the recommendation is not listed anymore.
         assert (
             'No recommendations None of your connected systems are affected by enabled recommendations'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20594

This PR adds a check to the IOP end-to-end test verifying that no 502 Bad Gateway errors are present in production.log after clicking a URL containing an encoded pipe character. Prior to the fix for SAT-35946, the `foreman_rh_cloud` plugin, clicking a URL that contained a `|` (such as an rule name on the Red Hat Lightspeed > Recommendations page of the Satellite webUI, which is clicked during `test_iop_recommendations_e2e`) would result in an HTTP 502 response on an IOP-enabled Satellite.

## Summary by Sourcery

Tests:
- Extend the IOP recommendations end-to-end UI test to verify that no 502 Bad Gateway errors are logged in production.log after interacting with a URL containing an encoded pipe character.