### PR TITLE
[6.18.z] Add a contenthost_factory to perform post-deploy actions

### DIFF
--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -17,6 +17,8 @@ content_host:
     vm:
       workflow: deploy-base-rhel-fips
       deploy_rhel_version: '7'
+    post_configs:
+      - fips
   rhel8:
     vm:
       workflow: deploy-rhel
@@ -27,6 +29,8 @@ content_host:
     vm:
       workflow: deploy-base-rhel-fips
       deploy_rhel_version: '8'
+    post_configs:
+      - fips
   rhel9:
     vm:
       workflow: deploy-rhel
@@ -37,6 +41,8 @@ content_host:
     vm:
       workflow: deploy-base-rhel-fips
       deploy_rhel_version: '9'
+    post_configs:
+      - fips
   rhel10:
     vm:
       workflow: deploy-rhel
@@ -49,9 +55,9 @@ content_host:
       deploy_rhel_version: '10'
   centos7:
     vm:
-      workflow: deploy-centos
-      deploy_scenario: centos
       deploy_rhel_version: '7'
+      deploy_scenario: centos
+      workflow: deploy-centos
   centos8:
     vm:
       workflow: deploy-centos
@@ -67,4 +73,10 @@ content_host:
       workflow: deploy-oracle-linux
       deploy_scenario: oracle
       deploy_rhel_version: '8.10'
