### PR TITLE
Update all host details inventory status message

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -363,7 +363,10 @@ def test_host_details_page(
         # Verify Insights status of host.
         result = session.host_new.get_host_statuses(rhel_insights_vm.hostname)
         assert result['Red Hat Lightspeed']['Status'] == 'Reporting'
-        assert result['Inventory']['Status'] == 'Host is uploaded and present on console.redhat.com Inventory service'
+        assert (
+            result['Inventory']['Status']
+            == 'Host is uploaded and present on console.redhat.com Inventory service'
+        )
 
         # Verify recommendations exist for host.
         result = session.host_new.search(rhel_insights_vm.hostname)[0]

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -363,7 +363,7 @@ def test_host_details_page(
         # Verify Insights status of host.
         result = session.host_new.get_host_statuses(rhel_insights_vm.hostname)
         assert result['Red Hat Lightspeed']['Status'] == 'Reporting'
-        assert result['Inventory']['Status'] == 'Successfully uploaded to your RH cloud inventory'
+        assert result['Inventory']['Status'] == 'Host is uploaded and present on console.redhat.com Inventory service'
 
         # Verify recommendations exist for host.
         result = session.host_new.search(rhel_insights_vm.hostname)[0]


### PR DESCRIPTION
### Problem Statement
Inventory status message on All host details page has been updated to `Host is uploaded and present on [console.redhat.com](http://console.redhat.com/) Inventory service
`
Earlier it was  `'Successfully uploaded to your RH cloud inventory'`
It has been changed as a part of  https://github.com/theforeman/foreman_rh_cloud/pull/1182

### Solution
Update Inventory status message on All host details page 

### Related Issues


## PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_insights.py -k test_host_details_page

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Adjust host details page test to assert the new inventory status message text for Red Hat cloud inventory.