### PR TITLE
permission list updated

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1311,6 +1311,12 @@ PERMISSIONS = {
         'edit_scap_contents',
         'view_scap_contents',
     ],
+    'ForemanRhCloud': [
+        'view_vulnerability',
+        'edit_vulnerability',
+        'view_advisor',
+        'edit_advisor',
+    ],
     'ForemanTasks::Task': ['edit_foreman_tasks', 'view_foreman_tasks'],
     'JobInvocation': [
         'view_job_invocations',


### PR DESCRIPTION
### Problem Statement
new stuff for 6.19

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update permission constants to include new role-based permissions for Foreman RH Cloud resources.

New Features:
- Add permissions for viewing and editing vulnerability data under the Foreman RH Cloud resource.
- Add permissions for viewing and editing advisor data under the Foreman RH Cloud resource.