### PR TITLE
Master CP of Sat42501 Coverage

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -530,3 +530,179 @@ def test_positive_bulk_disable_vulnerability_analysis(
         assert table_data[0]['Total CVEs'] == 'Analysis disabled', (
             f"Expected 'Analysis disabled' but got '{table_data[0]['Total CVEs']}'"
         )
+
+
+@pytest.fixture(scope='module')
+def repos_exceeding_page_limit(
+    module_target_sat_insights, rhcloud_manifest_org, setup_content_for_iop
+):
+    """Enable and sync Red Hat repos to exceed the Katello API page limit.
+
+    VMaaS only processes repos that have been synced in Katello (custom
+    repos with no real content are ignored). This fixture enables and
+    syncs RHEL 9 and RHEL 8 repos with multiple release versions to
+    push the total synced repo count beyond the default API page limit
+    of 20.
+    """
+
+    satellite = module_target_sat_insights
+    org = rhcloud_manifest_org
+
+    # Create 20 custom repos that sort before "Red Hat..." to fill API page 1.
+    # These don't register in VMaaS (no real content), but they push
+    # Red Hat repos to page 2+ of the Katello API response.
+    custom_product = satellite.api.Product(
+        organization=org,
+        name='AAA Pagination Test Product',
+    ).create()
+
+    for i in range(20):
+        satellite.api.Repository(
+            product=custom_product,
+            name=f'AAA_pagination_repo_{i:02d}',
+            url=f'http://example.com/repo/{i}',
+            content_type='yum',
+        ).create()
+
+    # Enable and sync RHEL 9 and RHEL 8 repos with multiple release versions
+    repo_configs = [
+        ('rhel9', ['9.0', '9.1', '9.2', '9.3', '9.4', '9.5']),
+        ('rhel8', ['8.6', '8.7', '8.8', '8.9', '8.10']),
+    ]
+    sync_tasks = []
+    for rhel_ver, release_versions in repo_configs:
+        for releasever in release_versions:
+            for reposet_key, repo_name_tpl in [
+                (
+                    f'{rhel_ver}_bos',
+                    f'Red Hat Enterprise Linux {rhel_ver[-1]} for x86_64 - BaseOS RPMs {{}}',
+                ),
+                (
+                    f'{rhel_ver}_aps',
+                    f'Red Hat Enterprise Linux {rhel_ver[-1]} for x86_64 - AppStream RPMs {{}}',
+                ),
+            ]:
+                rh_repo_id = satellite.api_factory.enable_rhrepo_and_fetchid(
+                    basearch=constants.DEFAULT_ARCHITECTURE,
+                    org_id=org.id,
+                    product=constants.PRDS[rhel_ver],
+                    repo=repo_name_tpl.format(releasever),
+                    reposet=constants.REPOSET[reposet_key],
+                    releasever=releasever,
+                )
+                rh_repo = satellite.api.Repository(id=rh_repo_id).read()
+                task = rh_repo.sync(synchronous=False)
+                sync_tasks.append(task['id'])
+
+    # Wait for all repo syncs to complete (accept 'warning' for Pulp base_path conflicts)
+    for task_id in sync_tasks:
+        satellite.wait_for_tasks(
+            search_query=f'id = {task_id}',
+            poll_timeout=2500,
+            must_succeed=False,
+        )
+        task_status = satellite.api.ForemanTask(id=task_id).poll(must_succeed=False)
+        assert task_status['result'] in ('success', 'warning')
+
+    # Re-trigger VMaaS sync
+    assert satellite.execute('systemctl start iop-service-vuln-vmaas-sync').status == 0
+
+    yield
+
+    custom_product.delete()
+
+
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+def test_positive_iop_cve_display_when_repos_exceeding_api_page_limit(
+    vulnerable_rhel_host,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+    repos_exceeding_page_limit,
+):
+    """Verify vulnerabilities are displayed when Satellite has more than 20 synced repos.
+
+    VMaaS reposync used the default page limit of 20 when querying
+    GET /katello/api/repositories, causing repositories beyond the
+    first page to be excluded from vulnerability scanning. Hosts with
+    errata from those missed repos would show no vulnerabilities
+    despite having installable errata.
+
+    This test syncs 20+ real Red Hat repos (RHEL 10, 9, 8 with multiple
+    release versions) to exceed the API page limit. VMaaS only processes
+    synced repos, so custom repos with dummy URLs are not sufficient.
+    With the bug present, VMaaS would only process the first 20 synced repos.
+    With the bug fixed, VMaaS paginates through all pages and syncs all repos.
+
+    :id: acc1e3e1-b41a-4344-8818-0b38e59ed2be
+
+    :setup:
+        1. IOP-enabled Satellite with manifest
+        2. RHEL 10 BaseOS and AppStream repos synced
+        3. RHEL 9 and RHEL 8 repos with multiple release versions synced
+
+    :steps:
+        1. Verify total synced repository count exceeds 20
+        2. Register a host and install a vulnerable package (mariadb)
+        3. Check host vulnerabilities in Satellite UI
+
+    :expectedresults:
+        1. Host displays expected CVE despite total repos exceeding page limit
+        2. VMaaS correctly paginates through all Katello API pages
+
+    :customerscenario: true
+
+    :Verifies: SAT-42501
+    """
+    satellite = module_target_sat_insights
+    hostname = vulnerable_rhel_host.hostname
+
+    # Verify total repo count exceeds the default page limit
+    repos = satellite.api.Repository(organization=rhcloud_manifest_org).search(
+        query={'per_page': '100'}
+    )
+    assert len(repos) > 20, (
+        f'Expected more than 20 repos, got {len(repos)}. '
+        f'Test requires > 20 repos to validate VMaaS pagination.'
+    )
+
+    # Verify the RHEL 10 repos (containing the vulnerable package) are beyond page 1.
+    # Custom repos named AAA_* fill page 1, pushing Red Hat repos to page 2+.
+    page1_repos = satellite.api.Repository(organization=rhcloud_manifest_org).search(
+        query={'per_page': '20', 'page': '1'}
+    )
+    rhel10_on_page1 = [r for r in page1_repos if 'Enterprise Linux 10' in r.name]
+    assert not rhel10_on_page1, (
+        f'RHEL 10 repos must be on page 2+ to test pagination fix, '
+        f'but found on page 1: {[r.name for r in rhel10_on_page1]}'
+    )
+
+    # Verify VMaaS synced all repos (not capped at 20 due to pagination bug).
+    # This directly proves the fix: without pagination, VMaaS DB would have <= 20 repos.
+    pg_pass = satellite.execute(
+        'podman exec iop-service-vmaas-reposcan printenv POSTGRESQL_PASSWORD'
+    ).stdout.strip()
+    result = satellite.execute(
+        f'podman exec iop-service-vmaas-reposcan bash -c '
+        f'"PGPASSWORD={pg_pass} psql -U vmaas_admin -d vmaas_db -t -A '
+        f"-c 'SELECT COUNT(*) FROM repo;'\""
+    )
+    vmaas_repo_count = int(result.stdout.strip())
+    assert vmaas_repo_count > 20, (
+        f'VMaaS synced only {vmaas_repo_count} repos, expected > 20. '
+        f'This indicates VMaaS did not paginate beyond the first API page.'
+    )
+
+    with satellite.ui_session() as session:
+        session.organization.select(org_name=rhcloud_manifest_org.name)
+
+        # Verify the CVE appears on the Vulnerabilities page and the host is affected
+        affected_hosts = session.cloudvulnerability.get_affected_hosts_by_cve(
+            constants.RHEL10_VULNERABILITY_CVE_ID
+        )
+        assert any(host['Name'] == hostname for host in affected_hosts), (
+            f'Host {hostname} not found in affected hosts for '
+            f'CVE {constants.RHEL10_VULNERABILITY_CVE_ID}. '
+            f'VMaaS may not have synced repos beyond the first API page (20 repos).'
+        )


### PR DESCRIPTION
Manual CP for master branch of https://github.com/SatelliteQE/robottelo/pull/21247 and https://github.com/SatelliteQE/robottelo/pull/21236

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_positive_iop_cve_display_when_repos_exceeding_api_page_limit
```

## Summary by Sourcery

Add test coverage to validate VMaaS vulnerability pagination behavior when Satellite has more than 20 synced repositories.

Tests:
- Introduce a fixture that syncs sufficient Red Hat repositories to exceed the Katello API page limit while triggering a VMaaS sync.
- Add a UI test ensuring CVEs are still displayed for vulnerable hosts when relevant repositories fall beyond the first Katello API page.