### PR TITLE
List enabled repos to refresh the package profile

### DIFF
--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -1135,6 +1135,7 @@ def test_positive_check_errata(session, registered_contenthost):
     vm = registered_contenthost
     hostname = vm.hostname
     assert vm.execute(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}').status == 0
+    assert vm.execute('subscription-manager repos').status == 0
     with session:
         session.location.select(loc_name=DEFAULT_LOC)
         read_errata = session.host_new.get_details(hostname, 'Content.Errata')


### PR DESCRIPTION
### Problem Statement
The `test_positive_check_errata` fails for RHEL10 - no errata is displayed. It looks like the package profile is not updated right after installation.


### Solution
List repos to refresh the package profile.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_errata.py::test_positive_check_errata
```

## Summary by Sourcery

Tests:
- Update the positive errata check UI test to list enabled repositories on the content host after installing a package.