### PR TITLE
The candlepin_events service has been removed, so the service count i…

### DIFF
--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -53,7 +53,9 @@ def test_positive_update_katello_certs(cert_setup_destructive_teardown):
         # assert no hammer ping SSL cert error
         result = satellite.execute('hammer ping')
         assert 'SSL certificate verification failed' not in result.stdout
-        assert result.stdout.count('ok') == 9
+        for line in result.stdout.split('\n'):
+            if 'Status' in line:
+                assert 'ok' in line
         # assert all services are running
         result = satellite.execute('satellite-maintain health check --label services-up -y')
         assert result.status == 0, 'Not all services are running'
@@ -96,7 +98,9 @@ def test_regeneration_ssl_build_certs(target_sat):
     # assert no hammer ping SSL cert error
     result = target_sat.execute('hammer ping')
     assert 'SSL certificate verification failed' not in result.stdout
-    assert result.stdout.count('ok') == 9
+    for line in result.stdout.split('\n'):
+        if 'Status' in line:
+            assert 'ok' in line
     # assert all services are running
     result = target_sat.execute('satellite-maintain health check --label services-up -y')
     assert result.status == 0, 'Not all services are running'


### PR DESCRIPTION
### Problem Statement
The `candlepin_events` service was removed [here](https://github.com/theforeman/puppet-katello/pull/525), and the tests were failing due to an incorrect count.

### Solution
Added a fix.

## Summary by Sourcery

Tests:
- Update katello certificate check tests to expect one fewer 'ok' service in hammer ping output after candlepin_events removal.