### PR TITLE
[6.18.z] Added job template clone and crud operation

### DIFF
--- a/robottelo/cli/job_template.py
+++ b/robottelo/cli/job_template.py
@@ -9,9 +9,12 @@ Parameters:
 
 Subcommands:
 
+     clone          Clone a provision template
      create         Create a job template
      delete         Delete a job template
      dump           View job template content
+     export         Export a template including all metadata
+     import         Import a job template from ERB
      info           Show job template details
      list           List job templates
      update         Update a job template
@@ -42,3 +45,11 @@ class JobTemplate(Base):
         """
         cls.command_sub = 'import'
         return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def clone(cls, options=None, output_format="json", timeout=None):
+        """Clone a job template"""
+        cls.command_sub = 'clone'
+        return cls.execute(
+            cls._construct_command(options), output_format=output_format, timeout=timeout
+        )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19045

Added Clone operation to job template and merged job template create and delete tests  into CRUD test.

## Summary by Sourcery

Add CLI support and tests for cloning job templates and consolidate job template create/delete scenarios into a single CRUD test.

New Features:
- Introduce a CLI helper method to clone job templates via the `job-template` command.
- Document new `export` and `import` subcommands in the job template CLI help text.

Enhancements:
- Refactor job template tests to cover create, update, and delete operations in a single CRUD test case.
- Extend job template tests to validate cloning, dumping, unlocking, and cleanup of original and cloned templates.

Tests:
- Replace separate job template create and delete tests with a unified CRUD test covering create, update, and delete flows.
- Add a positive clone job template test that verifies clone creation, dump, unlock, and deletion of both cloned and original templates.