### PR TITLE
flakyRegUITest

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -820,8 +820,8 @@ def test_registering_with_title_using_global_registration_parameter(
         session.location.select(module_location.name)
         cmd = session.host.get_register_command(
             {
-                'general.operating_system': default_os.title,
                 'general.host_group': hostgroup.name,
+                'general.operating_system': default_os.title,
                 'general.activation_keys': module_activation_key.name,
                 'advanced.setup_insights': 'Yes (override)',
                 'general.insecure': True,


### PR DESCRIPTION
### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Correct the ordering of registration parameters in the registration UI test to avoid flaky behavior.