### PR TITLE
Adding pytest-reportlog plugin for live logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pytest-order==1.3.0
 pytest-services==2.2.2
 pytest-mock==3.15.1
 pytest-reportportal==5.6.6
+pytest-reportlog==1.0.0
 pytest-xdist==3.6.1
 pytest-fixturecollection==0.1.2
 pytest-ibutsu==3.1.6


### PR DESCRIPTION
### Problem Statement

Need` pytest-reportlog `plugin for the live logging in more readable format(CI's internal use)

### Solution

Added `pytest-reportlog: 1.0.0` in the requirements.txt

### Related Issues

SAT-43046

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->