### PR TITLE
Fix PRN scenarios tests

### DIFF
--- a/pytest_fixtures/component/pulp.py
+++ b/pytest_fixtures/component/pulp.py
@@ -130,8 +130,15 @@ def _setup_prn_content(sat, manifest, test_name=None):
         docker_repository,
         ac_repository,
     ]
-    cv = sat.api.ContentView(organization=org, repository=repos).create()
-    lce = sat.api.LifecycleEnvironment(organization=org).create()
+    cv = sat.api.ContentView(organization=org, repository=repos, name=gen_string('alpha')).create()
+    library = (
+        sat.api.LifecycleEnvironment()
+        .search(query={'search': f'name={constants.ENVIRONMENT} and organization_id={org.id}'})[0]
+        .read()
+    )
+    lce = sat.api.LifecycleEnvironment(
+        organization=org, prior=library.id, name=gen_string('alpha')
+    ).create()
 
     cv.publish()
     cvv = cv.read().version[0].read()


### PR DESCRIPTION
### Problem Statement
In CI the PRN new_upgrade-scenarios tests are failing in setup to create a CV since the nailgun fails to `create_missing` parameters:
```
tests/new_upgrades/test_pulp.py:37: in pulp_upgrade_setup
    test_data = _setup_prn_content(
pytest_fixtures/component/pulp.py:133: in _setup_prn_content
    cv = sat.api.ContentView(organization=org, repository=repos).create()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../lib64/python3.12/site-packages/nailgun/entity_mixins.py:1004: in create
    return self.read(attrs=self.create_json(create_missing))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../lib64/python3.12/site-packages/nailgun/entity_mixins.py:974: in create_json
    raise_for_status_add_to_exception(response)
../../lib64/python3.12/site-packages/nailgun/entity_mixins.py:58: in raise_for_status_add_to_exception
    raise e
../../lib64/python3.12/site-packages/nailgun/entity_mixins.py:54: in raise_for_status_add_to_exception
    response.raise_for_status()
../../lib64/python3.12/site-packages/requests/models.py:1026: in raise_for_status
    raise HTTPError(http_error_msg, response=self)
E   requests.exceptions.HTTPError: ('422 Client Error: Unprocessable Content for url: https://satellite.redhat.com/katello/api/v2/content_views', {'displayMessage': "Validation failed: Label can't be blank, Name can't be blank, Name cannot be blank, Label can't be blank", 'errors': {'label': ["can't be blank", "can't be blank"], 'name': ["can't be blank", 'cannot be blank']}})
```


### Solution
It feels like some version mismatch related inconsistency in nailgun (master nailgun runs against 6.18.z instance).
Since there are the "single-branch" discussion in progress, I'm not to dig into this deeper. This PR just provides a quick fix - provides the missing parameters explicitly so we don't depend on the `create_missing` method.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/new_upgrades/test_pulp.py -n 2
env:
    ROBOTTELO_server__xdist_behavior: 'run-on-one'
    ROBOTTELO_upgrade__from_version: '6.18'
    ROBOTTELO_upgrade__to_version: 'stream'
```

## Summary by Sourcery

Ensure PRN upgrade scenario tests can create content views and lifecycle environments by explicitly providing required attributes instead of relying on automatic parameter creation.

Bug Fixes:
- Provide explicit name when creating content views used in PRN upgrade scenario tests to avoid validation errors in CI.
- Create lifecycle environments with a valid prior environment and explicit name to fix setup failures in PRN upgrade scenario tests.