-
+host_post_configs:
+  fips:
+    workflow: enable-fips
+    target_vm: "{host.name}"
+  fapolicyd:
+    workflow: enable-fapolicyd
+    target_vm: "{host.name}"

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -5,6 +5,8 @@ The functions in this module are read in the pytest_plugins/fixture_markers.py m
 All functions in this module will be treated as fixtures that apply the contenthost mark
 """
 
+from contextlib import contextmanager
+
 from broker import Broker
 import pytest
 
@@ -20,7 +22,7 @@ def host_conf(request):
     if hasattr(request, 'param'):
         params = request.param
     distro = params.get('distro', 'rhel')
-    network = params.get('network')
+    network = params.get('network', settings.content_host.network_type)
     _rhelver = f"{distro}{params.get('rhel_version', settings.content_host.default_rhel_version)}"
 
     # check to see if no-containers is passed as an argument to pytest
@@ -47,12 +49,55 @@ def host_conf(request):
     return conf
 
 
+def host_post_config(hosts, config_name):
+    """A function that runs a specified post config on a list of content hosts.
+
+    Args:
+        hosts (list): A list of ContentHost objects to run the config on.
+        config_name (str): The name of the post config to run (must be defined in settings).
+
+    The `broker_args` are retrieved from `settings.content_host.host_post_configs.<config_name>`.
+    Values in `broker_args` can contain template strings like "{host.name}", which will be
+    substituted with the actual host's attributes.
+    """
+    try:
+        post_config = settings.content_host.host_post_configs[config_name]
+    except (KeyError, AttributeError) as e:
+        available_configs = getattr(settings.content_host, 'host_post_configs', {})
+        raise ValueError(
+            f"Invalid post_config name: '{config_name}'. "
+            f"Available options in content_host.yaml: {list(available_configs.keys())}"
+        ) from e
+
+    base_broker_args = post_config.to_dict()
+    for host in hosts:
+        # Copy arguments to avoid modifying the base dictionary for subsequent hosts
+        broker_args = base_broker_args.copy()
+        for key, val in broker_args.items():
+            if isinstance(val, str) and "{" in val:
+                broker_args[key] = val.format(host=host)
+        Broker(**broker_args).execute()
+
+
+@contextmanager
+def contenthost_factory(request, **kwargs):
+    """A factory function that checks out and (optionally) configures a content host."""
+    host_params = host_conf(request)
+    post_configs = host_params.pop("post_configs", [])
+    host_class = kwargs.pop("host_class", ContentHost)
+    with Broker(**host_params, host_class=host_class, **kwargs) as host:
+        if post_configs:
+            hosts = host if isinstance(host, list) else [host]
+            for config_name in post_configs:
+                host_post_config(hosts, config_name)
+        yield host
+
+
 @pytest.fixture
 def rhel_contenthost(request):
     """A function-level fixture that provides a content host object parametrized"""
     # Request should be parametrized through pytest_fixtures.fixture_markers
-    # unpack params dict
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with contenthost_factory(request=request) as host:
         yield host
 
 
@@ -60,65 +105,42 @@ def rhel_contenthost(request):
 def module_rhel_contenthost(request):
     """A module-level fixture that provides a content host object parametrized"""
     # Request should be parametrized through pytest_fixtures.fixture_markers
-    # unpack params dict
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with contenthost_factory(request=request) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': '7'}])
 def rhel7_contenthost(request):
     """A function-level fixture that provides a rhel7 content host object"""
-    with Broker(
-        **host_conf(request),
-        host_class=ContentHost,
-        deploy_network_type=settings.content_host.network_type,
-    ) as host:
-        yield host
-
-
-@pytest.fixture(scope="class", params=[{'rhel_version': '7'}])
-def rhel7_contenthost_class(request):
-    """A fixture for use with unittest classes. Provides a rhel7 Content Host object"""
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with contenthost_factory(request=request) as host:
         yield host
 
 
 @pytest.fixture(scope='module', params=[{'rhel_version': '7'}])
 def rhel7_contenthost_module(request):
     """A module-level fixture that provides a rhel7 content host object"""
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with contenthost_factory(request=request) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': '8'}])
 def rhel8_contenthost(request):
     """A fixture that provides a rhel8 content host object"""
-    with Broker(
-        **host_conf(request),
-        host_class=ContentHost,
-        deploy_network_type=settings.content_host.network_type,
-    ) as host:
-        yield host
-
-
-@pytest.fixture(scope='module', params=[{'rhel_version': '8'}])
-def rhel8_contenthost_module(request):
-    """A module-level fixture that provides a rhel8 content host object"""
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with contenthost_factory(request=request) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': '9'}])
 def rhel9_contenthost(request):
     """A fixture that provides a rhel9 content host object"""
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with contenthost_factory(request=request) as host:
         yield host
 
 
 @pytest.fixture
 def content_hosts(request):
     """A function-level fixture that provides two rhel content hosts object"""
-    with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
+    with contenthost_factory(request=request, _count=2) as hosts:
         hosts[0].set_infrastructure_type('physical')
         yield hosts
 
@@ -126,8 +148,20 @@ def content_hosts(request):
 @pytest.fixture(scope='module')
 def mod_content_hosts(request):
     """A module-level fixture that provides two rhel content hosts object"""
-    with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
+    with contenthost_factory(request=request, _count=2) as hosts:
         hosts[0].set_infrastructure_type('physical')
+        yield hosts
+
+
+@pytest.fixture
+def registered_hosts(request, target_sat, module_org, module_ak_with_cv):
+    """Fixture that registers content hosts to Satellite, based on rh_cloud setup"""
+    with contenthost_factory(request=request, _count=2) as hosts:
+        for vm in hosts:
+            repo = settings.repos['SATCLIENT_REPO'][f'RHEL{vm.os_version.major}']
+            vm.register(
+                module_org, None, module_ak_with_cv.name, target_sat, repo_data=f'repo={repo}'
+            )
         yield hosts
 
 
@@ -165,7 +199,7 @@ def cockpit_host(class_target_sat, class_org, rhel_contenthost):
 @pytest.fixture
 def rex_contenthost(request, module_org, target_sat, module_ak_with_cv):
     request.param['no_containers'] = True
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with contenthost_factory(request=request) as host:
         repo = settings.repos['SATCLIENT_REPO'][f'RHEL{host.os_version.major}']
         host.register(
             module_org, None, module_ak_with_cv.name, target_sat, repo_data=f'repo={repo}'
@@ -176,7 +210,7 @@ def rex_contenthost(request, module_org, target_sat, module_ak_with_cv):
 @pytest.fixture
 def rex_contenthosts(request, module_org, target_sat, module_ak_with_cv):
     request.param['no_containers'] = True
-    with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
+    with contenthost_factory(request=request, _count=2) as hosts:
         for host in hosts:
             repo = settings.repos['SATCLIENT_REPO'][f'RHEL{host.os_version.major}']
             host.register(
@@ -245,7 +279,7 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
         "no_containers": True,
         "network": "ipv6" if module_target_sat.network_type == NetworkType.IPV6 else "ipv4",
     }
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with contenthost_factory(request=request) as host:
         host.register_to_cdn()
         for client in settings.container.clients:
             assert host.execute(f'yum -y install {client}').status == 0, (
@@ -280,11 +314,7 @@ def centos_host(request, version):
         "distro": "centos",
         "no_containers": True,
     }
-    with Broker(
-        **host_conf(request),
-        host_class=ContentHost,
-        deploy_network_type=settings.content_host.network_type,
-    ) as host:
+    with contenthost_factory(request=request) as host:
         yield host
 
 
@@ -295,11 +325,7 @@ def oracle_host(request, version):
         "distro": "oracle",
         "no_containers": True,
     }
-    with Broker(
-        **host_conf(request),
-        host_class=ContentHost,
-        deploy_network_type=settings.content_host.network_type,
-    ) as host:
+    with contenthost_factory(request=request) as host:
         yield host
 
 
@@ -336,10 +362,7 @@ def bootc_host():
 
 @pytest.fixture(scope='module', params=[{'rhel_version': 8, 'no_containers': True}])
 def external_puppet_server(request):
-    deploy_args = host_conf(request)
-    deploy_args['target_cores'] = 2
-    deploy_args['target_memory'] = '4GiB'
-    with Broker(**deploy_args, host_class=ContentHost) as host:
+    with contenthost_factory(request=request, target_cores=2, target_memory='4GiB') as host:
         host.register_to_cdn()
         # Install puppet packages
         assert (
@@ -370,23 +393,34 @@ def external_puppet_server(request):
 
 
 @pytest.fixture(scope="module")
-def sat_upgrade_chost():
-    """A module-level fixture that provides a UBI_8 content host for upgrade scenario testing"""
-    return Broker(
-        container_host=settings.content_host.rhel8.container.container_host, host_class=ContentHost
-    ).checkout()
+def sat_upgrade_chost(request):
+    """A module-level fixture that provides a RHEL8 container content host for upgrade scenario testing"""
+    with contenthost_factory(
+        request=request, container_host=settings.content_host.rhel8.container.container_host
+    ) as host:
+        yield host
 
 
 @pytest.fixture
 def custom_host(request):
     """A rhel content host that passes custom host config through request.param"""
-    deploy_args = request.param
-    # if 'deploy_rhel_version' is not set, let's default to what's in content_host.yaml
-    deploy_args['deploy_rhel_version'] = deploy_args.get(
+    # Make a copy to avoid mutating the original
+    params = request.param.copy() if hasattr(request, 'param') else {}
+
+    # Extract known parameters and set defaults
+    deploy_rhel_version = params.pop(
         'deploy_rhel_version', settings.content_host.default_rhel_version
     )
-    deploy_args['workflow'] = 'deploy-rhel'
-    with Broker(**deploy_args, host_class=Satellite) as host:
+    workflow = params.pop('workflow', 'deploy-rhel')
+
+    # Pass all parameters explicitly to contenthost_factory
+    with contenthost_factory(
+        request=request,
+        host_class=Satellite,
+        workflow=workflow,
+        deploy_rhel_version=deploy_rhel_version,
+        **params,  # Pass any remaining custom params
+    ) as host:
         yield host
 
 

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -12,6 +12,7 @@
 
 """
 
