### PR TITLE
AzureRM E2E: Fix false negatives on VM delete by polling find_vms (Automation Failure)

### DIFF
--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -143,21 +143,24 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
                 with sat_azure.api_factory.satellite_setting('destroy_vm_on_host_delete=True'):
                     session.host_new.delete(fqdn)
                 wait_for(
-                    lambda: session.host_new.search(fqdn)[0].get('Name') == 'No Results',
-                    timeout=300,
-                    delay=10,
+                    lambda: (
+                        session.host_new.search(fqdn)[0].get('Name') == 'No Results'
+                        and not azurermclient.find_vms(name=hostname.lower())
+                    ),
+                    timeout=900,
+                    delay=15,
                 )
-
-                # AzureRm Cloud assertion
-                assert not azurecloud_vm.exists
 
         except Exception as error:
             azure_vm = sat_azure.api.Host().search(query={'search': f'name={fqdn}'})
             if azure_vm:
                 azure_vm[0].delete(synchronous=False)
-            azurecloud_vm = azurermclient.get_vm(name=hostname.lower())
-            if azurecloud_vm.exists:
-                azurecloud_vm.delete()
+            try:
+                matching_vms = azurermclient.find_vms(name=hostname.lower())
+                if matching_vms:
+                    matching_vms[0].delete()
+            except Exception:
+                pass
             raise error
 
 

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -147,8 +147,8 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
                         session.host_new.search(fqdn)[0].get('Name') == 'No Results'
                         and not azurermclient.find_vms(name=hostname.lower())
                     ),
-                    timeout=900,
-                    delay=15,
+                    timeout=300,
+                    delay=10,
                 )
 
         except Exception as error:


### PR DESCRIPTION
### Problem Statement
End-to-end AzureRM host provisioning test intermittently fails during deletion verification because the existence check raises on “not found,” causing false negatives

### Solution
Replace brittle VM deletion assertion using azurecloud_vm.exists with a resilient poll based on azurermclient.find_vms(name=...), which returns an empty list when the VM is gone and never raises.
Make teardown cleanup best-effort (wrap Azure lookups/deletes in try/except) so cleanup errors don’t mask root failures.

### Rationale
wrapanapi.entities.vm.Vm.exists only treats NotFoundError as absence, but the Azure path raises VMInstanceNotFound/Azure ResourceNotFoundError on 404, which bubbles out and fails the test despite successful deletion. Polling find_vms avoids exception paths and handles Azure’s eventual consistency.

## Summary by Sourcery

Strengthen AzureRM end-to-end host provisioning test deletion verification and make teardown cleanup best-effort to reduce flaky failures.

Tests:
- Update AzureRM host deletion wait condition to also poll Azure for absence of the VM instead of asserting on azurecloud_vm.exists.
- Increase deletion verification timeout and interval to accommodate Azure eventual consistency.
- Wrap Azure VM lookup/deletion in teardown in a best-effort try/except block so cleanup issues do not mask the original test failure.