### PR TITLE
Coverage for SAT-42501

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -632,6 +632,8 @@ def test_positive_iop_cve_display_when_repos_exceeding_api_page_limit(
         2. VMaaS correctly paginates through all Katello API pages
 
     :customerscenario: true
+
+    :Verifies: SAT-42501
     """
     satellite = module_target_sat_insights
     hostname = vulnerable_rhel_host.hostname

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -530,3 +530,130 @@ def test_positive_bulk_disable_vulnerability_analysis(
         assert table_data[0]['Total CVEs'] == 'Analysis disabled', (
             f"Expected 'Analysis disabled' but got '{table_data[0]['Total CVEs']}'"
         )
+
+
+@pytest.fixture(scope='module')
+def repos_exceeding_page_limit(
+    module_target_sat_insights, rhcloud_manifest_org, setup_content_for_iop
+):
+    """Enable and sync Red Hat repos to exceed the Katello API page limit.
+
+    VMaaS only processes repos that have been synced in Katello (custom
+    repos with no real content are ignored). This fixture enables and
+    syncs RHEL 9 and RHEL 8 repos with multiple release versions to
+    push the total synced repo count beyond the default API page limit
+    of 20.
+    """
+
+    satellite = module_target_sat_insights
+    org = rhcloud_manifest_org
+
+    # Enable and sync RHEL 9 and RHEL 8 repos with multiple release versions
+    repo_configs = [
+        ('rhel9', ['9.0', '9.1', '9.2', '9.3', '9.4', '9.5']),
+        ('rhel8', ['8.6', '8.7', '8.8', '8.9', '8.10']),
+    ]
+    sync_tasks = []
+    for rhel_ver, release_versions in repo_configs:
+        for releasever in release_versions:
+            for reposet_key, repo_name_tpl in [
+                (
+                    f'{rhel_ver}_bos',
+                    f'Red Hat Enterprise Linux {rhel_ver[-1]} for x86_64 - BaseOS RPMs {{}}',
+                ),
+                (
+                    f'{rhel_ver}_aps',
+                    f'Red Hat Enterprise Linux {rhel_ver[-1]} for x86_64 - AppStream RPMs {{}}',
+                ),
+            ]:
+                rh_repo_id = satellite.api_factory.enable_rhrepo_and_fetchid(
+                    basearch=constants.DEFAULT_ARCHITECTURE,
+                    org_id=org.id,
+                    product=constants.PRDS[rhel_ver],
+                    repo=repo_name_tpl.format(releasever),
+                    reposet=constants.REPOSET[reposet_key],
+                    releasever=releasever,
+                )
+                rh_repo = satellite.api.Repository(id=rh_repo_id).read()
+                task = rh_repo.sync(synchronous=False)
+                sync_tasks.append(task['id'])
+
+    # Wait for all repo syncs to complete (accept 'warning' for Pulp base_path conflicts)
+    for task_id in sync_tasks:
+        satellite.wait_for_tasks(
+            search_query=f'id = {task_id}',
+            poll_timeout=2500,
+            must_succeed=False,
+        )
+        task_status = satellite.api.ForemanTask(id=task_id).poll(must_succeed=False)
+        assert task_status['result'] in ('success', 'warning')
+
+    # Re-trigger VMaaS sync
+    assert satellite.execute('systemctl start iop-service-vuln-vmaas-sync').status == 0
+
+
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+def test_positive_iop_cve_display_when_repos_exceeding_api_page_limit(
+    vulnerable_rhel_host,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+    repos_exceeding_page_limit,
+):
+    """Verify vulnerabilities are displayed when Satellite has more than 20 synced repos.
+
+    VMaaS reposync used the default page limit of 20 when querying
+    GET /katello/api/repositories, causing repositories beyond the
+    first page to be excluded from vulnerability scanning. Hosts with
+    errata from those missed repos would show no vulnerabilities
+    despite having installable errata.
+
+    This test syncs 20+ real Red Hat repos (RHEL 10, 9, 8 with multiple
+    release versions) to exceed the API page limit. VMaaS only processes
+    synced repos, so custom repos with dummy URLs are not sufficient.
+    With the bug present, VMaaS would only process the first 20 synced repos.
+    With the bug fixed, VMaaS paginates through all pages and syncs all repos.
+
+    :id: acc1e3e1-b41a-4344-8818-0b38e59ed2be
+
+    :setup:
+        1. IOP-enabled Satellite with manifest
+        2. RHEL 10 BaseOS and AppStream repos synced
+        3. RHEL 9 and RHEL 8 repos with multiple release versions synced
+
+    :steps:
+        1. Verify total synced repository count exceeds 20
+        2. Register a host and install a vulnerable package (mariadb)
+        3. Check host vulnerabilities in Satellite UI
+
+    :expectedresults:
+        1. Host displays expected CVE despite total repos exceeding page limit
+        2. VMaaS correctly paginates through all Katello API pages
+
+    :customerscenario: true
+    """
+    satellite = module_target_sat_insights
+    hostname = vulnerable_rhel_host.hostname
+
+    # Verify total repo count exceeds the default page limit
+    repos = satellite.api.Repository(organization=rhcloud_manifest_org).search(
+        query={'per_page': '100'}
+    )
+    assert len(repos) > 20, (
+        f'Expected more than 20 repos, got {len(repos)}. '
+        f'Test requires > 20 repos to validate VMaaS pagination.'
+    )
+
+    with satellite.ui_session() as session:
+        session.organization.select(org_name=rhcloud_manifest_org.name)
+
+        # Verify the CVE appears on the Vulnerabilities page and the host is affected
+        affected_hosts = session.cloudvulnerability.get_affected_hosts_by_cve(
+            constants.RHEL10_VULNERABILITY_CVE_ID
+        )
+        assert any(host['Name'] == hostname for host in affected_hosts), (
+            f'Host {hostname} not found in affected hosts for '
+            f'CVE {constants.RHEL10_VULNERABILITY_CVE_ID}. '
+            f'VMaaS may not have synced repos beyond the first API page (20 repos).'
+        )


### PR DESCRIPTION
### Problem Statement                                                                                                                                                        
On IOP-enabled Satellite with more than 20 synced repositories, VMaaS reposync only processed the first page of the Katello repositories API response (default page size of 20), causing repositories beyond the first page to be excluded from vulnerability scanning. 
Hosts with errata from those missed repos would show no vulnerabilities despite having installable errata.                                                                                  
                                                                                                                                                          
### Solution
Added a new test `test_positive_iop_cve_display_when_repos_exceeding_api_page_limit` that:                                                                
  - Enables and syncs 20+ Red Hat repos (RHEL 10, 9, 8 with multiple release versions) to exceed the default API page limit of 20
  - Re-triggers VMaaS reposync after all repos are synced                                                                                                 
  - Verifies the total repo count exceeds 20                                                                                                           
  - Registers a RHEL 10 host with a vulnerable mariadb package                                                                                            
  - Confirms the expected CVE is displayed on the Vulnerabilities page                                                                                    
                                                                                                                                                          
### PRT Example                                                                                                                                             
                   
<img width="493" height="71" alt="Screenshot 2026-04-08 at 18 24 47" src="https://github.com/user-attachments/assets/dfd771dd-f6a4-4da0-9948-bf59d0033af2" />

```                                                                                                                                       
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_positive_iop_cve_display_when_repos_exceeding_api_page_limit
```