### PR TITLE
Automate setting IoP log levels via satellite-installer

### DIFF
--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -348,7 +348,7 @@ def process_iop_log_options(installer_output):
     return options_dict
 
 
-def test_set_iop_log_level_via_installer(module_target_sat_insights):
+def test_set_iop_log_level_via_installer(module_satellite_iop):
     """Set IoP log level to DEBUG using satellite-installer options.
 
     :id: 0268a6c1-56b5-4a0c-9df9-6c1b34f6cbd7
@@ -369,7 +369,7 @@ def test_set_iop_log_level_via_installer(module_target_sat_insights):
 
     # Retrieve the IoP log level settings from satellite-installer help output
     help_command = InstallerCommand('full-help').get_command()
-    log_level_settings = module_target_sat_insights.execute(
+    log_level_settings = module_satellite_iop.execute(
         f'{help_command} | grep iop.*log-level | grep -v reset'
     ).stdout
 
@@ -386,10 +386,10 @@ def test_set_iop_log_level_via_installer(module_target_sat_insights):
         iop_core_engine_log_level_insights_messaging=NEW_LOG_LEVEL,
         iop_core_engine_log_level_root=NEW_LOG_LEVEL,
     ).get_command()
-    module_target_sat_insights.execute(command)
+    module_satellite_iop.execute(command)
 
     # Verify that log levels are now DEBUG
-    new_log_level_settings = module_target_sat_insights.execute(
+    new_log_level_settings = module_satellite_iop.execute(
         f'{help_command} | grep iop.*log-level | grep -v reset'
     ).stdout
     new_settings_dict = process_iop_log_options(new_log_level_settings)
@@ -403,8 +403,8 @@ def test_set_iop_log_level_via_installer(module_target_sat_insights):
         'reset-iop-core-engine-log-level-insights-messaging',
         'reset-iop-core-engine-log-level-root',
     ).get_command()
-    module_target_sat_insights.execute(command)
-    log_level_settings = module_target_sat_insights.execute(
+    module_satellite_iop.execute(command)
+    log_level_settings = module_satellite_iop.execute(
         f'{help_command} | grep iop.*log-level | grep -v reset'
     ).stdout
     settings_dict = process_iop_log_options(log_level_settings)


### PR DESCRIPTION
This PR automates testing of SAT-41750, which introduced satellite-installer options that set the verbosity level of the IoP loggers. It verifies that none of these loggers are set to DEBUG by default, that all of them can be switched to DEBUG using satellite-installer, and that all of them can be switched back to their default values using satellite-installer. It also introduces a helper method for processing satellite-installer help output into a dictionary.

## Summary by Sourcery

Add automated coverage for configuring IoP log levels via satellite-installer and introduce a helper for parsing installer help output.

New Features:
- Add a test that verifies IoP log levels can be viewed, set to DEBUG, and reset to defaults via satellite-installer options.

Enhancements:
- Introduce a helper function to convert satellite-installer help output into a dictionary of options and descriptions for easier assertions in tests.

Tests:
- Extend IoP-related CLI tests to validate default IoP log levels, changing them to DEBUG, and resetting them using satellite-installer.