### PR TITLE
[6.17.z] Sync package versions from master branch

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,7 +2,7 @@
 pytest-cov==7.1.0
 redis==7.4.0
 pre-commit==4.5.1
-ruff==0.15.7
+ruff==0.15.9
 
 # For generating documentation.
 sphinx==9.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,22 @@
 # Version updates managed by dependabot
 
 apypie==0.7.1
-broker[satlab,docker,ssh2_python]==0.8.4
-cryptography==46.0.5
-deepdiff==8.6.1
-dynaconf[vault]==3.2.11
-fauxfactory==3.1.2
+broker[satlab,docker,ssh2_python]==0.8.5
+cryptography==46.0.7
+deepdiff==9.0.0
+dynaconf[vault]==3.2.13
+fastmcp==3.2.2
+fauxfactory==4.2.1
 jira==3.10.5
 jinja2==3.1.6
 manifester==0.2.14
 navmazing==1.3.0
-productmd==1.49
+productmd==1.50
+PyGithub==2.9.0
 pyotp==2.9.0
-python-box==7.3.2
-pytest==8.4.1
+python-box==7.4.1
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-order==1.3.0
 pytest-services==2.2.2
 pytest-mock==3.15.1


### PR DESCRIPTION
## Summary
- Updated package versions in requirements.txt and requirements-optional.txt to match master branch
- Preserved nailgun and airgun on 6.17.z branch as required for this maintenance branch

## Key Changes
**requirements.txt updates:**
- broker: 0.8.4 → 0.8.5
- cryptography: 46.0.5 → 46.0.7
- deepdiff: 8.6.1 → 9.0.0
- dynaconf: 3.2.11 → 3.2.13
- fauxfactory: 3.1.2 → 4.2.1
- productmd: 1.49 → 1.50
- python-box: 7.3.2 → 7.4.1
- pytest: 8.4.1 → 9.0.3

**New packages added:**
- fastmcp==3.2.2
- PyGithub==2.9.0
- pytest-asyncio==1.3.0

**requirements-optional.txt updates:**
- ruff: 0.15.7 → 0.15.9

**Preserved (unchanged):**
- airgun @ 6.17.z
- nailgun @ 6.17.z

🤖 Generated with [Claude Code](https://claude.com/claude-code)