### PR TITLE
[6.19.z] Use non deprecated RHEL 7 image for azure

### DIFF
--- a/pytest_fixtures/component/provision_azure.py
+++ b/pytest_fixtures/component/provision_azure.py
@@ -9,7 +9,7 @@ from robottelo.constants import (
     AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
     AZURERM_RHEL7_FT_GALLERY_IMG_URN,
     AZURERM_RHEL7_FT_IMG_URN,
-    AZURERM_RHEL7_UD_IMG_URN,
+    AZURERM_RHEL9_UD_IMG_URN,
     DEFAULT_ARCHITECTURE,
     DEFAULT_OS_SEARCH_QUERY,
 )
@@ -149,7 +149,7 @@ def module_azurerm_cloudimg(
         name=gen_string('alpha'),
         operatingsystem=sat_azure_default_os,
         username=settings.azurerm.username,
-        uuid=AZURERM_RHEL7_UD_IMG_URN,
+        uuid=AZURERM_RHEL9_UD_IMG_URN,
         user_data=True,
     ).create()
 

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -163,7 +163,7 @@ AZURERM_VALID_REGIONS = [
     'Norway East',
 ]
 AZURERM_RHEL7_FT_IMG_URN = 'marketplace://RedHat:RHEL:7-RAW:latest'
-AZURERM_RHEL7_UD_IMG_URN = 'marketplace://RedHat:rhel-byos:rhel-raw-ci76:7.6.20190814'
+AZURERM_RHEL9_UD_IMG_URN = 'marketplace://RedHat:rhel-byos:rhel-lvm97:9.7.2026012716'
 AZURERM_RHEL7_FT_BYOS_IMG_URN = 'marketplace://RedHat:rhel-byos:rhel-lvm78:7.8.20200410'
 AZURERM_RHEL7_FT_CUSTOM_IMG_URN = 'custom://imageVM1-RHEL7-image-20220617150105'
 AZURERM_RHEL7_FT_GALLERY_IMG_URN = 'gallery://RHSG_1/RHEL77img'

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -20,7 +20,7 @@ from robottelo.constants import (
     AZURERM_FILE_URI,
     AZURERM_PLATFORM_DEFAULT,
     AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
-    AZURERM_RHEL7_UD_IMG_URN,
+    AZURERM_RHEL9_UD_IMG_URN,
     AZURERM_VM_SIZE_DEFAULT,
     AZURERM_PREMIUM_OS_Disk,
 )
@@ -106,7 +106,7 @@ class TestAzureRMComputeResourceTestCase:
         assert module_azurerm_cloudimg.architecture.id == sat_azure_default_architecture.id
         assert module_azurerm_cloudimg.compute_resource.id == module_azurerm_cr.id
         assert module_azurerm_cloudimg.username == settings.azurerm.username
-        assert module_azurerm_cloudimg.uuid == AZURERM_RHEL7_UD_IMG_URN
+        assert module_azurerm_cloudimg.uuid == AZURERM_RHEL9_UD_IMG_URN
 
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
@@ -318,7 +318,7 @@ class TestAzureRMUserDataProvisioning:
         """
 
         request.cls.region = settings.azurerm.azure_region
-        request.cls.rhel7_ud_img = AZURERM_RHEL7_UD_IMG_URN
+        request.cls.rhel9_ud_img = AZURERM_RHEL9_UD_IMG_URN
         request.cls.rg_default = settings.azurerm.resource_group
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
@@ -334,7 +334,7 @@ class TestAzureRMUserDataProvisioning:
             "platform": self.platform,
             "script_command": 'touch /var/tmp/text.txt',
             "script_uris": AZURERM_FILE_URI,
-            "image_id": self.rhel7_ud_img,
+            "image_id": self.rhel9_ud_img,
         }
         results = module_azurerm_cr.available_networks()['results']
         nw_id = next((item for item in results if item['name'] == 'default'), None)['id']

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -20,7 +20,7 @@ from robottelo.constants import (
     AZURERM_FILE_URI,
     AZURERM_PLATFORM_DEFAULT,
     AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
-    AZURERM_RHEL7_UD_IMG_URN,
+    AZURERM_RHEL9_UD_IMG_URN,
     AZURERM_VM_SIZE_DEFAULT,
     AZURERM_PREMIUM_OS_Disk,
 )
@@ -117,7 +117,7 @@ class TestAzureRMComputeResourceTestCase:
     @pytest.mark.parametrize(
         "image",
         [
-            AZURERM_RHEL7_UD_IMG_URN,
+            AZURERM_RHEL9_UD_IMG_URN,
             AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
         ],
     )
@@ -434,7 +434,7 @@ class TestAzureRMUserDataProvisioning:
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
         request.cls.region = settings.azurerm.azure_region
-        request.cls.rhel7_ft_img = AZURERM_RHEL7_UD_IMG_URN
+        request.cls.rhel9_ft_img = AZURERM_RHEL9_UD_IMG_URN
         request.cls.rg_default = settings.azurerm.resource_group
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20908

### Problem Statement

The Azure VM image used for AZURERM_RHEL7_UD_IMG_URN is deprecated:
When attempting to use this image, Azure returns the error:
```
$ az vm image show --location <location> --urn RedHat:rhel-byos:rhel-raw-ci76:7.6.20190814

(ImageVersionDeprecated) VM Image from publisher: RedHat with - Offer: rhel-byos, Sku: rhel-raw-ci76, Version: 7.6.20190814 is deprecated.
Code: ImageVersionDeprecated
Message: VM Image from publisher: RedHat with - Offer: rhel-byos, Sku: rhel-raw-ci76, Version: 7.6.20190814 is deprecated.

```
### Solution

Update AZURERM_RHEL7_UD_IMG_URN to use non deprecated RHEL7 marketplace image
### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_computeresource_azurerm.py::TestAzureRMComputeResourceTestCase -k 'test_positive_create_cloud_init_image'
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update Azure user-data VM image configuration and tests to use a non-deprecated RHEL image for Azure provisioning.

Bug Fixes:
- Switch Azure user-data image URN from a deprecated RHEL 7 image to a supported RHEL 9 image to restore Azure provisioning functionality.

Enhancements:
- Align Azure-related tests and fixtures with the new RHEL 9 user-data image constant across API, CLI, and provisioning components.