### PR TITLE
Update Jira issue handler code for cloud Jira

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,8 @@
 # 5. To use secret from vault for any settings in conf/*.yaml, use the format: '@format {this._secret_name_in_vault_}'
 # 6. jira.yaml Example:
 #    JIRA:
-#      URL: https://issues.redhat.com
+#      URL: https://redhat.atlassian.net
+#      EMAIL: your_email@redhat.com
 #      API_KEY: '@format {this.vault_jira_api_key}'
 #      COMMENT_TYPE: group
 #      COMMENT_VISIBILITY: "Red Hat Employee"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,7 @@ on:
 env:
     PYCURL_SSL_LIBRARY: openssl
     ROBOTTELO_JIRA__API_KEY: ${{ secrets.JIRA_KEY }}
+    ROBOTTELO_JIRA__EMAIL: ${{ secrets.JIRA_EMAIL }}
 
 jobs:
   codechecks:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -83,6 +83,7 @@ jobs:
         id: cscheck
         env:
           ROBOTTELO_JIRA__API_KEY: ${{ secrets.JIRA_KEY }}
+          ROBOTTELO_JIRA__EMAIL: ${{ secrets.JIRA_EMAIL }}
 
       - name: Customer scenario status
         run: |

--- a/conf/jira.yaml.template
+++ b/conf/jira.yaml.template
@@ -1,7 +1,8 @@
 JIRA:
-  # url default value is set to 'https://issues.redhat.com' even if not provided.
-  URL: https://issues.redhat.com
-  # Provide api_key to access Jira REST API
+  # url default value is set to 'https://redhat.atlassian.net' even if not provided.
+  URL: https://redhat.atlassian.net
+  # Provide email and api_key to access Jira REST API
+  EMAIL: your_email@redhat.com
   API_KEY: replace-with-jira-api-key
   COMMENT_TYPE: group
   COMMENT_VISIBILITY: "Red Hat Employee"

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -252,7 +252,8 @@ VALIDATORS = dict(
         ),
     ],
     jira=[
-        Validator('jira.url', default='https://issues.redhat.com'),
+        Validator('jira.url', default='https://redhat.atlassian.net'),
+        Validator('jira.email', must_exist=True),
         Validator('jira.api_key', must_exist=True),
         Validator('jira.comment_type', default="group"),
         Validator('jira.comment_visibility', default="Red Hat Employee"),

--- a/robottelo/utils/issue_handlers/jira.py
+++ b/robottelo/utils/issue_handlers/jira.py
@@ -181,10 +181,10 @@ CACHED_RESPONSES = defaultdict(dict)
 
 
 def _jira_client():
-    """Create a JIRA client with token auth (api_key)."""
+    """Create a JIRA client with basic auth (email and api_key)."""
     return JIRA(
         server=settings.jira.url,
-        token_auth=settings.jira.api_key,
+        basic_auth=(settings.jira.email, settings.jira.api_key),
     )
 
 
@@ -263,8 +263,10 @@ def get_data_jira(issue_ids, cached_data=None, jira_fields=None):  # pragma: no 
         return [cached_issues[issue_id] for issue_id in issue_ids]
 
     # Ensure API key is set
-    if not settings.jira.api_key:
-        logger.warning("Config file is missing jira api_key. Provide api_key or a jira_cache.json.")
+    if not (settings.jira.email and settings.jira.api_key):
+        logger.warning(
+            "Config file is missing either jira email or api_key. Provide Jira email and api_key or a jira_cache.json."
+        )
         # Provide default data for collected Jira's.
         default_data = [get_default_jira(issue_id) for issue_id in remaining_issues]
         # Update cache with defaults
@@ -357,7 +359,7 @@ def get_default_jira(issue_id):  # pragma: no cover
         "is_deselected": False,
         "status": "",
         "resolution": "",
-        "error": "missing jira api_key",
+        "error": "missing jira email/api_key",
     }
 
 

--- a/tests/robottelo/test_issue_handlers_jira.py
+++ b/tests/robottelo/test_issue_handlers_jira.py
@@ -91,7 +91,7 @@ class TestJiraIssueHandler:
         assert out['key'] == 'SAT-999'
         assert out['is_open'] is True
         assert out['is_deselected'] is False
-        assert 'missing jira api_key' in out['error']
+        assert 'missing jira email/api_key' in out['error']
 
     def test_jira_status_cache_update_and_get(self, tmp_path):
         """JiraStatusCache stores and returns issue data by id."""
@@ -129,9 +129,12 @@ class TestJiraIssueHandler:
         assert jira.get_data_jira([]) == []
 
     def test_get_data_jira_missing_credentials_returns_default(self):
-        """get_data_jira without api_key returns default issue data."""
+        """get_data_jira without email/api_key returns default issue data."""
         jira.CACHED_RESPONSES['get_data'].clear()
-        with mock.patch('robottelo.utils.issue_handlers.jira.settings.jira.api_key', None):
+        with (
+            mock.patch('robottelo.utils.issue_handlers.jira.settings.jira.email', None),
+            mock.patch('robottelo.utils.issue_handlers.jira.settings.jira.api_key', None),
+        ):
             result = jira.get_data_jira(['SAT-999'])
         assert len(result) == 1
         assert result[0]['key'] == 'SAT-999'


### PR DESCRIPTION
### Problem Statement
Red Hat Jira will be migrating to Atlassian Cloud, which will break the current token authentication method used in Robottelo's Jira issue handler.

Note: Do Not Merge this PR before March 16.

### Solution
- Update Jira issue handler to use Basic auth (email, api_key)
- Update unit tests
- Update `conf/jira.yaml.template`
- Update Jira url
- [To Do] Update GitHub secrets
- Dependency: Update `conf/jira.yaml` conf file in CI.

### Related Issues
- SAT-42998

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Switch Jira issue handling to use basic authentication with email and API key and require both credentials in configuration and CI.

Enhancements:
- Update Jira client construction and configuration validation to require both Jira email and API key for authentication.

CI:
- Propagate Jira email secret into pull request and weekly GitHub workflows for Jira-dependent jobs.

Documentation:
- Adjust Jira configuration template to reflect the new email-based authentication requirements.

Tests:
- Extend Jira issue handler unit tests to cover missing email/api_key scenarios and updated error messaging.