### PR TITLE
Update HostGroup UI Tests

### DIFF
--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -16,7 +16,7 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_CV, ENVIRONMENT
+from robottelo.constants import ENVIRONMENT
 
 
 @pytest.mark.e2e
@@ -44,8 +44,7 @@ def test_positive_end_to_end(session, module_org, module_location, module_target
             {
                 'host_group.name': name,
                 'host_group.description': description,
-                'host_group.lce': ENVIRONMENT,
-                'host_group.content_view': DEFAULT_CV,
+                'host_group.content_view_environment': ENVIRONMENT,
                 'network.domain': domain.name,
                 'operating_system.architecture': architecture.name,
                 'operating_system.operating_system': os_name,
@@ -54,8 +53,7 @@ def test_positive_end_to_end(session, module_org, module_location, module_target
         hostgroup_values = session.hostgroup.read(name)
         assert hostgroup_values['host_group']['name'] == name
         assert hostgroup_values['host_group']['description'] == description
-        assert hostgroup_values['host_group']['lce'] == ENVIRONMENT
-        assert hostgroup_values['host_group']['content_view'] == DEFAULT_CV
+        assert hostgroup_values['host_group']['content_view_environment'] == ENVIRONMENT
         assert hostgroup_values['operating_system']['architecture'] == architecture.name
         assert hostgroup_values['operating_system']['operating_system'] == os_name
         # Update host group with new name
@@ -240,6 +238,8 @@ def test_positive_nested_host_groups(
     :BZ: 1996077
 
     :customerscenario: true
+
+    :BlockedBy: SAT-44612
     """
     parent_hg_name = gen_string('alpha')
     child_hg_name = gen_string('alpha')
@@ -253,8 +253,7 @@ def test_positive_nested_host_groups(
             {
                 'host_group.name': parent_hg_name,
                 'host_group.description': description,
-                'host_group.lce': ENVIRONMENT,
-                'host_group.content_view': DEFAULT_CV,
+                'host_group.content_view_environment': ENVIRONMENT,
                 'operating_system.architecture': architecture.name,
                 'operating_system.operating_system': os_name,
             }
@@ -271,22 +270,23 @@ def test_positive_nested_host_groups(
         assert target_sat.api.HostGroup().search(query={'search': f'name={child_hg_name}'})
         child_hostgroup_values = session.hostgroup.read(f'{parent_hg_name}/{child_hg_name}')
         assert parent_hg_name in child_hostgroup_values['host_group']['parent_name']
-        assert ENVIRONMENT in child_hostgroup_values['host_group']['lce']
-        assert DEFAULT_CV in child_hostgroup_values['host_group']['content_view']
+        assert ENVIRONMENT in child_hostgroup_values['host_group']['content_view_environment']
 
         # Update nested host group
         session.hostgroup.update(
             f'{parent_hg_name}/{child_hg_name}',
             {
-                'host_group.lce': module_lce.name,
-                'host_group.content_view': module_published_cv.name,
+                'host_group.content_view_environment': (
+                    f'{module_lce.name} / {module_published_cv.name}'
+                ),
                 'activation_keys.activation_keys': module_ak_cv_lce.name,
             },
         )
         child_hostgroup_values = session.hostgroup.read(f'{parent_hg_name}/{child_hg_name}')
         assert parent_hg_name in child_hostgroup_values['host_group']['parent_name']
-        assert module_lce.name in child_hostgroup_values['host_group']['lce']
-        assert module_published_cv.name in child_hostgroup_values['host_group']['content_view']
+        cve = child_hostgroup_values['host_group']['content_view_environment']
+        assert module_lce.name in cve
+        assert module_published_cv.name in cve
 
         # Delete nested host group
         session.hostgroup.delete(f'{parent_hg_name}/{child_hg_name}')
@@ -311,7 +311,7 @@ def test_positive_clone_host_groups(
 
     :BZ: 2122261
 
-    :BlockedBy: SAT-20435
+    :BlockedBy: SAT-20435, SAT-44612
 
     :customerscenario: true
     """
@@ -327,8 +327,9 @@ def test_positive_clone_host_groups(
             {
                 'host_group.name': parent_hg_name,
                 'host_group.description': description,
-                'host_group.lce': module_lce.name,
-                'host_group.content_view': module_published_cv.name,
+                'host_group.content_view_environment': (
+                    f'{module_lce.name} / {module_published_cv.name}'
+                ),
                 'operating_system.architecture': architecture.name,
                 'operating_system.operating_system': os_name,
                 'activation_keys.activation_keys': module_ak_cv_lce.name,
@@ -345,8 +346,9 @@ def test_positive_clone_host_groups(
         )
         assert target_sat.api.HostGroup().search(query={'search': f'name={clone_hg_name}'})
         clone_hostgroup_values = session.hostgroup.read(clone_hg_name)
-        assert module_lce.name in clone_hostgroup_values['host_group']['lce']
-        assert module_published_cv.name in clone_hostgroup_values['host_group']['content_view']
+        cve = clone_hostgroup_values['host_group']['content_view_environment']
+        assert module_lce.name in cve
+        assert module_published_cv.name in cve
         assert (
             module_ak_cv_lce.name in clone_hostgroup_values['activation_keys']['ak_chip_group'][0]
         )
@@ -357,13 +359,11 @@ def test_positive_clone_host_groups(
         session.hostgroup.update(
             clone_hg_name,
             {
-                'host_group.lce': ENVIRONMENT,
-                'host_group.content_view': DEFAULT_CV,
+                'host_group.content_view_environment': ENVIRONMENT,
             },
         )
         clone_hostgroup_values = session.hostgroup.read(clone_hg_name)
-        assert ENVIRONMENT in clone_hostgroup_values['host_group']['lce']
-        assert DEFAULT_CV in clone_hostgroup_values['host_group']['content_view']
+        assert ENVIRONMENT in clone_hostgroup_values['host_group']['content_view_environment']
 
         # Delete parent and clone host group
         session.hostgroup.delete(parent_hg_name)

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -284,9 +284,9 @@ def test_positive_nested_host_groups(
         )
         child_hostgroup_values = session.hostgroup.read(f'{parent_hg_name}/{child_hg_name}')
         assert parent_hg_name in child_hostgroup_values['host_group']['parent_name']
-        cve = child_hostgroup_values['host_group']['content_view_environment']
-        assert module_lce.name in cve
-        assert module_published_cv.name in cve
+        cve_env = child_hostgroup_values['host_group']['content_view_environment']
+        assert module_lce.name in cve_env
+        assert module_published_cv.name in cve_env
 
         # Delete nested host group
         session.hostgroup.delete(f'{parent_hg_name}/{child_hg_name}')
@@ -346,9 +346,9 @@ def test_positive_clone_host_groups(
         )
         assert target_sat.api.HostGroup().search(query={'search': f'name={clone_hg_name}'})
         clone_hostgroup_values = session.hostgroup.read(clone_hg_name)
-        cve = clone_hostgroup_values['host_group']['content_view_environment']
-        assert module_lce.name in cve
-        assert module_published_cv.name in cve
+        cve_env = clone_hostgroup_values['host_group']['content_view_environment']
+        assert module_lce.name in cve_env
+        assert module_published_cv.name in cve_env
         assert (
             module_ak_cv_lce.name in clone_hostgroup_values['activation_keys']['ak_chip_group'][0]
         )


### PR DESCRIPTION
Update UI HG tests so they comply with the change made in https://github.com/Katello/katello/pull/11707/changes.
Also block 2 tests accessing ActivationKeys HostGroup Tab which is broken by SAT-44612


Needs: https://github.com/SatelliteQE/airgun/pull/2415
### PRT test Cases example
<img width="252" height="29" alt="image" src="https://github.com/user-attachments/assets/8ba2fdec-04ac-4d93-ac7b-122b90aa6c8a" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostgroup.py -k 'test_positive_end_to_end'
airgun: 2415
Katello:
    katello: 11707
```