### PR TITLE
Added automation to support new multi-cv activation key

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1136,9 +1136,9 @@ def test_positive_new_ak_lce_cv_assignment(target_sat):
         )
         ak_values = session.activationkey.read(ak_name, widget_names='details')
 
-        assert ak_values['details']['content_view_details'][0]['content_view'] == constants.DEFAULT_CV, (
-            'Default Organization View is not assigned to newly created AK'
-        )
+        assert (
+            ak_values['details']['content_view_details'][0]['content_view'] == constants.DEFAULT_CV
+        ), 'Default Organization View is not assigned to newly created AK'
         assert (
             ak_values['details']['content_view_details'][0]['lce'] == 'Library'  # noqa: E712, explicit comparison fits this case
         ), 'Library view is not assigned to newly created AK'


### PR DESCRIPTION
### Problem Statement
In recent snap activation key test cases started failing due to addition of new Multi-CV functionality
Story : https://issues.redhat.com/browse/SAT-30913 

### Solution
Updated views and Model as part of airgun PR https://github.com/SatelliteQE/airgun/pull/2300

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_activationkey.py
airgun: 2300
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Update activation key tests to assert lifecycle environments using list index-based values instead of nested environment-name keys across CRUD, environment assignment, permissions, and default assignment scenarios.