### PR TITLE
[6.15.z] Add client_release marker

### DIFF
--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -16,6 +16,7 @@ def pytest_configure(config):
         "stream: Tests unique to stream builds; purged when robottelo is branched.",
         "pit_server: PIT server scenario tests",
         "pit_client: PIT client scenario tests",
+        "client_release: For Client release testing; selected client side tests from OpenSCAP, pull provider, tracer etc.",
         "run_in_one_thread: Sequential tests",
         "build_sanity: Fast, basic tests that confirm build is ready for full test suite",
         "rhel_ver_list: Filter rhel_contenthost versions by list",

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -100,6 +100,7 @@ def vm(
 @pytest.mark.tier2
 @pytest.mark.pit_client
 @pytest.mark.pit_server
+@pytest.mark.client_release
 def test_positive_list_installable_updates(vm, module_target_sat):
     """Ensure packages applicability is functioning properly.
 
@@ -144,6 +145,7 @@ def test_positive_list_installable_updates(vm, module_target_sat):
 @pytest.mark.upgrade
 @pytest.mark.pit_client
 @pytest.mark.pit_server
+@pytest.mark.client_release
 def test_positive_erratum_installable(vm, module_target_sat):
     """Ensure erratum applicability is showing properly, without attaching
     any subscription.

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2311,6 +2311,7 @@ def test_positive_dump_enc_yaml(target_sat):
 @pytest.mark.pit_client
 @pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6].*')
+@pytest.mark.client_release
 def test_positive_tracer_list_and_resolve(tracer_host, target_sat):
     """Install tracer on client, downgrade the service, check from the satellite
     that tracer shows and resolves the problem. The test works with a package specified

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -823,6 +823,7 @@ class TestPullProviderRex:
     @pytest.mark.upgrade
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_match('[^6].*')
+    @pytest.mark.client_release
     @pytest.mark.parametrize(
         'setting_update',
         ['remote_execution_global_proxy=False'],
@@ -1035,6 +1036,7 @@ class TestPullProviderRex:
     @pytest.mark.pit_client
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_match('[^6].*')
+    @pytest.mark.client_release
     @pytest.mark.parametrize(
         'setting_update',
         ['remote_execution_global_proxy=False'],

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -51,6 +51,7 @@ def test_positive_CRD_satellite(run_puppet_agent, session_puppet_enabled_sat):
 
 
 @pytest.mark.e2e
+@pytest.mark.client_release
 @pytest.mark.rhel_ver_match('[^6]')
 def test_positive_install_configure_host(
     session_puppet_enabled_sat, session_puppet_enabled_capsule, content_hosts

--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.destructive
 @pytest.mark.tier3
 @pytest.mark.no_containers
 @pytest.mark.pit_client
+@pytest.mark.client_release
 @pytest.mark.rhel_ver_match('[^6]')
 def test_host_registration_rex_pull_mode(
     module_org,

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -124,6 +124,7 @@ def update_scap_content(module_org, module_target_sat):
 @pytest.mark.upgrade
 @pytest.mark.tier4
 @pytest.mark.parametrize('distro', ['rhel7', 'rhel8'])
+@pytest.mark.client_release
 def test_positive_oscap_run_via_ansible(
     module_org, default_proxy, content_view, lifecycle_env, distro, target_sat
 ):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20716 
Fixes https://github.com/SatelliteQE/robottelo/issues/20727

### Problem Statement
We'll be adding new client-release jobs to test client snaps. We're missing a targeted set of test collections for those jobs.

### Solution
- Add `client_release` and mark some of the tests related to client bits.

### Related Issues
- SAT-40731

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Introduce a dedicated pytest marker to target client-side release testing and apply it to relevant existing tests.

Enhancements:
- Register a new pytest marker for client release-focused scenarios in the shared markers configuration.

Tests:
- Tag selected OpenSCAP, tracer, client installation, and registration tests with the new client_release marker to support focused client release runs.

## Summary by Sourcery

Introduce a dedicated pytest marker to target client-focused release testing and apply it to selected existing tests.

Enhancements:
- Register a new client_release pytest marker in the shared markers configuration for client-side release scenarios.

Tests:
- Tag selected content access, remote execution, OpenSCAP, tracer, client installation, and registration tests with the client_release marker to enable focused client release runs.

## Summary by Sourcery

Introduce a dedicated pytest marker for client release testing and apply it to selected client-focused tests.

Enhancements:
- Register a new client_release pytest marker in the shared markers configuration for client-side release scenarios.

Tests:
- Tag selected content access, remote execution, OpenSCAP, tracer, host installation/configuration, and registration tests with the client_release marker to enable targeted client release runs.

## Summary by Sourcery

Introduce a dedicated pytest marker for client release runs and apply it to selected client-focused tests.

Enhancements:
- Register a new client_release pytest marker in the shared markers configuration for client-side release scenarios.

Tests:
- Tag selected content access, remote execution, tracer, host installation/configuration, registration, and OpenSCAP tests with the client_release marker to support targeted client release testing.