### PR TITLE
Capsule foremanctl certificate bundle deploy

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1603,6 +1603,12 @@ class ContentHost(Host, ContentHostMixins):
                     raise ContentHostError(
                         f'Enabling Capsule repos on host failed\n{result.stdout}'
                     )
+        elif settings.server.version.source == 'upstream':
+            self.create_custom_repos(
+                foreman='https://yum.theforeman.org/nightly/el9/x86_64/',
+                foreman_plugins='https://yum.theforeman.org/plugins/nightly/el9/x86_64/',
+                katello='https://yum.theforeman.org/katello/nightly/katello/el9/x86_64/',
+            )
         else:
             self.download_repofile(
                 product='capsule',
@@ -1873,6 +1879,29 @@ class Capsule(ContentHost, CapsuleMixins):
             raise CapsuleHostError(
                 f'A core service is not running at capsule host\n{result.stdout}'
             )
+
+    def foremanctl_capsule_setup(self, sat_host=None, capsule_cert_opts=None):
+        """Prepare the host and copy cert to capsule"""
+        self.register_to_cdn()
+        self.setup_rhel_repos()
+        self.setup_capsule_repos()
+
+        # After capsule registration to cdn, it should be initialized with the Satellite.
+        self._satellite = sat_host or Satellite()
+
+        # Update system, firewall services and check capsule is already installed from template
+        # Setups firewall on Capsule
+        self.execute('dnf -y update', timeout=0)
+        assert (
+            self.execute(
+                "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
+            ).status
+            == 0
+        ), "firewalld is not present and can't be installed"
+        self.execute('firewall-cmd --add-service RH-Satellite-6-capsule')
+        self.execute('firewall-cmd --runtime-to-permanent')
+        certs_tar = self.satellite.foremanctl_capsule_certs_generate(self, **capsule_cert_opts)
+        self.satellite.session.remote_copy(certs_tar, self)
 
     def update_download_policy(self, policy):
         """Updates capsule's download policy to desired value"""
@@ -2354,6 +2383,24 @@ class Satellite(Capsule, SatelliteMixins):
         )
         install_cmd = InstallerCommand.from_cmd_str(cmd_str=result.stdout)
         return cert_file_path, result, install_cmd
+
+    def foremanctl_capsule_certs_generate(self, capsule, cert_source=None, **extra_kwargs):
+        """Generate foremanctl capsule certs, returning the cert path, installer command stdout and args"""
+        cert_file_path = cert_source or f'/root/{capsule.hostname}.tar.gz'
+        result = self.install(
+            InstallerCommand(
+                command='foremanctl certificate-bundle',
+                foreman_proxy_fqdn=capsule.hostname,
+                certs_tar=cert_file_path,
+                installer_args=['no-colors'],
+                **extra_kwargs,
+            )
+        )
+        assert result == 0
+        return cert_file_path
+        # The capsule bundle has been created. The capsule installation part is still pending, as it has not yet been developed.
+        # install_cmd = InstallerCommand.from_cmd_str(cmd_str=result.stdout)
+        # return cert_file_path, result, install_cmd
 
     def __enter__(self):
         """Satellite objects can be used as a context manager to temporarily force everything

--- a/tests/foreman/installer/test_install_foremanctl.py
+++ b/tests/foreman/installer/test_install_foremanctl.py
@@ -17,7 +17,7 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import FOREMANCTL_PARAMETERS_FILE
-from robottelo.hosts import Satellite
+from robottelo.hosts import Capsule, Satellite
 from robottelo.utils.issue_handlers import is_open
 
 pytestmark = [pytest.mark.foremanctl, pytest.mark.upgrade]
@@ -165,3 +165,16 @@ def test_foremanctl_deploy_reset_parameters(module_sat_ready_rhel):
     parameters_file = module_sat_ready_rhel.load_remote_yaml_file(FOREMANCTL_PARAMETERS_FILE)
     assert 'foreman_puma_workers' not in parameters_file
     assert 'pulp_worker_count' not in parameters_file
+
+
+@pytest.fixture(scope='module')
+def foremanctl_capsule_configured(request, module_sat_ready_rhel):
+    with Broker(
+        workflow=settings.server.deploy_workflows.os,
+        deploy_rhel_version=settings.server.version.rhel_version,
+        deploy_flavor=settings.flavors.default,
+        deploy_network_type=settings.server.network_type,
+        host_class=Capsule,
+    ) as capsule:
+        capsule.foremanctl_capsule_setup(sat_host=module_sat_ready_rhel)
+        return capsule

--- a/tests/foreman/installer/test_install_foremanctl.py
+++ b/tests/foreman/installer/test_install_foremanctl.py
@@ -12,6 +12,8 @@
 
 """
 
