### PR TITLE
[6.16.z] destructive registration test fix

### DIFF
--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.destructive
 @pytest.mark.rhel_ver_match('[^6]')
 def test_host_registration_rex_pull_mode(
     module_org,
+    module_lce,
     module_satellite_mqtt,
     module_location,
     module_ak_with_cv,
@@ -41,6 +42,7 @@ def test_host_registration_rex_pull_mode(
     client = rhel_contenthost_with_repos
     org = module_org
     client_repo = settings.repos.SATCLIENT_REPO[f'rhel{client.os_version.major}']
+
     # register host to satellite with pull provider rex
     result = client.api_register(
         module_satellite_mqtt,
@@ -53,7 +55,6 @@ def test_host_registration_rex_pull_mode(
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # check mqtt client is running
-
     service_name = client.get_yggdrasil_service_name()
     result = client.execute(f'systemctl status {service_name}')
     assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
@@ -64,6 +65,10 @@ def test_host_registration_rex_pull_mode(
     nc = module_capsule_configured_mqtt.nailgun_smart_proxy
     module_satellite_mqtt.api.SmartProxy(id=nc.id, organization=[org]).update(['organization'])
     module_satellite_mqtt.api.SmartProxy(id=nc.id, location=[module_location]).update(['location'])
+    if module_capsule_configured_mqtt.nailgun_capsule.lifecycle_environments == []:
+        module_capsule_configured_mqtt.nailgun_capsule.content_add_lifecycle_environment(
+            data={'environment_id': module_lce.id}
+        )
 
     # register host to capsule with pull provider rex
     result = client.api_register(
@@ -77,6 +82,7 @@ def test_host_registration_rex_pull_mode(
         force=True,
     )
     assert result.status == 0, f'Failed to register host: {result.stderr}'
+    assert client.subscribed
 
     # check mqtt client is running
     result = client.execute(f'systemctl status {service_name}')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20946

Manual CP of https://github.com/SatelliteQE/robottelo/pull/19560


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/destructive/test_registration.py -k "test_host_registration_rex_pull_mode"
```

## Summary by Sourcery

Update destructive host registration test to ensure capsule has a lifecycle environment and verify subscription after registration in pull mode.

Tests:
- Add lifecycle environment association for the test capsule when missing to allow successful host registration in pull mode.
- Assert that the client is subscribed after registering to the capsule in the pull-mode registration test.