### PR TITLE
[6.17.z] Modifications in CLI and UI Libvirt CR to resolve key error #20176

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -147,6 +147,7 @@ def module_provisioning_sat(
     It calls a workflow using broker to set up the network and to run satellite-installer.
     It uses the artifacts from the workflow to create all the necessary Satellite entities
     that are later used by the tests.
+    For IPv4, it clears DHCP leases and restarts dhcpd to ensure provisioning can obtain addresses.
     """
     provisioning_type = getattr(request, 'param', '')
     sat = module_target_sat
@@ -208,6 +209,9 @@ def module_provisioning_sat(
         remote_execution_proxy=[module_provisioning_capsule.id],
         domain=[domain.id],
     ).create()
+    if sat.network_type == NetworkType.IPV4:
+        assert sat.execute('cat /dev/null > /var/lib/dhcpd/dhcpd.leases').status == 0
+        assert sat.execute('systemctl restart dhcpd').status == 0
     return Box(sat=sat, domain=domain, subnet=subnet, provisioning_type=provisioning_type)
 
 

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -40,6 +40,7 @@ from robottelo.constants import FOREMAN_PROVIDERS, LIBVIRT_RESOURCE_URL
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import parametrized
+from robottelo.utils.issue_handlers import is_open
 
 LIBVIRT_URL = LIBVIRT_RESOURCE_URL % settings.libvirt.libvirt_hostname
 
@@ -408,6 +409,10 @@ def test_positive_provision_end_to_end(
 
     :customerscenario: true
     """
+    # Skip test for UEFI and SecureBoot loaders
+    if is_open('SAT-41340') and pxe_loader.vm_firmware in ['uefi', 'uefi_secure_boot']:
+        pytest.skip(f"Test not supported for {pxe_loader.vm_firmware} firmware")
+
     sat = module_libvirt_provisioning_sat.sat
     cr_name = gen_string('alpha')
     hostname = gen_string('alpha').lower()
@@ -450,12 +455,16 @@ def test_positive_provision_end_to_end(
         f'su foreman -s /bin/bash -c "virsh -c {LIBVIRT_URL} list --state-running"'
     )
     assert hostname in result.stdout
-
     wait_for(
-        lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
-        != 'Pending installation',
+        lambda: (
+            sat.cli.Host.info({'name': hostname})
+            .get('status', {})
+            .get('build-status', 'Pending installation')
+            != 'Pending installation'
+        ),
         timeout=1800,
         delay=30,
+        handle_exception=True,
     )
     host_info = sat.cli.Host.info({'id': host['id']})
     assert host_info['status']['build-status'] == 'Installed'

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -181,8 +181,8 @@ def test_positive_provision_end_to_end(
         )
         name = f'{hostname}.{module_libvirt_provisioning_sat.domain.name}'
         request.addfinalizer(lambda: sat.provisioning_cleanup(name))
-        assert session.host.search(name)[0]['Name'] == name
-
+        result = session.host_new.search(name)[0]
+        assert result['Name'] == name
         # Check on Libvirt, if VM exists
         result = sat.execute(
             f'su foreman -s /bin/bash -c "virsh -c {LIBVIRT_URL} list --state-running"'
@@ -203,7 +203,7 @@ def test_positive_provision_end_to_end(
 
         # Verify SecureBoot is enabled on host after provisioning is completed successfully
         if pxe_loader.vm_firmware == 'uefi_secure_boot':
-            host = sat.api.Host().search(query={'host': hostname})[0].read()
+            host = sat.api.Host().search(query={"search": f'name={name}'})[0].read()
             provisioning_host = ContentHost(host.ip)
             # Wait for the host to be rebooted and SSH daemon to be started.
             provisioning_host.wait_for_connection()


### PR DESCRIPTION
### Problem Statement

Cherry pick of `Modifications in CLI and UI Libvirt CR to resolve key error failed`

### Solution

New PR to add CP manually for https://github.com/SatelliteQE/robottelo/pull/20176

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Adjust Libvirt compute resource provisioning tests and fixtures to improve robustness and alignment with current APIs.

Bug Fixes:
- Prevent key errors in CLI provisioning status checks by safely accessing host status fields and enabling exception handling in the wait loop.
- Update UI provisioning tests to use the correct host search API and query format when validating created hosts and secure boot configuration.
- Ensure IPv4 provisioning reliably obtains addresses by clearing DHCP leases and restarting the DHCP service before tests.

Enhancements:
- Skip the Libvirt CLI end-to-end provisioning test when a known issue affecting UEFI or SecureBoot firmware is still open.