### PR TITLE
Replace sleep with wait for

### DIFF
--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -475,11 +475,11 @@ def test_positive_health_check_tftp_storage(sat_maintain, request):
         assert sat_maintain.execute(f'touch /var/lib/tftpboot/boot/{file}').status == 0
     # Wait until the created files are older than token_duration (set to 2 minutes above).
     token_duration_seconds = 2 * 60
-    mtime_path = f'/var/lib/tftpboot/boot/{files_to_delete[0]}'
-    mtime = int(sat_maintain.execute(f'stat -c %Y {mtime_path}').stdout.strip())
+    file_path = f'/var/lib/tftpboot/boot/{files_to_delete[0]}'
+    file_mtime = int(sat_maintain.execute(f'stat -c %Y {file_path}').stdout.strip())
     wait_for(
         lambda: (
-            int(sat_maintain.execute('date +%s').stdout.strip()) - mtime
+            int(sat_maintain.execute('date +%s').stdout.strip()) - file_mtime
             >= token_duration_seconds + 5
         ),
         timeout=token_duration_seconds + 60,

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -478,8 +478,10 @@ def test_positive_health_check_tftp_storage(sat_maintain, request):
     mtime_path = f'/var/lib/tftpboot/boot/{files_to_delete[0]}'
     mtime = int(sat_maintain.execute(f'stat -c %Y {mtime_path}').stdout.strip())
     wait_for(
-        lambda: int(sat_maintain.execute('date +%s').stdout.strip()) - mtime
-        >= token_duration_seconds + 5,
+        lambda: (
+            int(sat_maintain.execute('date +%s').stdout.strip()) - mtime
+            >= token_duration_seconds + 5
+        ),
         timeout=token_duration_seconds + 60,
         delay=10,
     )

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -475,17 +475,17 @@ def test_positive_health_check_tftp_storage(sat_maintain, request):
     # Create files for testing check-tftp-storage check.
     for file in files_to_delete:
         assert sat_maintain.execute(f'touch /var/lib/tftpboot/boot/{file}').status == 0
-    # The check removes TFTP artifacts older than the `token_duration` setting.
-    # Wait until files are "old enough" instead of sleeping a fixed amount.
-    token_duration = int(sat_maintain.cli.Settings.list({'search': 'name=token_duration'})[0]['value'])
-    token_duration_seconds = token_duration * 60
+    # Wait until the created files are older than token_duration (set to 2 minutes above).
+    token_duration_seconds = 2 * 60
     mtime_path = f'/var/lib/tftpboot/boot/{files_to_delete[0]}'
-
-    def _is_old_enough():
-        mtime = int(sat_maintain.execute(f'stat -c %Y {mtime_path}').stdout.strip())
-        return (time.time() - mtime) >= (token_duration_seconds + 5)
-
-    wait_for(_is_old_enough, timeout=(token_duration_seconds + 60), delay=5)
+    wait_for(
+        lambda: (
+            time.time() - int(sat_maintain.execute(f'stat -c %Y {mtime_path}').stdout.strip())
+            >= token_duration_seconds + 5
+        ),
+        timeout=token_duration_seconds + 60,
+        delay=5,
+    )
     assert sat_maintain.execute(f'touch /var/lib/tftpboot/boot/{files_to_keep[0]}').status == 0
     # Run check-tftp-storage check.
     result = sat_maintain.cli.Health.check(

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -12,8 +12,6 @@
 
 """
 
-import time
-
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for
@@ -478,13 +476,12 @@ def test_positive_health_check_tftp_storage(sat_maintain, request):
     # Wait until the created files are older than token_duration (set to 2 minutes above).
     token_duration_seconds = 2 * 60
     mtime_path = f'/var/lib/tftpboot/boot/{files_to_delete[0]}'
+    mtime = int(sat_maintain.execute(f'stat -c %Y {mtime_path}').stdout.strip())
     wait_for(
-        lambda: (
-            time.time() - int(sat_maintain.execute(f'stat -c %Y {mtime_path}').stdout.strip())
-            >= token_duration_seconds + 5
-        ),
+        lambda: int(sat_maintain.execute('date +%s').stdout.strip()) - mtime
+        >= token_duration_seconds + 5,
         timeout=token_duration_seconds + 60,
-        delay=5,
+        delay=10,
     )
     assert sat_maintain.execute(f'touch /var/lib/tftpboot/boot/{files_to_keep[0]}').status == 0
     # Run check-tftp-storage check.

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -16,11 +16,11 @@ import time
 
 from fauxfactory import gen_string
 import pytest
+from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.enums import NetworkType
 from robottelo.utils.installer import InstallerCommand
-from wait_for import wait_for
 
 upstream_url = {
     'foreman_repo': 'https://yum.theforeman.org/releases/nightly/el9/x86_64/',

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -20,6 +20,7 @@ import pytest
 from robottelo.config import settings
 from robottelo.enums import NetworkType
 from robottelo.utils.installer import InstallerCommand
+from wait_for import wait_for
 
 upstream_url = {
     'foreman_repo': 'https://yum.theforeman.org/releases/nightly/el9/x86_64/',
@@ -474,7 +475,17 @@ def test_positive_health_check_tftp_storage(sat_maintain, request):
     # Create files for testing check-tftp-storage check.
     for file in files_to_delete:
         assert sat_maintain.execute(f'touch /var/lib/tftpboot/boot/{file}').status == 0
-    time.sleep(200)
+    # The check removes TFTP artifacts older than the `token_duration` setting.
+    # Wait until files are "old enough" instead of sleeping a fixed amount.
+    token_duration = int(sat_maintain.cli.Settings.list({'search': 'name=token_duration'})[0]['value'])
+    token_duration_seconds = token_duration * 60
+    mtime_path = f'/var/lib/tftpboot/boot/{files_to_delete[0]}'
+
+    def _is_old_enough():
+        mtime = int(sat_maintain.execute(f'stat -c %Y {mtime_path}').stdout.strip())
+        return (time.time() - mtime) >= (token_duration_seconds + 5)
+
+    wait_for(_is_old_enough, timeout=(token_duration_seconds + 60), delay=5)
     assert sat_maintain.execute(f'touch /var/lib/tftpboot/boot/{files_to_keep[0]}').status == 0
     # Run check-tftp-storage check.
     result = sat_maintain.cli.Health.check(


### PR DESCRIPTION
Made-with: Agentic AI 

### Problem Statement
Replace fixed sleep with wait_for in health check

## Summary by Sourcery

Tests:
- Update the TFTP storage health check test to wait dynamically on file age instead of using a hard-coded sleep.