### PR TITLE
[6.19.z] Set IPv6 http proxy for wget to route through

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2465,6 +2465,7 @@ class TestFileRepository:
         # Making Setup For Creating Local Directory using Pulp Manifest
         target_sat.execute(f'mkdir -p {CUSTOM_LOCAL_FOLDER}')
         target_sat.execute(
+            f'https_proxy={settings.http_proxy.http_proxy_ipv6_url} '
             f'wget -P {CUSTOM_LOCAL_FOLDER} -r -np -nH --cut-dirs=5 -R "index.html*" '
             f'{CUSTOM_FILE_REPO}'
         )
@@ -2502,6 +2503,7 @@ class TestFileRepository:
         # Downloading the pulp repository into Satellite Host
         target_sat.execute(f'mkdir -p {CUSTOM_LOCAL_FOLDER}')
         target_sat.execute(
+            f'https_proxy={settings.http_proxy.http_proxy_ipv6_url} '
             f'wget -P {CUSTOM_LOCAL_FOLDER} -r -np -nH --cut-dirs=5 -R "index.html*" '
             f'{CUSTOM_FILE_REPO}'
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20992

### Problem Statement
Two tests trying to wget a repo from IPv4 internet to an IPv6 hosts fail with `Network is unreachable`.


### Solution
Set `https_proxy` env var with our IPv6 proxy so that `wget` can use it.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_repository.py -k 'file_repo_local_directory_sync or symlinks_sync'
network_type: ipv6
```

## Summary by Sourcery

Tests:
- Update repository sync tests to export the IPv6 HTTPS proxy before invoking wget to download test content.

## Summary by Sourcery

Ensure repository CLI tests use the configured IPv6 HTTPS proxy when downloading content with wget.

Tests:
- Update file repository local directory sync test to export the IPv6 HTTPS proxy before running wget.
- Update symlinks sync test to export the IPv6 HTTPS proxy before running wget.