### PR TITLE
Automation to support MultiCV bulk update

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2071,7 +2071,7 @@ def test_all_hosts_bulk_cve_reassign(
         session.location.select(module_location.name)
         try:
             headers = session.all_hosts.get_displayed_table_headers()
-            if "Lifecycle environment" not in headers:
+            if 'Lifecycle environment' not in headers:
                 session.all_hosts.manage_table_columns(
                     {
                         'Lifecycle environment': True,


### PR DESCRIPTION
### Problem Statement
Due to addition of new MutiCV feature, existing flow to bulk update `Manage content->Content view environments` was breaking

### Solution
Added automation to support MultiCV bulk update `Manage content->Content view environments`

### Related Issues
Its part of card : https://issues.redhat.com/browse/SAT-631
Airgun PR :https://github.com/SatelliteQE/airgun/pull/2308

 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k  test_all_hosts_bulk_cve_reassign
airgun: 2308

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Extend all-hosts bulk CVE reassignment test to verify lifecycle environment values before and after MultiCV updates and to always reset the Lifecycle environment column visibility.