### PR TITLE
Introduce MCP component

### DIFF
--- a/tests/foreman/sys/test_mcp.py
+++ b/tests/foreman/sys/test_mcp.py
@@ -2,11 +2,11 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: API
+:CaseComponent: MCP
 
 :Team: Endeavour
 
-:Requirement: API
+:Requirement: MCP
 
 :CaseImportance: High
 


### PR DESCRIPTION
### Problem Statement
MCP component doesn't have its tests

### Solution
Align existing MCP tests under MCP component

### Related Issues
satelliteqe/satellite-jenkins/-/merge_requests/1870

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Enhancements:
- Update MCP system test case metadata to use the MCP component and requirement instead of the generic API classification.