### PR TITLE
Update usage_report.yml to Snap 181.0

### DIFF
--- a/tests/foreman/data/usage_report.yml
+++ b/tests/foreman/data/usage_report.yml
@@ -1,87 +1,136 @@
 ---
-custom_alternate_content_sources_count: 0
-simplified_alternate_content_sources_count: 0
-rhui_alternate_content_sources_count: 0
-yum_alternate_content_sources_count: 0
-file_alternate_content_sources_count: 0
-custom_library_yum_repositories_count: 0
-redhat_library_yum_repositories_count: 0
-library_debian_repositories_count: 0
-library_container_repositories_count: 0
-library_file_repositories_count: 0
-library_python_repositories_count: 0
-library_ansible_collection_repositories_count: 0
-library_ostree_repositories_count: 0
-iop_remediations_enabled: false
-iop_remediations_count:
-bookmarks_custom_public_count: 0
-bookmarks_custom_private_count: 0
+activation_keys_count: 0
+activation_keys_multi_cv_count: 0
+ansible_collections_count: 0
+assigned_custom_roles_count: 0
+audits|max_created_at: '2026-04-22 21:01:09.216596'
+audits|min_created_at: '2026-04-22 20:04:37.085545'
+audits|records_count: 58
+bookmarks_by_public_by_type|public|User: 20
 bookmarks_custom_count: 0
+bookmarks_custom_private_count: 0
+bookmarks_custom_public_count: 0
+compliance_arf_report_last_year_count: 0
+compliance_non_default_scap_contents_count: 0
 compliance_policy_count: 0
 compliance_policy_with_tailoring_file_count: 0
 compliance_scap_contents_count: 5
-compliance_non_default_scap_contents_count: 0
-compliance_arf_report_last_year_count: 0
+compute_resource_vmware_count: 0
+container_manifest_lists_count: 0
+container_manifests_count: 0
+container_meta_tags_count: 0
+container_tags_count: 0
+content_views_composite_count: 0
+content_views_count: 0
+content_views_rolling_count: 0
+content_views_rolling_using_library_count: 0
+content_views_rolling_using_lifecycle_environments_count: 0
+custom_alternate_content_sources_count: 0
+custom_library_yum_repositories_count: 0
+custom_roles_count: 0
+dashboard_widgets_count|User ID 1: 22
+dashboard_widgets_count|User ID 2: 22
+dashboard_widgets_count|User ID 3: 22
+dashboard_widgets_count|User ID 4: 22
 disconnected_environment: false
-last_login_on_through_external_auth_source_in_days:
-host_collections_count: 0
-host_collections_with_limit_count: 0
-hostgroup_nesting: false
-hostgroup_max_nesting_level: 0
-use_selectable_columns: false
-usergroup_max_nesting_level: 0
-user_group_roles_max_count: 0
-user_group_roles_min_count: 0
-remote_execution_transient_package_actions_count: 0
-instance_uuid: ad176452-88b9-5d42-bf1e-1a9714a290b9
-hosts_by_type_count|Managed: 1
-hosts_by_os_count|RedHat: 1
-hosts_by_family_count|Redhat: 1
-facts_by_type|Puppet|min_update_time: "2025-08-14 08:28:58.921124"
-facts_by_type|Puppet|max_update_time: "2025-08-14 08:28:59.818802"
-facts_by_type|Puppet|values_count: 404
-audits|records_count: 57
-audits|min_created_at: "2025-08-14 08:27:17.575698"
-audits|max_created_at: "2025-08-14 08:32:00.221025"
-parameters_count|CommonParameter: 7
-rhel_ai_workload_host_count: 0
-kerberos_use: false
-kerberos_api_use: false
+discovery_rules_count: 0
+errata_count: 0
+export_complete_count: 0
+export_content_view_version_histories_count: 0
+export_format_importable_count: 0
+export_format_syncable_count: 0
+export_incremental_count: 0
+export_library_histories_count:
+export_repository_histories_count:
 external_user_group_mapping_count: 0
