### PR TITLE
[6.16.z] Bump broker[docker,satlab,ssh2_python] from 0.8.0 to 0.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Version updates managed by dependabot
 
 apypie==0.7.1
-broker[satlab,docker,ssh2_python]==0.8.0
+broker[satlab,docker,ssh2_python]==0.8.3
 cryptography==46.0.5
 deepdiff==8.6.1
 dynaconf[vault]==3.2.11


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21001

cherry pick https://github.com/SatelliteQE/robottelo/pull/20935