### PR TITLE
verify custom repo sync succeeds with upstream username only

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -56,6 +56,9 @@ REPOS:
   # which are essentially required for generating swid tags in RHEL8 content host.
   SWID_TOOLS_REPO: replace-with-swid-tools-repo
   FAKE_REPO_ZOO3: replace-with-zoo-fedorapeople-repo
+  # Custom yum upstream for UI tests: HTTP basic auth with username (token) only, no password.
+  USERNAME_ONLY_UPSTREAM_URL: replace-with-username-only-upstream-url
+  USERNAME_ONLY_UPSTREAM_USERNAME: replace-with-username-only-upstream-username
   MOCK_SERVICE_REPO_BASE: replace-with-repo-providing-robttelo-mock-service
   MOCK_SERVICE_REPO:
     RHEL7: "@format {this[repos].MOCK_SERVICE_REPO_BASE}/epel-7-x86_64/"

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -68,9 +68,6 @@ EC2_REGION_CA_CENTRAL_1 = 'ca-central-1'
 
 CONTENT_CREDENTIALS_TYPES = {'gpg': 'GPG Key', 'ssl': 'Certificate'}
 
-# Custom yum upstream for UI tests: HTTP basic auth with username (token) only, no password.
-USERNAME_ONLY_UPSTREAM_URL = 'https://registration-triage.phishme.com/artifactory/triage-rhel9-prod'
-USERNAME_ONLY_UPSTREAM_USERNAME = '7f4fab26704c60bdd7028f5b2c1c4708'
 VIRT_WHO_HYPERVISOR_TYPES = {
     'esx': 'esx',
     'hyperv': 'hyperv',

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -68,6 +68,9 @@ EC2_REGION_CA_CENTRAL_1 = 'ca-central-1'
 
 CONTENT_CREDENTIALS_TYPES = {'gpg': 'GPG Key', 'ssl': 'Certificate'}
 
+# Custom yum upstream for UI tests: HTTP basic auth with username (token) only, no password.
+USERNAME_ONLY_UPSTREAM_URL = 'https://registration-triage.phishme.com/artifactory/triage-rhel9-prod'
+USERNAME_ONLY_UPSTREAM_USERNAME = '7f4fab26704c60bdd7028f5b2c1c4708'
 VIRT_WHO_HYPERVISOR_TYPES = {
     'esx': 'esx',
     'hyperv': 'hyperv',

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -31,8 +31,6 @@ from robottelo.constants import (
     REPOSET,
     SUPPORTED_REPO_CHECKSUMS,
     SYNC_COMPLETE,
-    USERNAME_ONLY_UPSTREAM_URL,
-    USERNAME_ONLY_UPSTREAM_USERNAME,
     VERSIONED_REPOS,
     DataFile,
 )
@@ -577,13 +575,15 @@ def test_positive_sync_custom_repo_username_only_no_password(target_sat, module_
             {
                 'name': repo_name,
                 'repo_type': REPO_TYPE['yum'],
-                'repo_content.upstream_url': USERNAME_ONLY_UPSTREAM_URL,
-                'repo_content.upstream_username': USERNAME_ONLY_UPSTREAM_USERNAME,
+                'repo_content.upstream_url': settings.repos.username_only_upstream_url,
+                'repo_content.upstream_username': settings.repos.username_only_upstream_username,
             },
         )
         assert session.repository.search(module_prod.name, repo_name)[0]['Name'] == repo_name
         repo_values = session.repository.read(module_prod.name, repo_name)
-        assert repo_values['repo_content']['upstream_url'] == USERNAME_ONLY_UPSTREAM_URL
+        assert (
+            repo_values['repo_content']['upstream_url'] == settings.repos.username_only_upstream_url
+        )
         result = session.repository.synchronize(module_prod.name, repo_name)
         assert result['result'] == 'success'
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -552,7 +552,7 @@ def test_positive_sync_custom_repo_username_only_no_password(target_sat, module_
     Pulp/Satellite must allow synchronizing a custom repository whose upstream uses HTTP basic auth
     with a non-empty username and an empty password.
 
-    :id: c3equt2a-8bnf-0e2t-9ofa-5fue1d8blagc
+    :id: 96005f4f-82f7-4a78-8ec7-a25d92831297
 
     :customerscenario: true
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -31,6 +31,8 @@ from robottelo.constants import (
     REPOSET,
     SUPPORTED_REPO_CHECKSUMS,
     SYNC_COMPLETE,
+    USERNAME_ONLY_UPSTREAM_URL,
+    USERNAME_ONLY_UPSTREAM_USERNAME,
     VERSIONED_REPOS,
     DataFile,
 )
@@ -542,6 +544,48 @@ def test_positive_upstream_with_credentials(session, module_prod):
         )
         repo_values = session.repository.read(module_prod.name, repo_name)
         assert not repo_values['repo_content']['upstream_authorization']
+
+
+def test_positive_sync_custom_repo_username_only_no_password(target_sat, module_prod, module_org):
+    """Custom yum repository sync succeeds when upstream requires only a username (no password).
+
+    Pulp/Satellite must allow synchronizing a custom repository whose upstream uses HTTP basic auth
+    with a non-empty username and an empty password.
+
+    :id: c3equt2a-8bnf-0e2t-9ofa-5fue1d8blagc
+
+    :customerscenario: true
+
+    :steps:
+        1. Create a product with a custom yum repository: set upstream URL and upstream username;
+           do not set an upstream password.
+        2. Synchronize the repository.
+
+    :expectedresults:
+        1. Repository is created without validation errors.
+        2. Repository sync completes successfully.
+
+    :CaseImportance: High
+
+    :Verifies: SAT-41022
+    """
+    repo_name = gen_string('alpha')
+    with target_sat.ui_session() as session:
+        session.organization.select(org_name=module_org.name)
+        session.repository.create(
+            module_prod.name,
+            {
+                'name': repo_name,
+                'repo_type': REPO_TYPE['yum'],
+                'repo_content.upstream_url': USERNAME_ONLY_UPSTREAM_URL,
+                'repo_content.upstream_username': USERNAME_ONLY_UPSTREAM_USERNAME,
+            },
+        )
+        assert session.repository.search(module_prod.name, repo_name)[0]['Name'] == repo_name
+        repo_values = session.repository.read(module_prod.name, repo_name)
+        assert repo_values['repo_content']['upstream_url'] == USERNAME_ONLY_UPSTREAM_URL
+        result = session.repository.synchronize(module_prod.name, repo_name)
+        assert result['result'] == 'success'
 
 
 # TODO: un-comment when OSTREE functionality is restored in Satellite 6.11


### PR DESCRIPTION
### Problem Statement
https://redhat.atlassian.net/browse/SAT-41022
Custom repository sync does not work without the upstream password

### Solution
Newly added test will verify the the scenario

### Related Issues
N/A

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_repository.py -k 'test_positive_sync_custom_repo_username_only_no_password'

```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Add a UI test that verifies syncing a custom yum repository succeeds when configured with an upstream URL and username but no password.