### PR TITLE
[6.19.z] fix Future Dated Subs Test

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -226,8 +226,7 @@ def sca_manifest_for_upgrade():
 
 
 @pytest.fixture
-def func_future_dated_subscription_manifest(target_sat, function_org):
-    """Create and upload future date subscription manifest into org"""
+def func_future_dated_subscription_manifest():
+    """Returns future dated manifest. Used only for future date subscription scenarios."""
     with Manifester(manifest_category=settings.manifest.future_date_subscription) as manifest:
-        target_sat.upload_manifest(function_org.id, manifest.content)
-    return manifest
+        yield manifest

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -371,6 +371,8 @@ def test_positive_populate_future_date_subcription(
 
     :customerscenario: true
     """
+    target_sat.upload_manifest(function_org.id, func_future_dated_subscription_manifest.content)
+
     with target_sat.ui_session() as session:
         session.organization.select(function_org.name)
         assert session.subscription.has_manifest, 'Manifest not uploaded'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20873

- Fix future-dated subscription UI test by ensuring the manifest is uploaded within the test rather than implicitly in the fixture.

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k "test_positive_populate_future_date_subcription"
```

## Summary by Sourcery

Bug Fixes:
- Fix future-dated subscription UI test by uploading the manifest within the test using the future-dated manifest fixture.