### PR TITLE
[6.18.z] use a non read-only setting for a validation test

### DIFF
--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -121,8 +121,8 @@ def test_positive_httpd_proxy_url_update(session, setting_update):
         assert result['table'][0]['Value'] == param_value
 
 
-@pytest.mark.parametrize('setting_update', ['foreman_url'], indirect=True)
-def test_negative_validate_foreman_url_error_message(session, setting_update):
+@pytest.mark.parametrize('setting_update', ['unattended_url'], indirect=True)
+def test_negative_validate_unattended_url_error_message(session, setting_update):
     """Updates some settings with invalid values
 
     :id: 7c75083d-1b4d-4744-aaa4-6fb9e93ab3c2
@@ -136,7 +136,7 @@ def test_negative_validate_foreman_url_error_message(session, setting_update):
     property_name = setting_update.name
     with session:
         invalid_value = [invalid_value for invalid_value in invalid_settings_values()][0]
-        err_msg = 'URL must be valid and schema must be one of http and https, Invalid HTTP(S) URL'
+        err_msg = "Validation errors present on page, displayed messages: ['Invalid value']"
         with pytest.raises(AssertionError) as context:
             session.settings.update(f'name = {property_name}', invalid_value)
         assert err_msg in str(context.value)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20979

### Problem Statement
foreman_url is read only trough UI, msg also changed

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Adjust the negative URL validation UI test to target the unattended_url setting instead of the read-only foreman_url and expect the updated validation error text.