### PR TITLE
[6.18.z] Fixes for IPV6 failures in Hosts component

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -630,9 +630,10 @@ def test_positive_katello_and_openscap_loaded(target_sat):
         )
 
 
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.cli_host_create
 def test_positive_list_and_unregister(
-    module_ak_with_cv, module_lce, module_org, rhel7_contenthost, target_sat
+    module_ak_with_cv, module_lce, module_org, rhel_contenthost, target_sat
 ):
     """List registered host for a given org and unregister the host
 
@@ -643,21 +644,20 @@ def test_positive_list_and_unregister(
 
     :parametrized: yes
     """
-    result = rhel7_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
+    result = rhel_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
     assert result.status == 0
-    assert rhel7_contenthost.subscribed
+    assert rhel_contenthost.subscribed
     hosts = target_sat.cli.Host.list({'organization-id': module_org.id})
-    assert rhel7_contenthost.hostname in [host['name'] for host in hosts]
-    result = rhel7_contenthost.unregister()
+    assert rhel_contenthost.hostname in [host['name'] for host in hosts]
+    result = rhel_contenthost.unregister()
     assert result.status == 0
     hosts = target_sat.cli.Host.list({'organization-id': module_org.id})
-    assert rhel7_contenthost.hostname in [host['name'] for host in hosts]
+    assert rhel_contenthost.hostname in [host['name'] for host in hosts]
 
 
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.cli_host_create
-def test_positive_list_by_last_checkin(
-    module_org, rhel7_contenthost, target_sat, module_ak_with_cv
-):
+def test_positive_list_by_last_checkin(module_org, rhel_contenthost, target_sat, module_ak_with_cv):
     """List all content hosts using last checkin criteria
 
     :id: e7d86b44-28c3-4525-afac-61a20e62daf8
@@ -670,19 +670,20 @@ def test_positive_list_by_last_checkin(
 
     :parametrized: yes
     """
-    result = rhel7_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
+    result = rhel_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
     assert result.status == 0, f'Failed to register host: {result.stderr}'
-    assert rhel7_contenthost.subscribed
+    assert rhel_contenthost.subscribed
     hosts = target_sat.cli.Host.list(
         {'search': 'last_checkin = "Today" or last_checkin = "Yesterday"'}
     )
     assert len(hosts) >= 1
-    assert rhel7_contenthost.hostname in [host['name'] for host in hosts]
+    assert rhel_contenthost.hostname in [host['name'] for host in hosts]
 
 
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.cli_host_create
 def test_positive_list_infrastructure_hosts(
-    module_org, rhel7_contenthost, target_sat, module_ak_with_cv
+    module_org, rhel_contenthost, target_sat, module_ak_with_cv
 ):
     """List infrasturcture hosts (Satellite and Capsule)
 
@@ -692,21 +693,21 @@ def test_positive_list_infrastructure_hosts(
 
     :parametrized: yes
     """
-    result = rhel7_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
+    result = rhel_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
     assert result.status == 0
-    assert rhel7_contenthost.subscribed
+    assert rhel_contenthost.subscribed
     target_sat.cli.Host.update({'name': target_sat.hostname, 'new-organization-id': module_org.id})
     # list satellite hosts
     hosts = target_sat.cli.Host.list({'search': 'infrastructure_facet.foreman=true'})
     assert len(hosts) == 1
     hostnames = [host['name'] for host in hosts]
-    assert rhel7_contenthost.hostname not in hostnames
+    assert rhel_contenthost.hostname not in hostnames
     assert target_sat.hostname in hostnames
     # list capsule hosts
     hosts = target_sat.cli.Host.list({'search': 'infrastructure_facet.smart_proxy_id=1'})
     hostnames = [host['name'] for host in hosts]
     assert len(hosts) == 1
-    assert rhel7_contenthost.hostname not in hostnames
+    assert rhel_contenthost.hostname not in hostnames
     assert target_sat.hostname in hostnames
 
 

--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -20,9 +20,10 @@ from robottelo.constants import FAKE_0_CUSTOM_PACKAGE, FAKE_1_CUSTOM_PACKAGE
 pytestmark = pytest.mark.destructive
 
 
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.run_in_one_thread
 @pytest.mark.upgrade
