### PR TITLE
Fix automation failure in test_positive_all_options (Hammer host uuid)

### DIFF
--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -22172,6 +22172,12 @@
               "value": "SCHEMA"
             },
             {
+              "help": "UUID of a VM to import from a compute resource",
+              "name": "uuid",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
               "help": "Volume parameters Can be specified multiple times.",
               "name": "volume",
               "shortname": null,
@@ -25460,6 +25466,12 @@
               "name": "typed-parameters",
               "shortname": null,
               "value": "SCHEMA"
+            },
+            {
+              "help": "UUID of a VM to import from a compute resource",
+              "name": "uuid",
+              "shortname": null,
+              "value": "VALUE"
             },
             {
               "help": "Volume parameters Can be specified multiple times.",


### PR DESCRIPTION
### Problem Statement
test_positive_all_options compares live hammer full-help from the test Satellite to the frozen tree in tests/foreman/data/hammer_commands.json. On current Satellite/Hammer builds, hammer host create and hammer host update advertise a uuid option that was not present in the snapshot, so the test failed in automation 


### Solution
Extend tests/foreman/data/hammer_commands.json so hammer host create and hammer host update each include the uuid option in their options list, aligned with the CLI help text.

## Summary by Sourcery

Tests:
- Extend hammer_commands.json so host create and host update include the uuid option in their recorded options, resolving automation failures in test_positive_all_options.