### PR TITLE
[6.18.z] Add client_release marker

### DIFF
--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -11,6 +11,7 @@ def pytest_configure(config):
         "stream: Tests unique to stream builds; purged when robottelo is branched.",
         "pit_server: PIT server scenario tests",
         "pit_client: PIT client scenario tests",
+        "client_release: For Client release testing; selected client side tests from OpenSCAP, pull provider, tracer etc.",
         "run_in_one_thread: Sequential tests",
         "build_sanity: Fast, basic tests that confirm build is ready for full test suite",
         "rhel_ver_list: Filter rhel_contenthost versions by list",

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -96,6 +96,7 @@ def vm(
 
 @pytest.mark.pit_client
 @pytest.mark.pit_server
+@pytest.mark.client_release
 @pytest.mark.rhel_ver_match('9')
 def test_positive_list_installable_updates(vm, module_target_sat):
     """Ensure packages applicability is functioning properly.
@@ -138,6 +139,7 @@ def test_positive_list_installable_updates(vm, module_target_sat):
 @pytest.mark.upgrade
 @pytest.mark.pit_client
 @pytest.mark.pit_server
+@pytest.mark.client_release
 @pytest.mark.rhel_ver_match('9')
 def test_positive_erratum_installable(vm, module_target_sat):
     """Ensure erratum applicability is showing properly, without attaching

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2224,6 +2224,7 @@ def test_positive_dump_enc_yaml(target_sat):
 
 # -------------------------- HOST TRACE SUBCOMMAND SCENARIOS -------------------------
 @pytest.mark.pit_client
+@pytest.mark.client_release
 @pytest.mark.rhel_ver_match('^[0-9]+$')
 def test_positive_tracer_list_and_resolve(tracer_host, target_sat):
     """Install tracer on client, downgrade the service, check from the satellite

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1205,6 +1205,7 @@ class TestPullProviderRex:
 
     @pytest.mark.upgrade
     @pytest.mark.no_containers
+    @pytest.mark.client_release
     @pytest.mark.parametrize(
         'setting_update',
         ['remote_execution_global_proxy=False'],
@@ -1415,6 +1416,7 @@ class TestPullProviderRex:
     @pytest.mark.e2e
     @pytest.mark.pit_client
     @pytest.mark.no_containers
+    @pytest.mark.client_release
     @pytest.mark.parametrize(
         'setting_update',
         ['remote_execution_global_proxy=False'],

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -50,6 +50,7 @@ def test_positive_CRD_satellite(run_puppet_agent, session_puppet_enabled_sat):
 
 
 @pytest.mark.e2e
+@pytest.mark.client_release
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.parametrize('client_repo_ver', ['1', '2'], ids=['client1', 'client2'])
 def test_positive_install_configure_host(

--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.destructive
 
 @pytest.mark.no_containers
 @pytest.mark.pit_client
+@pytest.mark.client_release
 @pytest.mark.rhel_ver_match('[^6]')
 def test_host_registration_rex_pull_mode(
     module_org,

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -384,6 +384,7 @@ def test_positive_oscap_update_default_content(
 @pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.rhel_ver_match('[^6].*')
+@pytest.mark.client_release
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 def test_positive_oscap_run_via_ansible(
@@ -461,6 +462,7 @@ def test_positive_oscap_run_via_ansible(
 
 @pytest.mark.e2e
 @pytest.mark.rhel_ver_list([8])
+@pytest.mark.client_release
 def test_positive_oscap_remediation(
     module_org, default_proxy, content_view, lifecycle_env, target_sat, rex_contenthost
 ):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20716

### Problem Statement
We'll be adding new client-release jobs to test client snaps. We're missing a targeted set of test collections for those jobs.

### Solution
- Add `client_release` and mark some of the tests related to client bits.

### Related Issues
- SAT-40731

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Introduce a dedicated pytest marker to target client-side release testing and apply it to relevant existing tests.

Enhancements:
- Register a new pytest marker for client release-focused scenarios in the shared markers configuration.

Tests:
- Tag selected OpenSCAP, tracer, client installation, and registration tests with the new client_release marker to support focused client release runs.

## Summary by Sourcery

Introduce a dedicated pytest marker to target client-focused release testing and apply it to selected existing tests.

Enhancements:
- Register a new client_release pytest marker in the shared markers configuration for client-side release scenarios.

Tests:
- Tag selected content access, remote execution, OpenSCAP, tracer, client installation, and registration tests with the client_release marker to enable focused client release runs.