### PR TITLE
[6.17.z] Change 'iop_advisor_engine' settings to 'iop'

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -33,7 +33,7 @@ def module_target_sat_insights(request, module_target_sat, satellite_factory):
     satellite = module_target_sat if hosted_insights else satellite_factory()
 
     if not hosted_insights:
-        iop_settings = settings.rh_cloud.iop_advisor_engine
+        iop_settings = settings.rh_cloud.iop
 
         # Use HTTPS_PROXY to reach container registry for IPv6
         satellite.enable_ipv6_system_proxy()

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -400,7 +400,7 @@ def test_positive_install_iop_custom_certs(
     """
     satellite = sat_ready_rhel
     host = rhel_contenthost
-    iop_settings = settings.rh_cloud.iop_advisor_engine
+    iop_settings = settings.rh_cloud.iop
 
     # Set IPv6 system proxy on Satellite, to reach container registry
     satellite.enable_ipv6_system_proxy()


### PR DESCRIPTION
### Problem Statement

Manual [6.17.z] cherry-pick of PR 20861


### Solution

Change `settings.rh_cloud.iop_advisor_engine` to `settings.rh_cloud.iop`.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update IoP-related configuration and helpers to use the new rh_cloud.iop settings namespace instead of rh_cloud.iop_advisor_engine.

Bug Fixes:
- Align IoP podman login/logout and deployment helpers with the updated rh_cloud.iop settings keys to prevent configuration mismatches.

Enhancements:
- Adjust configuration validators and IoP image path helpers to read from rh_cloud.iop.image_paths.

## Summary by Sourcery

Update IoP-related test fixtures and CLI tests to use the new rh_cloud.iop settings namespace instead of rh_cloud.iop_advisor_engine.

Bug Fixes:
- Align IoP Satellite test setup with the updated rh_cloud.iop settings key to prevent configuration mismatches during test runs.

Enhancements:
- Refresh IoP CLI inventory tests to reference the consolidated rh_cloud.iop settings configuration.