### PR TITLE
feat: Removes tweak for updated foreman discovery image

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -483,11 +483,6 @@ def test_positive_verify_updated_fdi_image(target_sat):
     discovery_ks_path = '/usr/share/foreman-discovery-image/foreman-discovery-image.ks'
     target_sat.register_to_cdn()
     target_sat.execute('yum -y --disableplugin=foreman-protector install foreman-discovery-image')
-
-    if target_sat.os_version.major == 9:
-        version = '9.6' if is_open('SAT-40503') else str(target_sat.os_version)
-    elif target_sat.os_version.major == 8:
-        version = str(target_sat.os_version)
-
+    version = str(target_sat.os_version)
     result = target_sat.execute(f'grep "url=" {discovery_ks_path}')
     assert version in result.stdout


### PR DESCRIPTION
### Problem Statement
FDI needs to be built on RHEL 9.7. The test function test_positive_verify_updated_fdi_image under foreman/cli previously included a temporary workaround to allow the test to pass on older versions until the underlying issue was resolved.

### Solution
Removed the temporary workaround used for this check. Specifically, the conditional block that verified the status of the related Jira ticket for the updated FDI image has been closed.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Remove the temporary Jira-dependent version workaround from the FDI image verification test so it consistently asserts against the target system OS version.