### PR TITLE
Unblock RHC CLI test

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -448,7 +448,7 @@ def test_positive_download_reports_job_cli_disconnected(
 
     :expectedresults: Reports download works as expected.
 
-    :BlockedBy: SAT-41462
+    :Verifies: SAT-41462
     """
     org = rhcloud_manifest_org
     generate_report(org, module_target_sat, disconnected=True)


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Adjust RHC CLI inventory test case annotation from blocked-by to verifies for SAT-41462.