### PR TITLE
Change 'iop_advisor_engine' settings to 'iop'.

### DIFF
--- a/conf/rh_cloud.yaml.template
+++ b/conf/rh_cloud.yaml.template
@@ -4,7 +4,7 @@ RH_CLOUD:
   ORGANIZATION:
   ACTIVATION_KEY: ak_name
   CRC_ENV: prod
-  IOP_ADVISOR_ENGINE:
+  IOP:
     IMAGE_PATH:   # For 6.17 IoP
     IMAGE_PATHS:  # For 6.18+ IoP
     REGISTRY:

--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -61,7 +61,7 @@ def sat_maintain(request):
     yield infra_host
 
     if host_type == 'satellite_iop':
-        iop_settings = settings.rh_cloud.iop_advisor_engine
+        iop_settings = settings.rh_cloud.iop
         if not infra_host.is_podman_logged_in(iop_settings.stage_registry):
             infra_host.podman_login(
                 iop_settings.stage_username,

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -225,8 +225,7 @@ def module_unconfigured_satellite():
 def get_iop_deploy_args():
     """Get deploy arguments for IoP workflow"""
     image_args = {
-        f'iop_{service}_image': path
-        for service, path in settings.rh_cloud.iop_advisor_engine.image_paths.items()
+        f'iop_{service}_image': path for service, path in settings.rh_cloud.iop.image_paths.items()
     }
     return settings.server.deploy_arguments.to_dict() | image_args
 

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -338,9 +338,7 @@ VALIDATORS = dict(
     ],
     rh_cloud=[
         Validator('rh_cloud.token', required=True),
-        Validator(
-            'rh_cloud.iop_advisor_engine.image_paths', default={}, apply_default_on_none=True
-        ),
+        Validator('rh_cloud.iop.image_paths', default={}, apply_default_on_none=True),
     ],
     repos=[
         Validator(

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -453,7 +453,7 @@ class IoPSetup:
     def get_iop_image_paths():
         return {
             f'iop::{service}::image': path
-            for service, path in settings.rh_cloud.iop_advisor_engine.image_paths.items()
+            for service, path in settings.rh_cloud.iop.image_paths.items()
         }
 
     def configure_iop(self):
@@ -466,7 +466,7 @@ class IoPSetup:
 
         self.ensure_podman_installed()
 
-        iop_settings = settings.rh_cloud.iop_advisor_engine
+        iop_settings = settings.rh_cloud.iop
         self.podman_login(iop_settings.username, iop_settings.token, iop_settings.registry)
         self.podman_login(
             iop_settings.stage_username, iop_settings.stage_token, iop_settings.stage_registry

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1621,7 +1621,7 @@ class ContentHost(Host, ContentHostMixins):
 
     def podman_login(self, username=None, password=None, registry=None):
         """Login to a podman registry."""
-        iop_settings = settings.rh_cloud.iop_advisor_engine
+        iop_settings = settings.rh_cloud.iop
         username = username or iop_settings.username
         password = password or iop_settings.token
         registry = registry or iop_settings.registry
@@ -1652,7 +1652,7 @@ class ContentHost(Host, ContentHostMixins):
 
     def is_podman_logged_in(self, registry=None):
         """Check if podman is logged into a registry."""
-        registry = registry or settings.rh_cloud.iop_advisor_engine.registry
+        registry = registry or settings.rh_cloud.iop.registry
         return (
             self.execute(
                 f'podman login --get-login --authfile {constants.PODMAN_AUTHFILE_PATH} {registry}'
@@ -1663,7 +1663,7 @@ class ContentHost(Host, ContentHostMixins):
 
     def podman_logout(self, registry=None):
         """Logout of a podman registry."""
-        registry = registry or settings.rh_cloud.iop_advisor_engine.registry
+        registry = registry or settings.rh_cloud.iop.registry
         if self.is_podman_logged_in(registry):
             cmd_result = self.execute(
                 f'podman logout --authfile {constants.PODMAN_AUTHFILE_PATH} {registry}'

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -70,7 +70,7 @@ def test_positive_install_iop_custom_certs(
     """
     satellite = sat_ready_rhel
     host = rhel_contenthost
-    iop_settings = settings.rh_cloud.iop_advisor_engine
+    iop_settings = settings.rh_cloud.iop
 
     # Satellite + IoP installation
 

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -45,7 +45,7 @@ def test_podman_login_check(request, sat_maintain):
 
     :Verifies: SAT-35282
     """
-    iop_settings = settings.rh_cloud.iop_advisor_engine
+    iop_settings = settings.rh_cloud.iop
 
     request.addfinalizer(lambda: sat_maintain.podman_logout(iop_settings.registry))
 


### PR DESCRIPTION
### Problem Statement

`iop_advisor_engine` is not an accurate label anymore for IoP settings.

### Solution

Change 'iop_advisor_engine' to 'iop'.

6.18.z and 6.17.z PRs will be done manually.

### Related Issues


<!-- ### PRT test Cases example

PRT test passed on internal Jenkins instance (which has the updated `iop` dynaconf settings):

```
16:29:37  + pytest 'tests/foreman/ui/test_rhcloud_iop.py::test_iop_recommendations_e2e[rhel10-ipv4-local]' --junit-xml=sat-results.xml -o junit_suite_name=sat-result
[...]
16:30:33  collected 1 item
16:30:33  
16:59:32  tests/foreman/ui/test_rhcloud_iop.py .                                   [100%]
```

trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Rename IoP configuration usage from the deprecated `iop_advisor_engine` namespace to the new `iop` namespace across code, configuration validation, and tests.

Enhancements:
- Update podman helper methods and IoP setup mixins to read IoP credentials and registry details from `settings.rh_cloud.iop`.
- Adjust configuration validators and IoP image path handling to use the new `rh_cloud.iop.image_paths` key.
- Refresh fixtures and tests to reference the new IoP settings namespace for image paths and authentication.

## Summary by Sourcery

Rename the IoP configuration namespace from `rh_cloud.iop_advisor_engine` to `rh_cloud.iop` across runtime code, configuration validation, and tests.

Enhancements:
- Update host podman helper methods and IoP setup mixins to read credentials, registries, and image paths from `settings.rh_cloud.iop`.
- Adjust configuration validation to expect IoP image paths under `rh_cloud.iop.image_paths` instead of the deprecated `iop_advisor_engine` key.
- Refresh fixtures and tests to consume the new `rh_cloud.iop` settings namespace for IoP image paths and authentication.