### PR TITLE
[6.19.z] Limit random name chars to valid charsets in api/test_user.py

### DIFF
--- a/robottelo/utils/datafactory.py
+++ b/robottelo/utils/datafactory.py
@@ -115,6 +115,16 @@ def add_uppercase_char_into_string(text=None, length=10):
     return ''.join(st_chars)
 
 
+def valid_first_and_last_name_strings(length=50):
+    r"""
+    Generate valid first/last names for API positive tests.
+    Foreman validates user first/last names using User.name_format:
+    /\A[[:alnum:]\s'_\-.()<>;=,]*\z/
+    so random utf8/latin1 values may include symbols outside the allowed charset.
+    """
+    return generate_strings_list(exclude_types=['html', 'utf8', 'latin1'], max_length=50)
+
+
 @filtered_datapoint
 def invalid_emails_list():
     """

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -35,6 +35,7 @@ from robottelo.utils.datafactory import (
     parametrized,
     valid_data_list,
     valid_emails_list,
+    valid_first_and_last_name_strings,
     valid_usernames_list,
 )
 
@@ -63,9 +64,7 @@ class TestUser:
         user = target_sat.api.User(login=username).create()
         assert user.login == username
 
-    @pytest.mark.parametrize(
-        'firstname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
-    )
+    @pytest.mark.parametrize('firstname', **parametrized(valid_first_and_last_name_strings()))
     def test_positive_create_with_firstname(self, firstname, target_sat):
         """Create User for all variations of First Name
 
@@ -82,9 +81,7 @@ class TestUser:
         user = target_sat.api.User(firstname=firstname).create()
         assert user.firstname == firstname
 
-    @pytest.mark.parametrize(
-        'lastname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
-    )
+    @pytest.mark.parametrize('lastname', **parametrized(valid_first_and_last_name_strings()))
     def test_positive_create_with_lastname(self, lastname, target_sat):
         """Create User for all variations of Last Name
 
@@ -198,9 +195,7 @@ class TestUser:
         with pytest.raises(HTTPError):
             create_user.update(['login'])
 
-    @pytest.mark.parametrize(
-        'firstname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
-    )
+    @pytest.mark.parametrize('firstname', **parametrized(valid_first_and_last_name_strings()))
     def test_positive_update_firstname(self, create_user, firstname):
         """Update a user and provide new firstname.
 
@@ -218,9 +213,7 @@ class TestUser:
         user = create_user.update(['firstname'])
         assert user.firstname == firstname
 
-    @pytest.mark.parametrize(
-        'lastname', **parametrized(generate_strings_list(exclude_types=['html'], max_length=50))
-    )
+    @pytest.mark.parametrize('lastname', **parametrized(valid_first_and_last_name_strings()))
     def test_positive_update_lastname(self, create_user, lastname):
         """Update a user and provide new lastname.
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21065

Exclude `utf8` and `latin1` from `generate_strings_list` for user first/last name create+update positive tests. Foreman validates names with a restricted character set, so random UTF-8/Latin-1 values can introduce sporadic false negatives; this keeps coverage broad while making these tests more stable.

In the long term, I would ideally want most of the tests in this test file moved to upstream since they are mainly unit tests, but that will require more work and reviews. For short term, this fixes the test failures.

## Summary by Sourcery

Stabilize user name API tests by restricting randomized first and last name inputs to valid character sets.

Bug Fixes:
- Prevent sporadic failures in user first and last name create/update tests by excluding utf8 and latin1 strings from generated test data.

Tests:
- Adjust parameterized first and last name create/update tests to generate strings only from character sets accepted by Foreman validation.