### PR TITLE
[6.18.z] Fix IPv6 subnet creation in tests and fixtures

### DIFF
--- a/pytest_fixtures/component/subnet.py
+++ b/pytest_fixtures/component/subnet.py
@@ -1,9 +1,20 @@
 # Subnet Fixtures
+from fauxfactory import gen_ipaddr
 import pytest
 
 
 @pytest.fixture(scope='module')
 def module_default_subnet(module_target_sat, module_org, module_location):
-    return module_target_sat.api.Subnet(
-        location=[module_location], organization=[module_org]
-    ).create()
+    subnet_kwargs = {
+        'location': [module_location],
+        'organization': [module_org],
+    }
+    # Create subnet with appropriate network type based on satellite configuration
+    if module_target_sat.network_type.has_ipv6:
+        subnet_kwargs['network_type'] = 'IPv6'
+        subnet_kwargs['network'] = gen_ipaddr(ip3=True, ipv6=True)
+        subnet_kwargs['mask'] = 'ffff:ffff:ffff:ffff::'
+        subnet_kwargs['ipam'] = 'EUI-64'
+    else:
+        subnet_kwargs['network_type'] = 'IPv4'
+    return module_target_sat.api.Subnet(**subnet_kwargs).create()

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -396,9 +396,19 @@ def test_positive_create_and_update_with_subnet(
         location=module_location, organization=module_org, subnet=module_default_subnet
     ).create()
     assert host.subnet.read().name == module_default_subnet.name
-    new_subnet = module_target_sat.api.Subnet(
-        location=[module_location], organization=[module_org]
-    ).create()
+    # Create subnet with appropriate network type based on satellite configuration
+    subnet_kwargs = {
+        'location': [module_location],
+        'organization': [module_org],
+    }
+    if module_target_sat.network_type.has_ipv6:
+        subnet_kwargs['network_type'] = 'IPv6'
+        subnet_kwargs['network'] = gen_ipaddr(ip3=True, ipv6=True)
+        subnet_kwargs['mask'] = 'ffff:ffff:ffff:ffff::'
+        subnet_kwargs['ipam'] = 'EUI-64'
+    else:
+        subnet_kwargs['network_type'] = 'IPv4'
+    new_subnet = module_target_sat.api.Subnet(**subnet_kwargs).create()
     host.subnet = new_subnet
     host = host.update(['subnet'])
     assert host.subnet.read().name == new_subnet.name


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20941

### Problem Statement
When running tests on IPv6-configured Satellite, subnet creation was failing because subnets were defaulting to IPv4. This caused test failures in test_positive_create_and_update_with_subnet when checking IPv6 subnet counts in usage reports.


### Solution
- Modified module_default_subnet fixture to detect Satellite network type and create appropriate subnet (IPv4 or IPv6)
- Updated test_positive_create_and_update_with_subnet to create IPv6 subnets when running on IPv6 Satellite
- IPv6 subnets now include required parameters: network_type, network address, mask (ffff:ffff:ffff:ffff::), and ipam (EUI-64)

This ensures subnet-related tests pass on both IPv4 and IPv6 Satellite configurations.

### Related Issues


### PRT test Cases example
```
trigger: test-robottelo
pytest:  tests/foreman/api/test_host.py -k  test_positive_create_and_update_with_subnet
network_type: ipv6
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Ensure subnet fixtures and host subnet tests create IPv4 or IPv6 subnets based on the Satellite network configuration.

Bug Fixes:
- Fix failing IPv6 subnet creation in tests by specifying correct IPv6 subnet attributes when Satellite is configured for IPv6.

Tests:
- Update host subnet creation and update test to dynamically create IPv4 or IPv6 subnets according to the Satellite network type.