### PR TITLE
Update Download Report CLI test

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -435,6 +435,7 @@ def test_positive_generate_reports_job_cli_disconnected(
     assert expected == result['output']
 
 
+@pytest.mark.rhel_ver_match('N-2')
 def test_positive_download_reports_job_cli_disconnected(
     rhcloud_manifest_org, module_target_sat, rhcloud_registered_hosts
 ):
@@ -448,7 +449,7 @@ def test_positive_download_reports_job_cli_disconnected(
 
     :expectedresults: Reports download works as expected.
 
-    :BlockedBy: SAT-41462
+    :Verifies: SAT-41462
     """
     org = rhcloud_manifest_org
     generate_report(org, module_target_sat, disconnected=True)


### PR DESCRIPTION
Issue which was blocking this test is resolved in upstream.

### PRT test Cases example
<img width="345" height="83" alt="image" src="https://github.com/user-attachments/assets/fe541e7a-bbb6-4993-a404-5140b42a87e1" />


```
trigger: test-robottelo
pytest: tests/foreman/cli/test_rhcloud_inventory.py -k "test_positive_download_reports_job_cli_disconnected"
theforeman:
    foreman_rh_cloud: 1155
```

## Summary by Sourcery

Tests:
- Restrict the disconnected download reports CLI test to RHEL N-2 and update its metadata to verify SAT-41462 instead of marking it blocked.