### PR TITLE
[6.16.z] Modifications in CLI and UI Libvirt CR to resolve key error

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -11,6 +11,7 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
+from robottelo.enums import NetworkType
 from robottelo.hosts import ContentHost
 
 
@@ -146,6 +147,7 @@ def module_provisioning_sat(
     It calls a workflow using broker to set up the network and to run satellite-installer.
     It uses the artifacts from the workflow to create all the necessary Satellite entities
     that are later used by the tests.
+    For IPv4, it clears DHCP leases and restarts dhcpd to ensure provisioning can obtain addresses.
     """
     provisioning_type = getattr(request, 'param', '')
     sat = module_target_sat
@@ -202,7 +204,9 @@ def module_provisioning_sat(
         remote_execution_proxy=[module_provisioning_capsule.id],
         domain=[domain.id],
     ).create()
-
+    if sat.network_type == NetworkType.IPV4:
+        assert sat.execute('cat /dev/null > /var/lib/dhcpd/dhcpd.leases').status == 0
+        assert sat.execute('systemctl restart dhcpd').status == 0
     return Box(sat=sat, domain=domain, subnet=subnet, provisioning_type=provisioning_type)
 
 


### PR DESCRIPTION
### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Update PXE provisioning fixture to clear DHCP leases and restart dhcpd for IPv4-based Satellite setups to reduce flaky address assignment in tests.