### PR TITLE
Refactor jira issue handler code

### DIFF
--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -12,9 +12,10 @@ from robottelo.hosts import Satellite, lru_sat_ready_rhel
 @pytest.fixture(scope='session')
 def _default_sat(align_to_satellite):
     """Returns a Satellite object for settings.server.hostname"""
-    if settings.server.hostname:
+    hostname = getattr(settings.server, 'hostname', None)
+    if hostname:
         try:
-            return Satellite.get_host_by_hostname(settings.server.hostname)
+            return Satellite.get_host_by_hostname(hostname)
         except ContentHostError:
             return Satellite()
     return None

--- a/pytest_plugins/issue_handlers.py
+++ b/pytest_plugins/issue_handlers.py
@@ -47,6 +47,14 @@ IMPORTANCE = re.compile(
     re.IGNORECASE,
 )
 
+# Only treat as Jira issue if it looks like PROJECT-NUM (e.g. SAT-20548, RHEL-55871)
+JIRA_ISSUE_PATTERN = re.compile(r'^[A-Za-z]+[-]\d+$')
+
+
+def _is_jira_issue_key(text):
+    """Return True if text looks like a Jira issue id (e.g. SAT-12345, RHEL-55871)."""
+    return bool(text and JIRA_ISSUE_PATTERN.match(text.strip()))
+
 
 def generate_issue_collection(items, config):  # pragma: no cover
     """Generates a dictionary with the usage of Issue blockers
@@ -89,7 +97,7 @@ def generate_issue_collection(items, config):  # pragma: no cover
             }
     """
     valid_markers = ["skip", "deselect"]
-    collected_data = defaultdict(lambda: {"data": {}, "used_in": []})
+    collected_data = defaultdict(lambda: {"used_in": []})
 
     deselect_data = {}  # a local cache for deselected tests
 
@@ -119,6 +127,8 @@ def generate_issue_collection(items, config):  # pragma: no cover
             if marker.name in valid_markers:
                 issue = marker.kwargs.get('reason') or marker.args[0]
                 issue_key = issue.strip()
