### PR TITLE
Remove pxegrub from new upgrade provisioning template test

### DIFF
--- a/tests/new_upgrades/test_provisioningtemplate.py
+++ b/tests/new_upgrades/test_provisioningtemplate.py
@@ -24,7 +24,7 @@ from robottelo.constants import (
 )
 from robottelo.utils.shared_resource import SharedResource
 
-provisioning_template_kinds = ['provision', 'PXEGrub', 'PXEGrub2', 'PXELinux', 'iPXE']
+provisioning_template_kinds = ['provision', 'PXEGrub2', 'PXELinux', 'iPXE']
 
 PXE_LOADER_MAP = {
     'bios': {'vm_firmware': 'bios', 'pxe_loader': 'PXELinux BIOS'},


### PR DESCRIPTION
### Problem Statement
New upgrade provisioning template test is failing as pxegrub template has been removed in SAT-39844

### Solution
Remove pxegrub template from the new upgrade provisioning template test 

### Related Issues
SAT-39844

## Summary by Sourcery

Tests:
- Update provisioning template kinds list in new upgrade provisioning template test to remove the deprecated PXEGrub template.