### PR TITLE
[6.18.z] Use the hostname shortened for AD.

### DIFF
--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -441,12 +441,12 @@ def rhsso_setting_setup_with_timeout(module_target_sat, rhsso_setting_setup):
 
 @pytest.fixture(scope='module')
 def module_enroll_ad_and_configure_external_auth(ad_data, module_target_sat):
-    module_target_sat.enroll_ad_and_configure_external_auth(ad_data)
+    return module_target_sat.enroll_ad_and_configure_external_auth(ad_data)
 
 
 @pytest.fixture
 def func_enroll_ad_and_configure_external_auth(ad_data, target_sat):
-    target_sat.enroll_ad_and_configure_external_auth(ad_data)
+    return target_sat.enroll_ad_and_configure_external_auth(ad_data)
 
 
 @pytest.fixture

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2486,6 +2486,7 @@ class Satellite(Capsule, SatelliteMixins):
 
         :param ad_data: Callable method that returns AD server details
         :type ad_data: Callable
+        :return: New Satellite hostname if hostname changed, otherwise None
         """
         ad_data = ad_data()
         version_dependent = (
@@ -2529,6 +2530,7 @@ class Satellite(Capsule, SatelliteMixins):
         # if this is an IPv6 machine, we'll probably get a hostname
         # that is TOOOO LOOOONG for Active Directory which can only count to 15
         hostname_changed = False
+        new_fqdn = None
         if self.network_type == NetworkType.IPV6:
             original_shortname = self.execute('hostname -s').stdout.strip()
             if len(original_shortname) > 15:
@@ -2651,6 +2653,8 @@ class Satellite(Capsule, SatelliteMixins):
         assert (
             self.execute('systemctl daemon-reload && systemctl restart httpd.service').status == 0
         )
+
+        return new_fqdn
 
     def generate_inventory_report(self, org, disconnected='false'):
         """Function to perform inventory upload."""

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -248,12 +248,16 @@ def test_single_sign_on_ldap_ad_server(
 
     :BZ: 1941997
     """
+    if func_enroll_ad_and_configure_external_auth is not None:
+        url = f'{settings.server.scheme}://{func_enroll_ad_and_configure_external_auth}'
+    else:
+        url = target_sat.url
     # create the kerberos ticket for authentication
     result = target_sat.execute(f'echo {settings.ldap.password} | kinit {settings.ldap.username}')
     assert result.status == 0
-    result = target_sat.execute(f'curl -k -u : --negotiate {target_sat.url}/users/extlogin/')
+    result = target_sat.execute(f'curl -k -u : --negotiate {url}/users/extlogin/')
     assert 'redirected' in result.stdout
-    assert f'{target_sat.url}/new/hosts' in result.stdout
+    assert f'{url}/new/hosts' in result.stdout
 
 
 def test_single_sign_on_using_rhsso(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20735

Otherwise, the Service ticket won't be obtained because the client won't
be found by the unshortened hostname. Remember, AD can only count to 15.

## Summary by Sourcery

Use the potentially shortened Satellite hostname returned from AD enrollment when performing SSO tests against external auth.

Bug Fixes:
- Ensure Kerberos SSO tests against AD use the hostname produced by AD enrollment, avoiding failures when the original hostname exceeds AD length limits.

Enhancements:
- Have the AD enrollment helper return the new FQDN when the hostname is changed so callers can reliably construct the correct Satellite URL.