### PR TITLE
[6.19.z] Add test for bulk vulnerability analysis

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -73,7 +73,7 @@ def setup_content_for_iop(module_target_sat_insights, rhcloud_manifest_org):
 @pytest.mark.rhel_ver_match('10')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_rhcloud_insights_vulnerabilities_e2e(
-    rhel_insights_vm,
+    vulnerable_rhel_host,
     rhcloud_manifest_org,
     module_target_sat_insights,
     setup_content_for_iop,
@@ -98,22 +98,8 @@ def test_rhcloud_insights_vulnerabilities_e2e(
     :verifies: SAT-30762
     """
     satellite = module_target_sat_insights
-    client = rhel_insights_vm
+    client = vulnerable_rhel_host
     hostname = client.hostname
-
-    # Remove any static repos and update to the latest packages available from the Satellite
-    assert (
-        client.execute(
-            'find /etc/yum.repos.d/ -type f | grep -vF redhat.repo | xargs -I \'{}\' rm \'{}\''
-        ).status
-        == 0
-    )
-    assert client.execute('dnf -y update').status == 0
-
-    # Install vulnerable mariadb version (dnf install with NEVRA handles install/downgrade)
-    assert client.execute(f'dnf install -y {constants.RHEL10_VULNERABLE_MARIADB_RPM}').status == 0
-    # Run insights-client to report the vulnerabilities to Satellite
-    assert client.execute('insights-client').status == 0
 
     with satellite.ui_session() as session:
         session.organization.select(org_name=rhcloud_manifest_org.name)
@@ -389,9 +375,9 @@ def test_positive_disable_vulnerability_analysis_for_host(
     module_target_sat_insights,
     setup_content_for_iop,
 ):
-    """Test disabling vulnerability analysis for a host via kebab menu on All Hosts page
+    """Test bulk disabling vulnerability analysis for a host via kebab menu on All Hosts page
 
-    :id: 4e7ba195-235d-4f4e-86d0-2ab9b2db4bf0
+    :id: d086ca66-542a-4492-a079-77ace4658135
 
     :steps:
         1. Navigate to All Hosts page
@@ -433,7 +419,6 @@ def test_positive_disable_vulnerability_analysis_for_host(
         assert hostname in table_data[0]['Name'], (
             f"Expected host {hostname}, but got {host_row['Name']}"
         )
-
         session.all_hosts.disable_vulnerability_analysis(hostname)
         # Search for the host again and verify status changed
         table_data = session.all_hosts.search(hostname)
@@ -442,4 +427,69 @@ def test_positive_disable_vulnerability_analysis_for_host(
         host_row = table_data[0]
         assert hostname in table_data[0]['Name'], (
             f"Expected host {hostname}, but got {host_row['Name']}"
+        )
+
+
+@pytest.mark.e2e
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+def test_positive_bulk_disable_vulnerability_analysis(
+    vulnerable_rhel_host,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+    setup_content_for_iop,
+):
+    """Test bulk disabling vulnerability analysis for a host via kebab menu on All Hosts page
+
+    :id: d9d73165-3227-433b-a355-254b3a05a2da
+
+    :steps:
+        1. Navigate to All Hosts page
+        2. Add "Total CVEs" column from Red Hat Lightspeed section
+        3. Search for the registered insights RHEL host
+        4. Verify the Total CVEs value is greater than 1
+        5. Use bulk action to select all hosts and disable vulnerability analysis
+        6. Verify the Total CVEs column now shows "Analysis disabled"
+
+    :expectedresults:
+        1. Total CVEs column is successfully added and displayed
+        2. Host shows CVE count greater than 1 initially
+        3. After bulk disable action, Total CVEs column shows "Analysis disabled"
+
+    :Verifies: SAT-40203
+    """
+    satellite = module_target_sat_insights
+    client = vulnerable_rhel_host
+    hostname = client.hostname
+
+    with satellite.ui_session() as session:
+        # Select the correct organization
+        session.organization.select(org_name=rhcloud_manifest_org.name)
+        session.all_hosts.get_displayed_table_headers()
+        session.all_hosts.manage_table_columns({'Total CVEs': True})
+
+        # Verify the column is displayed
+        displayed_columns = session.all_hosts.get_displayed_table_headers()
+        assert 'Total CVEs' in displayed_columns, (
+            f"Total CVEs column not found. Available columns: {displayed_columns}"
+        )
+
+        # Search for the registered host and total cves
+        table_data = session.all_hosts.search(hostname)
+        assert len(table_data) > 0, f"Host {hostname} not found after search"
+        assert int(table_data[0]['Total CVEs']) > 1
+        host_row = table_data[0]
+        assert hostname in table_data[0]['Name'], (
+            f"Expected host {hostname}, but got {host_row['Name']}"
+        )
+
+        # Use bulk action to disable vulnerability analysis for all hosts
+        session.all_hosts.manage_vulnerability_analysis('Disable')
+
+        # Search for the host again and verify status changed to "Analysis disabled"
+        table_data = session.all_hosts.search(hostname)
+        assert len(table_data) > 0, f"Host {hostname} not found after search"
+        assert table_data[0]['Total CVEs'] == 'Analysis disabled', (
+            f"Expected 'Analysis disabled' but got '{table_data[0]['Total CVEs']}'"
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20733

Test for SAT-40203 
Bulk Vulnerability Analysis toggle
https://github.com/SatelliteQE/airgun/pull/2299

## Summary by Sourcery

Add UI test coverage for bulk disabling vulnerability analysis and reuse a pre-configured vulnerable RHEL host fixture instead of preparing it inline.

New Features:
- Introduce an end-to-end test that validates bulk disabling of vulnerability analysis via the All Hosts page.

Enhancements:
- Refactor existing vulnerability analysis E2E test to use the shared vulnerable RHEL host fixture instead of performing manual package setup within the test.
- Update an existing single-host vulnerability analysis disable test’s metadata to reflect its non-bulk behavior.