### PR TITLE
Add a test case for CCV publish dependency chaining

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -2257,7 +2257,7 @@ class TestContentViewPublishPromote:
                 f'and action = "Auto Publish content view \'{ccv.name}\'; '
                 f'organization \'{module_sca_manifest_org.name}\'"'
             ),
-            search_rate=2,
+            search_rate=10,
             max_tries=30,
             poll_timeout=600,
         )[0]


### PR DESCRIPTION
### Problem Statement
New approach has been taken for publishing CCVs to address SAT-24497 (when multiple component CVs are published simultaneously) and we should add coverage for that case.


### Solution
This PR proposes such a test case.


### Requires
https://github.com/theforeman/foreman-tasks/pull/788
https://github.com/Katello/katello/pull/11621


### Related Issues
https://issues.redhat.com/browse/SAT-24497


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_contentview.py -k test_ccv_publish_dependency_chaining
theforeman:
    foreman-tasks: 788
Katello:
    katello: 11621
```

## Summary by Sourcery

Tests:
- Add an API-level test ensuring composite content view publish tasks are correctly chained and scheduled after their component content view publishes when triggered asynchronously.