### PR TITLE
[6.19.z] exclude FAM tests in n-minus testing

### DIFF
--- a/pytest_plugins/capsule_n-minus.py
+++ b/pytest_plugins/capsule_n-minus.py
@@ -30,6 +30,7 @@ def pytest_collection_modifyitems(items, config):
         if not (
             item.get_closest_marker('destructive')
             or 'session_puppet_enabled_sat' in item.fixturenames
+            or 'setup_fam' in item.fixturenames
         ) and (
             'capsule_factory' in item.fixturenames
             or 'sat_maintain' in item.fixturenames


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21282

### Problem Statement

The n-minus selection wrongly selects those tests as they do setup a Capsule, but they don't test any n-minus functionality.

### Solution

Exclude them.

### Related Issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: -v tests/foreman/sys/test_fam.py --n-minus --continue-on-collection-errors
```

## Summary by Sourcery

Bug Fixes:
- Prevent FAM setup tests from being incorrectly selected by n-minus test runs.