### PR TITLE
[6.19.z] Update test_documentation_links to verify custom docs server url setting

### DIFF
--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -31,4 +31,6 @@ ROBOTTELO:
     IGNORE_VALIDATION_ERRORS: false
   # Stage docs url
   STAGE_DOCS_URL: https://docs.redhat.com
+  # Custom docs url (RHOKP)
+  CUSTOM_DOCS_URL: https://docs.redhat.com
   SHARED_RESOURCE_WAIT: 2

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -427,6 +427,7 @@ VALIDATORS = dict(
     ],
     robottelo=[
         Validator('robottelo.stage_docs_url', default='https://docs.redhat.com'),
+        Validator('robottelo.custom_docs_url', default=''),
         Validator('robottelo.settings.ignore_validation_errors', is_type_of=bool, default=False),
         Validator('robottelo.rhel_source', default='ga', is_in=['ga', 'internal']),
         Validator(

--- a/tests/foreman/ui/test_documentation_links.py
+++ b/tests/foreman/ui/test_documentation_links.py
@@ -46,6 +46,14 @@ pages = [
     'dashboard',
 ]
 
+exceptions = {
+    'about': [
+        'https://access.redhat.com/',
+        'https://www.redhat.com/en/blog/channel/red-hat-satellite',
+    ],
+    'cloudinventory': ['https://www.redhat.com/en/topics/management/data-application-security'],
+}
+
 
 @pytest.fixture(scope='module')
 def session(module_target_sat):
@@ -54,9 +62,44 @@ def session(module_target_sat):
         yield session
 
 
+@pytest.fixture(scope='module')
+def custom_docs_url_setting(request, module_target_sat):
+    """Optionally set a custom satellite_documentation_url Satellite setting.
+
+    When parametrized with ``True``, reads the custom URL from
+    ``robottelo.custom_docs_url`` in robottelo.yaml, applies it to
+    the Satellite setting, and reverts the setting to its original value after
+    all tests in the module finish.
+
+    When parametrized with ``False`` the setting is left unchanged (default).
+    """
+    if not request.param:
+        yield None
+        return
+    if not settings.robottelo.custom_docs_url:
+        pytest.skip('robottelo.custom_docs_url is not set in robottelo.yaml')
+    setting_obj = module_target_sat.api.Setting().search(
+        query={'search': 'name=satellite_documentation_url'}
+    )[0]
+    original_value = setting_obj.value or ''
+    setting_obj.value = settings.robottelo.custom_docs_url
+    setting_obj.update({'value'})
+    yield settings.robottelo.custom_docs_url
+    setting_obj.value = original_value
+    setting_obj.update({'value'})
+
+
 @pytest.mark.parametrize('page', pages)
+@pytest.mark.parametrize(
+    'custom_docs_url_setting',
+    [
+        pytest.param(False, id='default_url'),
+        pytest.param(True, id='custom_url'),
+    ],
+    indirect=True,
+)
 @pytest.mark.e2e
-def test_positive_documentation_links(module_target_sat, session, page):
+def test_positive_documentation_links(module_target_sat, session, custom_docs_url_setting, page):
     """Verify that Satellite documentation links are working.
         Note: At the moment, the test doesn't support verifying links hidden behind a button.
         Currently, the only such link is on RH Cloud > Inventory Upload page.
@@ -66,7 +109,7 @@ def test_positive_documentation_links(module_target_sat, session, page):
     :Steps:
 
         1. Gather documentation links present on various Satellite pages.
-        2. Verify the links are working (returns 200).
+        2. Verify the links are working (returns 200). If Custom URL is set also check that it was applied
 
     :expectedresults: All the Documentation links present on Satellite are working
     """
@@ -86,15 +129,29 @@ def test_positive_documentation_links(module_target_sat, session, page):
     logger.info(f"Following are the documentation links collected from Satellite: \n {all_links}")
     for link in all_links:
         # Test stage docs url for Non-GA'ed Satellite
-        if float(sat_version) in settings.robottelo.sat_non_ga_versions:
+        if (
+            float(sat_version) in settings.robottelo.sat_non_ga_versions
+            and not custom_docs_url_setting
+        ):
             # The internal satellite doc url redirects to prod doc that is not available for Non-GA versions.
             # Get the end url first and then update it in later part of test.
+            # This does not apply when custom URL is set
             if module_target_sat.hostname in link:
                 link = requests.get(link, verify=False).url
             link = link.replace('https://docs.redhat.com', settings.robottelo.stage_docs_url)
         if requests.get(link, verify=False).status_code != 200:
             broken_links.append(link)
             logger.info(f"Following link on {page} page seems broken: \n {link}")
+        # If Custom URL is configured, check if it is applied, allow pre-defined exceptions
+        if (
+            custom_docs_url_setting
+            and custom_docs_url_setting not in link
+            and not (page in exceptions and link in exceptions[page])
+        ):
+            broken_links.append(link)
+            logger.info(
+                f"Following link on {page} does not comply with custom url setting: \n {link}"
+            )
     assert not broken_links, (
         f"There are broken documentation links on page \"{page}\": \n {broken_links}"
     )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21135

This change extends test_positive_documentation_links by adding a new parameter custom_url to test new functionality - configurable 'Red Hat documentation server URL' in Satellite. When custom url (RHOKP) is provided in robottelo.yaml the url is applied in Satellite settings and documentation links are tested. Setting is reverted after testing is finished.

## Summary by Sourcery

Add support in documentation link tests for validating a configurable custom Satellite documentation URL while maintaining existing default behavior.

Enhancements:
- Introduce configuration for a custom Satellite documentation URL via robottelo.custom_docs_url with validation support.

Tests:
- Extend documentation link UI test to run against both default and custom documentation URLs, including handling exceptions and non-GA behavior.