### PR TITLE
[6.18.z] Remove Ibutsu test result reporting from Robottelo

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -139,7 +139,7 @@ def pytest_collection_modifyitems(items, config):
 
     user_properties is used by the junit plugin, and thus by many test report systems
     Handle test function/class/module/session scope metadata coming from test docblocks
-    Apply user_properties, ibutsu metadata, and pytest markers
+    Apply user_properties and pytest markers
 
     Markers for metadata use the testimony token name as the mark name
     The value of the token for the mark is the first mark arg
@@ -204,7 +204,6 @@ def pytest_collection_modifyitems(items, config):
             item.add_marker(pytest.mark.verifies_issues(verifies_marks_to_add))
 
         # add markers as user_properties so they are recorded in XML properties of the report
-        # pytest-ibutsu will include user_properties dict in testresult metadata
         markers_prop_data = []
         exclude_markers = ['parametrize', 'skipif', 'usefixtures', 'skip_if_not_set']
         for marker in item.iter_markers():

--- a/pytest_plugins/rerun_rp/README.adoc
+++ b/pytest_plugins/rerun_rp/README.adoc
@@ -46,7 +46,7 @@ $ pytest tests/foreman/api/test_computeresource_azurerm.py --collect-only --rp-r
 platform darwin -- Python 3.9.12, pytest-7.1.2, pluggy-1.0.0
 shared_function enabled - OFF - scope:  - storage: file
 rootdir: /Users/jitendrayejare/JWorkspace/GitRepos/robottelo, configfile: pyproject.toml
-plugins: xdist-2.5.0, forked-1.4.0, reportportal-5.1.1, mock-3.7.0, services-2.2.1, ibutsu-2.0.2, cov-3.0.0
+plugins: xdist-2.5.0, forked-1.4.0, reportportal-5.1.1, mock-3.7.0, services-2.2.1, cov-3.0.0
 collected 11 items / 10 deselected / 1 selected
 
 <Package api>

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ pytest-reportportal==5.6.6
 pytest-reportlog==1.0.0
 pytest-xdist==3.6.1
 pytest-fixturecollection==0.1.2
-pytest-ibutsu==3.1.6
 PyYAML==6.0.3
 requests==2.33.1
 tenacity==9.1.4


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21232

### Problem Statement
Due to the Ibutsu project being deprioritized by its maintainers, we are decommissioning our integration with the platform.

### Solution
- Remove ibutsu from Robottelo requirements and any other reference.

### Related Issues
- SAT-43364

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Remove Ibutsu test reporting integration from the project.

Chores:
- Drop pytest-ibutsu from the runtime dependencies.
- Update metadata handling comments to no longer reference Ibutsu-specific reporting behavior.