### PR TITLE
[6.19.z] SAT-20386 Jira card is closed; removing it.

### DIFF
--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -498,6 +498,16 @@ def test_rhel_pxe_provisioning_fips_enabled(
 
     :Verifies: SAT-26071
     """
+    # Skip RHEL7 UEFI test due to known issue SAT-41340
+    if (
+        is_open('SAT-41340')
+        and pxe_loader.vm_firmware in ['uefi']
+        and module_provisioning_rhel_content.os.major == '7'
+    ):
+        pytest.skip(
+            f"Test not supported for rhel{module_provisioning_rhel_content.os.major} {pxe_loader.vm_firmware} firmware"
+        )
+
     sat = module_provisioning_sat.sat
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     # Verify password hashing algorithm SHA512 is set in OS used for provisioning
@@ -534,7 +544,7 @@ def test_rhel_pxe_provisioning_fips_enabled(
     # the result of the installation. Wait until Satellite reports that the host is installed.
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
-        timeout=1500,
+        timeout=2400,
         delay=10,
     )
     host = host.read()
@@ -573,7 +583,7 @@ def test_rhel_pxe_provisioning_fips_enabled(
 
     # Verify FIPS is enabled on host after provisioning is completed successfully
     result = provisioning_host.execute('cat /proc/sys/crypto/fips_enabled')
-    assert (0 if is_open('SAT-20386') else 1) == int(result.stdout)
+    assert int(result.stdout) == 1
 
     # Run a command on the host using REX to verify that Satellite's SSH key is present on the host
     # Add workaround for SAT-32007 and SAT-32006


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20839

The host is enabled with FIPS mode, so card `SAT-20386` is being removed as the condition is no longer required.

## Summary by Sourcery

Enforce FIPS being enabled after RHEL PXE provisioning and introduce a conditional skip for the known-broken RHEL7 UEFI scenario.

Bug Fixes:
- Always require FIPS to be enabled on provisioned hosts instead of conditionally allowing it to be disabled based on SAT-20386.
- Skip the RHEL7 UEFI PXE provisioning test when affected by the known SAT-41340 issue to avoid unstable failures.

Tests:
- Adjust the RHEL PXE provisioning FIPS test to assert FIPS is enabled unconditionally and to skip the RHEL7 UEFI case when a related known issue is open.