### PR TITLE
[6.19.z] Remove Redundant TC of health check - pre upgrade

### DIFF
--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -129,26 +129,6 @@ def test_positive_health_check_by_tags(sat_maintain):
 
 
 @pytest.mark.include_capsule
-def test_positive_health_check_pre_upgrade(sat_maintain):
-    """Verify pre-upgrade health checks
-
-    :id: f52bd43e-79cd-488b-adbb-3c9e5bac32cc
-
-    :parametrized: yes
-
-    :steps:
-        1. Run satellite-maintain health check --tags pre-upgrade
-
-    :expectedresults: Pre-upgrade health checks should pass.
-    """
-    result = sat_maintain.cli.Health.check(
-        options={'tags': 'pre-upgrade', 'whitelist': 'non-rh-packages'}
-    )
-    assert result.status == 0
-    assert 'FAIL' not in result.stdout
-
-
-@pytest.mark.include_capsule
 def test_positive_health_check_server_ping(sat_maintain):
     """Verify server ping check
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21195

### Problem Statement

The testcase test_positive_health_check_pre_upgrade is redundant and the scenario is covered in test_positive_health_check_by_tags

### Solution

Removing testcase as it is redundant.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Delete the test_positive_health_check_pre_upgrade test case since its scenario is covered by test_positive_health_check_by_tags.