### PR TITLE
discovery host creates with dhcp and static network

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -362,6 +362,57 @@ def pxeless_discovery_host(provisioning_host, module_discovery_sat, pxe_loader):
 
 
 @pytest.fixture
+def pxeless_static_discovery_host(
+    provisioning_host, module_discovery_sat, pxe_loader, provisioning_hostgroup
+):
+    """Fixture for returning a pxe-less discovery host for provisioning"""
+    sat = module_discovery_sat.sat
+    image_name = f"{gen_string('alpha')}-{module_discovery_sat.iso}"
+    subnet = sat.api.Subnet(id=provisioning_hostgroup.subnet.id).read()
+    ip = f"{subnet.from_}"
+    subnet.ipam, subnet.boot_mode, subnet.dhcp = 'Internal DB', 'Static', ''
+    subnet.update(['ipam', 'boot_mode', 'dhcp'])
+    mac = provisioning_host.provisioning_nic_mac_addr
+    # Remaster and upload discovery image to automatically input values
+    result = sat.execute(
+        f'cd /var/www/html/pub && discovery-remaster {module_discovery_sat.iso} '
+        f'"proxy.type=foreman proxy.url=https://{sat.ip_addr}:443 '
+        f'fdi.pxmac={mac} fdi.pxauto=1 fdi.pxip={ip} '
+        f'fdi.pxgw={subnet.gateway} fdi.pxdns={subnet.dns_primary} '
+        f'fdi.pxmask={subnet.mask} fdi.pxfactname=discovery"'
+    )
+    pattern = re.compile(r"foreman-discovery-image\S+")
+    fdi = pattern.findall(result.stdout)[0]
+    Broker(
+        workflow='import-disk-image',
+        import_disk_image_name=image_name,
+        import_disk_image_url=(f'https://{sat.hostname}/pub/{fdi}'),
+        firmware_type=pxe_loader.vm_firmware,
+    ).execute()
+    # Change host to boot discovery image
+    Broker(
+        job_template='configure-pxe-boot',
+        target_host=provisioning_host.name,
+        target_vlan_id=settings.provisioning.vlan_id,
+        target_vm_firmware=provisioning_host._broker_args['target_vm_firmware'],
+        target_pxeless_image=image_name,
+        target_boot_scenario='pxeless_pre',
+    ).execute()
+    yield provisioning_host
+    Broker(workflow='remove-disk-image', remove_disk_image_name=image_name).execute()
+
+
+@pytest.fixture(params=['pxeless_discovery_host', 'pxeless_static_discovery_host'])
+def pxeless_discovery_hosts(request):
+    """Parametrized fixture to select between pxe-less discovery host types
+
+    This fixture allows tests to run with both DHCP-based (pxeless_discovery_host)
+    and static IP-based (pxeless_static_discovery_host) discovery hosts.
+    """
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
 def configure_secureboot_provisioning(
     request, pxe_loader, module_provisioning_sat, module_provisioning_rhel_content
 ):

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -123,7 +123,7 @@ def test_rhel_pxe_discovery_provisioning(
 @pytest.mark.rhel_ver_match('7')
 def test_rhel_pxeless_discovery_provisioning(
     module_discovery_sat,
-    pxeless_discovery_host,
+    pxeless_discovery_hosts,
     module_provisioning_rhel_content,
     provisioning_hostgroup,
     request,
@@ -138,10 +138,12 @@ def test_rhel_pxeless_discovery_provisioning(
     :expectedresults: Host should be provisioned successfully
 
     :CaseImportance: Critical
+
+    :Verifies: SAT-39469
     """
     sat = module_discovery_sat.sat
-    pxeless_discovery_host.power_control(ensure=False)
-    mac = pxeless_discovery_host.provisioning_nic_mac_addr
+    pxeless_discovery_hosts.power_control(ensure=False)
+    mac = pxeless_discovery_hosts.provisioning_nic_mac_addr
     org = provisioning_hostgroup.organization[0].read()
     loc = provisioning_hostgroup.location[0].read()
     wait_for(
@@ -203,6 +205,7 @@ def test_rhel_pxeless_discovery_provisioning(
     )
     assert host.read().build_status_label == 'Installed'
     assert not sat.api.DiscoveredHost().search(query={'mac': mac})
+    assert not sat.api.Host().search(query={'search': 'name="localhost.localdomain"'})
 
 
 @pytest.mark.stubbed


### PR DESCRIPTION
### Problem Statement
When provisioning EL9 via fdi using static network information, localhost.localdomain will be created on Satellite webUI

### Solution
The issue has been resolved after applying the fix.

## Summary by Sourcery

Add support for testing PXE-less discovery hosts with both DHCP and static networking configurations and update provisioning target host configuration.

New Features:
- Introduce a fixture for creating PXE-less discovery hosts using static network configuration.
- Provide a parametrized fixture to run PXE-less discovery host tests against both DHCP-based and static IP-based discovery setups.

Enhancements:
- Adjust provisioning configuration to use a specific Satellite target host value for PXE-based provisioning.

Tests:
- Extend PXE-less provisioning tests to reuse the new parametrized discovery host fixture covering both DHCP and static scenarios.