### PR TITLE
Make test_positive_create_with_one_character_name more stable

### DIFF
--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -40,6 +40,7 @@ class TestPartitionTable:
         """
         ptable = target_sat.cli_factory.make_partition_table({'name': name})
         assert ptable['name'] == name
+        target_sat.cli.PartitionTable.delete({'id': ptable['id']})
 
     @pytest.mark.upgrade
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem statement
`test_positive_create_with_one_character_name` is flaky due to "Name has already been taken" errors. The test creates partition tables with 1-character names (generate_strings_list(length=1)) but never cleans
them up. With a pool of only ~26 possible characters for a given string type, repeated runs on the same Satellite collide with leftover partition tables from previous runs.                                 
                                                                                                                                                                                                                
### Solution                                                                                                                                                                                                      
                                                                                                                                                                                         
Added cleanup — delete the created partition table after the assertion so subsequent runs don't hit name conflicts.    
                                                                                       
---
STDERR:                                                                                                                                                                                                     
```
--------------------------------- Captured Err ---------------------------------
2026-04-16 22:17:14 - robottelo - ERROR - Test phase 'call' failed for test: tests/foreman/cli/test_partitiontable.py::TestPartitionTable::test_positive_create_with_one_character_name[2]
2026-04-16 22:17:14 - robottelo - ERROR - Exception thrown:
    robottelo/host_helpers/cli_factory.py:55: in create_object
        result = cli_object.create(options, timeout)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    robottelo/cli/base.py:96: in create
        result = cls.execute(cls._construct_command(options), output_format='csv', timeout=timeout)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    robottelo/cli/base.py:211: in execute
        return cls._handle_response(response, ignore_stderr=ignore_stderr)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    robottelo/cli/base.py:60: in _handle_response
        raise CLIReturnCodeError(*error_data)
    E   robottelo.exceptions.CLIReturnCodeError: CLIReturnCodeError(status=65, stderr='Could not create the partition table:\n  Name has already been taken\n', msg='Command "partition-table create" finished with status 65\nstderr contains:\nCould not create the partition table:\n  Name has already been taken\n'
    
    The above exception was the direct cause of the following exception:
    tests/foreman/cli/test_partitiontable.py:41: in test_positive_create_with_one_character_name
        ptable = target_sat.cli_factory.make_partition_table({'name': name})
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    robottelo/host_helpers/cli_factory.py:374: in make_partition_table
        return create_object(self._satellite.cli.PartitionTable, args, options)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    robottelo/host_helpers/cli_factory.py:58: in create_object
        raise CLIFactoryError(
    E   robottelo.exceptions.CLIFactoryError: Failed to create PartitionTable with data:
    E   { 'file': '/tmp/5Ph0pOPdzo',
    E     'location-ids': None,
    E     'locations': None,
    E     'name': 't',
    E     'operatingsystem-ids': None,
    E     'operatingsystems': None,
    E     'organization-ids': None,
    E     'organizations': None,
    E     'os-family': 'VRP'}
    E   Command "partition-table create" finished with status 65
    E   stderr contains:
    E   Could not create the partition table:
    E     Name has already been taken
```                                                                                                                                                         
---

### PRT Example
<img width="346" height="220" alt="image" src="https://github.com/user-attachments/assets/26221cbf-74a1-4661-994f-43e6f2d2ebc3" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_partitiontable.py -k test_positive_create_with_one_character_name
```

## Summary by Sourcery

Tests:
- Delete the partition table created in test_positive_create_with_one_character_name to prevent subsequent runs from failing due to reused one-character names.