### PR TITLE
manage_traces_session_timeout_fix

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -3913,42 +3913,42 @@ def test_positive_all_hosts_manage_traces(target_sat, module_org, tracer_hosts, 
             f'got type={mock_trace[0]["type"]}'
         )
 
+    timestamp = (datetime.now(UTC) - timedelta(minutes=1)).strftime('%Y-%m-%d %H:%M')
+
     with target_sat.ui_session() as session:
         session.organization.select(org_name=module_org.name)
 
         # Use bulk action to manage traces on both hosts
-        timestamp = (datetime.now(UTC) - timedelta(minutes=1)).strftime('%Y-%m-%d %H:%M')
-
         alert_message = session.all_hosts.manage_traces(
             host_names=host_names, traces_to_select=[mock_service]
         )
         assert 'Danger alert' not in alert_message, 'Manage traces action failed'
 
-        # Wait for REX job to complete
-        search_query = f'action = "Run hosts job: Restart Services" and started_at >= "{timestamp}"'
-        target_sat.wait_for_tasks(
-            search_query=search_query,
-            search_rate=15,
-            max_tries=10,
-        )
+    # Wait for REX job to complete
+    search_query = f'action = "Run hosts job: Restart Services" and started_at >= "{timestamp}"'
+    target_sat.wait_for_tasks(
+        search_query=search_query,
+        search_rate=15,
+        max_tries=10,
+    )
 
-        if require_reboot:
-            # Reboot hosts to clear static traces
-            for host in tracer_hosts:
-                host.power_control(state='reboot')
-
-            for host in tracer_hosts:
-                host.wait_for_connection()
-
-        # Verify all traces are resolved on both hosts after restart/reboot
+    if require_reboot:
+        # Reboot hosts to clear static traces
         for host in tracer_hosts:
-            host_info = target_sat.cli.Host.info({'name': host.hostname})
-            traces = target_sat.cli.HostTraces.list({'host-id': host_info['id']})
-            remaining_apps = {t['application'] for t in traces}
-            assert mock_service not in remaining_apps, (
-                f'Trace {mock_service} still present on {host.hostname} after {"reboot" if require_reboot else "restart"}. '
-                f'Remaining traces: {remaining_apps}'
-            )
+            host.power_control(state='reboot')
+
+        for host in tracer_hosts:
+            host.wait_for_connection()
+
+    # Verify all traces are resolved on both hosts after restart/reboot
+    for host in tracer_hosts:
+        host_info = target_sat.cli.Host.info({'name': host.hostname})
+        traces = target_sat.cli.HostTraces.list({'host-id': host_info['id']})
+        remaining_apps = {t['application'] for t in traces}
+        assert mock_service not in remaining_apps, (
+            f'Trace {mock_service} still present on {host.hostname} after {"reboot" if require_reboot else "restart"}. '
+            f'Remaining traces: {remaining_apps}'
+        )
 
 
 def verify_system_purpose_via_api(


### PR DESCRIPTION
### Problem Statement                                                

`test_positive_all_hosts_manage_traces` fails with InvalidSessionIdException during session teardown. The ui_session() context manager wraps wait_for_tasks (up to 150s), host reboots, wait_for_connection, and
   CLI trace verification — none of which touch the browser. The Selenium Grid kills the idle session due to inactivity timeout, and the __exit__ cleanup fails trying to quit a dead session.
                                                                                                                                                                                                                
  STDERR                                                           
```
  selenium.common.exceptions.InvalidSessionIdException: Message: Unable to find session with ID: 29689ae82ad123b393a4b36a179af78f. Session was removed at 2026-04-17T01:14:18.009807320Z (108 seconds ago),
  reason: session timed out due to inactivity                                                                                                                                                                   
```
### Solution                                                                                                                                                                                                      
                                                                   
  Close the ui_session block immediately after the last UI action (manage_traces). All subsequent work — waiting for REX tasks, rebooting hosts, verifying traces via CLI — now runs outside the session so the 
  Selenium Grid inactivity timeout is no longer a factor.
                                                                                                                                                                                                                
### PRT Example                                                      
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py::test_positive_all_hosts_manage_traces
```