### PR TITLE
manage_repo_sets_ui_test_refactor_for_ipv6

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2863,7 +2863,7 @@ def test_positive_manage_repository_sets(
                 if repository not in all_repo_names:
                     all_repo_names.append(repository)
         if 'Enabled:   0' in raw_output:
-            rep_status = host.execute('subscription-manager repos --enable *').stdout
+            rep_status = host.execute(r'subscription-manager repos --enable \*').stdout
             assert 'enabled for this system' in rep_status
         host_names.append(host.hostname)
 


### PR DESCRIPTION
Update the `test_positive_manage_repository_sets` so it does not use `rhel8_contenthost`, `rhel9_contenthost` fixtures, but rather `content_hosts`. This fixes test issues with IPV6.

### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py::test_positive_manage_repository_sets
network_type: ipv6
```

## Summary by Sourcery

Refactor the host repository set management UI test to use generic content host fixtures and target a single RHEL version-specific BOS repository.

Tests:
- Update the manage repository sets UI test to use the shared content_hosts fixture instead of version-specific RHEL content host fixtures.
- Restrict the test to the default RHEL version and simplify repository setup to a single BOS repo matching the hosts' OS version.
- Harden the test by deduplicating collected repository names and explicitly verifying enable/disable status across all hosts.