### PR TITLE
Verify cloned-from-id metadata via hammer

### DIFF
--- a/tests/foreman/cli/test_jobtemplate.py
+++ b/tests/foreman/cli/test_jobtemplate.py
@@ -235,10 +235,10 @@ def test_positive_clone_job_template(module_org, module_target_sat):
     :steps:
         1. Create a job template
         2. Clone the job template
-        3. assert dump of the data of the cloned job template is working
-        4. update job template to unlocked
-        5. Delete the cloned job template
-        6. Delete the original job template
+        3. Get cloned template info and verify the cloned-from-id metadata.
+        4. Assert dump of the data of the cloned job template is working
+        5. Update job template to unlocked
+        6. Delete the original and cloned job template
 
     :expectedresults: The job template is cloned successfully
 
@@ -265,7 +265,9 @@ def test_positive_clone_job_template(module_org, module_target_sat):
             'id': template['id'],
         }
     )
-    assert module_target_sat.cli.JobTemplate.info({'name': clone_name})['name'] == clone_name
+    cloned_template = module_target_sat.cli.JobTemplate.info({'name': clone_name})
+    assert cloned_template['name'] == clone_name
+    assert cloned_template['cloned-from-id'] == template['id']
     # assert dump of the data of the cloned job template is working
     dump = module_target_sat.cli.JobTemplate.dump({'name': clone_name})
     assert len(dump) > 0


### PR DESCRIPTION
### Problem Statement

Cloned template metadata tests need to explicitly cover cloned-from-id when cloning via hammer.

### Solution

Add/adjust tests to verify cloned-from-id metadata is set correctly for hammer-based cloning.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Add CLI template cloning coverage to verify cloned-from-id metadata across report, provisioning, and job templates when using hammer.

Tests:
- Add a report template CLI test that clones via hammer, validates cloned-from-id metadata, and ensures the clone can be unlocked (when applicable) and deleted.
- Add a provisioning template CLI test that clones via hammer, validates cloned-from-id metadata, and confirms the clone can be deleted.
- Extend the job template cloning test to assert cloned-from-id metadata on the cloned job template.