### PR TITLE
[6.18.z] iop_check_inventory_upload_absence_refactor

### DIFF
--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -253,29 +253,24 @@ def test_iop_recommendations_host_details_e2e(
         )
 
 
-# @pytest.mark.parametrize("module_target_sat_insights", [False], ids=["local"], indirect=True)
-def test_rhcloud_inventory_disabled_local_insights(module_target_sat_insights):
+@pytest.mark.parametrize("module_target_sat_insights", [False], ids=["local"], indirect=True)
+def test_iop_negative_rhcloud_inventory_upload_not_displayed(module_target_sat_insights):
     """Verify that the 'Red Hat Lightspeed > Inventory Upload' navigation item is not available
     when the Satellite is configured to use IoP.
 
     :id: 84023ae9-7bc4-4332-9aaf-749d6c48c2d2
 
     :steps:
-        1. Configure Satellite to use local Insights advisor engine.
-        2. Navigate to the Insights Recommendations page.
-        3. Select Insights > Inventory Upload from the navigation menu.
+        1. Configure Satellite with IOP
+        2. Check that 'Inventory Upload' is not visible under 'Red Hat Lightspeed'.
 
     :expectedresults:
-        1. "Inventory Upload" is not visible under "Insights".
-
-    :CaseImportance: Medium
-
-    :CaseAutomation: Automated
+        1. "Inventory Upload" is not visible under "Red Hat Lightspeed".
     """
     with module_target_sat_insights.ui_session() as session:
-        insights_view = session.cloudinsights.navigate_to(session.cloudinsights, 'All')
+        view = session.dashboard.navigate_to(session.dashboard, 'All')
         with pytest.raises(Exception, match='not found in navigation tree'):
-            insights_view.menu.select('Insights', 'Inventory Upload')
+            view.menu.select('Red Hat Lightspeed', 'Inventory Upload')
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21389

Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21388

Refactor and rename `test_rhcloud_inventory_disabled_local_insights` -> `test_iop_negative_rhcloud_inventory_upload_not_displayed` so it does what it is supposed to do based on its description


STDERR:
```
--------------------------------- Captured Err ---------------------------------
2026-04-17 01:14:22 - navmazing.null - ERROR - NAVIGATE: Timed out waiting for am_i_here.
2026-04-17 01:14:29 - robottelo - ERROR - Test phase 'call' failed for test: tests/foreman/ui/test_rhcloud_iop.py::test_rhcloud_inventory_disabled_local_insights
2026-04-17 01:14:29 - robottelo - ERROR - Exception thrown:
    tests/foreman/ui/test_rhcloud_iop.py:326: in test_rhcloud_inventory_disabled_local_insights
        insights_view = session.cloudinsights.navigate_to(session.cloudinsights, 'All')
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ../../lib64/python3.12/site-packages/airgun/navigation.py:156: in go
        raise navmazing.NavigationTriesExceeded(self._name)
    E   navmazing._errors.NavigationTriesExceeded: Navigation failed to reach [All] in the specified tries
```

### PRT test Cases example
<img width="364" height="95" alt="image" src="https://github.com/user-attachments/assets/c38d4f34-2320-4aa2-840f-c4cf4c827c50" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_iop.py::test_iop_negative_rhcloud_inventory_upload_not_displayed
```

## Summary by Sourcery

Refine an IoP UI test to assert that the Red Hat Lightspeed Inventory Upload item is absent when Satellite is configured with IoP.

Bug Fixes:
- Fix a UI navigation test to correctly validate absence of the Inventory Upload menu under Red Hat Lightspeed instead of Insights.

Enhancements:
- Rename and reparameterize the IoP inventory test to better reflect behavior and use the dashboard as the navigation entry point.