### PR TITLE
Simplify active service state for iop-service-vuln-vmaas-sync.timer

### DIFF
--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -92,10 +92,7 @@ def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
             options={'only': 'iop-service-vuln-vmaas-sync.timer'}
         )
         assert timer_status.status == 0
-        assert (
-            'Active: active (running)' in timer_status.stdout
-            or 'Active: active (waiting)' in timer_status.stdout
-        )
+        assert 'Active: active' in timer_status.stdout
 
     # Verify maintenance-mode start
     mm_start = sat_maintain.cli.MaintenanceMode.start()
@@ -154,7 +151,7 @@ def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
             options={'only': 'iop-service-vuln-vmaas-sync.timer'}
         )
         assert timer_status.status == 0
-        assert 'Active: active (waiting)' in timer_status.stdout
+        assert 'Active: active' in timer_status.stdout
 
     # Assert FOREMAN_MAINTAIN_TABLE not listed in nftables
     nftables = sat_maintain.execute('nft list tables')


### PR DESCRIPTION
### Problem Statement
In recent snap runs, the default state for `iop-service-vuln-vmaas-sync.timer` changed to `Active: active (elapsed)`, causing tests to fail as we just validate the existing test for `Active: active (running)` or `Active: active (waiting)`, while elapsed state is also valid and test fails with false reasons.

### Solution
Simplifying active service state for `iop-service-vuln-vmaas-sync.timer` where just checking for Active status

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Update maintenance mode timer status assertions to check only for an active state instead of specific active sub-states.