### PR TITLE
Use unattended_url setting instead of foreman_url

### DIFF
--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -25,7 +25,7 @@ from robottelo.utils.datafactory import filtered_datapoint, gen_string
 @filtered_datapoint
 def invalid_settings_values():
     """Returns a list of invalid settings values"""
-    return [' ', '-1', 'text', '0']
+    return ['', '-1', 'text', '0']
 
 
 def add_content_views_to_composite(composite_cv, org, repo, module_target_sat):
@@ -135,11 +135,11 @@ def test_negative_validate_unattended_url_error_message(session, setting_update)
     """
     property_name = setting_update.name
     with session:
-        invalid_value = [invalid_value for invalid_value in invalid_settings_values()][0]
-        err_msg = "Validation errors present on page, displayed messages: ['Invalid value']"
-        with pytest.raises(AssertionError) as context:
-            session.settings.update(f'name = {property_name}', invalid_value)
-        assert err_msg in str(context.value)
+        err_msg = 'URL must be valid and schema must be one of http and https'
+        for invalid_value in invalid_settings_values():
+            with pytest.raises(AssertionError) as context:
+                session.settings.update(f'name = {property_name}', invalid_value)
+            assert err_msg in str(context.value)
 
 
 @pytest.mark.parametrize('setting_update', ['host_dmi_uuid_duplicates'], indirect=True)


### PR DESCRIPTION
### Problem Statement
Since stream snap 122.0 and since 6.18.0 snap 1.0 `ui.settings.test_negative_validate_foreman_url_error_message[foreman_url` is failing with:
```
tests/foreman/ui/test_settings.py:141: in test_negative_validate_foreman_url_error_message
    session.settings.update(f'name = {property_name}', invalid_value)
../../lib64/python3.12/site-packages/airgun/entities/settings.py:26: in update
    view.table.row()['Value'].widget.fill(value)
...

../../lib64/python3.12/site-packages/widgetastic/browser.py:467: in element
    raise NoSuchElementException(f"Could not find an element {repr(locator)}") from None
E   selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator=".//button[contains(@data-ouia-component-id, 'edit-row')]"); For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#no-such-element-exception
```
Since then the setting `foreman_url` is read-only so there is no longer "pencil" button for an edit.

### Solution
Use `unattended_url` instead of `foreman_url`


### Related Issues
[SAT-42307](https://redhat.atlassian.net/browse/SAT-42307)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update UI settings validation test to target the editable unattended_url setting and broaden invalid input coverage.

Bug Fixes:
- Replace the obsolete foreman_url validation test with unattended_url to reflect the current read-only status of foreman_url.

Tests:
- Expand negative URL validation to iterate over multiple invalid values, including an empty string, instead of a single space-only input.