### PR TITLE
[6.18.z] flatpak pulpcore registry index return 500 code

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -794,6 +794,8 @@ class TestCapsuleContentManagement:
 
         :expectedresults:
             1. HTTP 200
+
+        :BlockedBy: SAT-44554
         """
         ep = FLATPAK_ENDPOINTS[endpoint].format(module_capsule_configured.hostname)
         rq = requests.get(ep, verify=settings.server.verify_ca)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21411

### Problem Statement
testcase `test_flatpak_endpoint[pulpcore]` is failing in `6.18.z`, `6.19.z` and `stream` due to below error.
```
AssertionError: Expected 200 but got 500 from pulpcore registry index
```
### Solution
Block test execution 

### Related Issues
https://redhat.atlassian.net/browse/SAT-44554

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Annotate the flatpak endpoint capsule content API test with a BlockedBy reference to SAT-44554 to reflect the known 500 response issue.