### PR TITLE
[6.19.z] Update test_rhc.py fixtures so it works with other RHELs too

### DIFF
--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -29,12 +29,18 @@ def fixture_enable_rhc_repos(module_target_sat):
     # subscribe rhc satellite to cdn.
     if settings.rh_cloud.crc_env == 'prod':
         module_target_sat.register_to_cdn()
-        if module_target_sat.os_version.major == 8:
-            module_target_sat.enable_repo(constants.REPOS['rhel8_bos']['id'])
-            module_target_sat.enable_repo(constants.REPOS['rhel8_aps']['id'])
+        major = module_target_sat.os_version.major
+        if major > 7:
+            module_target_sat.enable_repo(constants.REPOS[f'rhel{major}_bos']['id'])
+            module_target_sat.enable_repo(constants.REPOS[f'rhel{major}_aps']['id'])
         else:
             module_target_sat.enable_repo(constants.REPOS['rhscl7']['id'])
             module_target_sat.enable_repo(constants.REPOS['rhel7']['id'])
+        # yggdrasil-worker-forwarder is shipped in the Satellite repo, not RHEL.
+        sat_version = '.'.join(module_target_sat.version.split('.')[:2])
+        module_target_sat.enable_repo(
+            f'satellite-{sat_version}-for-rhel-{major}-x86_64-rpms', force=True
+        )
 
 
 @pytest.fixture(scope='module')
@@ -78,18 +84,25 @@ def fixture_setup_rhc_satellite(
     yield
     if request.node.report_call.passed:
         # Enable and sync required repos
-        repo1_id = module_target_sat.api_factory.enable_sync_redhat_repo(
-            constants.REPOS['rhel8_aps'], module_rhc_org.id
-        )
-        repo2_id = module_target_sat.api_factory.enable_sync_redhat_repo(
-            constants.REPOS['rhel7'], module_rhc_org.id
-        )
-        repo3_id = module_target_sat.api_factory.enable_sync_redhat_repo(
-            constants.REPOS['rhel8_bos'], module_rhc_org.id
-        )
+        major = module_target_sat.os_version.major
+        if major > 7:
+            repo_ids = [
+                module_target_sat.api_factory.enable_sync_redhat_repo(
+                    constants.REPOS[f'rhel{major}_bos'], module_rhc_org.id
+                ),
+                module_target_sat.api_factory.enable_sync_redhat_repo(
+                    constants.REPOS[f'rhel{major}_aps'], module_rhc_org.id
+                ),
+            ]
+        else:
+            repo_ids = [
+                module_target_sat.api_factory.enable_sync_redhat_repo(
+                    constants.REPOS['rhel7'], module_rhc_org.id
+                ),
+            ]
         # Add repos to Content view
         content_view = module_target_sat.api.ContentView(
-            organization=module_rhc_org, repository=[repo1_id, repo2_id, repo3_id]
+            organization=module_rhc_org, repository=repo_ids
         ).create()
         content_view.publish()
         # Create Activation key


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21354

### Problem Statement
test_rhc fixtures were working just for RHEL8 & 7

### Solution
Dynamically enable repos based on the Sat's RHEL version


### PRT test Cases example
I have run the tests against 6.16, 6.17, 6.18, and 6.19 PIT sat and it was passing.
``` 
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhc.py
```
-----
STDERR that was happening
```
--------------------------------- Captured Err ---------------------------------
2026-04-09 23:24:10 - robottelo - ERROR - Test phase 'call' failed for test: tests/foreman/ui/test_rhc.py::test_positive_configure_cloud_connector
2026-04-09 23:24:10 - robottelo - ERROR - Exception thrown:
    tests/foreman/ui/test_rhc.py:155: in test_positive_configure_cloud_connector
        module_target_sat.wait_for_tasks(
    robottelo/host_helpers/capsule_mixins.py:66: in wait_for_tasks
        task.poll(poll_rate=poll_rate, timeout=poll_timeout, must_succeed=must_succeed)
    ../../lib64/python3.12/site-packages/nailgun/entities.py:3821: in poll
        return _poll_task(self.id, self._server_config, poll_rate, timeout, must_succeed)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ../../lib64/python3.12/site-packages/nailgun/entity_mixins.py:145: in _poll_task
        raise TaskFailedError(
    E   nailgun.entity_mixins.TaskFailedError: Task 2dfea9c7-4408-4fce-add5-1c362273064b did not succeed. Task information: {'id': '2dfea9c7-4408-4fce-add5-1c362273064b', 'label': 'Actions::RemoteExecution::RunHostsJob', 'pending': False, 'action': 'Run hosts job: Configure Cloud Connector', 'username': 'admin', 'started_at': '2026-04-09 23:23:36 UTC', 'ended_at': '2026-04-09 23:24:07 UTC', 'duration': '30.494296', 'state': 'stopped', 'result': 'warning', 'progress': 1.0, 'input': {'job_invocation': {'id': 3, 'name': 'Maintenance Operations', 'description': 'Configure Cloud Connector'}, 'job_features': ['ansible_configure_cloud_connector'], 'job_category': 'Maintenance Operations', 'job_invocation_id': 3, 'proxy_batch_size': 100, 'trigger_run_step_id': 5, 'current_request_id': 'caf00ee8-8215-423c-851c-3536175c8ad3', 'current_timezone': 'UTC', 'current_organization_id': 1, 'current_location_id': 2, 'current_user_id': 4, 'dynflow': {}}, 'output': {'host_count': 1, 'remote_triggered_count': 0, 'planned_count': 1, 'cancelled_count': 0, 'total_count': 1, 'failed_count': 1, 'pending_count': 0, 'success_count': 0}, 'humanized': {'action': 'Run hosts job:', 'input': 'Configure Cloud Connector', 'output': '1 task(s), 0 success, 1 fail', 'errors': ['A sub task failed']}, 'cli_example': None, 'start_at': '2026-04-09 23:23:36 UTC', 'available_actions': {'cancellable': False, 'resumable': False}}
    ```