### PR TITLE
contentAccessVmFixtureFix

### DIFF
--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -102,7 +102,7 @@ def vm(
     # Force package profile upload and applicability recalculation
     module_rhel_contenthost.run('subscription-manager repos')
     module_target_sat.cli.Host.errata_recalculate({'host-id': host_id})
-    if major == 10:
+    if major != 10:
         module_rhel_contenthost.install_katello_host_tools()
     return module_rhel_contenthost
 


### PR DESCRIPTION
In https://github.com/SatelliteQE/robottelo/pull/21361 I wrote incorrect if, fixing it here.

### PRT test Cases example
<img width="312" height="129" alt="image" src="https://github.com/user-attachments/assets/671267e9-2bf1-4eba-a520-59b96fb2a214" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentaccess.py -k 'test_positive_erratum_installable'
```