### PR TITLE
docs links test improvements

### DIFF
--- a/tests/foreman/ui/test_documentation_links.py
+++ b/tests/foreman/ui/test_documentation_links.py
@@ -12,17 +12,51 @@
 
 """
 
-from collections import defaultdict
-
 import pytest
 import requests
 
 from robottelo.config import settings
 from robottelo.logging import logger
 
+pages = [
+    'about',
+    'settings',
+    'bookmark',
+    'role',
+    'ldapauthentication',
+    'cloudinventory',
+    'ansiblevariables',
+    'ansibleroles',
+    'discoveryrule',
+    'global_parameter',
+    'oscapreport',
+    'oscappolicy',
+    'oscapcontent',
+    'jobtemplate',
+    'provisioningtemplate',
+    'partitiontable',
+    'operatingsystem',
+    'host',
+    'discoveredhosts',
+    'reporttemplate',
+    'configreport',
+    'jobinvocation',
+    'audit',
+    'factvalue',
+    'dashboard',
+]
 
+
+@pytest.fixture(scope='module')
+def session(module_target_sat):
+    """Helper function to create a session for testing documentation links."""
+    with module_target_sat.ui_session() as session:
+        yield session
+
+
+@pytest.mark.parametrize('page', pages)
 @pytest.mark.e2e
-def test_positive_documentation_links(target_sat):
+def test_positive_documentation_links(module_target_sat, session, page):
     """Verify that Satellite documentation links are working.
         Note: At the moment, the test doesn't support verifying links hidden behind a button.
         Currently, the only such link is on RH Cloud > Inventory Upload page.
@@ -36,69 +70,34 @@ def test_positive_documentation_links(target_sat):
 
     :expectedresults: All the Documentation links present on Satellite are working
     """
-    pages = [
-        'about',
-        'settings',
-        'bookmark',
-        'role',
-        'ldapauthentication',
-        'cloudinventory',
-        'ansiblevariables',
-        'ansibleroles',
-        'discoveryrule',
-        'global_parameter',
-        'oscapreport',
-        'oscappolicy',
-        'oscapcontent',
-        'jobtemplate',
-        'provisioningtemplate',
-        'partitiontable',
-        'operatingsystem',
-        'host',
-        'discoveredhosts',
-        'reporttemplate',
-        'configreport',
-        'jobinvocation',
-        'audit',
-        'factvalue',
-        'dashboard',
-    ]
-    sat_version = ".".join(target_sat.version.split('.')[0:2])
-    all_links = defaultdict(list)
-    pages_with_broken_links = defaultdict(list)
-    with target_sat.ui_session() as session:
-        for page in pages:
-            page_object = getattr(session, page)
-            if page == "host":
-                view = page_object.navigate_to(page_object, 'Register')
-            elif page == "oscappolicy":
-                view = page_object.navigate_to(page_object, 'New')
-            else:
-                view = page_object.navigate_to(page_object, 'All')
-            # Get the doc links present on the page.
-            all_links[page] = view.documentation_links()
-            assert all_links[page], f"Couldn't find any documentation links on {page} page."
-        logger.info(
-            f"Following are the documentation links collected from Satellite: \n {all_links}"
-        )
-        for page in pages:
-            for link in all_links[page]:
-                # Test stage docs url for Non-GA'ed Satellite
-                if float(sat_version) in settings.robottelo.sat_non_ga_versions:
-                    # The internal satellite doc url redirects to prod doc that is not available for Non-GA versions.
-                    # Get the end url first and then update it in later part of test.
-                    if target_sat.hostname in link:
-                        link = requests.get(link, verify=False).url
-                    link = link.replace(
-                        'https://docs.redhat.com', settings.robottelo.stage_docs_url
-                    )
-                    link = link.replace('html', 'html-single')
-                if requests.get(link, verify=False).status_code != 200:
-                    pages_with_broken_links[page].append(link)
-                    logger.info(f"Following link on {page} page seems broken: \n {link}")
-        assert not pages_with_broken_links, (
-            f"There are Satellite pages with broken documentation links. \n {print(pages_with_broken_links)}"
-        )
+    sat_version = ".".join(module_target_sat.version.split('.')[0:2])
+    all_links = []
+    broken_links = []
+    page_object = getattr(session, page)
+    if page == "host":
+        view = page_object.navigate_to(page_object, 'Register')
+    elif page == "oscappolicy":
+        view = page_object.navigate_to(page_object, 'New')
+    else:
+        view = page_object.navigate_to(page_object, 'All')
+    # Get the doc links present on the page.
+    all_links = view.documentation_links()
+    assert all_links, f"Couldn't find any documentation links on {page} page."
+    logger.info(f"Following are the documentation links collected from Satellite: \n {all_links}")
+    for link in all_links:
+        # Test stage docs url for Non-GA'ed Satellite
+        if float(sat_version) in settings.robottelo.sat_non_ga_versions:
+            # The internal satellite doc url redirects to prod doc that is not available for Non-GA versions.
+            # Get the end url first and then update it in later part of test.
+            if module_target_sat.hostname in link:
+                link = requests.get(link, verify=False).url
+            link = link.replace('https://docs.redhat.com', settings.robottelo.stage_docs_url)
+        if requests.get(link, verify=False).status_code != 200:
+            broken_links.append(link)
+            logger.info(f"Following link on {page} page seems broken: \n {link}")
+    assert not broken_links, (
+        f"There are broken documentation links on page \"{page}\": \n {broken_links}"
+    )
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Improvements to test_positive_documentation_links:
1. The test is parametrized, so there's one test per page, which makes it easier to analyze results
2. There's a module scoped session which keeps user logged in during testing links on each page (saves time)
3. Explicit redirect to single page in staging is no more needed since also production links lead to single page version (RedHatSatellite/foreman_theme_satellite/pull/202)
## Summary by Sourcery

Parametrize documentation link E2E test by page and reuse a shared UI session to speed up execution while keeping per-page assertions and logging.

Tests:
- Parametrize `test_positive_documentation_links` over individual pages instead of looping internally, producing separate test cases per page.
- Introduce a module-scoped UI session fixture to reuse a logged-in session across documentation link checks and reduce test runtime.

## Summary by Sourcery

Parametrize the documentation links E2E test per page and reuse a shared UI session to speed up execution and improve failure isolation.

Tests:
- Split `test_positive_documentation_links` into parametrized per-page test cases for clearer reporting of broken links.
- Introduce a module-scoped UI session fixture to reuse an authenticated session across documentation link checks.
- Simplify link collection and broken-link reporting to operate on a single page at a time with clearer error messages.