### PR TITLE
[6.18.z] Sync package versions from master branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,18 @@
 # Version updates managed by dependabot
 
 apypie==0.7.1
-broker[satlab,docker,ssh2_python]==0.8.4
-cryptography==46.0.5
-deepdiff==8.6.1
-dynaconf[vault]==3.2.11
-fastmcp==2.13.1
-fauxfactory==4.2.0
+broker[satlab,docker,ssh2_python]==0.8.5
+cryptography==46.0.7
+deepdiff==9.0.0
+dynaconf[vault]==3.2.13
+fastmcp==3.2.2
+fauxfactory==4.2.1
 jira==3.10.5
 jinja2==3.1.6
 manifester==0.2.14
 navmazing==1.3.0
-productmd==1.49
+productmd==1.50
+PyGithub==2.9.0
 pyotp==2.9.0
 python-box==7.4.1
 pytest==9.0.3


### PR DESCRIPTION
## Summary
- Sync package versions from master branch to 6.18.z
- Keep airgun and nailgun pointing to 6.18.z branch

## Updated packages
- broker: 0.8.4 → 0.8.5
- cryptography: 46.0.5 → 46.0.7
- deepdiff: 8.6.1 → 9.0.0
- dynaconf: 3.2.11 → 3.2.13
- fastmcp: 2.13.1 → 3.2.2
- fauxfactory: 4.2.0 → 4.2.1
- productmd: 1.49 → 1.50
- Added PyGithub==2.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)