### PR TITLE
Fix failing errata ui tests

### DIFF
--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -1199,7 +1199,6 @@ def test_positive_host_content_library(
         assert host_tab_erratum[0]['Errata'] == CUSTOM_REPO_ERRATA_ID
 
 
-@pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('N-1')
 @pytest.mark.parametrize(
     'registered_contenthost',
@@ -1229,7 +1228,7 @@ def test_positive_errata_search_type(
         TIMESTAMP_FMT
     )
     assert vm.execute(f'yum install -y {pkgs}').status == 0
-
+    assert vm.execute('subscription-manager repos').status == 0
     applicability_tasks = module_target_sat.wait_for_tasks(
         search_query=(
             f'Bulk generate applicability for host {hostname}'


### PR DESCRIPTION
### Problem Statement
Some Errata UI tests failing due to content hosts page removal

### Solution
Remove/fix parts of test that use content hosts page

### Related Issues
https://issues.redhat.com/browse/SAT-42273

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_errata.py -k "positive_check_errata or positive_content_host_previous_env or positive_errata_search_type or positive_filtered_errata_status_installable_param"
```
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples

## Summary by Sourcery

Adjust errata UI tests to avoid removed content hosts page and ensure errata applicability is reflected after package installation tasks complete.

Bug Fixes:
- Remove reliance on the deprecated content hosts page in errata UI tests that caused failures.
- Ensure errata-related tests wait for and verify bulk applicability generation tasks after yum installs to avoid timing-related failures.

Enhancements:
- Tag affected errata UI tests with the no_containers marker and standardize timestamp formatting using the shared time format constant.