### PR TITLE
[6.19.z] Use Convert2RHEL repofiles instead of deprecated repos for tests

### DIFF
--- a/robottelo/content_info.py
+++ b/robottelo/content_info.py
@@ -69,6 +69,27 @@ def get_repo_files_by_url(url, extension='rpm'):
     return sorted([os.path.basename(f) for f in get_repo_files_urls_by_url(url, extension)])
 
 
+def get_baseurl_by_repofile(repo_url, verify_ssl=True):
+    """
+    Returns the baseurl from a remote yum .repo file.
+
+    :param repo_url: URL to the .repo file
+    :return: baseurl string
+    :raises requests.HTTPError: if URL not accessible
+    :raises ValueError: if baseurl not found
+    """
+    response = requests.get(repo_url, verify=verify_ssl, timeout=10)
+    response.raise_for_status()
+
+    for line in response.text.splitlines():
+        line = line.strip()
+
+        if line.startswith('baseurl='):
+            return line.split('=', 1)[1].strip()
+
+    raise ValueError(f'No baseurl found in {repo_url}')
+
+
 def get_repomd(repo_url):
     """Fetches content of the repomd file of a repository
 

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -19,6 +19,7 @@ import requests
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ARCHITECTURE, REPOS
+from robottelo.content_info import get_baseurl_by_repofile
 from robottelo.utils.issue_handlers import is_open
 
 
@@ -134,7 +135,8 @@ def centos(
 
     centos_host.enable_ipv6_dnf_proxy()
     assert centos_host.execute('yum -y update').status == 0
-    repo_url = settings.repos.convert2rhel.convert_to_rhel_repo.format(major)
+    repofile_url = settings.repos.convert2rhel.convert_to_rhel_repofile.format(major)
+    repo_url = get_baseurl_by_repofile(repofile_url)
     repo = create_repo(module_target_sat, module_els_sca_manifest_org, repo_url)
     cv = update_cv(
         module_target_sat, module_promoted_cv, module_lce, enable_rhel_subscriptions + [repo]
@@ -229,7 +231,8 @@ def oracle(
     if oracle_host.execute('needs-restarting -r').status == 1:
         oracle_host.power_control(state='reboot')
 
-    repo_url = settings.repos.convert2rhel.convert_to_rhel_repo.format(major)
+    repofile_url = settings.repos.convert2rhel.convert_to_rhel_repofile.format(major)
+    repo_url = get_baseurl_by_repofile(repofile_url)
     repo = create_repo(module_target_sat, module_els_sca_manifest_org, repo_url, ssl_cert)
     cv = update_cv(
         module_target_sat, module_promoted_cv, module_lce, enable_rhel_subscriptions + [repo]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20869

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Switch tests to use Convert2RHEL .repo files to derive repository base URLs instead of hard-coded deprecated repository URLs.

New Features:
- Add a helper to extract a baseurl from a remote yum .repo file for reuse in tests.

Enhancements:
- Update Convert2RHEL API tests to consume repository base URLs from configurable .repo files obtained via settings.