### PR TITLE
Fix virt_who test case to inventory report generation

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -693,14 +693,14 @@ class TestVirtwhoConfigforEsx:
         )
 
         timestamp = (datetime.now(UTC) - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
-        org_session.cloudinventory.generate_report(module_sca_manifest_org.name)
+        org_session.cloudinventory.generate_and_upload_report(module_sca_manifest_org.name)
         # wait_for_tasks report generation task to finish
         wait_for(
             lambda: (
                 module_target_sat.api.ForemanTask()
                 .search(
                     query={
-                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        'search': f'label = ForemanInventoryUpload::Async::HostInventoryReportJob '
                         f'and started_at >= "{timestamp}"'
                     }
                 )[0]
@@ -713,7 +713,7 @@ class TestVirtwhoConfigforEsx:
             handle_exception=True,
         )
         # download report
-        report_path = org_session.cloudinventory.download_report(module_sca_manifest_org.name)
+        report_path = org_session.cloudinventory.download_report_only(module_sca_manifest_org.name)
         json_data = get_report_data(report_path)
         host_data = [item for item in json_data['hosts']]
         # Verify that guest hostname is NOT in report


### PR DESCRIPTION
### Problem Statement
virt who test case test_positive_minimal_report_hypervisor was failing as it was not updated to new inventory report generation mechanism

### Solution
Fix virt_who test case to inventory report generation

### Related Issues


 ### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_minimal_report_hypervisor
theforeman:
    foreman_rh_cloud: 1156
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Adjust virt-who minimal hypervisor report test to use the new generate-and-upload job and corresponding report download API.