### PR TITLE
Wait for organization deletion

### DIFF
--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -14,6 +14,7 @@
 
 from fauxfactory import gen_string
 import pytest
+from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT, DEFAULT_ORG, INSTALL_MEDIUM_URL
@@ -260,7 +261,13 @@ def test_positive_delete_with_manifest_lces(session, target_sat, function_sca_ma
         # So switching to Default Org and then deleting.
         session.organization.select(DEFAULT_ORG)
         session.organization.delete(org.name)
-        assert not session.organization.search(org.name)
+        out, _ = wait_for(
+            lambda: session.organization.search(org.name),
+            fail_condition=lambda out: bool(out),
+            silent_failure=True,
+            timeout=15,
+        )
+        assert out == [], 'Search for deleted organization should be empty'
 
 
 @pytest.mark.upgrade


### PR DESCRIPTION
### Problem Statement
UI says `Organization is *BEING* deleted` so the assert fails as the organization is not yet deleted.
```
AssertionError: assert not [{'Actions': ['Delete'], 'Hosts': '0', 'Name': 'JmOrmmlTk'}]
 +  where [{'Actions': ['Delete'], 'Hosts': '0', 'Name': 'JmOrmmlTk'}] = search('JmOrmmlTk')
 +    where search = <airgun.entities.organization.OrganizationEntity object at 0x7f3bfd6837d0>.search
 +      where <airgun.entities.organization.OrganizationEntity object at 0x7f3bfd6837d0> = <airgun.session.Session object at 0x7f3bf7c1ad50>.organization
 +    and   'JmOrmmlTk' = robottelo.hosts.DecClass(compute_resource=[], description=None, domain=[], environment=[], hostgroup=[], label='JmOrmmlTk', medium=[], name='JmOrmmlTk', provisioning_template=[nailgun.entities.ProvisioningTemplate(id=39), nailgun.entities.ProvisioningTemplate(id=40), nailgun.entities.ProvisioningTemplate(id=41), nailgun.entities.ProvisioningTemplate(id=46), nailgun.entities.ProvisioningTemplate(id=198), nailgun.entities.ProvisioningTemplate(id=199), nailgun.entities.ProvisioningTemplate(id=200), nailgun.entities.ProvisioningTemplate(id=66), nailgun.entities.ProvisioningTemplate(id=4), nailgun.entities.ProvisioningTemplate(id=67), nailgun.entities.ProvisioningTemplate(id=349), nailgun.entities.ProvisioningTemplate(id=6), nailgun.entities.ProvisioningTemplate(id=189), nailgun.entities.ProvisioningTemplate(id=5), nailgun.entities.ProvisioningTemplate(id=279), nailgun.entities.ProvisioningTemplate(id=201), nailgun.entities.ProvisioningTemplate(id=323), nailgun.entities.ProvisioningTemplate(id=32), nailgun.entities.ProvisioningTemplate(id=305), nailgun.entities.ProvisioningTemplate(id=31), nailgun.entities.ProvisioningTemplate(id=292), nailgun.entities.ProvisioningTemplate(id=378), na...visioningTemplate(id=34), nailgun.entities.ProvisioningTemplate(id=327), nailgun.entities.ProvisioningTemplate(id=37), nailgun.entities.ProvisioningTemplate(id=370), nailgun.entities.ProvisioningTemplate(id=21), nailgun.entities.ProvisioningTemplate(id=296), nailgun.entities.ProvisioningTemplate(id=22), nailgun.entities.ProvisioningTemplate(id=310), nailgun.entities.ProvisioningTemplate(id=311), nailgun.entities.ProvisioningTemplate(id=367), nailgun.entities.ProvisioningTemplate(id=312), nailgun.entities.ProvisioningTemplate(id=309), nailgun.entities.ProvisioningTemplate(id=371), nailgun.entities.ProvisioningTemplate(id=381), nailgun.entities.ProvisioningTemplate(id=314), nailgun.entities.ProvisioningTemplate(id=313), nailgun.entities.ProvisioningTemplate(id=195), nailgun.entities.ProvisioningTemplate(id=196), nailgun.entities.ProvisioningTemplate(id=197), nailgun.entities.ProvisioningTemplate(id=316)], redhat_repository_url='https://cdn.redhat.com', smart_proxy=[nailgun.entities.SmartProxy(id=1)], subnet=[], title='JmOrmmlTk', user=[], simple_content_access=True, default_content_view=nailgun.entities.ContentView(id=75), library=nailgun.entities.LifecycleEnvironment(id=70), id=90).name
```
### Solution
Retry the check for deleted organization absence

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Fix flaky organization deletion UI test by retrying the search until the organization is fully removed.