### PR TITLE
Add tests to validate ComputeResources-OCP-V

### DIFF
--- a/conf/kubevirt.yaml.template
+++ b/conf/kubevirt.yaml.template
@@ -1,0 +1,21 @@
+OCPV:
+  # Kubevirt/OCP-V Hostname
+  HOSTNAME: api.cnv2.example.com
+  # Default API Port to connect to OpenShift
+  API_PORT: 6443
+  # Namespace
+  NAMESPACE: team-satellite-provisioning
+  # Token
+  TOKEN:
+  # CA Certificate
+  CA_CERT:
+  # Image name
+  IMAGE_NAME: rhel10-vm-template
+  # image_os: Operating system of the image
+  IMAGE_OS: RedHat 10.1
+  # image_arch: Architecture of the image
+  IMAGE_ARCH: x86_64
+  # image_username: Login to the image
+  IMAGE_USERNAME: root
+  # image_password: Password to the image
+  IMAGE_PASSWORD:

--- a/conftest.py
+++ b/conftest.py
@@ -61,6 +61,7 @@ pytest_plugins = [
     'pytest_fixtures.component.provision_azure',
     'pytest_fixtures.component.provision_gce',
     'pytest_fixtures.component.provision_libvirt',
+    'pytest_fixtures.component.provision_ocpv',
     'pytest_fixtures.component.provision_pxe',
     'pytest_fixtures.component.provision_capsule_pxe',
     'pytest_fixtures.component.provision_vmware',

--- a/pytest_fixtures/component/provision_ocpv.py
+++ b/pytest_fixtures/component/provision_ocpv.py
@@ -1,0 +1,39 @@
+# Compute resource - OCP-V entities
+from fauxfactory import gen_string
+import pytest
+
+from robottelo.config import settings
+from robottelo.constants import FOREMAN_PROVIDERS_MODEL
+from robottelo.utils.installer import InstallerCommand
+
+
+@pytest.fixture(scope='module')
+def module_ocpv_sat(module_target_sat):
+    installer_result = module_target_sat.execute(
+        InstallerCommand(
+            installer_args=[
+                'enable-foreman-plugin-kubevirt',
+                'enable-foreman-cli-kubevirt',
+            ]
+        ).get_command(),
+        timeout='20m',
+    )
+    assert installer_result.status == 0
+    assert 'Success!' in installer_result.stdout
+    return module_target_sat
+
+
+@pytest.fixture(scope='module')
+def module_ocpv_cr(module_ocpv_sat, module_org, module_location):
+    """Create a OCP-V/Kubevirt compute resource for the module."""
+    return module_ocpv_sat.api.OCPVComputeResource(
+        name=gen_string('alpha'),
+        provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+        hostname=settings.ocpv.hostname,
+        api_port=settings.ocpv.api_port,
+        namespace=settings.ocpv.namespace,
+        token=settings.ocpv.token,
+        ca_cert=settings.ocpv.ca_cert,
+        organization=[module_org],
+        location=[module_location],
+    ).create()

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -50,6 +50,18 @@ FOREMAN_PROVIDERS = {
     'openstack': 'RHEL OpenStack Platform',
     'google': 'Google',
     'azurerm': 'Azure Resource Manager',
+    'ocp-v': 'OpenShift Virtualization',
+}
+
+FOREMAN_PROVIDERS_MODEL = {
+    'libvirt': 'Libvirt',
+    'rhev': 'RHV',
+    'ec2': 'EC2',
+    'vmware': 'Vmware',
+    'openstack': 'Openstack',
+    'google': 'Google',
+    'azurerm': 'AzureRm',
+    'ocp-v': 'Kubevirt',
 }
 
 EC2_REGION_CA_CENTRAL_1 = 'ca-central-1'

--- a/testimony.yaml
+++ b/testimony.yaml
@@ -31,7 +31,7 @@ CaseComponent:
     - Capsule-Content
     - ComputeResources
     - ComputeResources-Azure
-    - ComputeResources-CNV
+    - ComputeResources-OCP-V
     - ComputeResources-EC2
     - ComputeResources-GCE
     - ComputeResources-libvirt

--- a/tests/foreman/api/test_computeresource_ocpv.py
+++ b/tests/foreman/api/test_computeresource_ocpv.py
@@ -1,0 +1,409 @@
+"""
+:Requirement: Computeresource - OCP-V
+
+:CaseAutomation: Automated
+
+:CaseComponent: ComputeResources-OCP-V
+
+:Team: Rocket
+
+:CaseImportance: High
+"""
+
+from fauxfactory import gen_string
+import pytest
+from requests.exceptions import HTTPError
+from wait_for import wait_for
+
+from robottelo.config import settings
+from robottelo.constants import FOREMAN_PROVIDERS, FOREMAN_PROVIDERS_MODEL
+from robottelo.hosts import ContentHost
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
+
+pytestmark = [pytest.mark.skip_if_not_set('ocpv')]
+
+
+@pytest.mark.e2e
+def test_positive_crud_ocpv_cr(module_ocpv_sat, module_org, module_location):
+    """CRUD test to validate Compute Resource - OCP-V
+
+    :id: 1e545c56-2f53-44c1-a17e-38c83f8fe0c9
+
+    :expectedresults: Compute resources are created with expected names
+    """
+    name = gen_string('alphanumeric')
+    description = gen_string('alphanumeric')
+
+    cr = module_ocpv_sat.api.OCPVComputeResource(
+        name=name,
+        description=description,
+        provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+        organization=[module_org],
+        location=[module_location],
+        hostname=settings.ocpv.hostname,
+        api_port=settings.ocpv.api_port,
+        namespace=settings.ocpv.namespace,
+        token=settings.ocpv.token,
+        ca_cert=settings.ocpv.ca_cert,
+    ).create()
+    assert cr.name == name
+    assert cr.description == description
+    assert cr.provider == FOREMAN_PROVIDERS_MODEL['ocp-v']
+    assert cr.provider_friendly_name == FOREMAN_PROVIDERS['ocp-v']
+    assert cr.hostname == settings.ocpv.hostname
+    assert cr.api_port == settings.ocpv.api_port
+    assert cr.namespace == settings.ocpv.namespace
+
+    # Update
+    new_name = gen_string('alphanumeric')
+    new_description = gen_string('alphanumeric')
+    new_org = module_ocpv_sat.api.Organization().create()
+    new_loc = module_ocpv_sat.api.Location(organization=[new_org]).create()
+    cr.name = new_name
+    cr.description = new_description
+    cr.organization = [new_org]
+    cr.location = [new_loc]
+    cr.update(['name', 'description', 'organization', 'location'])
+
+    # READ
+    updated_cr = module_ocpv_sat.api.OCPVComputeResource(id=cr.id).read()
+    assert updated_cr.name == new_name
+    assert updated_cr.description == new_description
+    assert updated_cr.organization[0].id == new_org.id
+    assert updated_cr.location[0].id == new_loc.id
+    assert updated_cr.hostname == settings.ocpv.hostname
+    assert updated_cr.api_port == settings.ocpv.api_port
+    assert updated_cr.namespace == settings.ocpv.namespace
+
+    # DELETE
+    updated_cr.delete()
+    assert not module_ocpv_sat.api.OCPVComputeResource().search(
+        query={'search': f'name={new_name}'}
+    )
+
+
+@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+def test_positive_create_with_name_description(
+    name, request, module_ocpv_sat, module_org, module_location
+):
+    """Create compute resources with different names and descriptions
+
+    :id: 1e545c56-2f53-44c1-a17e-38c83f8fe0c8
+
+    :expectedresults: Compute resources are created with expected names and descriptions
+
+    :parametrized: yes
+    """
+    cr = module_ocpv_sat.api.OCPVComputeResource(
+        name=name,
+        description=name,
+        organization=[module_org],
+        location=[module_location],
+        provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+        hostname=settings.ocpv.hostname,
+        api_port=settings.ocpv.api_port,
+        namespace=settings.ocpv.namespace,
+        token=settings.ocpv.token,
+        ca_cert=settings.ocpv.ca_cert,
+    ).create()
+    request.addfinalizer(cr.delete)
+    assert cr.name == name
+    assert cr.description == name
+
+
+@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+def test_negative_create_with_invalid_name(name, module_ocpv_sat, module_org, module_location):
+    """Attempt to create compute resources with invalid names
+
+    :id: f73bf838-3ffd-46d3-869c-81b334b47b15
+
+    :expectedresults: Compute resources are not created
+
+    :parametrized: yes
+    """
+    with pytest.raises(HTTPError):
+        module_ocpv_sat.api.OCPVComputeResource(
+            name=name,
+            organization=[module_org],
+            location=[module_location],
+            provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+            hostname=settings.ocpv.hostname,
+            api_port=settings.ocpv.api_port,
+            namespace=settings.ocpv.namespace,
+            token=settings.ocpv.token,
+            ca_cert=settings.ocpv.ca_cert,
+        ).create()
+
+
+def test_negative_create_with_same_name(
+    request,
+    module_ocpv_sat,
+    module_org,
+    module_location,
+):
+    """Attempt to create a compute resource with already existing name
+
+    :id: 9376e25c-2aa8-4d99-83aa-2eec160c030g
+
+    :expectedresults: Compute resources is not created
+    """
+    name = gen_string('alphanumeric')
+    cr = module_ocpv_sat.api.OCPVComputeResource(
+        name=name,
+        organization=[module_org],
+        location=[module_location],
+        provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+        hostname=settings.ocpv.hostname,
+        api_port=settings.ocpv.api_port,
+        namespace=settings.ocpv.namespace,
+        token=settings.ocpv.token,
+        ca_cert=settings.ocpv.ca_cert,
+    ).create()
+
+    request.addfinalizer(cr.delete)
+    assert cr.name == name
+    with pytest.raises(HTTPError):
+        module_ocpv_sat.api.OCPVComputeResource(
+            name=name,
+            organization=[module_org],
+            location=[module_location],
+            provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+            hostname=settings.ocpv.hostname,
+            api_port=settings.ocpv.api_port,
+            namespace=settings.ocpv.namespace,
+            token=settings.ocpv.token,
+            ca_cert=settings.ocpv.ca_cert,
+        ).create()
+
+
+@pytest.mark.parametrize('hostname', **parametrized({'random': gen_string('alpha'), 'empty': ''}))
+def test_negative_create_with_hostname(module_ocpv_sat, module_org, module_location, hostname):
+    """Attempt to create compute resources with invalid hostname
+
+    :id: 37e9bf39-382e-4f02-af54-d3a17e285c2h
+
+    :expectedresults: Compute resources are not created
+
+    :parametrized: yes
+    """
+    with pytest.raises(HTTPError):
+        module_ocpv_sat.api.OCPVComputeResource(
+            organization=[module_org],
+            location=[module_location],
+            provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+            hostname=hostname,
+            api_port=settings.ocpv.api_port,
+            namespace=settings.ocpv.namespace,
+            token=settings.ocpv.token,
+            ca_cert=settings.ocpv.ca_cert,
+        ).create()
+
+
+@pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
+def test_negative_update_invalid_name(
+    request, module_ocpv_sat, module_org, module_location, new_name
+):
+    """Attempt to update compute resource with invalid names
+
+    :id: a6554c1f-e52f-4614-9fc3-2127ced31479
+
+    :expectedresults: Compute resource is not updated
+
+    :parametrized: yes
+    """
+    name = gen_string('alphanumeric')
+    cr = module_ocpv_sat.api.OCPVComputeResource(
+        name=name,
+        organization=[module_org],
+        location=[module_location],
+        provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+        hostname=settings.ocpv.hostname,
+        api_port=settings.ocpv.api_port,
+        namespace=settings.ocpv.namespace,
+        token=settings.ocpv.token,
+        ca_cert=settings.ocpv.ca_cert,
+    ).create()
+    request.addfinalizer(cr.delete)
+    cr.name = new_name
+    with pytest.raises(HTTPError):
+        cr.update(['name'])
+    assert cr.read().name == name
+
+
+def test_negative_update_same_name(request, module_ocpv_sat, module_org, module_location):
+    """Attempt to update a compute resource with already existing name
+
+    :id: 4d7c5eb0-b8cb-414f-aa10-fe464a164abe
+
+    :expectedresults: Compute resources is not updated
+    """
+    name = gen_string('alphanumeric')
+    cr = module_ocpv_sat.api.OCPVComputeResource(
+        name=name,
+        organization=[module_org],
+        location=[module_location],
+        provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+        hostname=settings.ocpv.hostname,
+        api_port=settings.ocpv.api_port,
+        namespace=settings.ocpv.namespace,
+        token=settings.ocpv.token,
+        ca_cert=settings.ocpv.ca_cert,
+    ).create()
+    request.addfinalizer(cr.delete)
+    new_cr = module_ocpv_sat.api.OCPVComputeResource(
+        organization=[module_org],
+        location=[module_location],
+        provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+        hostname=settings.ocpv.hostname,
+        api_port=settings.ocpv.api_port,
+        namespace=settings.ocpv.namespace,
+        token=settings.ocpv.token,
+        ca_cert=settings.ocpv.ca_cert,
+    ).create()
+    request.addfinalizer(new_cr.delete)
+    new_cr.name = name
+    with pytest.raises(HTTPError):
+        new_cr.update(['name'])
+    assert new_cr.read().name != name
+
+
+@pytest.mark.parametrize('hostname', **parametrized({'random': gen_string('alpha'), 'empty': ''}))
+def test_negative_update_hostname(hostname, request, module_ocpv_sat, module_org, module_location):
+    """Attempt to update a compute resource with invalid url
+
+    :id: b5256090-2ceb-4976-b54e-60d60419fe59
+
+    :expectedresults: Compute resources is not updated
+
+    :parametrized: yes
+    """
+    cr = module_ocpv_sat.api.OCPVComputeResource(
+        organization=[module_org],
+        location=[module_location],
+        provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+        hostname=settings.ocpv.hostname,
+        api_port=settings.ocpv.api_port,
+        namespace=settings.ocpv.namespace,
+        token=settings.ocpv.token,
+        ca_cert=settings.ocpv.ca_cert,
+    ).create()
+    request.addfinalizer(cr.delete)
+    cr.hostname = hostname
+    with pytest.raises(HTTPError):
+        cr.update(['hostname'])
+    assert cr.read().hostname != hostname
+
+
+@pytest.mark.e2e
+@pytest.mark.on_premises_provisioning
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
+@pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
+@pytest.mark.rhel_ver_match('8')
+@pytest.mark.skip(reason='Skipping this until we have OCP-V provisioning support')
+def test_positive_provision_end_to_end(
+    request,
+    setting_update,
+    module_provisioning_rhel_content,
+    module_ocpv_sat,
+    module_provisioning_sat,
+    configure_secureboot_provisioning,
+    module_sca_manifest_org,
+    module_location,
+    module_ssh_key_file,
+    pxe_loader,
+    provisioning_hostgroup,
+):
+    """Provision a host on OCP-V compute resource with the help of hostgroup.
+
+    :id: 6985e7c0-d258-4fc4-833b-e680804b55eg
+
+    :steps:
+        1. Configure provisioning setup.
+        2. Create OCP-V CR
+        3. Configure host group setup.
+        4. Create a host on OCP-V compute resource using the Hostgroup
+        5. Verify created host on OCP-V.
+
+    :expectedresults: Host is provisioned successfully with hostgroup
+    """
+    sat = module_provisioning_sat.sat
+    cr_name = gen_string('alpha')
+    host_name = gen_string('alpha').lower()
+    cr = sat.api.OCPVComputeResource(
+        name=cr_name,
+        provider=FOREMAN_PROVIDERS_MODEL['ocp-v'],
+        organization=[module_sca_manifest_org],
+        location=[module_location],
+        hostname=settings.ocpv.hostname,
+        api_port=settings.ocpv.api_port,
+        namespace=settings.ocpv.namespace,
+        token=settings.ocpv.token,
+        ca_cert=settings.ocpv.ca_cert,
+    ).create()
+    request.addfinalizer(cr.delete)
+    assert cr.name == cr_name
+
+    host = sat.api.Host(
+        hostgroup=provisioning_hostgroup,
+        organization=module_sca_manifest_org,
+        location=module_location,
+        name=host_name,
+        compute_resource=cr,
+        compute_attributes={
+            'cpus': 1,
+            'memory': 6442450944,
+            'firmware': pxe_loader.vm_firmware,
+            'start': '1',
+            'volumes_attributes': {
+                '0': {
+                    'capacity': '10G',
+                    'storage_class': 'trident-nfs (csi.trident.netapp.io)',
+                },
+            },
+        },
+        interfaces_attributes={
+            '0': {
+                'type': 'interface',
+                'primary': True,
+                'managed': True,
+                'compute_attributes': {
+                    'compute_cni_provider': 'multus',
+                    'compute_network': f'nad-vlan-{settings.provisioning.vlan_id}',
+                },
+            }
+        },
+        provision_method='build',
+        host_parameters_attributes=[
+            {'name': 'remote_execution_connect_by_ip', 'value': 'true', 'parameter_type': 'boolean'}
+        ],
+        build=True,
+    ).create(create_missing=False)
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
+    assert host.name == f'{host_name}.{module_provisioning_sat.domain.name}'
+
+    # check the build status
+    wait_for(
+        lambda: host.read().build_status_label != 'Pending installation',
+        timeout=1500,
+        delay=10,
+    )
+    assert host.read().build_status_label == 'Installed'
+
+    # Verify SecureBoot is enabled on host after provisioning is completed successfully
+    if pxe_loader.vm_firmware == 'uefi_secure_boot':
+        provisioning_host = ContentHost(host.ip, auth=module_ssh_key_file)
+        # Wait for the host to be rebooted and SSH daemon to be started.
+        provisioning_host.wait_for_connection()
+        # Enable Root Login
+        if int(host.operatingsystem.read().major) >= 9:
+            assert (
+                provisioning_host.execute(
+                    'echo -e "\nPermitRootLogin yes" >> /etc/ssh/sshd_config; systemctl restart sshd'
+                ).status
+                == 0
+            )
+        assert 'SecureBoot enabled' in provisioning_host.execute('mokutil --sb-state').stdout

--- a/tests/foreman/cli/test_computeresource_ocpv.py
+++ b/tests/foreman/cli/test_computeresource_ocpv.py
@@ -1,0 +1,479 @@
+"""
+:Requirement: Computeresource OCP-V
+
+:CaseAutomation: Automated
+
+:CaseComponent: ComputeResources-OCP-V
+
+:Team: Rocket
+
+:CaseImportance: High
+
+"""
+
+import random
+
+from fauxfactory import gen_domain, gen_string
+import pytest
+from wait_for import wait_for
+
+from robottelo.config import settings
+from robottelo.constants import FOREMAN_PROVIDERS, FOREMAN_PROVIDERS_MODEL
+from robottelo.exceptions import CLIReturnCodeError
+from robottelo.hosts import ContentHost
+from robottelo.utils.datafactory import parametrized
+
+
+def valid_name_desc_data():
+    """Random data for valid name and description"""
+    return {
+        'numeric': {'name': gen_string('numeric'), 'description': gen_string('numeric')},
+        'alpha_long_name': {
+            'name': gen_string('alphanumeric', 255),
+            'description': gen_string('alphanumeric'),
+        },
+        'alpha_long_descr': {
+            'name': gen_string('alphanumeric'),
+            'description': gen_string('alphanumeric', 255),
+        },
+        'utf8': {'name': gen_string('utf8'), 'description': gen_string('utf8')},
+        'html': {
+            'name': f'<html>{gen_string("alpha")}</html>',
+            'description': f'<html>{gen_string("alpha")}</html>',
+        },
+        'non_letters': {
+            'name': f"{gen_string('utf8')}[]@#$%^&*(),./?\\\"{{}}><|''",
+            'description': "{gen_string('alpha')}[]@#$%^&*(),./?\\\"{{}}><|''",
+        },
+    }
+
+
+def invalid_create_data():
+    """Random data for invalid name and url"""
+    return {
+        'long_name': {'name': gen_string('alphanumeric', 256)},
+        'empty_name': {'name': ''},
+        'invalid_hostname': {'hostname': 'invalid hostname'},
+        'empty_hostname': {'hostname': ''},
+    }
+
+
+def valid_update_data():
+    """Random data for valid update"""
+    return {
+        'utf8_name': {'new-name': gen_string('utf8', 255)},
+        'alpha_name': {'new-name': gen_string('alphanumeric')},
+        'white_space_name': {'new-name': f'white spaces {gen_string("alphanumeric")}'},
+        'utf8_descr': {'description': gen_string('utf8', 255)},
+        'alpha_descr': {'description': gen_string('alphanumeric')},
+    }
+
+
+def invalid_update_data():
+    """Random data for invalid update"""
+    return {
+        'long_name': {'new-name': gen_string('utf8', 256)},
+        'empty_name': {'new-name': ''},
+        'invalid_hostname': {'hostname': 'invalid hostname'},
+        'empty_hostname': {'hostname': ''},
+    }
+
+
+@pytest.mark.e2e
+@pytest.mark.upgrade
+def test_positive_crud_ocpv_cr(module_ocpv_sat, module_org, module_location):
+    """CRUD compute resource OCP-v
+
+    :id: a2f99c0e-53b6-435d-9b59-c6cbbcabca1g
+
+    :expectedresults: All crud operations are performed successfully
+    """
+    name = gen_string('alpha')
+    description = gen_string('alpha')
+    # CREATE
+    cr = module_ocpv_sat.cli.ComputeResource.create(
+        {
+            'name': name,
+            'description': description,
+            'provider': FOREMAN_PROVIDERS_MODEL['ocp-v'],
+            'location-ids': module_location.id,
+            'organization-ids': module_org.id,
+            'hostname': settings.ocpv.hostname,
+            'api-port': settings.ocpv.api_port,
+            'namespace': settings.ocpv.namespace,
+            'token': settings.ocpv.token,
+            'ca-cert': settings.ocpv.ca_cert,
+        }
+    )
+    assert cr['name'] == name
+    assert cr['provider'] == FOREMAN_PROVIDERS['ocp-v']
+    assert cr['description'] == description
+    assert cr['hostname'] == settings.ocpv.hostname
+    assert cr['locations'][0] == module_location.name
+    assert cr['organizations'][0] == module_org.name
+    # UPDATE
+    new_name = gen_string('alphanumeric')
+    new_description = gen_string('alphanumeric')
+    new_org = module_ocpv_sat.cli.Org.create({'name': gen_string('alpha')})
+    new_loc = module_ocpv_sat.cli.Location.create({'name': gen_string('alpha')})
+    cr_update = module_ocpv_sat.cli.ComputeResource.update(
+        {
+            'id': cr['id'],
+            'new-name': new_name,
+            'description': new_description,
+            'location-ids': new_loc['id'],
+            'organization-ids': new_org['id'],
+        }
+    )
+    # READ
+    cr_read = module_ocpv_sat.cli.ComputeResource.info({'id': cr_update[0]['id']})
+    assert cr_read['name'] == new_name
+    assert cr_read['description'] == new_description
+    assert cr_read['provider'] == FOREMAN_PROVIDERS['ocp-v']
+    assert cr_read['hostname'] == settings.ocpv.hostname
+    assert cr_read['locations'][0] == new_loc['name']
+    assert cr_read['organizations'][0] == new_org['name']
+    # LIST
+    cr_list = module_ocpv_sat.cli.ComputeResource.list({'search': f'name={cr_read["name"]}'})
+    assert len(cr_list) == 1
+    assert cr_list[0]['id'] == cr['id']
+    assert cr_list[0]['name'] == new_name
+    assert cr_list[0]['provider'] == FOREMAN_PROVIDERS['ocp-v']
+    # DELETE
+    module_ocpv_sat.cli.ComputeResource.delete({'name': cr_list[0]['name']})
+    assert not module_ocpv_sat.cli.ComputeResource.exists(search=('name', cr_list[0]['name']))
+
+
+@pytest.mark.upgrade
+@pytest.mark.parametrize('options', **parametrized(valid_name_desc_data()))
+def test_positive_create_with_ocpv(options, module_ocpv_sat):
+    """Test Compute Resource create
+
+    :id: adc6f4f8-6420-4044-89d1-c69e0bfeeabz
+
+    :expectedresults: Compute Resource created
+
+    :parametrized: yes
+    """
+    module_ocpv_sat.cli.ComputeResource.create(
+        {
+            'description': options['description'],
+            'name': options['name'],
+            'provider': FOREMAN_PROVIDERS_MODEL['ocp-v'],
+            'hostname': settings.ocpv.hostname,
+            'api-port': settings.ocpv.api_port,
+            'namespace': settings.ocpv.namespace,
+            'token': settings.ocpv.token,
+            'ca-cert': settings.ocpv.ca_cert,
+        }
+    )
+
+
+def test_positive_create_with_locs(module_ocpv_sat):
+    """Create Compute Resource with multiple locations
+
+    :id: f665c586-39bf-480a-a0fc-81d9e1eb7c55
+
+    :expectedresults: Compute resource is created and has multiple
+        locations assigned
+    """
+    locations_amount = random.randint(3, 5)
+    locations = [module_ocpv_sat.cli_factory.make_location() for _ in range(locations_amount)]
+    comp_resource = module_ocpv_sat.cli_factory.compute_resource(
+        {
+            'location-ids': [location['id'] for location in locations],
+            'provider': FOREMAN_PROVIDERS_MODEL['ocp-v'],
+            'hostname': settings.ocpv.hostname,
+            'api-port': settings.ocpv.api_port,
+            'namespace': settings.ocpv.namespace,
+            'token': settings.ocpv.token,
+            'ca-cert': settings.ocpv.ca_cert,
+        }
+    )
+    assert len(comp_resource['locations']) == locations_amount
+    for location in locations:
+        assert location['name'] in comp_resource['locations']
+
+
+### Negative create
+
+
+@pytest.mark.parametrize('options', **parametrized(invalid_create_data()))
+def test_negative_create_with_name_hostname(options, module_ocpv_sat):
+    """Compute Resource negative create with invalid values
+
+    :id: cd432ff3-b3b9-49cd-9a16-ed00d81679de
+
+    :expectedresults: Compute resource not created
+
+    :parametrized: yes
+    """
+    with pytest.raises(CLIReturnCodeError):
+        module_ocpv_sat.cli.ComputeResource.create(
+            {
+                'name': options.get('name', gen_string(str_type='alphanumeric')),
+                'provider': FOREMAN_PROVIDERS_MODEL['ocp-v'],
+                'hostname': options.get('hostname', gen_domain()),
+                'api-port': settings.ocpv.api_port,
+                'namespace': settings.ocpv.namespace,
+                'token': settings.ocpv.token,
+                'ca-cert': settings.ocpv.ca_cert,
+            }
+        )
+
+
+def test_negative_create_with_same_name(module_ocpv_sat):
+    """Compute Resource negative create with the same name
+
+    :id: ddb5c45b-1ea3-46d0-b248-56c0388d2e4c
+
+    :expectedresults: Compute resource not created
+    """
+    comp_res = module_ocpv_sat.cli_factory.compute_resource(
+        {
+            'provider': FOREMAN_PROVIDERS_MODEL['ocp-v'],
+            'hostname': settings.ocpv.hostname,
+            'api-port': settings.ocpv.api_port,
+            'namespace': settings.ocpv.namespace,
+            'token': settings.ocpv.token,
+            'ca-cert': settings.ocpv.ca_cert,
+        }
+    )
+    with pytest.raises(CLIReturnCodeError):
+        module_ocpv_sat.cli.ComputeResource.create(
+            {
+                'name': comp_res['name'],
+                'provider': FOREMAN_PROVIDERS_MODEL['ocp-v'],
+                'hostname': settings.ocpv.hostname,
+                'api-port': settings.ocpv.api_port,
+                'namespace': settings.ocpv.namespace,
+                'token': settings.ocpv.token,
+                'ca-cert': settings.ocpv.ca_cert,
+            }
+        )
+
+
+def test_negative_create_ocpv_with_hostname(module_location, module_org, module_ocpv_sat):
+    """OCP-V compute resource negative create with invalid values
+
+    :id: 1f318a4b-8dca-491b-b56d-cff773ed624g
+
+    :expectedresults: Compute resource is not created
+    """
+    cr_name = gen_string('alpha')
+    with pytest.raises(CLIReturnCodeError):
+        module_ocpv_sat.cli.ComputeResource.create(
+            {
+                'name': cr_name,
+                'provider': FOREMAN_PROVIDERS_MODEL['ocp-v'],
+                'hostname': 'invalid hostname',
+                'organizations': module_org.name,
+                'locations': module_location.name,
+                'api-port': settings.ocpv.api_port,
+                'namespace': settings.ocpv.namespace,
+                'token': settings.ocpv.token,
+                'ca-cert': settings.ocpv.ca_cert,
+            }
+        )
+
+
+### Update Positive
+
+
+@pytest.mark.parametrize('options', **parametrized(valid_update_data()))
+def test_positive_update_name(options, module_ocpv_sat):
+    """Compute Resource positive update
+
+    :id: 213d7f04-4c54-4985-8ca0-d2a1a9e3b309
+
+    :expectedresults: Compute Resource successfully updated
+
+    :parametrized: yes
+    """
+    comp_res = module_ocpv_sat.cli_factory.compute_resource(
+        {
+            'provider': FOREMAN_PROVIDERS_MODEL['ocp-v'],
+            'hostname': settings.ocpv.hostname,
+            'api-port': settings.ocpv.api_port,
+            'namespace': settings.ocpv.namespace,
+            'token': settings.ocpv.token,
+            'ca-cert': settings.ocpv.ca_cert,
+        }
+    )
+    options.update({'name': comp_res['name']})
+    # update Compute Resource
+    module_ocpv_sat.cli.ComputeResource.update(options)
+    # check updated values
+    result = module_ocpv_sat.cli.ComputeResource.info({'id': comp_res['id']})
+    assert result['description'] == options.get('description', comp_res['description'])
+    assert result['name'] == options.get('new-name', comp_res['name'])
+    assert result['hostname'] == options.get('hostname', comp_res['hostname'])
+    assert result['provider'].lower() == comp_res['provider'].lower()
+
+
+### Update Negative
+
+
+@pytest.mark.parametrize('options', **parametrized(invalid_update_data()))
+def test_negative_update(options, module_ocpv_sat):
+    """Compute Resource negative update
+
+    :id: e7aa9b39-dd01-4f65-8e89-ff5a6f4ee0e0
+
+    :expectedresults: Compute Resource not updated
+
+    :parametrized: yes
+    """
+    comp_res = module_ocpv_sat.cli_factory.compute_resource(
+        {
+            'provider': FOREMAN_PROVIDERS_MODEL['ocp-v'],
+            'hostname': settings.ocpv.hostname,
+            'api-port': settings.ocpv.api_port,
+            'namespace': settings.ocpv.namespace,
+            'token': settings.ocpv.token,
+            'ca-cert': settings.ocpv.ca_cert,
+        }
+    )
+    with pytest.raises(CLIReturnCodeError):
+        module_ocpv_sat.cli.ComputeResource.update(dict({'name': comp_res['name']}, **options))
+    result = module_ocpv_sat.cli.ComputeResource.info({'id': comp_res['id']})
+    # check attributes have not changed
+    assert result['name'] == comp_res['name']
+    options.pop('new-name', None)
+    for key in options:
+        assert comp_res[key] == result[key]
+
+
+@pytest.mark.e2e
+@pytest.mark.on_premises_provisioning
+@pytest.mark.rhel_ver_match('9')
+@pytest.mark.parametrize('pxe_loader', ['uefi', 'secureboot'], indirect=True)
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
+@pytest.mark.skip(reason='Skipping this until we have OCP-V provisioning support')
+def test_positive_provision_end_to_end(
+    request,
+    pxe_loader,
+    setting_update,
+    module_ocpv_sat,
+    module_provisioning_sat,
+    module_sca_manifest_org,
+    module_location,
+    provisioning_hostgroup,
+    module_provisioning_rhel_content,
+):
+    """Provision a host on OCP-V compute resource with the help of hostgroup.
+
+    :id: b003faa9-2810-4176-94d2-ea84bed248eh
+
+    :setup: Hostgroup and provisioning setup like domain, subnet etc.
+
+    :steps:
+        1. Create a Libvirt compute resource.
+        2. Create a host on Libvirt compute resource using the Hostgroup
+        3. Use compute-attributes parameter to specify key-value parameters
+           regarding the virtual machine.
+        4. Provision the host.
+
+    :expectedresults: Host should be provisioned with hostgroup
+
+    :parametrized: yes
+
+    :customerscenario: true
+    """
+    sat = module_provisioning_sat.sat
+    cr_name = gen_string('alpha')
+    hostname = gen_string('alpha').lower()
+    cr = sat.cli.ComputeResource.create(
+        {
+            'name': cr_name,
+            'provider': FOREMAN_PROVIDERS_MODEL['ocp-v'],
+            'hostname': settings.ocpv.hostname,
+            'organizations': module_sca_manifest_org.name,
+            'locations': module_location.name,
+            'api-port': settings.ocpv.api_port,
+            'namespace': settings.ocpv.namespace,
+            'token': settings.ocpv.token,
+            'ca-cert': settings.ocpv.ca_cert,
+        }
+    )
+    assert cr['name'] == cr_name
+
+    host = sat.cli.Host.create(
+        {
+            'name': hostname,
+            'location': module_location.name,
+            'organization': module_sca_manifest_org.name,
+            'hostgroup': provisioning_hostgroup.name,
+            'compute-resource-id': cr['id'],
+            'ip': None,
+            'mac': None,
+            'compute-attributes': f'cpus=1, memory=6442450944, start=1, firmware={pxe_loader.vm_firmware}',
+            'interface': f'compute_cni_provider=multus,compute_network=nad-vlan-{settings.provisioning.vlan_id}',
+            'volume': 'capacity=10,storage_class="trident-nfs (csi.trident.netapp.io)"',
+            'parameters': 'name=remote_execution_connect_by_ip,type=boolean,value=true',
+            'provision-method': 'build',
+        }
+    )
+    # teardown
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host['name'], interface='CLI'))
+
+    # checks
+    hostname = f'{hostname}.{module_provisioning_sat.domain.name}'
+    assert hostname == host['name']
+    host_info = sat.cli.Host.info({'name': hostname})
+
+    wait_for(
+        lambda: (
+            sat.cli.Host.info({'name': hostname})['status']['build-status']
+            != 'Pending installation'
+        ),
+        timeout=1800,
+        delay=30,
+    )
+    host_info = sat.cli.Host.info({'id': host['id']})
+    assert host_info['status']['build-status'] == 'Installed'
+
+    # Verify SecureBoot is enabled on host after provisioning is completed successfully
+    if pxe_loader.vm_firmware == 'uefi_secure_boot':
+        provisioning_host = ContentHost(host_info['network']['ipv4-address'])
+        # Wait for the host to be rebooted and SSH daemon to be started.
+        provisioning_host.wait_for_connection()
+        assert 'SecureBoot enabled' in provisioning_host.execute('mokutil --sb-state').stdout
+
+
+@pytest.mark.stubbed
+def test_positive_provision_ocpv_without_host_group():
+    """Provision a host on OCP-V compute resource without
+    the help of hostgroup.
+
+    :id: 861940cb-1550-4f00-9df2-5a45683635b9
+
+    :steps:
+        1. Create a OCP-V compute resource.
+        2. Create a host on OCP-V compute resource.
+        3. Use compute-attributes parameter to specify key-value parameters
+           regarding the virtual machine.
+        4. Provision the host.
+
+    :expectedresults: The host should be provisioned successfully
+
+    :CaseAutomation: NotAutomated
+    """
+
+
+@pytest.mark.stubbed
+def test_positive_provision_ocpv_image_based_and_disassociate():
+    """Provision a host on OCP-V compute resource using image-based provisioning
+
+    :id: ba78858f-5cff-462e-a35d-f5aa4d11db59
+
+    :steps:
+        1. Create a OCP-V CR
+        1. Create an image on that CR
+        2. Create a new host using that CR and image
+        3. Disassociate the host from the CR
+
+    :expectedresults: Host should be provisioned with image, associated to CR, then disassociated
+
+    :CaseAutomation: NotAutomated
+    """


### PR DESCRIPTION
### Problem Statement
Missing test coverage to validate ComputeResources-OCP-V component

### Solution
Adding test coverage to validate ComputeResources-OCP-V component

### Related Issues
https://github.com/SatelliteQE/nailgun/pull/1402

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Add test coverage and supporting fixtures for the OCP-V/Kubevirt compute resource, including end-to-end provisioning validation.

New Features:
- Introduce API tests covering CRUD operations and validation logic for OCP-V compute resources.
- Add an end-to-end provisioning test for hosts on OCP-V compute resources using host groups.
- Provide pytest fixtures to enable and configure the Kubevirt/OCP-V compute resource and related image objects.
- Extend compute resource providers to include the OCP-V (Kubevirt) provider key.
- Add a Kubevirt configuration template file for OCP-V-related setup.

Tests:
- Add positive and negative API tests for creating and updating OCP-V compute resources, including name and hostname validation and uniqueness constraints.
- Add an end-to-end provisioning test that verifies successful host installation and Secure Boot behavior on OCP-V.
- Introduce shared pytest fixtures to set up an OCP-V-enabled Satellite instance, a reusable OCP-V compute resource, and an associated image.