### PR TITLE
Fixes for upstream-pr option

### DIFF
--- a/pytest_plugins/upstream_pr.py
+++ b/pytest_plugins/upstream_pr.py
@@ -32,7 +32,7 @@ def match_file_to_rule(filename, rule):
     path_pattern = rule.path
 
     try:
-        return bool(re.search(path_pattern, filename))
+        return bool(re.search(path_pattern, filename, flags=re.IGNORECASE))
     except re.error as e:
         logger.error(f"Invalid regex pattern '{path_pattern}': {e}")
         return False
@@ -192,7 +192,7 @@ def pytest_collection_modifyitems(session, items, config):
                     if match_file_to_rule(filename, rule)
                 }
                 if matched_filenames:
-                    components.add(rule.component)
+                    components.add(rule.component.lower())
                     unprocessed_filenames.difference_update(matched_filenames)
                     logger.debug(
                         f"Rule '{rule.path}' matched {len(matched_filenames)} files, "


### PR DESCRIPTION
### Problem Statement

- Tests not collected when using the `--upstream-pr` option
- Case-sensitivity in filename-to-component mapping makes it harder to set up and use

### Solution

- Make upstream pull request filename matching case-insensitive
- Use lowercase when matching components to tests

### Related Issues

SAT-24770

### PRT test Cases example

```
trigger: test-robottelo
pytest: pytest tests/foreman/api/ --upstream-pr foreman/{PR_ID}
env:
  ROBOTTELO_GITHUB_REPOS__FOREMAN__RULES: '@json [{"path":"host", "component":"Hosts"},{"path":"setting","component":"Settings"}]'
```

## Summary by Sourcery

Make upstream pull request file matching case-insensitive and normalize matched components to lowercase.

Bug Fixes:
- Ensure upstream PR file path matching is case-insensitive to correctly apply rules regardless of filename casing.

Enhancements:
- Normalize matched rule components to lowercase for consistent component handling in upstream PR processing.

## Summary by Sourcery

Ensure upstream pull request rules match file paths case-insensitively and normalize matched components for consistent test selection.

Bug Fixes:
- Make upstream pull request file path matching case-insensitive so rules apply regardless of filename casing.

Enhancements:
- Normalize matched rule components to lowercase to ensure consistent component identification during test collection.