### PR TITLE
Hook flatpak E2E cases on SAT-44554

### DIFF
--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -824,6 +824,8 @@ def test_sync_consume_flatpak_repo_via_library(
         1. Entire workflow works and allows user to install a flatpak app at the registered
            contenthost.
 
+    :BlockedBy: SAT-44554
+
     """
     sat, caps, host = module_target_sat, module_capsule_configured, module_flatpak_contenthost
 
@@ -972,6 +974,8 @@ def test_sync_consume_flatpak_repo_via_cv(
     :expectedresults:
         1. Flatpak repos published in a CV are installable on a host via the CV through Capsule.
         2. Other flatpak repos published in a different CV are isolated from the first CV.
+
+    :BlockedBy: SAT-44554
 
     """
     sat, caps, host = module_target_sat, module_capsule_configured, module_flatpak_contenthost

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -311,6 +311,10 @@ def test_sync_consume_flatpak_repo_via_library(
         1. Entire workflow works and allows user to install a flatpak app at the registered
            contenthost.
 
+    :BlockedBy: SAT-44554
+
+    :Verifies: SAT-44554
+
     """
     sat, host = module_target_sat, module_flatpak_contenthost
 
@@ -449,6 +453,8 @@ def test_sync_consume_flatpak_repo_via_cv(
     :expectedresults:
         1. Flatpak repos published in a CV are installable on a host via the CV.
         2. Other flatpak repos published in a different CV are isolated from the first CV.
+
+    :BlockedBy: SAT-44554
 
     """
     sat, host = module_target_sat, module_flatpak_contenthost

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1495,6 +1495,8 @@ class TestContentViewSync:
 
         :customerscenario: true
 
+        :BlockedBy: SAT-44554
+
         """
         # Create CV, add all setup repos and publish.
         content_view = target_sat.cli_factory.make_content_view(


### PR DESCRIPTION
### Problem Statement
There is a regression that fails all flatpak E2E cases. We should block them until the issue is resolved.

### Solution
This PR.

### Related Issues
https://redhat.atlassian.net/browse/SAT-44554

## Summary by Sourcery

Mark flatpak-related E2E tests as blocked by SAT-44554 due to a known regression.

Tests:
- Annotate flatpak CLI and capsule content E2E tests with :BlockedBy: SAT-44554 so they are tracked as blocked by the current regression.
- Tag the mixed-content export/import CV test with :BlockedBy: SAT-44554 to reflect its dependency on the same issue.
- Mark one flatpak library workflow test as :Verifies: SAT-44554 for future resolution tracking.