### PR TITLE
[6.19.z] manage_host_cols_stability_fix

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -3547,8 +3547,8 @@ def test_positive_all_hosts_manage_host_collections(target_sat, function_org, fu
         )
         assert 'Added' in result
         hosts_in_host_col = read_host_collections_hosts(target_sat, host_col_names, function_org)
-        assert hosts_in_host_col[host_col_names[0]] == host_names
-        assert hosts_in_host_col[host_col_names[1]] == host_names
+        assert sorted(hosts_in_host_col[host_col_names[0]]) == sorted(host_names)
+        assert sorted(hosts_in_host_col[host_col_names[1]]) == sorted(host_names)
 
         # Remove 1 host from 1 host collection
         # at this state there are 2 hosts in both 'TestHostCol_1' and 'TestHostCol_2'
@@ -3580,8 +3580,8 @@ def test_positive_all_hosts_manage_host_collections(target_sat, function_org, fu
             option='Add',
         )
         hosts_in_host_col = read_host_collections_hosts(target_sat, host_col_names, function_org)
-        assert hosts_in_host_col[host_col_names[0]] == host_names
-        assert hosts_in_host_col[host_col_names[1]] == host_names
+        assert sorted(hosts_in_host_col[host_col_names[0]]) == sorted(host_names)
+        assert sorted(hosts_in_host_col[host_col_names[1]]) == sorted(host_names)
 
         # Remove 2 hosts from 2 host collections
         result = session.all_hosts.change_associations_host_collections(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21387

### Problem Statement

  `test_positive_all_hosts_manage_host_collections` fails with AssertionError because the API returns hosts in a different order than they were created. The test compares lists directly, but host collection
  membership has no guaranteed ordering.

### Solution

  Use sorted() on both sides of the multi-host assertions so ordering doesn't matter.

  STDERR:
```
  AssertionError: assert ['egmemccpyz.he7ywu8vcd', 'fzpxfrblvz.ylzbadxeed'] == ['fzpxfrblvz.ylzbadxeed', 'egmemccpyz.he7ywu8vcd']
    At index 0 diff: 'egmemccpyz.he7ywu8vcd' != 'fzpxfrblvz.ylzbadxeed'
```
###  PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py::test_positive_all_hosts_manage_host_collections
```

## Summary by Sourcery

Make host collection association UI test resilient to non-deterministic host ordering in API responses.

Bug Fixes:
- Prevent flaky failures in test_positive_all_hosts_manage_host_collections by comparing host lists in a deterministic, order-insensitive way.

Tests:
- Adjust host collection membership assertions in the UI host test to compare sorted host lists instead of relying on API return order.