### PR TITLE
Remove if/else from test_positive_verify_updated_fdi_image as it is not required

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -481,7 +481,7 @@ def test_positive_verify_updated_fdi_image(target_sat):
     target_sat.execute('yum -y --disableplugin=foreman-protector install foreman-discovery-image')
 
     if target_sat.os_version.major == 9:
-        version = '9.6' if is_open('SAT-40503') else str(target_sat.os_version)
+        version = '9.6'
     elif target_sat.os_version.major == 8:
         version = str(target_sat.os_version)
 


### PR DESCRIPTION
### Problem Statement

`SAT-40503` report the issue as closed, since the modifications are not CP in 6.18. it affects `test_positive_verify_updated_fdi_image` 

### Solution

Remove if else block since it is not required.

### Related Issues

https://github.com/SatelliteQE/robottelo/pull/20973

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->