### PR TITLE
[6.16.z] delete auto_provision_all DiscoveryRule after using it

### DIFF
--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -299,7 +299,12 @@ class TestDiscoveredHost:
         assert f'provisioned with rule {rule.name}' in result['message']
 
     def test_positive_auto_provision_all(
-        self, module_discovery_hostgroup, module_target_sat, discovery_org, discovery_location
+        self,
+        module_discovery_hostgroup,
+        module_target_sat,
+        discovery_org,
+        discovery_location,
+        request,
     ):
         """Auto provision all host by executing discovery rules
 
@@ -317,13 +322,14 @@ class TestDiscoveredHost:
 
         :CaseImportance: High
         """
-        module_target_sat.api.DiscoveryRule(
+        rule = module_target_sat.api.DiscoveryRule(
             max_count=25,
             hostgroup=module_discovery_hostgroup,
             search_=f'location = "{discovery_location.name}"',
             location=[discovery_location],
             organization=[discovery_org],
         ).create()
+        request.addfinalizer(rule.delete)
 
         for _ in range(2):
             module_target_sat.api_factory.create_discovered_host()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20910

### Problem Statement

if the rule is not deleted, it remains present and influences execution of other tests (esp the ones from `TestFakeDiscoveryTests`)

### Solution

delete the rule

### Related Issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ --component DiscoveryImage
provisioning: true
```

## Summary by Sourcery

Ensure temporary discovery auto-provisioning rules created in tests are cleaned up after execution to avoid side effects on other tests.

Bug Fixes:
- Delete the auto_provision_all DiscoveryRule created in the discovery host API test to prevent it from impacting subsequent tests.

Tests:
- Update the discovery host auto-provision-all test to register a finalizer that removes the created DiscoveryRule after the test completes.