### PR TITLE
Fix parametrization order for MCP server test

### DIFF
--- a/tests/foreman/sys/test_mcp.py
+++ b/tests/foreman/sys/test_mcp.py
@@ -28,7 +28,7 @@ from robottelo.enums import NetworkType
         'module_target_sat_foreman_mcp_stage',
         'module_target_sat_foreman_mcp_downstream',
     ],
-    ids=['upstream', 'downstream', 'stage'],
+    ids=['upstream', 'stage', 'downstream'],
 )
 @pytest.mark.skipif(
     settings.server.network_type == NetworkType.IPV6,


### PR DESCRIPTION
### Problem Statement
Incorrect parametrization order for MCP server test:
- running `downstream` parameter tests Stage
- running `stage` parameter tests Prod

### Solution
Fix parametrization order

### Related Issues
[SAT-42137](https://issues.redhat.com/browse/SAT-42137)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Fix mismatched parametrization IDs so that 'stage' and 'downstream' MCP server tests run against the correct environments.