### PR TITLE
content-access-mode-all option appears to be no longer needed or supported

### DIFF
--- a/robottelo/host_helpers/repository_mixins.py
+++ b/robottelo/host_helpers/repository_mixins.py
@@ -707,7 +707,7 @@ class RepositoryCollection:
         )
         if override is not None:
             for repo in self.satellite.cli.ActivationKey.product_content(
-                {'id': activation_key['id'], 'content-access-mode-all': 1}
+                {'id': activation_key['id']}
             ):
                 self.satellite.cli.ActivationKey.content_override(
                     {


### PR DESCRIPTION
### Problem Statement
--content-access-mode-all option not recognized in Satellite stream-166
SCA (Simple Content Access) is now the default mode, making this option obsolete

### Solution
Removed the content-access-mode-all parameter from the ActivationKey.product_content() call

### Related Issues


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostcollection.py -k "test_positive_install_errata or test_positive_change_assigned_content or test_positive_install_package"

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Stop passing an unsupported content-access-mode-all parameter when fetching activation key product content to avoid errors on newer Satellite streams.