### PR TITLE
RHEL_10_extensions_repos_in_recommended_repo

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -78,6 +78,13 @@ def module_sca_manifest_org(module_org, module_sca_manifest, module_target_sat):
     return module_org
 
 
+@pytest.fixture(scope='module')
+def module_sca_multiarch_manifest_org(module_org, module_sca_multiarch_manifest, module_target_sat):
+    """Creates an organization and uploads an SCA mode multiarch manifest generated with manifester"""
+    module_target_sat.upload_manifest(module_org.id, module_sca_multiarch_manifest.content)
+    return module_org
+
+
 @pytest.fixture(scope='class')
 def class_sca_manifest_org(class_org, class_sca_manifest, class_target_sat):
     """Creates an organization and uploads an SCA mode manifest generated with manifester"""
@@ -149,6 +156,14 @@ def module_sca_manifest():
     """Yields a manifest in Simple Content Access mode with subscriptions determined by the
     `manifest_category.golden_ticket` setting in conf/manifest.yaml."""
     with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='module')
+def module_sca_multiarch_manifest():
+    """Yields a manifest in Simple Content Access mode with multiarchitecture subscriptions
+    determined by the `manifest_category.arm_testing_manifest` setting in conf/manifest.yaml."""
+    with Manifester(manifest_category=settings.manifest.arm_testing_manifest) as manifest:
         yield manifest
 
 

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -356,9 +356,6 @@ RECOMMENDED_REPOS = [
     'satellite-client-6-for-rhel-10-x86_64-rpms',
     'satellite-client-6-for-rhel-9-x86_64-rpms',
     'satellite-client-6-for-rhel-8-x86_64-rpms',
-    'rhel-7-server-els-rpms',
-    'rhel-7-server-els-optional-rpms',
-    'rhel-7-server-els-satellite-client-6-rpms',
 ]
 RECOMMENDED_KICKSTART_REPOS = [
     'rhel-10-for-x86_64-appstream-kickstart',

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -343,6 +343,8 @@ RECOMMENDED_REPOS = [
     'rhel-10-for-x86_64-appstream-rpms',
     'rhel-10-for-x86_64-baseos-eus-rpms',
     'rhel-10-for-x86_64-appstream-eus-rpms',
+    'rhel-10-for-x86_64-extensions-rpms',
+    'rhel-10-for-aarch64-extensions-rpms',
     'rhel-9-for-x86_64-baseos-rpms',
     'rhel-9-for-x86_64-appstream-rpms',
     'rhel-9-for-x86_64-baseos-eus-rpms',
@@ -354,6 +356,9 @@ RECOMMENDED_REPOS = [
     'satellite-client-6-for-rhel-10-x86_64-rpms',
     'satellite-client-6-for-rhel-9-x86_64-rpms',
     'satellite-client-6-for-rhel-8-x86_64-rpms',
+    'rhel-7-server-els-rpms',
+    'rhel-7-server-els-optional-rpms',
+    'rhel-7-server-els-satellite-client-6-rpms',
 ]
 RECOMMENDED_KICKSTART_REPOS = [
     'rhel-10-for-x86_64-appstream-kickstart',

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -859,7 +859,7 @@ def test_positive_delete_rhel_repo(session, module_sca_manifest_org, target_sat)
     ],
     ids=['Kickstart', 'RPM'],
 )
-def test_recommended_repos(session, filter_type, expected_repos, module_sca_manifest_org):
+def test_recommended_repos(session, filter_type, expected_repos, module_sca_multiarch_manifest_org):
     """list recommended repositories using On/Off 'Recommended Repositories' toggle.
 
     :id: 1ae197d5-88ba-4bb1-8ecf-4da5013403d7
@@ -872,12 +872,14 @@ def test_recommended_repos(session, filter_type, expected_repos, module_sca_mani
     :Verifies: SAT-29446, SAT-29448, SAT-37160
     """
     with session:
-        session.organization.select(module_sca_manifest_org.name)
+        session.organization.select(module_sca_multiarch_manifest_org.name)
         rrepos_on = session.redhatrepository.read(recommended_repo='on', filter_type=filter_type)
         v = get_sat_version()
 
         displayed_repos = [repo['label'] for repo in rrepos_on]
-        assert all(repo in displayed_repos for repo in expected_repos)
+        assert len(displayed_repos) > len(expected_repos)
+        for repo in expected_repos:
+            assert repo in displayed_repos
         if filter_type == 'RPM':
             for repo in VERSIONED_REPOS:
                 assert repo.format(f'{v.major}.{v.minor}') in displayed_repos


### PR DESCRIPTION
### Problem Statement
https://redhat.atlassian.net/browse/SAT-42053

### Solution
Add RHEL 10 Extensions CDN repos to RECOMMENDED_REPOS: rhel-10-for-x86_64-extensions-rpms and rhel-10-for-aarch64-extensions-rpms, grouped with the other RHEL 10 entries.

### Note: 
This test cannot pass in stream until 6.20 GA.

### Related Issues
N/A

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_repository.py -k 'test_recommended_repos'
Katello:
    katello: 11680
```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Expand the set of recommended repositories to cover additional RHEL 10 extensions and RHEL 7 ELS content.

Enhancements:
- Include RHEL 10 x86_64 and aarch64 extensions CDN repositories in the recommended repositories list.
- Add RHEL 7 ELS base, optional, and Satellite client repositories to the recommended repositories list.