+                if not _is_jira_issue_key(issue_key):
+                    continue
                 collected_data[issue_key]['used_in'].append(
                     {
                         'filepath': filepath,
@@ -184,8 +194,8 @@ def generate_issue_collection(items, config):  # pragma: no cover
     # --- add deselect markers dynamically ---
     for item in items:
         issue = deselect_data.get(item.location)
-        if issue and should_deselect(issue, collected_data[issue]['data']):
-            collected_data[issue]['data']['is_deselected'] = True
+        if issue and should_deselect(issue):
+            collected_data[issue]['is_deselected'] = True
             item.add_marker(pytest.mark.deselect(reason=issue))
 
     return collected_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ deepdiff==8.6.1
 dynaconf[vault]==3.2.12
 fastmcp==3.1.0
 fauxfactory==4.2.0
+jira==3.10.5
 jinja2==3.1.6
 manifester==0.2.14
 navmazing==1.3.0

--- a/robottelo/utils/issue_handlers/__init__.py
+++ b/robottelo/utils/issue_handlers/__init__.py
@@ -11,19 +11,18 @@ def add_workaround(data, matches, usage, validation=(lambda *a, **k: True), **kw
             data[issue.strip()]['used_in'].append({'usage': usage, **kwargs})
 
 
-def should_deselect(issue, data=None):
+def should_deselect(issue):
     """Check if test should be deselected based on marked issue."""
-    return jira.should_deselect_jira(issue.strip(), data)
+    return jira.should_deselect_jira(issue.strip())
 
 
-def is_open(issue, data=None):
+def is_open(issue):
     """Check if specific Jira issue is open.
 
     Arguments:
         issue {str} -- A string containing Jira issue id e.g: SAT-12345
-        data {dict} -- Issue data indexed by issue id or None
     """
-    status = jira.is_open_jira(issue.strip(), data)
+    status = jira.is_open_jira(issue.strip())
     logger.debug(
         f"Is {issue} Jira open? - {'Nope! It is fixed!' if status else 'Yeah. It is still not fixed :('}"
     )

--- a/robottelo/utils/issue_handlers/jira.py
+++ b/robottelo/utils/issue_handlers/jira.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 import json
 from pathlib import Path
-import re
 import time
 
+from jira import JIRA
+from jira.exceptions import JIRAError
 import pytest
-import requests
 from wait_for import TimedOutError, wait_for
 
 from robottelo.config import settings
@@ -17,22 +17,25 @@ from robottelo.constants import (
 )
 from robottelo.logging import logger
 
-# match any version as in `sat-6.14.x` or `sat-6.13.0` or `6.13.9`
-# The .version group being a `d.d` string that can be casted to Version()
-VERSION_RE = re.compile(r'(?:sat-)*?(?P<version>\d\.\d)\.\w*')
+common_jira_fields = ['key', 'status', 'labels', 'resolution']
 
-common_jira_fields = ['key', 'summary', 'status', 'labels', 'resolution', 'fixVersions']
-
-mapped_response_fields = {
-    'key': "{obj_name}['key']",
-    'summary': "{obj_name}['fields']['summary']",
-    'status': "{obj_name}['fields']['status']['name']",
-    'labels': "{obj_name}['fields']['labels']",
-    'resolution': "{obj_name}['fields']['resolution']['name'] if {obj_name}['fields']['resolution'] else ''",
-    'fixVersions': "[ver['name'] for ver in {obj_name}['fields']['fixVersions']] if {obj_name}['fields']['fixVersions'] else []",
-    # Custom Field - SFDC Cases Counter
-    'customfield_12313440': "{obj_name}['fields']['customfield_12313440']",
+FIELD_EXTRACTORS = {
+    "key": lambda issue: issue.key,
+    "status": lambda issue: issue.fields.status.name if issue.fields.status else "",
+    "labels": lambda issue: list(issue.fields.labels or []),
+    "resolution": lambda issue: issue.fields.resolution.name if issue.fields.resolution else "",
 }
+
+
+def _issue_to_flat_dict(issue, out_fields):
+    """Build a flat dict from a jira Issue object using attribute access."""
+    result = {}
+    for field in out_fields:
+        if field in FIELD_EXTRACTORS:
+            result[field] = FIELD_EXTRACTORS[field](issue)
+        else:
+            result[field] = getattr(issue.fields, field, None)
+    return result
 
 
 class JiraStatusCache:
@@ -69,11 +72,7 @@ class JiraStatusCache:
         return results
 
     def update(self, issue_id, data):
-        self.cache[issue_id] = {"data": data, "timestamp": time.time()}
-
-    def update_many(self, issues_data):
-        for issue_id, data in issues_data.items():
-            self.update(issue_id, data)
+        self.cache[issue_id] = data | {"timestamp": time.time()}
 
     def save(self):
         logger.debug(f"Saving {len(self.cache)} entries to Jira cache file")
@@ -95,29 +94,14 @@ class JiraStatusCache:
 jira_cache = JiraStatusCache()
 
 
-def sanitized_issue_data(issue, out_fields):
-    """fetches the value for all the given fields from a given jira issue
-
-    :param issue: The json data for a jira issue
-    :type issue: dict
-    :param out_fields: The fields to return from the jira issue
-    :type out_fields: list
-    """
-    return {
-        field: eval(mapped_response_fields[field].format(obj_name=issue)) for field in out_fields
-    }
-
-
-def is_open_jira(issue_id, data=None):
-    """Check if specific Jira is open consulting a cached `data` dict or calling Jira REST API.
+def is_open_jira(issue_id):
+    """Check if specific Jira is open (uses pytest.issue_data, jira_cache, or API).
 
     :param issue_id: The Jira reference e.g: SAT-20548
     :type issue_id: str
-    :param data: Issue data indexed by issue id or None
-    :type data: dict
     """
     issue_id = issue_id.strip()
-    jira = try_from_cache(issue_id, data)
+    jira = try_from_cache(issue_id)
     if jira.get("is_open") is not None:  # issue has been already processed
         return jira["is_open"]
 
@@ -133,40 +117,20 @@ def is_open_jira(issue_id, data=None):
     return status not in JIRA_CLOSED_STATUSES and status != JIRA_ONQA_STATUS
 
 
-def are_all_jira_open(issue_ids, data=None):
-    """Check if all Jira is open consulting a cached `data` dict or
-    calling Jira REST API.
-
-    :param issue_ids: The Jira reference e.g: ['SAT-20548', 'SAT-20548']
-    :type issue_ids: list
-    :param data: Issue data indexed by issue id or None
-    :type data: dict
-    """
-    return all(is_open_jira(issue_id, data) for issue_id in issue_ids)
+def are_all_jira_open(issue_ids):
+    """Check if all given Jira issues are open."""
+    return all(is_open_jira(issue_id) for issue_id in issue_ids)
 
 
-def are_any_jira_open(issue_ids, data=None):
-    """Check if any of the Jira is open consulting a cached `data` dict or
-    calling Jira REST API.
-
-    :param issue_ids: The Jira reference e.g: ['SAT-20548', 'SAT-20548']
-    :type issue_ids: list
-    :param data: Issue data indexed by issue id or None
-    :type data: dict
-    """
-    return any(is_open_jira(issue_id, data) for issue_id in issue_ids)
+def are_any_jira_open(issue_ids):
+    """Check if any of the given Jira issues is open."""
+    return any(is_open_jira(issue_id) for issue_id in issue_ids)
 
 
-def should_deselect_jira(issue_id, data=None):
-    """Check if test should be deselected based on marked issue_id.
-
-    :param issue_id: The Jira reference e.g: SAT-12345
-    :type issue_id: str
-    :param data: Issue data indexed by issue id or None
-    :type data: dict
-    """
+def should_deselect_jira(issue_id):
+    """Check if test should be deselected based on marked issue_id."""
     issue_id = issue_id.strip()
-    jira = try_from_cache(issue_id, data)
+    jira = try_from_cache(issue_id)
     if jira.get("is_deselected") is not None:  # issue has been already processed
         return jira["is_deselected"]
 
@@ -188,31 +152,21 @@ def follow_duplicates(jira):
     return jira
 
 
-def try_from_cache(issue_id, data=None):
-    """Try to fetch issue from given data cache or previous loaded on pytest.
-
-    :param issue_id: The Jira reference e.g: SAT-12345
-    :type issue_id: str
-    :param data: Issue data indexed by issue id or None
-    :type data: dict
-    """
+def try_from_cache(issue_id):
+    """Fetch issue from pytest.issue_data, jira_cache, or API."""
     try:
-        # First try using data parameter
-        if data:
-            return data
-
-        # Then try from pytest cached data - with safe attribute check
-        if (
-            hasattr(pytest, 'issue_data')
-            and issue_id in getattr(pytest, 'issue_data', {})
-            and pytest.issue_data.get(issue_id, {}).get('data')
-        ):
-            return pytest.issue_data[issue_id]['data']
+        issue = (
+            getattr(pytest, 'issue_data', {}).get(issue_id)
+            if hasattr(pytest, 'issue_data')
+            else None
+        )
+        if issue and (issue.get('key') or issue.get('status') is not None):
+            return issue
 
         # Finally try from JiraStatusCache
         cached_data = jira_cache.get(issue_id)
         if cached_data:
-            return cached_data.get('data')
+            return cached_data
 
         raise ValueError
     except (KeyError, AttributeError, ValueError):  # pragma: no cover
@@ -220,64 +174,18 @@ def try_from_cache(issue_id, data=None):
         return get_single_jira(issue_id)
 
 
-def collect_data_jira(collected_data, cached_data):  # pragma: no cover
-    """Collect data from Jira API and aggregate in a dictionary.
-
-    :param collected_data: dict with Jira issues collected by pytest
-    :type collected_data: dict
-    :param cached_data: Cached data previously loaded from API
-    :type cached_data: dict
-    """
-    # Load persistent cache if available
-    if not cached_data:
-        issue_ids = [item for item in collected_data if item.startswith('SAT-')]
-        cached_data = {
-            issue_id: {'data': data['data']}
-            for issue_id, data in jira_cache.get_many(issue_ids).items()
-            if data is not None
-        }
-
-    jira_data = (
-        get_data_jira(
-            [item for item in collected_data if item.startswith('SAT-')], cached_data=cached_data
-        )
-        or []
-    )
-    for data in jira_data:
-        # If Jira is CLOSED/DUPLICATE collect the duplicate
-        collect_dupes(data, collected_data, cached_data=cached_data)
-
-        jira_key = data['key']
-        data["is_open"] = is_open_jira(jira_key, data)
-        collected_data[jira_key]['data'] = data
-
-
-def collect_dupes(jira, collected_data, cached_data=None):  # pragma: no cover
-    """Recursively find for duplicates
-
-    :param jira: Jira response from Jira REST API
-    :type jira: dict
-    :param collected_data: dict with Jira issues collected by pytest
-    :type collected_data: dict
-    :param cached_data: Cached data previously loaded from API
-    :type cached_data: dict
-    """
-    cached_data = cached_data or {}
-    if jira.get('resolution') == 'Duplicate':
-        # Collect duplicates
-        jira['dupe_data'] = get_single_jira(jira.get('dupe_of'), cached_data=cached_data)
-        dupe_key = jira['dupe_of']
-        # Store Duplicate also in the main collection for caching
-        if dupe_key not in collected_data:
-            collected_data[dupe_key]['data'] = jira['dupe_data']
-            collected_data[dupe_key]['is_dupe'] = True
-            collect_dupes(jira['dupe_data'], collected_data, cached_data)
-
-
 # --- API Calls ---
 
 # cannot use lru_cache in functions that has unhashable args
 CACHED_RESPONSES = defaultdict(dict)
+
+
+def _jira_client():
+    """Create a JIRA client with token auth (api_key)."""
+    return JIRA(
+        server=settings.jira.url,
+        token_auth=settings.jira.api_key,
+    )
 
 
 def get_jira(jql, fields=None):
@@ -287,24 +195,18 @@ def get_jira(jql, fields=None):
     :type jql: str
     :param fields: The custom fields in query to retrieve the data for
     :type fields: list
-    :returns: Jira object of response after status check
-    :rtype: dict
+    :returns: List of Issue objects from the jira library
+    :rtype: list
     """
-    params = {"jql": jql}
-    if fields:
-        params.update({"fields": ",".join(fields)})
+    fields_str = ','.join(fields) if fields else None
 
     def _make_request():
         try:
-            response = requests.get(
-                f"{settings.jira.url}/rest/api/latest/search/",
-                params=params,
-                headers={"Authorization": f"Bearer {settings.jira.api_key}"},
-            )
-            response.raise_for_status()
-            return response
-        except requests.exceptions.HTTPError as err:
-            if err.response.status_code == 429:
+            jira = _jira_client()
+            issues = jira.search_issues(jql_str=jql, fields=fields_str)
+            return list(issues)
+        except JIRAError as err:
+            if getattr(err, 'status_code', None) == 429:
                 logger.warning("Hit Jira API rate limit (429). Will retry after wait period.")
             raise
 
@@ -347,7 +249,7 @@ def get_data_jira(issue_ids, cached_data=None, jira_fields=None):  # pragma: no 
         logger.debug(f"Using cached data for {set(issue_ids)}")
         if not all([f'{number}' in cached_data for number in issue_ids]):
             logger.debug("There are Jira's out of cache.")
-        return [item['data'] for _, item in cached_data.items() if 'data' in item]
+        return [item for _, item in cached_data.items()]
 
     # Check JiraStatusCache for all issues
     cached_issues = jira_cache.get_many(issue_ids)
@@ -358,7 +260,7 @@ def get_data_jira(issue_ids, cached_data=None, jira_fields=None):  # pragma: no 
     # If all issues were in cache, return them
     if not remaining_issues:
         logger.debug(f"Using JiraStatusCache for {set(issue_ids)}")
-        return [cached_issues[issue_id]['data'] for issue_id in issue_ids]
+        return [cached_issues[issue_id] for issue_id in issue_ids]
 
     # Ensure API key is set
     if not settings.jira.api_key:
@@ -372,7 +274,7 @@ def get_data_jira(issue_ids, cached_data=None, jira_fields=None):  # pragma: no 
 
         # Return combination of cached and default data
         return [
-            cached_issues[issue_id]['data'] for issue_id in issue_ids if issue_id in cached_issues
+            cached_issues[issue_id] for issue_id in issue_ids if issue_id in cached_issues
         ] + default_data
 
     # No cached data so Call Jira API for remaining issues
@@ -385,10 +287,10 @@ def get_data_jira(issue_ids, cached_data=None, jira_fields=None):  # pragma: no 
     if isinstance(remaining_issues, str):
         remaining_issues = [issue_id.strip() for issue_id in remaining_issues.split(',')]
     jql = ' OR '.join([f"id = {issue_id}" for issue_id in remaining_issues])
-    response = get_jira(jql, jira_fields)
-    data = response.json().get('issues')
-    # Clean the data, only keep the required info.
-    fetched_data = [sanitized_issue_data(issue, jira_fields) for issue in data if issue is not None]
+    issues = get_jira(jql, jira_fields)
+    fetched_data = [
+        _issue_to_flat_dict(issue, jira_fields) for issue in issues if issue is not None
+    ]
 
     # Update cache with new data
     for issue in fetched_data:
@@ -397,7 +299,7 @@ def get_data_jira(issue_ids, cached_data=None, jira_fields=None):  # pragma: no 
 
     # Combine cached and fetched data
     result_data = [
-        cached_issues[issue_id]['data'] for issue_id in issue_ids if issue_id in cached_issues
+        cached_issues[issue_id] for issue_id in issue_ids if issue_id in cached_issues
     ] + fetched_data
     CACHED_RESPONSES['get_data'][str(sorted(issue_ids))] = result_data
     return result_data
@@ -418,12 +320,12 @@ def get_single_jira(issue_id, cached_data=None):  # pragma: no cover
         try:
             # First try from provided cache
             if issue_id in cached_data:
-                jira_data = cached_data[issue_id]['data']
+                jira_data = cached_data[issue_id]
             else:
                 # Then try from JiraStatusCache
                 cached = jira_cache.get(issue_id)
                 if cached:
-                    jira_data = cached.get('data')
+                    jira_data = cached
                 else:
                     # Finally call API
                     try:
@@ -478,37 +380,35 @@ def add_comment_on_jira(
     :type comment_visibility: str
     :param labels: Add/Remove Jira labels, ex. [{'add':'tests_passed'},{'remove':'tests_failed'}]
     :type labels: list
-    :returns: Response from Jira API
-    :rtype: list of dicts
+    :returns: Comment response from Jira API
+    :rtype: dict
     """
     issue_id = issue_id.strip()
-    # Raise a warning if any of the following option is not set. Note: It's a xor condition.
-    if settings.jira.enable_comment != bool(pytest.jira_comments):
+    if settings.jira.enable_comment != bool(getattr(pytest, 'jira_comments', False)):
         logger.warning(
             'Jira comments are currently disabled for this run. '
             'To enable it, please set "enable_comment" to "true" in "config/jira.yaml '
-            'and provide --jira-comment pytest option."'
+            'and provide --jira-comments pytest option."'
         )
         return None
+
+    jira = _jira_client()
+
     if labels:
         logger.debug(f"Updating labels for {issue_id} issue. \n labels: \n {labels}")
-        response = requests.put(
-            f"{settings.jira.url}/rest/api/latest/issue/{issue_id}/",
-            json={"update": {"labels": labels}},
-            headers={"Authorization": f"Bearer {settings.jira.api_key}"},
-        )
+        issue_url = f"{settings.jira.url}/rest/api/latest/issue/{issue_id}"
+        response = jira._session.put(issue_url, json={"update": {"labels": labels}})
         response.raise_for_status()
+
     logger.debug(f"Adding a new comment on {issue_id} Jira issue. \n comment: \n {comment}")
-    response = requests.post(
-        f"{settings.jira.url}/rest/api/latest/issue/{issue_id}/comment",
-        json={
-            "body": comment,
-            "visibility": {
-                "type": comment_type,
-                "value": comment_visibility,
-            },
+    url = f"{settings.jira.url}/rest/api/latest/issue/{issue_id}/comment"
+    payload = {
+        "body": comment,
+        "visibility": {
+            "type": comment_type,
+            "value": comment_visibility,
         },
-        headers={"Authorization": f"Bearer {settings.jira.api_key}"},
-    )
+    }
+    response = jira._session.post(url, json=payload)
     response.raise_for_status()
     return response.json()

--- a/tests/robottelo/test_issue_handlers_jira.py
+++ b/tests/robottelo/test_issue_handlers_jira.py
@@ -1,0 +1,286 @@
+"""Tests for module ``robottelo.utils.issue_handlers.jira``."""
+
+from unittest import mock
+
+import pytest
+
+from robottelo.config import settings
+from robottelo.constants import JIRA_WONTFIX_RESOLUTIONS
+from robottelo.utils.issue_handlers import jira
+
+
+def _flat_issue(key='SAT-123', status='Open', resolution=''):
+    """Build flat issue dict (key, status, resolution) as stored in pytest.issue_data / cache."""
+    return {'key': key, 'status': status, 'resolution': resolution or ''}
+
+
+def _issue_data(issue_dict):
+    """Pytest.issue_data issue: flat issue dict plus used_in (consistent with jira handler)."""
+    return {**issue_dict, 'used_in': []}
+
+
+class TestJiraIssueHandler:
+    """Core scenarios for Jira issue handler."""
+
+    def test_issue_to_flat_dict_uses_dot_access(self):
+        """_issue_to_flat_dict extracts fields from Issue object via .key, .fields.*."""
+        mock_issue = mock.Mock()
+        mock_issue.key = 'SAT-456'
+        mock_issue.fields.status.name = 'Closed'
+        mock_issue.fields.labels = ['bug']
+        mock_issue.fields.resolution.name = 'Done'
+        out = jira._issue_to_flat_dict(mock_issue, jira.common_jira_fields)
+        assert out['key'] == 'SAT-456'
+        assert out['status'] == 'Closed'
+        assert out['resolution'] == 'Done'
+        assert out['labels'] == ['bug']
+
+    def test_is_open_jira_open_vs_closed(self, monkeypatch):
+        """is_open_jira returns True for open status, False for closed."""
+        monkeypatch.setattr(pytest, 'issue_data', {'SAT-1': _issue_data(_flat_issue(status='New'))})
+        assert jira.is_open_jira('SAT-1') is True
+
+        monkeypatch.setattr(
+            pytest,
+            'issue_data',
+            {'SAT-1': _issue_data(_flat_issue(status='Closed', resolution='Done'))},
+        )
+        assert jira.is_open_jira('SAT-1') is False
+
+    def test_are_all_jira_open_any_closed_returns_false(self, monkeypatch):
+        """are_all_jira_open returns False when any issue is closed."""
+        monkeypatch.setattr(
+            pytest,
+            'issue_data',
+            {
+                'SAT-1': _issue_data(_flat_issue(key='SAT-1', status='New')),
+                'SAT-2': _issue_data(_flat_issue(key='SAT-2', status='Closed', resolution='Done')),
+            },
+        )
+        assert jira.are_all_jira_open(['SAT-1', 'SAT-2']) is False
+
+    def test_are_any_jira_open_all_closed_returns_false(self, monkeypatch):
+        """are_any_jira_open returns False when all issues are closed."""
+        monkeypatch.setattr(
+            pytest,
+            'issue_data',
+            {'SAT-1': _issue_data(_flat_issue(key='SAT-1', status='Closed', resolution='Done'))},
+        )
+        assert jira.are_any_jira_open(['SAT-1']) is False
+
+    def test_should_deselect_jira_closed_wontfix_returns_true(self, monkeypatch):
+        """should_deselect_jira returns True for closed + WONTFIX resolution."""
+        resolution = next(iter(JIRA_WONTFIX_RESOLUTIONS))
+        monkeypatch.setattr(
+            pytest,
+            'issue_data',
+            {'SAT-1': _issue_data(_flat_issue(status='Closed', resolution=resolution))},
+        )
+        assert jira.should_deselect_jira('SAT-1') is True
+
+    def test_follow_duplicates_returns_leaf_issue(self):
+        """follow_duplicates follows nested dupe_data to the leaf."""
+        leaf = {'key': 'SAT-3', 'status': 'Closed'}
+        mid = {'key': 'SAT-2', 'dupe_data': leaf}
+        top = {'key': 'SAT-1', 'dupe_data': mid}
+        assert jira.follow_duplicates(top) is leaf
+
+    def test_get_default_jira_returns_expected_structure(self):
+        """get_default_jira returns dict with key, is_open True, error message."""
+        out = jira.get_default_jira('SAT-999')
+        assert out['key'] == 'SAT-999'
+        assert out['is_open'] is True
+        assert out['is_deselected'] is False
+        assert 'missing jira api_key' in out['error']
+
+    def test_jira_status_cache_update_and_get(self, tmp_path):
+        """JiraStatusCache stores and returns issue data by id."""
+        with (
+            mock.patch(
+                'robottelo.utils.issue_handlers.jira.settings.jira.cache_file',
+                str(tmp_path / 'cache.json'),
+            ),
+            mock.patch(
+                'robottelo.utils.issue_handlers.jira.settings.jira.cache_ttl_days',
+                7,
+            ),
+        ):
+            cache = jira.JiraStatusCache()
+        data = {'key': 'SAT-1', 'status': 'Open'}
+        cache.update('SAT-1', data)
+        assert cache.get('SAT-1') == data | {'timestamp': mock.ANY}
+        assert cache.get('SAT-2') is None
+
+    def test_get_jira_returns_issue_objects_from_search(self):
+        """get_jira returns list of Issue objects (mocked client)."""
+        mock_issues = [mock.Mock(key='SAT-1'), mock.Mock(key='SAT-2')]
+        with mock.patch.object(jira, '_jira_client') as m_client:
+            m_jira = mock.Mock()
+            m_jira.search_issues.return_value = mock_issues
+            m_client.return_value = m_jira
+            result = jira.get_jira('id = SAT-1 OR id = SAT-2', ['key', 'status'])
+        assert result == mock_issues
+        m_jira.search_issues.assert_called_once_with(
+            jql_str='id = SAT-1 OR id = SAT-2', fields='key,status'
+        )
+
+    def test_get_data_jira_empty_ids_returns_empty_list(self):
+        """get_data_jira with empty issue_ids returns []."""
+        assert jira.get_data_jira([]) == []
+
+    def test_get_data_jira_missing_credentials_returns_default(self):
+        """get_data_jira without api_key returns default issue data."""
+        jira.CACHED_RESPONSES['get_data'].clear()
+        with mock.patch('robottelo.utils.issue_handlers.jira.settings.jira.api_key', None):
+            result = jira.get_data_jira(['SAT-999'])
+        assert len(result) == 1
+        assert result[0]['key'] == 'SAT-999'
+        assert result[0].get('error')
+        assert result[0]['is_open'] is True
+
+
+class TestTryFromCache:
+    """Focused tests for try_from_cache lookup order and fallback."""
+
+    def test_returns_pytest_issue_data_when_present(self, monkeypatch):
+        """When issue_id is in pytest.issue_data with issue fields, return it; no cache or API."""
+        flat = _flat_issue(key='SAT-1', status='Open')
+        monkeypatch.setattr(pytest, 'issue_data', {'SAT-1': _issue_data(flat)})
+        cache_get = mock.Mock()
+        get_single = mock.Mock()
+        with (
+            mock.patch.object(jira.jira_cache, 'get', cache_get),
+            mock.patch.object(jira, 'get_single_jira', get_single),
+        ):
+            result = jira.try_from_cache('SAT-1')
+        assert result == {**flat, 'used_in': []}
+        cache_get.assert_not_called()
+        get_single.assert_not_called()
+
+    def test_returns_jira_cache_when_no_issue_data(self, monkeypatch):
+        """When pytest.issue_data has no entry, return jira_cache.get result if present."""
+        monkeypatch.setattr(pytest, 'issue_data', {})
+        cached = {'key': 'SAT-2', 'status': 'Closed', 'resolution': 'Done'}
+        with mock.patch.object(jira.jira_cache, 'get', return_value=cached):
+            result = jira.try_from_cache('SAT-2')
+        assert result == cached
+
+    def test_falls_back_to_get_single_jira_when_neither_has_entry(self, monkeypatch):
+        """When neither pytest.issue_data nor jira_cache has the issue, call get_single_jira."""
+        monkeypatch.setattr(pytest, 'issue_data', {})
+        api_result = {'key': 'SAT-3', 'status': 'New'}
+        with (
+            mock.patch.object(jira.jira_cache, 'get', return_value=None),
+            mock.patch.object(jira, 'get_single_jira', return_value=api_result) as get_single,
+        ):
+            result = jira.try_from_cache('SAT-3')
+        assert result == api_result
+        get_single.assert_called_once_with('SAT-3')
+
+
+class TestAddCommentOnJira:
+    """Tests for add_comment_on_jira: disabled path, labels PUT, and comment POST."""
+
+    def test_disabled_comments_warns_and_returns_none_no_http(self, monkeypatch):
+        """When enable_comment != jira_comments (e.g. config off or option not set), warn and return None; no HTTP."""
+        monkeypatch.setattr(pytest, 'jira_comments', True)  # so enable_comment False != True
+        mock_client = mock.Mock()
+        with (
+            mock.patch('robottelo.utils.issue_handlers.jira.settings.jira.enable_comment', False),
+            mock.patch.object(jira, '_jira_client', return_value=mock_client),
+        ):
+            result = jira.add_comment_on_jira('SAT-1', 'comment text')
+        assert result is None
+        mock_client._session.put.assert_not_called()
+        mock_client._session.post.assert_not_called()
+
+    def test_disabled_comments_when_jira_comments_falsy(self, monkeypatch):
+        """When pytest.jira_comments is falsy, return None and make no HTTP calls."""
+        monkeypatch.setattr(pytest, 'jira_comments', False)
+        mock_client = mock.Mock()
+        with (
+            mock.patch('robottelo.utils.issue_handlers.jira.settings.jira.enable_comment', True),
+            mock.patch.object(jira, '_jira_client', return_value=mock_client),
+        ):
+            result = jira.add_comment_on_jira('SAT-1', 'comment text')
+        assert result is None
+        mock_client._session.put.assert_not_called()
+        mock_client._session.post.assert_not_called()
+
+    def test_comments_enabled_with_labels_puts_labels_then_posts_comment(self, monkeypatch):
+        """When labels are provided, PUT to issue with labels update, then POST comment."""
+        labels = [{'add': 'tests_passed'}, {'remove': 'tests_failed'}]
+        mock_session = mock.Mock()
+        mock_session.put.return_value.raise_for_status = mock.Mock()
+        mock_session.post.return_value.raise_for_status = mock.Mock()
+        mock_session.post.return_value.json.return_value = {'id': '123'}
+        mock_client = mock.Mock(_session=mock_session)
+        monkeypatch.setattr(pytest, 'jira_comments', True)
+        with (
+            mock.patch('robottelo.utils.issue_handlers.jira.settings.jira.enable_comment', True),
+            mock.patch(
+                'robottelo.utils.issue_handlers.jira.settings.jira.url', 'https://jira.example'
+            ),
+            mock.patch.object(jira, '_jira_client', return_value=mock_client),
+        ):
+            result = jira.add_comment_on_jira('SAT-42', 'Done', labels=labels)
+        assert result == {'id': '123'}
+        mock_session.put.assert_called_once()
+        put_url, put_kw = mock_session.put.call_args[0][0], mock_session.put.call_args[1]
+        assert put_url == 'https://jira.example/rest/api/latest/issue/SAT-42'
+        assert put_kw['json'] == {'update': {'labels': labels}}
+        mock_session.post.assert_called_once()
+        post_url = mock_session.post.call_args[0][0]
+        assert post_url == 'https://jira.example/rest/api/latest/issue/SAT-42/comment'
+
+    def test_comments_enabled_labels_none_only_posts_comment(self, monkeypatch):
+        """When labels is None, only POST to comment endpoint; no PUT."""
+        mock_session = mock.Mock()
+        mock_session.post.return_value.raise_for_status = mock.Mock()
+        mock_session.post.return_value.json.return_value = {'id': '456'}
+        mock_client = mock.Mock(_session=mock_session)
+        monkeypatch.setattr(pytest, 'jira_comments', True)
+        with (
+            mock.patch('robottelo.utils.issue_handlers.jira.settings.jira.enable_comment', True),
+            mock.patch(
+                'robottelo.utils.issue_handlers.jira.settings.jira.url', 'https://jira.example'
+            ),
+            mock.patch.object(jira, '_jira_client', return_value=mock_client),
+        ):
+            result = jira.add_comment_on_jira('SAT-99', 'Comment body', labels=None)
+        assert result == {'id': '456'}
+        mock_session.put.assert_not_called()
+        mock_session.post.assert_called_once()
+        call_kw = mock_session.post.call_args[1]
+        assert call_kw['json']['body'] == 'Comment body'
+        assert call_kw['json']['visibility'] == {
+            'type': settings.jira.comment_type,
+            'value': settings.jira.comment_visibility,
+        }
+
+    def test_post_payload_has_body_and_visibility(self, monkeypatch):
+        """POST payload includes body and visibility with comment_type and comment_visibility."""
+        mock_session = mock.Mock()
+        mock_session.post.return_value.raise_for_status = mock.Mock()
+        mock_session.post.return_value.json.return_value = {}
+        mock_client = mock.Mock(_session=mock_session)
+        monkeypatch.setattr(pytest, 'jira_comments', True)
+        with (
+            mock.patch('robottelo.utils.issue_handlers.jira.settings.jira.enable_comment', True),
+            mock.patch(
+                'robottelo.utils.issue_handlers.jira.settings.jira.url', 'https://jira.example'
+            ),
+            mock.patch.object(jira, '_jira_client', return_value=mock_client),
+        ):
+            jira.add_comment_on_jira(
+                'SAT-1',
+                'Verification comment',
+                comment_type='role',
+                comment_visibility='Internal',
+            )
+        mock_session.post.assert_called_once()
+        url = mock_session.post.call_args[0][0]
+        assert url == 'https://jira.example/rest/api/latest/issue/SAT-1/comment'
+        payload = mock_session.post.call_args[1]['json']
+        assert payload['body'] == 'Verification comment'
+        assert payload['visibility'] == {'type': 'role', 'value': 'Internal'}


### PR DESCRIPTION
### Problem Statement
Refactor Jira issue handler and add unit tests

### Solution

- Use the jira library instead of raw requests.
- Work with Issue objects and a small _issue_to_flat_dict() for flat dicts
- Fix bug related to `skip` causing unnecessary Jira API call.
- Remove dead code (collect_dupes, collect_data_jira, update_many) 
- fix cached_data handling and broker fixture settings.server.hostname access
- Add tests/robottelo/test_issue_handlers_jira.py
- Removed unrequired Jira fields

### Related Issues
- SAT-42998

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Refactor Jira issue handling to use the official jira client, simplify caching and issue lookup, and strengthen behavior around skip/deselect logic and non-Jira markers while adding dedicated tests.

Bug Fixes:
- Prevent unnecessary Jira API calls when skip markers are present by tightening cache usage and issue-key detection.
- Fix handling of cached Jira issue data so cached entries are stored and read in a consistent flat format.
- Handle missing settings.server.hostname safely when creating the default Satellite fixture to avoid attribute errors.
- Treat only valid Jira-looking strings as issue keys to avoid spurious Jira lookups for arbitrary skip reasons.

Enhancements:
- Replace raw HTTP requests with the jira library for querying issues and adding comments, and introduce an Issue-to-dict helper based on attribute access.
- Simplify Jira issue cache structure by storing flat issue dicts directly and removing unused collection and duplicate-handling helpers.
- Streamline is_open / should_deselect helpers to operate without external data dict parameters and rely on centralized caching.
- Introduce a small helper for constructing the Jira client with token-based authentication.
- Improve labeling and comment behavior to respect pytest-driven Jira comment toggles more robustly.

Build:
- Add jira==3.10.5 dependency to requirements.

Tests:
- Add unit tests for the Jira issue handler covering flat dict extraction, open/closed evaluation, default issue data, caching behavior, Jira client usage, and credential-missing paths.