### PR TITLE
[6.17.z] Improve parametrization for sat/puppet_sat fixtures in Azure/GCE CR tests

### DIFF
--- a/pytest_fixtures/component/provision_azure.py
+++ b/pytest_fixtures/component/provision_azure.py
@@ -16,9 +16,13 @@ from robottelo.constants import (
 
 
 @pytest.fixture(scope='session')
-def sat_azure(request, session_puppet_enabled_sat, session_target_sat):
-    hosts = {'sat': session_target_sat, 'puppet_sat': session_puppet_enabled_sat}
-    return hosts[request.param]
+def sat_azure(request):
+    host_type = getattr(request, 'param', 'sat')
+    if host_type == 'puppet_sat':
+        infra_sat_host = request.getfixturevalue('session_puppet_enabled_sat')
+    else:
+        infra_sat_host = request.getfixturevalue('session_target_sat')
+    return infra_sat_host
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/provision_gce.py
+++ b/pytest_fixtures/component/provision_gce.py
@@ -19,9 +19,13 @@ from robottelo.exceptions import GCECertNotFoundError
 
 
 @pytest.fixture(scope='session')
-def sat_gce(request, session_puppet_enabled_sat, session_target_sat):
-    hosts = {'sat': session_target_sat, 'puppet_sat': session_puppet_enabled_sat}
-    return hosts[getattr(request, 'param', 'sat')]
+def sat_gce(request):
+    host_type = getattr(request, 'param', 'sat')
+    if host_type == 'puppet_sat':
+        infra_sat_host = request.getfixturevalue('session_puppet_enabled_sat')
+    else:
+        infra_sat_host = request.getfixturevalue('session_target_sat')
+    return infra_sat_host
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21204

### Problem Statement
Currently, sat_azure and sat_gce fixtures checkouts both target_sat and puppet_sat at the same time, so if in case puppet enable step fails for some reason, it fails the entire test execution, where it was suppose to just run target_sat scenario and fail just puppet_sat scenario

### Solution
Improve parametrization for sat/puppet_sat fixtures in Azure/GCE CR tests, so it only needs to spin/call the fixture that the test needs.


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Adjust Azure and GCE Satellite fixtures to only provision the requested Satellite host type per test, avoiding unnecessary dependency on both target and puppet-enabled instances.

Enhancements:
- Refine sat_azure fixture to lazily request either target or puppet-enabled Satellite host based on the test parameter.
- Refine sat_gce fixture to lazily request either target or puppet-enabled Satellite host based on the test parameter.