### PR TITLE
Adjust tets to report templates being unlocked after cloning

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -263,6 +263,7 @@ def test_positive_lock_clone_nodelete_unlock_report(target_sat):
     )
     assert template_clone_name == cloned_rt.name
     assert template1 == cloned_rt.template
+    assert cloned_rt.locked is False
     # 4. Try to delete template
     with pytest.raises(HTTPError):
         rt.delete()

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -32,7 +32,6 @@ from robottelo.constants import (
 )
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.hosts import ContentHost
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -389,7 +388,7 @@ def test_positive_clone_locked_report(module_target_sat):
     result_list = module_target_sat.cli.ReportTemplate.list()
     assert new_name in [rt['name'] for rt in result_list]
     result_info = module_target_sat.cli.ReportTemplate.info({'id': report_template['id']})
-    assert result_info['locked'] == 'yes'
+    assert result_info['locked'] == 'no'
     assert result_info['default'] == 'yes'
 
 
@@ -1039,16 +1038,7 @@ def test_positive_clone_report_template(module_target_sat):
     cloned_template = module_target_sat.cli.ReportTemplate.info({'name': clone_name})
     assert cloned_template['name'] == clone_name
     assert cloned_template['cloned-from-id'] == template['id']
-    if is_open('SAT-42163'):
-        module_target_sat.cli.ReportTemplate.update(
-            {'id': cloned_template['id'], 'locked': 'false'}
-        )
-        assert (
-            module_target_sat.cli.ReportTemplate.info({'name': cloned_template['name']}).get(
-                'locked'
-            )
-            == 'no'
-        )
+    assert cloned_template['locked'] == 'no'
     module_target_sat.cli.ReportTemplate.delete({'name': clone_name})
     with pytest.raises(CLIReturnCodeError):
         module_target_sat.cli.ReportTemplate.info({'name': clone_name})

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -388,8 +388,10 @@ def test_positive_clone_locked_report(module_target_sat):
     result_list = module_target_sat.cli.ReportTemplate.list()
     assert new_name in [rt['name'] for rt in result_list]
     result_info = module_target_sat.cli.ReportTemplate.info({'id': report_template['id']})
-    assert result_info['locked'] == 'no'
+    assert result_info['locked'] == 'yes'
     assert result_info['default'] == 'yes'
+    result_info = module_target_sat.cli.ReportTemplate.info({'name': new_name})
+    assert result_info['locked'] == 'no'
 
 
 def test_positive_generate_report_sanitized(module_target_sat):
@@ -408,6 +410,8 @@ def test_positive_generate_report_sanitized(module_target_sat):
     :expectedresults: Report is generated in proper CSV format (value with comma is quoted)
 
     :CaseImportance: Medium
+
+    :Verifies: SAT-42163
     """
     # create a name that has a comma in it, some randomized text, and no spaces.
     os_name = gen_alpha(start='test', separator=',').replace(' ', '')


### PR DESCRIPTION
### Problem Statement
Since https://github.com/theforeman/foreman/pull/10917, locked report templates get unlocked upon cloning through api/cli.

### Solution
Adjust tests to match this new behaviour.

### Related Issues
https://redhat.atlassian.net/browse/SAT-42163

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Update CLI and API report template cloning tests to assert that cloned templates are unlocked instead of locked.