### PR TITLE
RBAC permission automation

### DIFF
--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -404,6 +404,7 @@ def test_iop_recommendations_remediation_type_and_status(
         )
         assert 'Decreased security: OpenSSH config permissions' in result[0]['Name']
 
+
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
@@ -550,7 +551,9 @@ def test_iop_insights_rbac_edit_permissions(
         # Verify that the disabled recommendation is filtered
         result = session.recommendationstab.apply_filter("Status", "Disabled")
         assert 'No recommendations' not in result[0]['Name']
-        assert 'Decreased security: OpenSSH config permissions' in [recommendation['Name'] for recommendation in result]
+        assert 'Decreased security: OpenSSH config permissions' in [
+            recommendation['Name'] for recommendation in result
+        ]
 
         # Test Vulnerability with edit permissions
         session.cloudvulnerability.edit_vulnerabilities(CVE_ID)


### PR DESCRIPTION
### Problem Statement
RBAC permission automation

### Solution
New permissions added:
view_vulnerability: Read access to Vulnerability app data
edit_vulnerability: Write access to CVE status, business risk, opt-out
view_advisor: Read access to Advisor recommendations and exports
edit_advisor: Write access to acknowledge/unacknowledge recommendations

Automation for :
https://issues.redhat.com/browse/SAT-40632
https://issues.redhat.com/browse/SAT-40631
https://issues.redhat.com/browse/SAT-40629

Require Airgun PR: 
https://github.com/SatelliteQE/airgun/pull/2315

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_iop.py -k "rbac"
airgun: 2315
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Add automated UI tests validating RBAC access levels for Insights Recommendations and Vulnerabilities in Red Hat Lightspeed.

Tests:
- Add view-only RBAC scenario test ensuring users can see Insights Recommendations and Vulnerabilities but cannot perform edit actions.
- Add edit-permissions RBAC scenario test ensuring users can remediate Insights Recommendations and update Vulnerabilities.
- Add no-permissions RBAC scenario test ensuring users without advisor or vulnerability permissions cannot access the corresponding pages.