### PR TITLE
[6.18.z] Hotfix MCP automation

### DIFF
--- a/tests/foreman/sys/test_mcp.py
+++ b/tests/foreman/sys/test_mcp.py
@@ -25,10 +25,8 @@ from robottelo.enums import NetworkType
     'mcp_server',
     [
         'module_target_sat_foreman_mcp',
-        'module_target_sat_foreman_mcp_stage',
-        'module_target_sat_foreman_mcp_downstream',
     ],
-    ids=['upstream', 'stage', 'downstream'],
+    ids=['upstream'],
 )
 @pytest.mark.skipif(
     settings.server.network_type == NetworkType.IPV6,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21246

### Problem Statement
There is a high percentage of failing tests in MCP component. The PASS rate is only at 44%.
```
20:13:37  [gw1] [ 11%] PASSED tests/foreman/sys/test_mcp.py::test_positive_call_mcp_server[upstream] 
20:13:55  tests/foreman/sys/test_mcp.py::test_positive_call_mcp_server[stage] 
20:13:55  [gw1] [ 22%] PASSED tests/foreman/sys/test_mcp.py::test_positive_call_mcp_server[stage] 
20:14:22  tests/foreman/sys/test_mcp.py::test_positive_call_mcp_server[downstream] 
20:14:22  [gw1] [ 33%] PASSED tests/foreman/sys/test_mcp.py::test_positive_call_mcp_server[downstream] 
20:14:22  tests/foreman/sys/test_mcp.py::test_negative_call_mcp_server 
20:14:22  [gw1] [ 44%] PASSED tests/foreman/sys/test_mcp.py::test_negative_call_mcp_server 
20:14:28  tests/foreman/sys/test_mcp.py::test_positive_mcp_user_view_permissions[host_viewer_user_password] 
20:14:28  [gw1] [ 55%] FAILED tests/foreman/sys/test_mcp.py::test_positive_mcp_user_view_permissions[host_viewer_user_password] 
20:14:30  tests/foreman/sys/test_mcp.py::test_positive_mcp_user_view_permissions[host_viewer_user_token] 
20:14:30  [gw1] [ 66%] FAILED tests/foreman/sys/test_mcp.py::test_positive_mcp_user_view_permissions[host_viewer_user_token] 
20:14:33  tests/foreman/sys/test_mcp.py::test_positive_mcp_user_view_permissions[domain_viewer_user_password] 
20:14:33  [gw1] [ 77%] FAILED tests/foreman/sys/test_mcp.py::test_positive_mcp_user_view_permissions[domain_viewer_user_password] 
20:14:35  tests/foreman/sys/test_mcp.py::test_positive_mcp_user_view_permissions[domain_viewer_user_token] 
20:14:35  [gw1] [ 88%] FAILED tests/foreman/sys/test_mcp.py::test_positive_mcp_user_view_permissions[domain_viewer_user_token] 
20:19:27  tests/foreman/sys/test_mcp.py::test_host_incremental_update 
20:22:48  [gw1] [100%] FAILED tests/foreman/sys/test_mcp.py::test_host_incremental_update 
```

### Solution
Hotfix only: Remove setting up multiple MCP servers on the same machine so that there is 100% pass rate.
In follow-up PR(s) new implementation of MCP server fixture will be introduced so that different robottelo branches will test different container images:
* `master` -> quay.io, tag: `latest`  (upstream)
* `6.*.z` -> registry.stage.redhat.io, tag: `6.*` (stage)
* not tested -> registry.redhat.io (downstream) 


### Related Issues
[SAT-44131](https://redhat.atlassian.net/browse/SAT-44131)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Update MCP system tests to no longer run against stage and downstream MCP server fixtures, leaving only the upstream configuration covered.