### PR TITLE
Automation for change power state on all host page

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -3230,7 +3230,8 @@ def test_positive_change_power_state(
                     'Power': False,
                 }
             )
-        
+
+
 def assert_hosts_owner_helper(target_sat, session, hosts, expected_owner, owner_type='user'):
     """
     Assert that all hosts have the expected owner both via API and UI.


### PR DESCRIPTION
### Problem Statement
Automation for change power state on all host page as part of https://issues.redhat.com/browse/SAT-38430

### Solution


### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k test_change_power_state

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Add end-to-end UI test that imports multiple VMware VMs, toggles their power state from the All Hosts page, and asserts corresponding power icon changes and final host states.