### PR TITLE
use a non read-only setting for a validation test

### DIFF
--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -122,7 +122,7 @@ def test_positive_httpd_proxy_url_update(session, setting_update):
 
 
 @pytest.mark.parametrize('setting_update', ['unattended_url'], indirect=True)
-def test_negative_validate_foreman_url_error_message(session, setting_update):
+def test_negative_validate_unattended_url_error_message(session, setting_update):
     """Updates some settings with invalid values
 
     :id: 7c75083d-1b4d-4744-aaa4-6fb9e93ab3c2


### PR DESCRIPTION
### Problem Statement
foreman_url is read only trough UI, msg also changed

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Adjust UI setting validation test to use a writable setting and align the expected validation error message with the current UI behavior.

Tests:
- Update the negative validation test to target the 'unattended_url' setting instead of read-only 'foreman_url'.
- Refresh the expected error message string to match the new validation message shown in the UI.