### PR TITLE
Check if last_scan_words and last_scan_text display in ui

### DIFF
--- a/tests/foreman/ui/test_flatpak.py
+++ b/tests/foreman/ui/test_flatpak.py
@@ -69,8 +69,8 @@ def test_view_flatpak_remotes(target_sat, function_org, function_flatpak_remote)
         assert matching_rows[0]['Name'] == random_repo.name
         assert matching_rows[0]['ID'] == random_repo.id
         assert matching_rows[0]['Last mirrored'] == 'Never'
-        assert not details['last_scan_words_text']
-        assert not details['last_scan_text']
+        assert details['last_scan_words_text']
+        assert details['last_scan_text']
 
 
 def test_CRUD_scan_and_mirror_flatpak_remote(target_sat, function_org, function_product):


### PR DESCRIPTION
Requires: Katello/katello#11619 
                SateliteQE/airgun#2292

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Add assertions that last scan text fields are empty for new Flatpak remotes and populated with appropriate values after a scan operation.