### PR TITLE
[6.19.z] Fix test_positive_verify_chronyd_timesource_kickstart_template for RHEL<9

### DIFF
--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -782,7 +782,7 @@ class TestProvisioningTemplate:
             assert f'timesource --ntp-server {ntp_server_value}' in render
             assert f'timezone --utc {timezone}' in render
         else:
-            assert f'timezone --utc {timezone} --ntpservers {ntp_server_value}' in render
+            assert f'timezone --ntpservers {ntp_server_value} --utc {timezone}' in render
 
     @pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
     def test_create_host_with_invalid_template(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20820

### Problem Statement
test_positive_verify_chronyd_timesource_kickstart_template started to fail after changes in https://github.com/theforeman/foreman/pull/10427 which impacted only RHEL < 9

### Solution
Fixing test_positive_verify_chronyd_timesource_kickstart_template for RHEL < 9 by changing the assertion as per the upstream PR

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Update chronyd timesource kickstart template test assertion to match the new ordering of timezone and ntpservers options on RHEL < 9.