### PR TITLE
SAT-42501 coverage followup

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -548,6 +548,22 @@ def repos_exceeding_page_limit(
     satellite = module_target_sat_insights
     org = rhcloud_manifest_org
 
+    # Create 20 custom repos that sort before "Red Hat..." to fill API page 1.
+    # These don't register in VMaaS (no real content), but they push
+    # Red Hat repos to page 2+ of the Katello API response.
+    custom_product = satellite.api.Product(
+        organization=org,
+        name='AAA Pagination Test Product',
+    ).create()
+
+    for i in range(20):
+        satellite.api.Repository(
+            product=custom_product,
+            name=f'AAA_pagination_repo_{i:02d}',
+            url=f'http://example.com/repo/{i}',
+            content_type='yum',
+        ).create()
+
     # Enable and sync RHEL 9 and RHEL 8 repos with multiple release versions
     repo_configs = [
         ('rhel9', ['9.0', '9.1', '9.2', '9.3', '9.4', '9.5']),
@@ -590,6 +606,10 @@ def repos_exceeding_page_limit(
 
     # Re-trigger VMaaS sync
     assert satellite.execute('systemctl start iop-service-vuln-vmaas-sync').status == 0
+
+    yield
+
+    custom_product.delete()
 
 
 @pytest.mark.no_containers
@@ -645,6 +665,33 @@ def test_positive_iop_cve_display_when_repos_exceeding_api_page_limit(
     assert len(repos) > 20, (
         f'Expected more than 20 repos, got {len(repos)}. '
         f'Test requires > 20 repos to validate VMaaS pagination.'
+    )
+
+    # Verify the RHEL 10 repos (containing the vulnerable package) are beyond page 1.
+    # Custom repos named AAA_* fill page 1, pushing Red Hat repos to page 2+.
+    page1_repos = satellite.api.Repository(organization=rhcloud_manifest_org).search(
+        query={'per_page': '20', 'page': '1'}
+    )
+    rhel10_on_page1 = [r for r in page1_repos if 'Enterprise Linux 10' in r.name]
+    assert not rhel10_on_page1, (
+        f'RHEL 10 repos must be on page 2+ to test pagination fix, '
+        f'but found on page 1: {[r.name for r in rhel10_on_page1]}'
+    )
+
+    # Verify VMaaS synced all repos (not capped at 20 due to pagination bug).
+    # This directly proves the fix: without pagination, VMaaS DB would have <= 20 repos.
+    pg_pass = satellite.execute(
+        'podman exec iop-service-vmaas-reposcan printenv POSTGRESQL_PASSWORD'
+    ).stdout.strip()
+    result = satellite.execute(
+        f'podman exec iop-service-vmaas-reposcan bash -c '
+        f'"PGPASSWORD={pg_pass} psql -U vmaas_admin -d vmaas_db -t -A '
+        f"-c 'SELECT COUNT(*) FROM repo;'\""
+    )
+    vmaas_repo_count = int(result.stdout.strip())
+    assert vmaas_repo_count > 20, (
+        f'VMaaS synced only {vmaas_repo_count} repos, expected > 20. '
+        f'This indicates VMaaS did not paginate beyond the first API page.'
     )
 
     with satellite.ui_session() as session:


### PR DESCRIPTION
### Problem Statement
Follow-up to SatelliteQE/robottelo#21236. Jeremy's after-merge review identified that the original test didn't verify the CVE-containing repo was actually on page 2+ of the Katello API response — meaning the test could pass even if VMaaS didn't paginate.

### Solution
Strengthened the test with two additional assertions:                                                                                                                                                         
   
  1. Page position check — Creates 20 custom repos (named AAA_* to sort first alphabetically) that fill page 1 of the Katello API response, pushing all Red Hat repos (including RHEL 10 with CVE data) to page 
  2+. Asserts RHEL 10 repos are not on page 1.                                                                                                                                         
  2. VMaaS DB count check — Queries the VMaaS database directly to verify it synced more than 20 repos. Without the pagination fix, VMaaS would only process page 1 (20 custom repos that don't register) and   
  miss all Red Hat repos on subsequent pages.                                                                                                                                                                   
                                         
  Together with the existing CVE visibility check, the test now has three layers of verification:                                                                                                               
  - RHEL 10 repos are beyond page 1 (pagination is required)                                                                                                                           
  - VMaaS DB has >20 repos (pagination happened)                                                                                                                                                                
  - CVE is displayed for the host (end-to-end works)

### PRT test Cases example
<img width="485" height="91" alt="image" src="https://github.com/user-attachments/assets/5b17cab8-a0f5-4020-bd0a-5ca5b6ab7b2d" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_positive_iop_cve_display_when_repos_exceeding_api_page_limit
```