### PR TITLE
fix test to use new foreman rake command

### DIFF
--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -325,7 +325,7 @@ def test_rhcloud_scheduled_insights_sync(
     # Assert that both hosts are synced successfully
     assert task_output[0].output['host_statuses']['sync'] == 2
     result = module_target_sat.execute(
-        "foreman-rake console SATELLITE_RH_CLOUD_REQUESTS_DELAY=0 <<< 'ForemanTasks.sync_task(InsightsCloud::Async::InsightsScheduledSync)'"
+        'foreman-rake console <<< "ForemanRhCloud.instance_variable_set(:@requests_delay, \'0\'); ForemanTasks.sync_task(InsightsCloud::Async::InsightsScheduledSync)"'
     )
     assert 'success' in result.stdout
     assert result.status == 0


### PR DESCRIPTION
### Problem Statement
test_rhcloud_scheduled_insights_sync is failing in ipv6 because its not reading the SATELLITE_RH_CLOUD_REQUESTS_DELAY=0 variable.

### Solution
While this seems to be working in ipv4. I am updating the request delay manually to 0 so it passes across both ipv6 and ipv4.

## Summary by Sourcery

Tests:
- Adjust RH Cloud scheduled insights sync API test to set the RH Cloud requests delay via Foreman runtime configuration instead of relying on an environment variable.