### PR TITLE
[6.19.z] update test for enable/disable recommendations (IoP)

### DIFF
--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -325,7 +325,7 @@ def test_iop_negative_rhcloud_inventory_upload_not_displayed(module_target_sat_i
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match(r'^(?![78]).*')
+@pytest.mark.rhel_ver_match('10')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_iop_recommendations_remediation_type_and_status(
     rhel_insights_vm,
@@ -333,7 +333,7 @@ def test_iop_recommendations_remediation_type_and_status(
     module_target_sat_insights,
 ):
     """Set up Satellite with iop enabled, verify recommendations remediation type,
-    and test filtering recommendations by status.
+    disable the recommendation, check status, then re-enable the recommendation.
 
     :id: 62834698-b4b8-4218-855c-2b2aa584b364
 
@@ -394,7 +394,6 @@ def test_iop_recommendations_remediation_type_and_status(
             "Name", OPENSSH_RECOMMENDATION, is_search=True
         )
         assert 'Decreased security: OpenSSH config permissions' in result[0]['Name']
-
 
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])

--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -395,6 +395,7 @@ def test_iop_recommendations_remediation_type_and_status(
         )
         assert 'Decreased security: OpenSSH config permissions' in result[0]['Name']
 
+
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20520

Test for disabling/enabling recommendations on IOP. 
SAT-38139
https://github.com/SatelliteQE/airgun/pull/2247

## Summary by Sourcery

Update IOP recommendations UI test to validate disabling and re-enabling a specific recommendation on RHEL 10.

Tests:
- Adjust IOP recommendations remediation test to cover disabling and re-enabling a specific recommendation instead of counting enabled/disabled items.
- Restrict the IOP recommendations test to run on RHEL 10 and update metadata to reference SAT-38139.