### PR TITLE
Relax BFA via API instead of CLI

### DIFF
--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -25,7 +25,7 @@ def allow_repo_discovery(target_sat):
 def relax_bfa(request, session_target_sat):
     """Relax BFA protection against failed login attempts"""
     if session_target_sat and 'sanity' not in request.config.option.markexpr:
-        session_target_sat.cli.Settings.set({'name': 'failed_login_attempts_limit', 'value': '0'})
+        session_target_sat.update_setting('failed_login_attempts_limit', '0')
 
 
 @pytest.fixture(autouse=True, scope='session')


### PR DESCRIPTION
### Problem Statement
Running a test against a DEV box fails to relax BFA (sessions-scoped autouse fixture) because of missing hammer CLI.


### Solution
Relax BFA via API instead.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_ping.py::test_positive_ping
```

## Summary by Sourcery

Enhancements:
- Switch BFA relaxation to use the generic settings update helper rather than direct CLI settings calls.