+import re
+
 from broker import Broker
 from fauxfactory import gen_string
 import pytest
@@ -550,3 +552,147 @@ def test_positive_foremanctl_tuning_profile(module_sat_foremanctl_tuning):
     parameters_file = sat.load_remote_yaml_file(FOREMANCTL_PARAMETERS_FILE)
     assert 'tuning' not in parameters_file
     assert_postgresql_tuning(sat, 'default')
+
+
+def assert_cert_validity_days(host, cert_paths, expected_days):
+    """Assert each certificate has the expected validity period in days."""
+    for cert_path in cert_paths:
+        assert get_cert_validity_days(host, cert_path) == expected_days
+
+
+def foremanctl_host_cert_paths(hostname):
+    """Return server and client certificate paths for a foremanctl host."""
+    return [
+        f'{FOREMANCTL_CERTS_DIR}/{hostname}.crt',
+        f'{FOREMANCTL_CERTS_DIR}/{hostname}-client.crt',
+    ]
+
+
+def foremanctl_capsule_cert_paths(sat, capsule, result, extract_dir):
+    """Return server and client certificate paths for a foremanctl capsule bundle."""
+    sat.execute(f'mkdir -p {extract_dir}')
+
+    bundle_path = re.search(r'/\S+?\.tar\.gz', result.stdout).group(0)
+    sat.execute(f'tar xf {bundle_path} -C {extract_dir}')
+
+    result = sat.execute(f'tar -tzf {bundle_path}')
+    assert result.status == 0, (
+        f'Certificate bundle tarball not found at {bundle_path}: {result.stderr}'
+    )
+    assert f'certs/{capsule.hostname}.crt' in result.stdout
+    assert f'certs/{capsule.hostname}-client.crt' in result.stdout
+
+    return [
+        f'{extract_dir}/certs/{capsule.hostname}.crt',
+        f'{extract_dir}/certs/{capsule.hostname}-client.crt',
+    ]
+
+
+@pytest.mark.parametrize('module_sat_ready_rhel', ['default'], indirect=True)
+@pytest.mark.rhel_ver_match('9')
+def test_positive_foremanctl_certificate_bundle(module_sat_ready_rhel, rhel_contenthost):
+    """Verify foremanctl certificate-bundle generation and renewal for a capsule.
+
+    :id: 9bd1d8d8-a22a-4917-9522-22b7165d224c
+
+    :steps:
+        1. Deploy Satellite with foremanctl using default certificates
+        2. Generate a certificate bundle via
+           foremanctl certificate-bundle
+        3. Extract the bundle tarball and verify it contains capsule server and
+           client certificate files
+        4. Verify capsule server and client certificates have default validity
+           (7300 days)
+        5. Verify capsule server and client certificates are signed by the bundle CA
+        6. Capture SHA256 fingerprints of the CA, capsule server, and capsule
+           client certificates
+        7. Renew the capsule certificate bundle with foremanctl certificate-bundle
+           --certificate-renew
+        8. Extract the renewed bundle tarball and verify its contents
+        9. Verify renewed capsule server and client certificates retain default
+           validity (7300 days)
+        10. Verify renewed capsule certificates chain to both the original and
+            renewed bundle CA
+        11. Verify CA fingerprint is unchanged between the original and renewed
+            bundle
+        12. Verify capsule server and client certificate fingerprints changed after
+            renewal
+
+    :expectedresults:
+        1. foremanctl certificate-bundle succeeds and produces a tarball
+        2. Extracted tarball contains the expected server and client certificate
+           files
+        3. Initial capsule certificate validity is 7300 days
+        4. Capsule certificates validate against the bundle CA
+        5. foremanctl certificate-bundle --certificate-renew succeeds
+        6. Renewed capsule certificates retain 7300-day validity
+        7. CA identity is preserved across renewal (fingerprint unchanged)
+        8. Capsule server and client certificates are regenerated (fingerprints change)
+        9. Renewed certificates maintain chain integrity against both the original
+           and renewed CA
+
+    :verifies: SAT-43475
+    """
+    extract_dir = '/var/tmp/capsule-tarball'
+    renewed_extract_dir = '/var/tmp/capsule-tarball-renewed'
+    ca_cert = f'{extract_dir}/certs/ca.crt'
+    renewed_ca_cert = f'{renewed_extract_dir}/certs/ca.crt'
+
+    sat = module_sat_ready_rhel
+    capsule = rhel_contenthost
+
+    # Generate bundle
+    result = sat.execute(f'foremanctl certificate-bundle {capsule.hostname}', timeout='10m')
+    assert result.status == 0, f'foremanctl certificate-bundle failed:\n{result.stderr}'
+
+    # Phase 1: initial capsule validity
+    capsule_certs = foremanctl_capsule_cert_paths(sat, capsule, result, extract_dir)
+    assert_cert_validity_days(sat, capsule_certs, 7300)
+
+    # verify certificate chain — capsule server and client signed by CA
+    for cert in capsule_certs:
+        verify = sat.execute(f'openssl verify -CAfile {ca_cert} {cert}')
+        assert verify.status == 0, f'Chain validation failed for {cert}: {verify.stderr}'
+
+    # capture fingerprints to track capsule certificate identity across renewal
+    ca_fp_before = get_cert_fingerprint(sat, ca_cert)
+    server_fp_before = get_cert_fingerprint(sat, capsule_certs[0])
+    client_fp_before = get_cert_fingerprint(sat, capsule_certs[1])
+
+    # Renew bundle
+    result = sat.execute(
+        f'foremanctl certificate-bundle --certificate-renew {capsule.hostname}',
+        timeout='10m',
+    )
+    assert result.status == 0, f'Capsule certificate renewal failed: {result.stderr}'
+
+    # Phase 2: renew capsule validate
+    capsule_certs = foremanctl_capsule_cert_paths(sat, capsule, result, renewed_extract_dir)
+    assert_cert_validity_days(sat, capsule_certs, 7300)
+
+    # verify certificate chain — capsule server and client signed by previous and current CA
+    for cert in capsule_certs:
+        verify = sat.execute(f'openssl verify -CAfile {ca_cert} {cert}')
+        assert verify.status == 0, (
+            f'Chain validation failed after renewal for {cert}: {verify.stderr}'
+        )
+        verify = sat.execute(f'openssl verify -CAfile {renewed_ca_cert} {cert}')
+        assert verify.status == 0, (
+            f'Chain validation failed after renewal for {cert}: {verify.stderr}'
+        )
+
+    # CA certificate fingerprint must be unchanged (CA not regenerated)
+    ca_fp_after = get_cert_fingerprint(sat, renewed_ca_cert)
+    assert ca_fp_after == ca_fp_before, (
+        'CA fingerprint changed after capsule --certificate-renew; CA should not be regenerated'
+    )
+
+    # server and client certificate fingerprint must be changed
+    server_fp_after = get_cert_fingerprint(sat, capsule_certs[0])
+    assert server_fp_after != server_fp_before, (
+        'Capsule server cert fingerprint unchanged — renewal did not regenerate it'
+    )
+    client_fp_after = get_cert_fingerprint(sat, capsule_certs[1])
+    assert client_fp_after != client_fp_before, (
+        'Capsule client cert fingerprint unchanged — renewal did not regenerate it'
+    )


### PR DESCRIPTION
Validate that the `foremanctl certificate-bundle` command successfully generates a valid certificate bundle tarball for a given Capsule hostname. The validation ensures that the generated tarball contains all required certificate files, including CA, server, and client certificates, and verifies the integrity and consistency of duplicated certificate pairs by confirming they are byte-identical.

## Summary by Sourcery

Add automated validation of foremanctl certificate bundle generation and renewal for Capsules using both default and custom server certificates.

Tests:
- Introduce capsule_certificate_bundle pytest fixture to provision Capsule certificate bundles from either default or custom server certificates and verify the resulting tarball exists.
- Add an end-to-end foremanctl certificate bundle test that checks initial certificate validity, Satellite renewal effects, and subsequent Capsule bundle renewal for both Satellite and Capsule hosts.