-ldap_auth_source_free_ipa_count: 0
-users_authenticated_through_ldap_auth_source_free_ipa: 0
-last_login_on_through_ldap_auth_source_free_ipa_in_days:
-ldap_auth_source_free_ipa_with_net_groups_count:
-ldap_auth_source_free_ipa_with_posix_groups_count:
-ldap_auth_source_free_ipa_with_account_creation_disabled_count: 0
-ldap_auth_source_free_ipa_with_user_group_sync_disabled_count: 0
-ldap_auth_source_posix_count: 0
-users_authenticated_through_ldap_auth_source_posix: 0
-last_login_on_through_ldap_auth_source_posix_in_days:
-ldap_auth_source_posix_with_net_groups_count:
-ldap_auth_source_posix_with_posix_groups_count:
-ldap_auth_source_posix_with_account_creation_disabled_count: 0
-ldap_auth_source_posix_with_user_group_sync_disabled_count: 0
-ldap_auth_source_active_directory_count: 0
-users_authenticated_through_ldap_auth_source_active_directory: 0
-last_login_on_through_ldap_auth_source_active_directory_in_days:
-ldap_auth_source_active_directory_with_net_groups_count:
-ldap_auth_source_active_directory_with_posix_groups_count:
-ldap_auth_source_active_directory_with_account_creation_disabled_count: 0
-ldap_auth_source_active_directory_with_user_group_sync_disabled_count: 0
-subnet_ipv4_count: 0
-subnet_ipv6_count: 0
-hosts_with_ipv4only_interface_count: 1
-hosts_with_ipv6only_interface_count: 0
-hosts_with_dualstack_interface_count: 0
+facts_by_type|Puppet|max_update_time: '2026-04-22 20:09:15.595223'
+facts_by_type|Puppet|min_update_time: '2026-04-22 20:06:57.212771'
+facts_by_type|Puppet|values_count: 412
+file_alternate_content_sources_count: 0
+file_units_count: 0
+flatpak_images_count: 0
+flatpak_remote_repositories_count: 0
+flatpak_remotes_count: 0
+foreman_interfaces_dualstack_count: 0
 foreman_interfaces_ipv4only_count: 1
 foreman_interfaces_ipv6only_count: 0
-foreman_interfaces_dualstack_count: 0
-setting_remote_execution_connect_by_ip_prefer_ipv6: false
-setting_discovery_prefer_ipv6: false
+foreman_virt_who_configure_ahv_count: 0
+foreman_virt_who_configure_configurations_count: 0
+foreman_virt_who_configure_esx_count: 0
+foreman_virt_who_configure_fakevirt_count: 0
+foreman_virt_who_configure_hyperv_count: 0
+foreman_virt_who_configure_kubevirt_count: 0
+foreman_virt_who_configure_libvirtd_count: 0
+host_collections_count: 0
+host_collections_with_limit_count: 0
+host_installed_packages_persistent_count: 0
+host_installed_packages_transient_count: 0
+hostgroup_max_nesting_level: 0
+hostgroup_nesting: false
+hosts_by_compute_profile|none: 1
+hosts_by_compute_resources_type|baremetal: 1
+hosts_by_family_count|Redhat: 1
+hosts_by_managed_count|unmanaged: 1
+hosts_by_os_count|RedHat: 1
+hosts_by_type_count|Managed: 1
+hosts_multi_cv_count: 0
+hosts_multi_cv_with_rolling_cv_count: 0
+hosts_with_assigned_smart_proxy_count: 0
+hosts_with_dualstack_interface_count: 0
+hosts_with_ipv4only_interface_count: 1
+hosts_with_ipv6only_interface_count: 0
+instance_uuid: ad176452-88b9-5d42-bf1e-1a9714a290b9
+iop_remediations_count:
+iop_remediations_enabled: false
+kerberos_api_use: false
+kerberos_use: false
+last_login_on_through_external_auth_source_in_days:
+last_login_on_through_ldap_auth_source_active_directory_in_days:
+last_login_on_through_ldap_auth_source_free_ipa_in_days:
+last_login_on_through_ldap_auth_source_posix_in_days:
+ldap_auth_source_active_directory_count: 0
+ldap_auth_source_active_directory_with_account_creation_disabled_count: 0
+ldap_auth_source_active_directory_with_net_groups_count:
+ldap_auth_source_active_directory_with_posix_groups_count:
+ldap_auth_source_active_directory_with_user_group_sync_disabled_count: 0
+ldap_auth_source_free_ipa_count: 0
+ldap_auth_source_free_ipa_with_account_creation_disabled_count: 0
+ldap_auth_source_free_ipa_with_net_groups_count:
+ldap_auth_source_free_ipa_with_posix_groups_count:
+ldap_auth_source_free_ipa_with_user_group_sync_disabled_count: 0
+ldap_auth_source_posix_count: 0
+ldap_auth_source_posix_with_account_creation_disabled_count: 0
+ldap_auth_source_posix_with_net_groups_count:
+ldap_auth_source_posix_with_posix_groups_count:
+ldap_auth_source_posix_with_user_group_sync_disabled_count: 0
+library_ansible_collection_repositories_count: 0
+library_container_repositories_count: 0
+library_debian_repositories_count: 0
+library_file_repositories_count: 0
+library_ostree_repositories_count: 0
+library_python_repositories_count: 0
+lifecycle_environment_paths_count: 0
+lifecycle_environments_count: 0
+location_ignore_types_used: true
+locations_count: 1
+managed_hosts_created_in_last_3_months: 0
+modified_settings: bcrypt_cost,default_organization,default_location_subscribed_hosts,default_location,db_pending_seed,instance_id,failed_login_attempts_limit
+module_streams_count: 0
+nics_by_type_count|Managed: 1
+non_admin_users_count: 0
 oidc_use: false
