### PR TITLE
[6.18.z] IoP test framework updates

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -232,28 +232,14 @@ def get_iop_deploy_args():
 
 
 @pytest.fixture(scope='module')
-def module_satellite_iop():
-    """Deploy and configure Red Hat Lightspeed in Satellite
+def module_satellite_iop(module_target_sat):
+    """Configure Red Hat Lightspeed in Satellite"""
+    satellite = module_target_sat
+    satellite.configure_iop()
 
-    Use the IoP workflow which deploys Satellite + IoP
-    """
-    deploy_args = get_iop_deploy_args()
+    yield satellite
 
-    with Broker(
-        workflow=settings.server.deploy_workflows.iop, **deploy_args, host_class=Satellite
-    ) as satellite:
-        yield satellite
-
-
-@pytest.fixture
-def satellite_iop():
-    """Deploy and configure Red Hat Lightspeed in Satellite"""
-    deploy_args = get_iop_deploy_args()
-
-    with Broker(
-        workflow=settings.server.deploy_workflows.iop, **deploy_args, host_class=Satellite
-    ) as satellite:
-        yield satellite
+    satellite.uninstall_iop()
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -173,8 +173,8 @@ def test_positive_install_iop_custom_certs(
 
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('N-0')
-def test_disable_enable_iop(satellite_iop, module_sca_manifest, rhel_contenthost):
-    """Install Satellite + IoP, disable, re-enable.
+def test_disable_enable_iop(module_satellite_iop, module_sca_manifest, rhel_contenthost):
+    """Disable and re-enable IoP on Satellite.
 
     :id: abe165e1-a3a4-413d-b6aa-5cb51acfeb2e
 
@@ -191,7 +191,7 @@ def test_disable_enable_iop(satellite_iop, module_sca_manifest, rhel_contenthost
 
     :CaseAutomation: Automated
     """
-    satellite = satellite_iop
+    satellite = module_satellite_iop
     host = rhel_contenthost
 
     # Register the Insights client


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20521

### Problem Statement

IoP fixtures deploy a new host, separate from the default Satellite host deployed by the Satellite fixture factory. This causes problems with upstream PRT, RHEL interop, and other test pipelines that deploy the Satellite from other sources: the default Satellite has the expected packages installed, but the IoP Satellite under test does not.

### Solution

Update the IoP fixtures to use the default Satellite host. The fixture will enable IoP, and then disable it again during teardown.


### Related Issues

SAT-41499

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

### PRT

```
trigger: test-robottelo
pytest: tests/foreman/ui --component Insights-Advisor,Insights-Vulnerability
```

This will run two pytest modules, with a setup / teardown between each.


To verify that PRT + upstream PR works:

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_e2e[rhel10-ipv4-local]
theforeman:
  foreman_rh_cloud: 1144
robottelo: 20521
```

## Summary by Sourcery

Update IoP test fixtures and Satellite helpers to configure IoP on the existing Satellite host instead of deploying a separate IoP-specific Satellite instance.

Enhancements:
- Rename and extend the Satellite helper to configure IoP with explicit enablement checks and add an uninstall helper to disable IoP via the installer.
- Adjust the IoP module fixture to reuse the default module_target_sat host, enabling IoP for tests and cleaning it up during teardown.
- Update the CLI IoP test to consume the new module-level IoP fixture rather than deploying a dedicated IoP Satellite.

## Summary by Sourcery

Update IoP test fixtures and Satellite helper methods to enable and disable IoP on the existing Satellite host instead of deploying a separate IoP-specific Satellite instance.

Bug Fixes:
- Ensure IoP configuration validates success and raises explicit errors when enable or disable operations fail.

Enhancements:
- Replace the generic IoP configuration helper with a dedicated configure/uninstall pair that handles multiple registry logins and explicit IoP state checks.
- Refactor the module-level IoP fixture to reuse the default module_target_sat host and clean up IoP configuration during teardown.

Tests:
- Update the CLI IoP enable/disable test to consume the new module-level IoP fixture rather than deploying a dedicated IoP Satellite.