### PR TITLE
[6.18.z] Add new RH cloud usage metrics keys

### DIFF
--- a/tests/foreman/data/usage_report.yml
+++ b/tests/foreman/data/usage_report.yml
@@ -83,6 +83,17 @@ oidc_use: false
 pat_counts: 0
 pat_recently_used_count: 0
 revoked_pats_count: 0
+rh_cloud_connector_enabled: false
+rh_cloud_exclude_host_package_info: false
+rh_cloud_hosts_count: 0
+rh_cloud_inventory_upload_enabled: true
+rh_cloud_minimal_data_collection: false
+rh_cloud_mismatched_auto_delete: false
+rh_cloud_mismatched_hosts_count: 0
+rh_cloud_obfuscate_inventory_hostnames: false
+rh_cloud_obfuscate_inventory_ips: false
+rh_cloud_recommendations_sync_enabled: true
+rh_cloud_total_hits: 0
 smart_proxies_count: 1
 smart_proxies_creation_date|1: "2025-08-14 08:29:47.536836"
 total_users_count: 4


### PR DESCRIPTION
Manual cherrypick of PR:  #20980
(cherry picked from commit cf37a78bc5a01a08e84e79ec314e661994a5d5e9)

The  changes got to `6.18.5` so lets cherrypick automation changes as well:
```
tests/foreman/cli/test_usage_report.py:29: in compare_report_keys
    pytest.fail(
E   Failed: Report field mismatch: added items: {'rh_cloud_connector_enabled', 'rh_cloud_exclude_host_package_info', 'rh_cloud_recommendations_sync_enabled', 'rh_cloud_mismatched_hosts_count', 'rh_cloud_hosts_count', 'rh_cloud_minimal_data_collection', 'rh_cloud_obfuscate_inventory_ips', 'rh_cloud_inventory_upload_enabled', 'rh_cloud_mismatched_auto_delete', 'rh_cloud_obfuscate_inventory_hostnames', 'rh_cloud_total_hits'}, removed items: set()
```

### Problem Statement

https://github.com/theforeman/foreman_maintain/pull/1071 added new usage metrics keys to be collected by `foreman-maintain report generate`. This started causing `tests/foreman/cli/test_usage_report.py::test_positive_usage_report_items` to fail.

### Solution

Update the failing test with the new usage metrics keys.

### Related Issues

[SAT-43531](https://redhat.atlassian.net/browse/SAT-43531)



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->