### PR TITLE
[6.16.z] Replace library/busybox with lighter container repo

### DIFF
--- a/conf/container.yaml.template
+++ b/conf/container.yaml.template
@@ -4,7 +4,7 @@ CONTAINER:
     - docker
     - podman
   REGISTRY_HUB: https://mirror.gcr.io
-  UPSTREAM_NAME: 'library/busybox'
+  UPSTREAM_NAME: jmalloc/echo-server
   ALTERNATIVE_UPSTREAM_NAMES:
     - hello-world
     - alpine

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -119,7 +119,7 @@ VALIDATORS = dict(
             'container.upstream_name',
             must_exist=True,
             is_type_of=str,
-            default='library/busybox',
+            default='jmalloc/echo-server',
         ),
         Validator(
             'container.alternative_upstream_names',


### PR DESCRIPTION
Manual cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20671
(cherry picked from commit 8ac73bc97a2531bb9b282f00adced329b16c0c93)

### Problem Statement
Gradually over time the `library/busybox` repo is becoming more and more huge.
The problem with repo sync arises especially in IPv6 environment where the traffic goes over IPv6-to-4 proxy.

Testing revealed that syncing over IPv4 takes approx. 10 min while syncing over IPv6 takes 25 min and tends to time out quite often.

### Solution 
Find more suitable replacement for testing container repo target

### Related Issues
[SAT-41831](https://issues.redhat.com/browse/SAT-41831)
#20855

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update container test image configuration and improve container lifecycle handling in CLI tests.

Enhancements:
- Run test containers in detached mode and guard stop/remove operations by validating container IDs from docker output.

Tests:
- Adjust CLI container management test to work with the new default test container image and more robustly manage created containers.

Chores:
- Change the default upstream test container image from the large library/busybox repository to the lighter jmalloc/echo-server repository in configuration and templates.