### PR TITLE
[6.19.z] Add a contenthost_factory to perform post-deploy actions

### DIFF
--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -17,6 +17,8 @@ content_host:
     vm:
       workflow: deploy-base-rhel-fips
       deploy_rhel_version: '7'
+    post_configs:
+      - fips
   rhel8:
     vm:
       workflow: deploy-rhel
@@ -27,6 +29,8 @@ content_host:
     vm:
       workflow: deploy-base-rhel-fips
       deploy_rhel_version: '8'
+    post_configs:
+      - fips
   rhel9:
     vm:
       workflow: deploy-rhel
@@ -37,6 +41,8 @@ content_host:
     vm:
       workflow: deploy-base-rhel-fips
       deploy_rhel_version: '9'
+    post_configs:
+      - fips
   rhel10:
     vm:
       workflow: deploy-rhel
@@ -49,9 +55,9 @@ content_host:
       deploy_rhel_version: '10'
   centos7:
     vm:
-      workflow: deploy-centos
-      deploy_scenario: centos
       deploy_rhel_version: '7'
+      deploy_scenario: centos
+      workflow: deploy-centos
   centos8:
     vm:
       workflow: deploy-centos
@@ -67,4 +73,10 @@ content_host:
       workflow: deploy-oracle-linux
       deploy_scenario: oracle
       deploy_rhel_version: '8.10'
-
+host_post_configs:
+  fips:
+    workflow: enable-fips
+    target_vm: "{host.name}"
+  fapolicyd:
+    workflow: enable-fapolicyd
+    target_vm: "{host.name}"


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16981

The intent of this change is to enable us to add post-deploy actions when requesting specific types of content hosts, like fips-enabled. Users can define a set of host_post_configs in conf/content_host.yaml file. They can then add the post config action under the host definition.

## Summary by Sourcery

Introduce a reusable content host factory that centralizes host checkout and optional post-deploy configuration, and update fixtures and upgrade tests to use it while improving network defaults and host cleanup.

New Features:
- Add a contenthost_factory context manager to create and optionally post-configure content hosts based on settings-defined post-config profiles.
- Add a host_post_config helper to run configurable post-deploy broker actions on one or more content hosts.
- Introduce a registered_hosts fixture that provisions and registers multiple content hosts to Satellite based on the current setup.

Enhancements:
- Default content host network configuration to settings.content_host.network_type when not explicitly provided in fixture parameters.
- Refactor existing content host fixtures to rely on the shared contenthost_factory for consistent provisioning behavior, including _count-based multi-host scenarios and Satellite-based custom hosts.
- Adjust CentOS and Oracle host fixtures to derive deploy_network_type from the server IPv4/IPv6 configuration.
- Update the sat_upgrade_chost fixture to use the common contenthost_factory and UBI8 container host configuration instead of directly invoking Broker.

Tests:
- Add explicit cleanup of the post-upgrade RHEL client in the repository upgrade test via a finalizer that checks in the host through Broker.