### PR TITLE
Fix test_positive_module_stream_details_search_in_repo

### DIFF
--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -53,10 +53,16 @@ def test_positive_module_stream_details_search_in_repo(
 
     :BZ: 1948758
     """
-    ducks_count = len(module_target_sat.api.ModuleStream().search(query={'search': 'name="duck"'}))
+    ducks_count = len(
+        module_target_sat.api.ModuleStream().search(
+            query={'search': f'name~"duck" and repository="{module_yum_repo.name}"'}
+        )
+    )
     with module_target_sat.ui_session() as session:
         session.organization.select(org_name=module_org.name)
-        duck_results = session.modulestream.search('name ~ "duck"')
+        duck_results = session.modulestream.search(
+            f'name~"duck" and repository="{module_yum_repo.name}"'
+        )
         assert len(duck_results) == ducks_count
         assert all(item['Name'].startswith('duck') for item in duck_results)
         walrus_details = session.modulestream.read('walrus', '5.21')


### PR DESCRIPTION
### Problem Statement
The `test_positive_module_stream_details_search_in_repo` still fails flakily in CI with this assertion error:
```
tests/foreman/ui/test_modulestreams.py:60: in test_positive_module_stream_details_search_in_repo
    assert len(duck_results) == ducks_count
E   AssertionError: assert 3 == 5
E    +  where 3 = len([{'Arch': 'noarch', 'Context': 'deadbeef', 'Name': 'duck', 'Stream': '0', ...}, {'Arch': 'noarch', 'Context': 'deadbeef', 'Name': 'duck', 'Stream': '0', ...}, {'Arch': 'noarch', 'Context': 'deadbeef', 'Name': 'duck', 'Stream': '0', ...}])
```

After some digging it seems the module streams search through API returns Satellite-wide modules (no Organization scoping), while the UI search scopes by the selected Organization properly. This way other `duck` modules from other tests can sneak in (`module_stream1` and `module_stream2` fixture repos provide different ones with same name).


### Solution
Use the fixture repo name for more deterministic search.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_modulestreams.py -k test_positive_module_stream_details_search_in_repo
```

## Summary by Sourcery

Tests:
- Update modulestream UI test to filter module search by repository name for deterministic result counts.