### PR TITLE
[6.17.z] Actually use the cleaned up cache

### DIFF
--- a/robottelo/utils/issue_handlers/jira.py
+++ b/robottelo/utils/issue_handlers/jira.py
@@ -53,9 +53,8 @@ class JiraStatusCache:
             logger.debug(f"Loading Jira cache from {self.cache_file}")
             data = json.loads(self.cache_file.read_text())
             self._clean_expired_entries(data)
-            cache = data.get("issues", {})
-            logger.debug(f"Loaded {len(cache)} entries from Jira cache")
-            return cache
+            logger.debug(f"Loaded {len(self.cache)} entries from Jira cache")
+            return self.cache
         logger.debug("Jira cache file does not exist, using empty cache")
         return {}
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20703

Actually use the cleaned up cache.

After calling the cleanup on data, the cleaned up cache has been saved to self.cache but never used in the load method. The load method used the original data instead. This should fix it.

## Summary by Sourcery

Bug Fixes:
- Fix Jira cache loading to return the cleaned cache entries after expired entries are removed.