+from broker import Broker
 import pytest
 
 from robottelo.config import settings
@@ -173,7 +174,7 @@ class TestScenarioCustomRepoCheck:
         )
 
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_custom_repo_check)
-    def test_post_scenario_custom_repo_check(self, target_sat, pre_upgrade_data):
+    def test_post_scenario_custom_repo_check(self, request, target_sat, pre_upgrade_data):
         """This is post-upgrade scenario test to verify if we can alter the
         created custom repository and satellite will be able to sync back
         the repo.
@@ -190,6 +191,12 @@ class TestScenarioCustomRepoCheck:
 
         """
         client_hostname = pre_upgrade_data.get('rhel_client')
+        rhel_client = ContentHost.get_host_by_hostname(client_hostname)
+
+        @request.addfinalizer
+        def _cleanup():
+            Broker(hosts=[rhel_client]).checkin()
+
         content_view_name = pre_upgrade_data.get('content_view_name')
         lce_id = pre_upgrade_data.get('lce_id')
         repo_name = pre_upgrade_data.get('repo_name')
@@ -206,7 +213,6 @@ class TestScenarioCustomRepoCheck:
             data={'environment_ids': lce_id}
         )
 
-        rhel_client = ContentHost.get_host_by_hostname(client_hostname)
         result = rhel_client.execute(f'yum install -y {FAKE_4_CUSTOM_PACKAGE_NAME}')
         assert result.status == 0
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16981

The intent of this change is to enable us to add post-deploy actions when requesting specific types of content hosts, like fips-enabled. Users can define a set of host_post_configs in conf/content_host.yaml file. They can then add the post config action under the host definition.

## Summary by Sourcery

Introduce a reusable content host factory that centralizes host checkout and optional post-deploy configuration, and update fixtures and upgrade tests to use it while improving network defaults and host cleanup.

New Features:
- Add a contenthost_factory context manager to create and optionally post-configure content hosts based on settings-defined post-config profiles.
- Add a host_post_config helper to run configurable post-deploy broker actions on one or more content hosts.
- Introduce a registered_hosts fixture that provisions and registers multiple content hosts to Satellite based on the current setup.

Enhancements:
- Default content host network configuration to settings.content_host.network_type when not explicitly provided in fixture parameters.
- Refactor existing content host fixtures to rely on the shared contenthost_factory for consistent provisioning behavior, including _count-based multi-host scenarios and Satellite-based custom hosts.
- Adjust CentOS and Oracle host fixtures to derive deploy_network_type from the server IPv4/IPv6 configuration.
- Update the sat_upgrade_chost fixture to use the common contenthost_factory and UBI8 container host configuration instead of directly invoking Broker.

Tests:
- Add explicit cleanup of the post-upgrade RHEL client in the repository upgrade test via a finalizer that checks in the host through Broker.