### PR TITLE
[6.18.z] Change 'iop_advisor_engine' settings to 'iop'

### DIFF
--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -61,7 +61,7 @@ def sat_maintain(request):
     yield infra_host
 
     if host_type == 'satellite_iop':
-        iop_settings = settings.rh_cloud.iop_advisor_engine
+        iop_settings = settings.rh_cloud.iop
         if not infra_host.is_podman_logged_in(iop_settings.stage_registry):
             infra_host.podman_login(
                 iop_settings.stage_username,

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -225,8 +225,7 @@ def module_unconfigured_satellite():
 def get_iop_deploy_args():
     """Get deploy arguments for IoP workflow"""
     image_args = {
-        f'iop_{service}_image': path
-        for service, path in settings.rh_cloud.iop_advisor_engine.image_paths.items()
+        f'iop_{service}_image': path for service, path in settings.rh_cloud.iop.image_paths.items()
     }
     return settings.server.deploy_arguments.to_dict() | image_args
 

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -332,9 +332,7 @@ VALIDATORS = dict(
     ],
     rh_cloud=[
         Validator('rh_cloud.token', required=True),
-        Validator(
-            'rh_cloud.iop_advisor_engine.image_paths', default={}, apply_default_on_none=True
-        ),
+        Validator('rh_cloud.iop.image_paths', default={}, apply_default_on_none=True),
     ],
     repos=[
         Validator(

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -463,7 +463,7 @@ class IoPSetup:
     def get_iop_image_paths():
         return {
             f'iop::{service}::image': path
-            for service, path in settings.rh_cloud.iop_advisor_engine.image_paths.items()
+            for service, path in settings.rh_cloud.iop.image_paths.items()
         }
 
     def configure_iop(self):
@@ -476,7 +476,7 @@ class IoPSetup:
 
         self.ensure_podman_installed()
 
-        iop_settings = settings.rh_cloud.iop_advisor_engine
+        iop_settings = settings.rh_cloud.iop
         self.podman_login(iop_settings.username, iop_settings.token, iop_settings.registry)
         self.podman_login(
             iop_settings.stage_username, iop_settings.stage_token, iop_settings.stage_registry

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1638,7 +1638,7 @@ class ContentHost(Host, ContentHostMixins):
 
     def podman_login(self, username=None, password=None, registry=None):
         """Login to a podman registry."""
-        iop_settings = settings.rh_cloud.iop_advisor_engine
+        iop_settings = settings.rh_cloud.iop
         username = username or iop_settings.username
         password = password or iop_settings.token
         registry = registry or iop_settings.registry
@@ -1669,7 +1669,7 @@ class ContentHost(Host, ContentHostMixins):
 
     def is_podman_logged_in(self, registry=None):
         """Check if podman is logged into a registry."""
-        registry = registry or settings.rh_cloud.iop_advisor_engine.registry
+        registry = registry or settings.rh_cloud.iop.registry
         return (
             self.execute(
                 f'podman login --get-login --authfile {constants.PODMAN_AUTHFILE_PATH} {registry}'
@@ -1680,7 +1680,7 @@ class ContentHost(Host, ContentHostMixins):
 
     def podman_logout(self, registry=None):
         """Logout of a podman registry."""
-        registry = registry or settings.rh_cloud.iop_advisor_engine.registry
+        registry = registry or settings.rh_cloud.iop.registry
         if self.is_podman_logged_in(registry):
             cmd_result = self.execute(
                 f'podman logout --authfile {constants.PODMAN_AUTHFILE_PATH} {registry}'


### PR DESCRIPTION
### Problem Statement

Manual [6.18.z] cherry-pick of PR 20861


### Solution

Change `settings.rh_cloud.iop_advisor_engine` to `settings.rh_cloud.iop`.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update IoP-related configuration and helpers to use the new rh_cloud.iop settings namespace instead of rh_cloud.iop_advisor_engine.

Bug Fixes:
- Align IoP podman login/logout and deployment helpers with the updated rh_cloud.iop settings keys to prevent configuration mismatches.

Enhancements:
- Adjust configuration validators and IoP image path helpers to read from rh_cloud.iop.image_paths.