### PR TITLE
Fix test to call new Red Hat Light speed instead of old Insights view. 

### DIFF
--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -311,16 +311,21 @@ def test_iop_negative_rhcloud_inventory_upload_not_displayed(module_target_sat_i
     :id: 84023ae9-7bc4-4332-9aaf-749d6c48c2d2
 
     :steps:
-        1. Configure Satellite with IOP
-        2. Check that 'Inventory Upload' is not visible under 'Red Hat Lightspeed'.
+        1. Configure Satellite to use local Insights advisor engine.
+        2. Navigate to the Insights Recommendations page.
+        3. Try to navigate to Red Hat Lightspeed > Inventory Upload from the navigation menu.
 
     :expectedresults:
         1. "Inventory Upload" is not visible under "Red Hat Lightspeed".
+
+    :CaseImportance: Medium
+
+    :CaseAutomation: Automated
     """
     with module_target_sat_insights.ui_session() as session:
-        view = session.dashboard.navigate_to(session.dashboard, 'All')
+        session.recommendationstab.navigate_to(session.recommendationstab, 'All Recommendations')
         with pytest.raises(Exception, match='not found in navigation tree'):
-            view.menu.select('Red Hat Lightspeed', 'Inventory Upload')
+            session.cloudinventory.navigate_to(session.cloudinventory, 'All')
 
 
 @pytest.mark.e2e

--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -312,7 +312,7 @@ def test_iop_negative_rhcloud_inventory_upload_not_displayed(module_target_sat_i
 
     :steps:
         1. Configure Satellite to use local Insights advisor engine.
-        2. Navigate to the Insights Recommendations page.
+        2. Navigate to the Red Hat Lightspeed Recommendations page.
         3. Try to navigate to Red Hat Lightspeed > Inventory Upload from the navigation menu.
 
     :expectedresults:


### PR DESCRIPTION
### Problem Statement
test_rhcloud_inventory_disabled_local_insights was failing because Insights was renamed to Red Hat Lightspeed. Even if IOP is enabled. So we needed to verify that Trying to navigate to Red Hat Lightspeed - > Inventory Upload, does not work when IOP is enabled. 

### Solution
Navigate to new Red Hat Lightspeed view when IOP is enabled. Then try to navigate to the Non IOP enabled view Red Hat Lightspeed -> Inventory Upload

## Summary by Sourcery

Tests:
- Adjust rhcloud inventory disabled test to navigate via Red Hat Lightspeed recommendations and verify Inventory Upload is inaccessible in the new navigation.