### PR TITLE
[6.18.z] Skip TemplateImporter negate filter test until SAT-43284 is resolved

### DIFF
--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -159,6 +159,8 @@ class TestTemplateSyncTestCase:
             2. Assert templates matching the regex were not pulled.
 
         :CaseImportance: Medium
+
+        :BlockedBy: SAT-43284
         """
         prefix = gen_string('alpha')
         filtered_imported_templates = module_target_sat.api.Template().imports(
@@ -933,6 +935,8 @@ class TestTemplateSyncTestCase:
         :Requirement: Take Templates out of tech preview
 
         :CaseImportance: Low
+
+        :BlockedBy: SAT-43284
         """
         prefix = gen_string('alpha')
         imported_templates = target_sat.api.Template().imports(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20976

### Problem Statement
TemplateImporter returns import failure which fails test assertions

### Solution
Skip the test until issue is fixed

### Related Issues
https://issues.redhat.com/browse/SAT-43284


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Annotate affected template sync import and export tests with a BlockedBy SAT-43284 marker to indicate they are temporarily disabled or blocked.