### PR TITLE
[6.18.z] adjusted asserts for mcp user tests

### DIFF
--- a/tests/foreman/sys/test_mcp.py
+++ b/tests/foreman/sys/test_mcp.py
@@ -158,6 +158,11 @@ async def test_positive_mcp_user_view_permissions(
         result = await client.call_tool(
             'call_foreman_api_get', {'resource': allowed_resource, 'action': 'index', 'params': {}}
         )
+        if 'error' in result.data and 'Max retries exceeded' in result.data['error']:
+            result = await client.call_tool(
+                'call_foreman_api_get',
+                {'resource': allowed_resource, 'action': 'index', 'params': {}},
+            )
         assert (
             result.data['message']
             == f"Action 'index' on resource '{allowed_resource}' executed successfully."
@@ -170,3 +175,4 @@ async def test_positive_mcp_user_view_permissions(
             f"Failed to execute action 'index' on resource '{denied_resource}'"
             in result.data['message']
         )
+        assert result.data['response']['error']['message'] == 'Access denied'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20852

### Problem Statement
targeting an issue that isn't reproducible outside of our regular automation runs, therefore a bit mysterious. My hypothesis is that on the first run attempt the mcp client queries the mcp server before the connection with satellite is established using custom credentials. 

### Solution
Allow for a second try if the aforementioned issue happens

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Adjust mcp user permission system tests to better handle transient API connectivity issues when querying allowed resources.

Tests:
- Retry the Foreman API call in the mcp user view permissions test when a transient max-retries error occurs before asserting success.
- Strengthen negative permission assertions by verifying the specific access-denied error message in the mcp user view permissions test.