### PR TITLE
SAT-20386 Jira card is closed; removing it.

### DIFF
--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -498,6 +498,16 @@ def test_rhel_pxe_provisioning_fips_enabled(
 
     :Verifies: SAT-26071
     """
+    # Skip RHEL7 UEFI test due to known issue SAT-41340
+    if (
+        is_open('SAT-41340')
+        and pxe_loader.vm_firmware in ['uefi']
+        and module_provisioning_rhel_content.os.major == '7'
+    ):
+        pytest.skip(
+            f"Test not supported for rhel{module_provisioning_rhel_content.os.major} {pxe_loader.vm_firmware} firmware"
+        )
+
     sat = module_provisioning_sat.sat
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     # Verify password hashing algorithm SHA512 is set in OS used for provisioning
@@ -573,7 +583,7 @@ def test_rhel_pxe_provisioning_fips_enabled(
 
     # Verify FIPS is enabled on host after provisioning is completed successfully
     result = provisioning_host.execute('cat /proc/sys/crypto/fips_enabled')
-    assert (0 if is_open('SAT-20386') else 1) == int(result.stdout)
+    assert int(result.stdout) == 1
 
     # Run a command on the host using REX to verify that Satellite's SSH key is present on the host
     # Add workaround for SAT-32007 and SAT-32006


### PR DESCRIPTION
The host is enabled with FIPS mode, so card `SAT-20386` is being removed as the condition is no longer required.

## Summary by Sourcery

Adjust RHEL PXE FIPS provisioning test expectations and skipping behavior for specific firmware/OS combinations.

Tests:
- Add a conditional skip for the RHEL PXE FIPS provisioning test when running on RHEL 7 with UEFI firmware under an open SAT-41340.
- Update the FIPS-enabled assertion in the RHEL PXE provisioning test to always require FIPS to be enabled, removing the SAT-20386 conditional.