### PR TITLE
authentication: update message for expired hammer session

### DIFF
--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -23,6 +23,7 @@ from robottelo.exceptions import CLIReturnCodeError
 
 LOGEDIN_MSG = "Session exists, currently logged in as '{0}'"
 NOTCONF_MSG = "Credentials are not configured."
+ACCESS_DENIED_MSG = "Access denied"
 password = gen_string('alpha')
 
 
@@ -58,43 +59,45 @@ def non_admin_user(module_target_sat):
     return user
 
 
-def test_positive_create_session(admin_user, target_sat):
-    """Check if user stays authenticated with session enabled
+@pytest.mark.parametrize('setting_update', ['idle_timeout=1'], indirect=True)
+def test_positive_create_session(admin_user, target_sat, setting_update):
+    """Check if user stays authenticated with sessions enabled.
+    Check that user doesn't stay authenticated after the session expires.
 
     :id: fcee7f5f-1040-41a9-bf17-6d0c24a93e22
 
-    :BlockedBy: SAT-38951
+    :Verifies: SAT-38951
+
+    :setup:
+
+        1. Set short session idle timeout
 
     :steps:
 
-        1. Set use_sessions, set short expiration time
+        1. Enable sessions in hammer config file
         2. Authenticate, assert credentials are not demanded
            on next command run
-        3. Wait until session expires, assert credentials
-           are required
+        3. Wait until session expires, run the command again,
+           assert the command execution has been denied
+           and the user is no longer authenticated, i.e., the session user is empty
 
     :expectedresults: The session is successfully created and
         expires after specified time
     """
-    try:
-        idle_timeout = target_sat.cli.Settings.list({'search': 'name=idle_timeout'})[0]['value']
-        target_sat.cli.Settings.set({'name': 'idle_timeout', 'value': 1})
-        result = configure_sessions(target_sat)
-        assert result == 0, 'Failed to configure hammer sessions'
-        target_sat.cli.AuthLogin.basic({'username': admin_user['login'], 'password': password})
-        result = target_sat.cli.Auth.with_user().status()
-        assert LOGEDIN_MSG.format(admin_user['login']) in result[0]['message']
-        # list organizations without supplying credentials
-        assert target_sat.cli.Org.with_user().list()
-        # wait until session expires
-        sleep(70)
-        with pytest.raises(CLIReturnCodeError):
-            target_sat.cli.Org.with_user().list()
-        result = target_sat.cli.Auth.with_user().status()
-        assert NOTCONF_MSG in result[0]['message']
-    finally:
-        # reset timeout to default
-        target_sat.cli.Settings.set({'name': 'idle_timeout', 'value': f'{idle_timeout}'})
+    result = configure_sessions(target_sat)
+    assert result == 0, 'Failed to configure hammer sessions'
+    target_sat.cli.AuthLogin.basic({'username': admin_user['login'], 'password': password})
+    result = target_sat.cli.Auth.with_user().status()
+    assert LOGEDIN_MSG.format(admin_user['login']) in result[0]['message']
+    # list organizations without explicitly supplying credentials
+    assert target_sat.cli.Org.with_user().list()
+    # wait until session expires and try to list organizations again
+    sleep(70)
+    with pytest.raises(CLIReturnCodeError) as err:
+        target_sat.cli.Org.with_user().list()
+    assert ACCESS_DENIED_MSG in str(err.value)
+    result = target_sat.cli.Auth.with_user().status()
+    assert LOGEDIN_MSG.format('') in result[0]['message']
 
 
 @pytest.mark.upgrade


### PR DESCRIPTION
### Problem Statement

Fix for test `tests.foreman.cli.test_auth::test_positive_create_session`.


### Solution

The message for expired hammer session has been updated.

Additional changes:
- idle timeout setting is now handled via `setting_update` marker
  instead of try-finally block
- additional assert to check the error message of failed command execution
- test description updated to reflect current state


### Related Issues

Bug https://redhat.atlassian.net/browse/SAT-38951


### PRT
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_auth.py -k test_positive_create_session
```

## Summary by Sourcery

Update hammer session expiration test to validate new access-denied behavior and rely on a setting marker for idle timeout management.

Bug Fixes:
- Adjust the expired hammer session test to match the updated error message and post-expiration authentication state.

Enhancements:
- Refine the session expiration test flow to assert explicit access-denied errors and use a parameterized idle_timeout setting instead of manual setup/teardown.

Tests:
- Extend the positive session creation test to also verify behavior after session expiry, including error messaging and session user state, and update its documentation metadata.

## Summary by Sourcery

Align hammer CLI session authentication test with new behavior for expired sessions and centralized idle timeout configuration.

Bug Fixes:
- Update the expired hammer session test to expect an access-denied error and cleared session user after timeout.

Enhancements:
- Use a parameterized idle_timeout setting via a test marker instead of manual setup/teardown and improve test description clarity.

Tests:
- Refine the positive session creation test flow to cover post-expiration behavior, including asserting access-denied errors and updated status messaging.