### PR TITLE
check logout redirection

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2138,6 +2138,8 @@ RHSSO_NEW_GROUP = {
 
 RHSSO_RESET_PASSWORD = {"temporary": "false", "type": "password", "value": ""}
 
+LOGIN_DELEGATION_LOGOUT_URL = "https://theforeman.org/"
+
 FOREMAN_ANSIBLE_MODULES = [
     "activation_key",
     "architecture",


### PR DESCRIPTION
### Problem Statement
SAT-40322

I'm opening this mainly for TDD of https://github.com/theforeman/foreman/pull/10854, not sure if it would pass as permanent a coverage as well, I change the fixture for every test which might be considered problematic, but I leave it to later discussion at this point

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Verify RH-SSO single sign-on logout redirection using a shared logout URL constant.

Enhancements:
- Replace hard-coded RH-SSO login delegation logout URL in auth settings with a shared constant.

Tests:
- Extend RH-SSO single sign-on test to assert correct logout redirection URL.

## Summary by Sourcery

Validate RH-SSO single sign-on logout redirection and centralize the configured logout URL.

Bug Fixes:
- Verify RH-SSO external authentication logs users out to the configured login delegation logout URL.

Enhancements:
- Introduce a shared constant for the login delegation logout URL and use it in RH-SSO auth settings fixtures.

Tests:
- Extend the RH-SSO single sign-on test to cover logout flow and assert the expected logout redirect URL.