+organization_ignore_types_used: false
+organizations_count: 1
+parameters_count|CommonParameter: 7
 pat_counts: 0
 pat_recently_used_count: 0
+recurring_logics_indefinite_rex_ansible_count: 0
+recurring_logics_indefinite_rex_count: 0
+redhat_file_repositories_enabled_count: 0
+redhat_library_yum_repositories_count: 0
+redhat_repositories_enabled_count: 0
+registry_name_patterns_count: 0
+remote_execution_transient_package_actions_count: 0
 revoked_pats_count: 0
 rh_cloud_connector_enabled: false
 rh_cloud_exclude_host_package_info: false
@@ -94,41 +143,41 @@ rh_cloud_obfuscate_inventory_hostnames: false
 rh_cloud_obfuscate_inventory_ips: false
 rh_cloud_recommendations_sync_enabled: true
 rh_cloud_total_hits: 0
-smart_proxies_count: 1
-smart_proxies_creation_date|1: "2025-08-14 08:29:47.536836"
-total_users_count: 4
-non_admin_users_count: 0
-custom_roles_count: 0
-taxonomies_counts|Organization: 1
-taxonomies_counts|Location: 1
-modified_settings: bcrypt_cost,default_organization,default_location_subscribed_hosts,default_location,db_pending_seed,instance_id
-bookmarks_by_public_by_type|public|User: 20
-user_mail_notifications_count: 1
-user_groups_count: 0
-managed_hosts_created_in_last_3_months: 0
-hosts_by_compute_resources_type|baremetal: 1
-hosts_by_compute_profile|none: 1
-nics_by_type_count|Managed: 1
-hosts_by_managed_count|unmanaged: 1
-discovery_rules_count: 0
-users_count: 1
-assigned_custom_roles_count: 0
-organizations_count: 1
-locations_count: 1
-organization_ignore_types_used: false
-location_ignore_types_used: true
-recurring_logics_indefinite_rex_count: 0
-recurring_logics_indefinite_rex_ansible_count: 0
+rhel_ai_workload_host_count: 0
+rhui_alternate_content_sources_count: 0
+rpms_count: 0
 selinux_enforced: true
-foreman_virt_who_configure_configurations_count: 0
-foreman_virt_who_configure_ahv_count: 0
-foreman_virt_who_configure_esx_count: 0
-foreman_virt_who_configure_fakevirt_count: 0
-foreman_virt_who_configure_hyperv_count: 0
-foreman_virt_who_configure_kubevirt_count: 0
-foreman_virt_who_configure_libvirtd_count: 0
-compute_resource_vmware_count: 0
-webhooks_enabled_count: 0
-webhooks_subscribed_events: ""
+setting_discovery_prefer_ipv6: false
+setting_remote_execution_connect_by_ip_prefer_ipv6: false
 shell_hooks_count: 0
-version: 1
+simplified_alternate_content_sources_count: 0
+smart_proxies_assigned_hosts_count_average: 0.0
+smart_proxies_assigned_hosts_count_max: 0
+smart_proxies_assigned_hosts_count_median: 0.0
+smart_proxies_assigned_hosts_count_min: 0
+smart_proxies_count: 0
+smart_proxies_creation_date|1: '2026-04-22 20:07:04.263039'
+smart_proxies_syncing_library_count: 0
+smart_proxies_syncing_multiple_lifecycle_environments_count: 0
+smart_proxies_with_assigned_hosts_count: 0
+subnet_ipv4_count: 0
+subnet_ipv6_count: 0
+sync_plans_count: 0
+sync_plans_used: false
+taxonomies_counts|Location: 1
+taxonomies_counts|Organization: 1
+total_users_count: 4
+use_selectable_columns: false
+user_group_roles_max_count: 0
+user_group_roles_min_count: 0
+user_groups_count: 0
+user_mail_notifications_count: 1
+usergroup_max_nesting_level: 0
+users_authenticated_through_ldap_auth_source_active_directory: 0
+users_authenticated_through_ldap_auth_source_free_ipa: 0
+users_authenticated_through_ldap_auth_source_posix: 0
+users_count: 1
+webhooks_enabled_count: 0
+webhooks_subscribed_events: ''
+yum_alternate_content_sources_count: 0
+version: 3


### PR DESCRIPTION
### Problem Statement
Outdated `usage_report.yml` causes reporting tests to fail

### Solution
Update  `usage_report.yml`  to match Snap 181.0 / 6.19.0 state

### Related Issues
[SAT-44622](https://redhat.atlassian.net/browse/SAT-44622)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Refresh usage_report.yml test fixture values and keys to reflect the latest usage reporting fields, defaults, and version.