-def test_content_access_after_stopped_foreman(target_sat, rhel7_contenthost):
+def test_content_access_after_stopped_foreman(target_sat, rhel_contenthost):
     """Install a package even after foreman service is stopped
 
     :id: 71ae6a56-30bb-11eb-8489-d46d6dd3b5b2
@@ -46,12 +47,12 @@ def test_content_access_after_stopped_foreman(target_sat, rhel7_contenthost):
         ],
     )
     repos_collection.setup_content(org.id, lce.id, override=True)
-    repos_collection.setup_virtual_machine(rhel7_contenthost)
-    result = rhel7_contenthost.execute(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
+    repos_collection.setup_virtual_machine(rhel_contenthost)
+    result = rhel_contenthost.execute(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0
     assert target_sat.cli.Service.stop(options={'only': 'foreman'}).status == 0
     assert target_sat.cli.Service.status(options={'only': 'foreman'}).status == 1
-    result = rhel7_contenthost.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
+    result = rhel_contenthost.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
     assert result.status == 0
     assert target_sat.cli.Service.start(options={'only': 'foreman'}).status == 0
     assert target_sat.cli.Service.status(options={'only': 'foreman'}).status == 0

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -126,7 +126,7 @@ def module_ak(
 
 @pytest.fixture(scope='module')
 def host(
-    rhel7_contenthost_module,
+    module_rhel_contenthost,
     module_sca_manifest_org,
     dev_lce,
     qe_lce,
@@ -135,17 +135,18 @@ def host(
     module_cv,
     module_target_sat,
 ):
-    # Create client machine and register it to satellite with rhel_7_partial_ak
+    # Create client machine and register it to satellite
     # Register, enable tools repo and install katello-host-tools.
-    rhel7_contenthost_module.register(
+    module_rhel_contenthost.register(
         module_sca_manifest_org, None, module_ak.name, module_target_sat
     )
-    rhel7_contenthost_module.enable_repo(REPOS['rhsclient7']['id'])
+    rhel_ver = module_rhel_contenthost.os_version.major
+    module_rhel_contenthost.enable_repo(REPOS[f'rhsclient{rhel_ver}']['id'])
     # make a note of time for later wait_for_tasks, and include 4 mins margin of safety.
     timestamp = (datetime.now(UTC) - timedelta(minutes=4)).strftime('%Y-%m-%d %H:%M')
     # AK added custom repo for errata package, just install it.
-    rhel7_contenthost_module.execute(f'yum install -y {FAKE_4_CUSTOM_PACKAGE}')
-    rhel7_contenthost_module.execute('subscription-manager repos')
+    module_rhel_contenthost.execute(f'yum install -y {FAKE_4_CUSTOM_PACKAGE}')
+    module_rhel_contenthost.execute('subscription-manager repos')
     # Wait for applicability update event (in case Satellite system slow)
     module_target_sat.wait_for_tasks(
         search_query='label = Actions::Katello::Applicability::Hosts::BulkGenerate'
@@ -162,9 +163,10 @@ def host(
     ).create()
     module_cv.publish()
     module_cv = module_cv.read()
-    return rhel7_contenthost_module
+    return module_rhel_contenthost
 
 
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.upgrade
 def test_positive_noapply_api(
     module_sca_manifest_org, module_cv, custom_repo, host, dev_lce, module_target_sat


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20939

### Problem Statement
Several tests (`test_positive_list_and_unregister`, `test_positive_list_by_last_checkin`, `test_positive_list_infrastructure_hosts`, `test_positive_noapply_api`, `test_content_access_after_stopped_foreman`) use the `rhel7_contenthost` / `rhel7_contenthost_module` fixtures, which don't work with IPV6.

### Solution
Change these fixtures to `rhel_contenthost` and parametrize these tests with `@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])`

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py::test_positive_list_and_unregister tests/foreman/cli/test_host.py::test_positive_list_by_last_checkin tests/foreman/cli/test_host.py::test_positive_list_infrastructure_hosts tests/foreman/longrun/test_inc_updates.py::test_positive_noapply_api tests/foreman/destructive/test_contenthost.py::test_content_access_after_stopped_foreman
network_type: ipv6
```

### Additional info
_I believe that the tests should:) pass, but if they don't they will be at least unstuck and could at least run normally with IPV6._

## Summary by Sourcery

Update host-related tests to use generic RHEL content host fixtures and parameterize them for the default RHEL version to ensure compatibility with IPv6 environments.

Tests:
- Switch host tests from RHEL7-specific content host fixtures to version-agnostic RHEL content host fixtures.
- Parameterize affected tests with the default RHEL version via rhel_ver_list to support execution in IPv6 setups.

## Summary by Sourcery

Update host-related tests to use generic RHEL content host fixtures and parameterization for the default RHEL version to ensure compatibility with IPv6 environments.

Tests:
- Switch CLI and long-run host tests from RHEL7-specific content host fixtures to generic RHEL content host fixtures.
- Parameterize affected tests with the default RHEL version using rhel_ver_list for broader OS version support in IPv6 setups.