### PR TITLE
[6.19.z] Add check for insights-client status 

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -14,6 +14,9 @@ def enable_insights(host, satellite, org, activation_key):
         org=org,
         rhel_distro=f"rhel{host.os_version.major}",
     )
+    result = host.execute('insights-client --status')
+    assert result.status == 0, f'insights-client not registered on {host.hostname}: {result.stdout}'
+    assert "Insights API confirms registration" in result.stdout
     # Sync inventory if using hosted Insights
     if not satellite.iop_enabled:
         satellite.generate_inventory_report(org)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21111

SAT-42272 

Add assertion for checking insights-client status after registering host.

## Summary by Sourcery

Tests:
- Add assertions in the rh_cloud insights enablement flow to verify insights-client status and confirmed registration output after host registration.