### PR TITLE
[6.17.z] Fix Discovery provisioning tests

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -209,6 +209,10 @@ def module_provisioning_sat(
         remote_execution_proxy=[module_provisioning_capsule.id],
         domain=[domain.id],
     ).create()
+    if provisioning_type == 'discovery':
+        for host in sat.api.DiscoveredHost().search():
+            host.delete()
+
     if sat.network_type == NetworkType.IPV4:
         assert sat.execute('cat /dev/null > /var/lib/dhcpd/dhcpd.leases').status == 0
         assert sat.execute('systemctl restart dhcpd').status == 0

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -436,10 +436,6 @@ class TestDiscoveredHost:
         )
 
         discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
-        discovered_host.hostgroup = provisioning_hostgroup
-        discovered_host.location = provisioning_hostgroup.location[0]
-        discovered_host.organization = provisioning_hostgroup.organization[0]
-        discovered_host.build = True
         result = sat.api.DiscoveredHost(id=discovered_host.id).reboot_all()
         assert 'Unable to perform reboot' not in result
 

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -169,10 +169,28 @@ def test_positive_custom_provision_pxe_host(
         delay=20,
     )
     discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
-    discovered_host.hostgroup = provisioning_hostgroup
-    discovered_host.location = provisioning_hostgroup.location[0]
-    discovered_host.organization = provisioning_hostgroup.organization[0]
-    discovered_host.build = True
+    if is_open('SAT-33477') and (
+        sat.cli.DiscoveredHost.list(
+            {
+                'organization-id': module_org.id,
+                'location-id': module_location.id,
+            }
+        )
+        == []
+    ):
+        with sat.ui_session() as temp_session:
+            temp_session.organization.select(org_name='Any organization')
+            temp_session.location.select(loc_name='Any location')
+            temp_session.discoveredhosts.apply_action(
+                'Assign Organization',
+                discovered_host.name,
+                values=dict(organization=module_org.name),
+            )
+            temp_session.discoveredhosts.apply_action(
+                'Assign Location',
+                discovered_host.name,
+                values=dict(location=module_location.name),
+            )
 
     discovered_host_name = discovered_host.name
     domain_name = provisioning_hostgroup.domain.read().name
@@ -323,10 +341,28 @@ def test_positive_auto_provision_host_with_rule(
         delay=20,
     )
     discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
-    discovered_host.hostgroup = provisioning_hostgroup
-    discovered_host.location = provisioning_hostgroup.location[0]
-    discovered_host.organization = provisioning_hostgroup.organization[0]
-    discovered_host.build = True
+    if is_open('SAT-33477') and (
+        sat.cli.DiscoveredHost.list(
+            {
+                'organization-id': module_org.id,
+                'location-id': module_location.id,
+            }
+        )
+        == []
+    ):
+        with sat.ui_session() as temp_session:
+            temp_session.organization.select(org_name='Any organization')
+            temp_session.location.select(loc_name='Any location')
+            temp_session.discoveredhosts.apply_action(
+                'Assign Organization',
+                discovered_host.name,
+                values=dict(organization=module_org.name),
+            )
+            temp_session.discoveredhosts.apply_action(
+                'Assign Location',
+                discovered_host.name,
+                values=dict(location=module_location.name),
+            )
 
     discovered_host_name = discovered_host.name
     domain_name = provisioning_hostgroup.domain.read().name


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20638

### Problem Statement
Discovery provisioning tests are failing because `dhcpd` is not restarted after building PXE templates in the `module_discovery_sat` fixture. Without the restart, dhcpd serves old cached configuration.

### Solution
Added `dhcpd` service restart in the `module_discovery_sat` fixture after all discovery configuration is complete. This ensures dhcpd picks up the updated PXE boot configuration and serves the correct discovery boot files to VMs.

### Related Issues
Fixes: [SAT-39920](https://issues.redhat.com/browse/SAT-39920)


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Adjust discovery host provisioning tests and fixtures to handle discovery-specific preconditions and avoid relying on deprecated host assignment paths.

Bug Fixes:
- Work around SAT-33477 in UI discovery provisioning tests by ensuring discovered hosts are assigned to the correct organization and location when they are missing from the CLI list.
- Prevent stale discovered hosts from interfering with discovery provisioning by clearing existing discovered hosts in the provisioning fixture for discovery runs.

Tests:
- Update UI discovery provisioning scenarios to use conditional organization/location assignment instead of directly setting provisioning attributes on discovered hosts.
- Simplify API discovery reboot tests by removing unnecessary hostgroup and provisioning attribute assignments that are no longer required for the scenario.