### PR TITLE
[6.18.z] Display error message in case of failure

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -225,7 +225,7 @@ class ContentInfo:
         Runs satellite-maintain report generate and extracts the value for a given key
         """
         result = self.execute(f'satellite-maintain report generate | grep -i "{report_key}"')
-        assert result.status == 0, 'report failed or key not found'
+        assert result.status == 0, f'report failed or key not found: {result.stderr}'
         return "".join(result.stdout.split(":", 1)[1].split())
 
     def get_reported_condensed_value(self, report_key):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20940

### Problem Statement
stderr missing from assertion

### Solution
see code

## Summary by Sourcery

Bug Fixes:
- Include command stderr in the assertion message when satellite-maintain report generation fails or the key is not found.