### PR TITLE
[6.18.z] hostgroup nonadmin viewer read

### DIFF
--- a/pytest_fixtures/component/hostgroup.py
+++ b/pytest_fixtures/component/hostgroup.py
@@ -10,6 +10,13 @@ def module_hostgroup(module_target_sat):
     return module_target_sat.api.HostGroup().create()
 
 
+@pytest.fixture(scope='module')
+def module_hostgroup_with_org_loc(module_target_sat, module_org, module_location):
+    return module_target_sat.api.HostGroup(
+        organization=[module_org], location=[module_location]
+    ).create()
+
+
 @pytest.fixture(scope='class')
 def class_hostgroup(class_target_sat, class_org, class_location):
     """Create a hostgroup linked to specific org and location created at the class scope"""

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -370,3 +370,41 @@ def test_positive_clone_host_groups(
         assert target_sat.api.HostGroup().search(query={'search': f'name={clone_hg_name}'})
         session.hostgroup.delete(clone_hg_name)
         assert not target_sat.api.HostGroup().search(query={'search': f'name={clone_hg_name}'})
+
+
+def test_positive_non_admin_viewer_role_read(
+    test_name,
+    module_target_sat,
+    module_org,
+    module_location,
+    module_hostgroup_with_org_loc,
+    module_user_viewer,
+):
+    """Verify that a non-admin user with Viewer role assigned is able to see a host group created by admin user.
+
+    :ID: c4f5e236-0bfb-11f1-acba-000c29a0e355
+
+    :CaseImportance: High
+
+    :Setup:
+        1. Create new host group as admin.
+        2. Create new non-admin user with Viewer role assigned.
+
+    :Steps:
+        1. Log in as the user with Viewer role and go to the Configure->Host Groups page.
+
+    :ExpectedResults: The page is displayed correctly, i.e., no error is shown. User sees the host group in the list.
+
+    :Verifies: SAT-38451
+
+    :CustomerScenario: true
+    """
+    with module_target_sat.ui_session(
+        test_name, module_user_viewer.login, module_user_viewer.password
+    ) as session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_location.name)
+        assert (
+            session.hostgroup.search(module_hostgroup_with_org_loc.name)[0]['Name']
+            == module_hostgroup_with_org_loc.name
+        )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20875

### Problem Statement
New test coverage for bug SAT-38451: Non-admin users on Satellite with viewer role, unable to see the hostgroup.

### Solution
Ensure that non-admin user with viewer role can see hostgroup created by admin user.

Also added new `UserFactory` class to help with more reusable user fixtures.

### PRT
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostgroup.py -k test_positive_non_admin_viewer_role_read
```

## Summary by Sourcery

Add test coverage and shared fixtures to validate that non-admin users with the Viewer role can read host groups created by admin users.

New Features:
- Introduce a reusable UserFactory helper to create users with defaulted passwords in fixtures.
- Add a module-scoped fixture providing a Viewer-role non-admin user bound to a specific organization and location.
- Add a module-scoped fixture creating a host group associated with a given organization and location.

Tests:
- Add a UI test ensuring a non-admin user with the Viewer role can see a host group created by an admin user, verifying SAT-38451 behavior.