### PR TITLE
Remove 6.15.z branch from dependabot to not auto-cherrypick

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,30 +5,28 @@
 version: 2
 updates:
   # Maintain dependencies for Robottelo itself
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     labels:
       - '6.18.z'
       - '6.17.z'
       - '6.16.z'
-      - "CherryPick"
-      - "dependencies"
-      - "6.15.z"
+      - 'CherryPick'
+      - 'dependencies'
     ignore:
-      - dependency-name: "cryptography"
-        update-types: ["version-update:semver-minor"]
+      - dependency-name: 'cryptography'
+        update-types: ['version-update:semver-minor']
 
   # Maintain dependencies for our GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     labels:
       - '6.18.z'
       - '6.17.z'
       - '6.16.z'
-      - "CherryPick"
-      - "dependencies"
-      - "6.15.z"
+      - 'CherryPick'
+      - 'dependencies'


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove 6.15.z labels from Dependabot-managed updates to prevent automated cherry-picks for that branch and normalize quoting in the Dependabot YAML config.