### PR TITLE
[6.17.z] use a non read-only setting for a validation test

### DIFF
--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -129,7 +129,7 @@ def test_negative_validate_unattended_url_error_message(session, setting_update)
     property_name = setting_update.name
     with session:
         invalid_value = [invalid_value for invalid_value in invalid_settings_values()][0]
-        err_msg = "Validation errors present on page, displayed messages: ['Invalid value']"
+        err_msg = "Validation errors present on page, displayed messages: ['URL must be valid and schema must be one of http and https']"
         with pytest.raises(AssertionError) as context:
             session.settings.update(f'name = {property_name}', invalid_value)
         assert err_msg in str(context.value)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20979

### Problem Statement
foreman_url is read only trough UI, msg also changed

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update negative UI settings validation test to use a writable URL setting and align expected error message with current UI behavior.

Tests:
- Switch the negative validation test from the read-only 'foreman_url' setting to the writable 'unattended_url' setting.
- Update the expected validation error message string to match the current UI validation response.