### PR TITLE
[6.18.z] Modifications in CLI and UI Libvirt CR to resolve key error

### DIFF
--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -181,8 +181,8 @@ def test_positive_provision_end_to_end(
         )
         name = f'{hostname}.{module_libvirt_provisioning_sat.domain.name}'
         request.addfinalizer(lambda: sat.provisioning_cleanup(name))
-        assert session.host.search(name)[0]['Name'] == name
-
+        result = session.host_new.search(name)[0]
+        assert result['Name'] == name
         # Check on Libvirt, if VM exists
         result = sat.execute(
             f'su foreman -s /bin/bash -c "virsh -c {LIBVIRT_URL} list --state-running"'


### PR DESCRIPTION
### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Adjust libvirt CLI and UI provisioning tests to handle firmware-specific limitations and improve robustness of PXE-based end-to-end provisioning.

Bug Fixes:
- Avoid KeyError when checking host build status by safely accessing nested status fields and enabling exception handling in the wait loop.
- Update UI libvirt provisioning test to use the correct host search API, preventing failures when asserting on the created host name.

Enhancements:
- Extend PXE loader coverage in libvirt end-to-end provisioning tests to include BIOS while conditionally skipping unsupported UEFI/SecureBoot scenarios based on an open issue.
- Ensure reliable IPv4 provisioning by clearing DHCP leases and restarting the dhcpd service in the PXE provisioning fixture.