### PR TITLE
Removed assertion as we just need to check permission for Recommendation/Vulnarability page

### DIFF
--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -561,7 +561,6 @@ def test_iop_insights_rbac_edit_permissions(
         assert vulnerabilities[0]['Status'] == 'In review'
 
 
-@pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_iop_insights_rbac_no_permissions(
@@ -613,10 +612,6 @@ def test_iop_insights_rbac_no_permissions(
     # Log in as the user with no insights permissions
     # User is already in their default organization, no need to select
     with module_target_sat_insights.ui_session(test_name, user.login, user_password) as session:
-        # Verify that we can see the rule hit via insights-client (as admin)
-        result = rhel_insights_vm.execute('insights-client --diagnosis')
-        assert result.status == 0
-        assert 'OPENSSH_HARDENING_CONFIG_PERMS' in result.stdout
         # Attempt to access Recommendations - should fail or be inaccessible
         permission = session.recommendationstab.read_no_authorized_message()
         assert permission == "You do not have access to Advisor"


### PR DESCRIPTION
### Problem Statement
Test case was failing since long back with assertion 
`assert 'OPENSSH_HARDENING_CONFIG_PERMS' in '{"id": "3942fed6-ba1f-4cda-80a0-11e613388678", "insights_id": "3942fed6-ba1f-4cda-80a0-11e613388678", "details": {"dn...UPDATE_ISSUE_INFO": {"type": "rule", "dnf_rpm": "dnf-4.14.0-31.el9", "error_key": "DNF_INSTALL_UPDATE_ISSUE_INFO"}}}`

### Solution
We dont need that assertion in that test case as we are checking `No Authorization` message  in case of no view permission.

### Related Issues
Airgun PR: https://github.com/SatelliteQE/airgun/pull/2398

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_iop.py -k "test_iop_insights_rbac_no_permissions"
airgun: 2398
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Fix failing RBAC no-permissions test by dropping an irrelevant Insights rule assertion that is not required for verifying lack of access messaging.