### PR TITLE
Automation for SAT-32425 and SAT-42710

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -29,7 +29,6 @@ import yaml
 from robottelo.config import settings
 from robottelo.constants import (
     ANY_CONTEXT,
-    ANY_LOCATION,
     DEFAULT_ARCHITECTURE,
     DEFAULT_CV,
     DEFAULT_LOC,
@@ -4271,7 +4270,7 @@ def test_positive_only_single_library_option_in_create_form(target_sat):
     """
     with target_sat.ui_session() as session:
         session.organization.select(org_name=DEFAULT_ORG)
-        session.location.select(loc_name=ANY_LOCATION)
+        session.location.select(loc_name=ANY_CONTEXT['location'])
         create_form = session.host.get_create_form()
         create_form.host.lce.open_filter.click()
         # Check that 'Library' appears just once


### PR DESCRIPTION
Check that only 1 Library LCE option is displayed in the Host create form when the Any location is set.
Needs: https://github.com/SatelliteQE/airgun/pull/2323

### PRT test Cases example
<img width="397" height="48" alt="image" src="https://github.com/user-attachments/assets/d26fe1d2-8b3b-4876-9c8a-0ad90fd1d25a" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_positive_only_single_library_option_in_create_form'
airgun: 2323
```

## Summary by Sourcery

Tests:
- Add a UI test that validates only a single Library lifecycle environment option appears in the Create Host form for the Any location context.