### PR TITLE
Add no_containers mark to cloud inventory E2E test

### DIFF
--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -97,6 +97,7 @@ def common_assertion(
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.run_in_one_thread
+@pytest.mark.no_containers
 @pytest.mark.usefixtures('setting_update')
 @pytest.mark.parametrize(
     'setting_update',

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -98,6 +98,7 @@ def common_assertion(
 @pytest.mark.pit_client
 @pytest.mark.run_in_one_thread
 @pytest.mark.no_containers
+@pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
 @pytest.mark.usefixtures('setting_update')
 @pytest.mark.parametrize(
     'setting_update',


### PR DESCRIPTION
We see frequent failures in automation runs of the RH Cloud Inventory end-to-end test, but many of these failures do not occur locally when run with VM hosts instead of container hosts. This PR adds the `no_containers` mark to the cloud inventory end-to-end test.

## Summary by Sourcery

Tests:
- Tag the RH Cloud Inventory end-to-end UI test with the no_containers mark so it only runs on supported non-container environments.