### PR TITLE
Block CLI flatpak endpoint test for SAT-44554

### DIFF
--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -221,6 +221,8 @@ def test_flatpak_endpoint(target_sat, endpoint):
 
     :expectedresults:
         1. HTTP 200
+
+    :BlockedBy: SAT-44554
     """
     ep = FLATPAK_ENDPOINTS[endpoint].format(target_sat.hostname)
     rq = requests.get(ep, verify=settings.server.verify_ca)


### PR DESCRIPTION
### Problem Statement

The `test_flatpak_endpoint[pulpcore]` test in `tests/foreman/cli/test_flatpak.py` is failing due to SAT-44554 with the below error:
```
AssertionError: Expected 200 but got 500 from pulpcore registry index
```

### Solution

Block test execution.

### Related Issues

https://redhat.atlassian.net/browse/SAT-44554

## Summary by Sourcery

Tests:
- Annotate the pulpcore Flatpak endpoint CLI test as blocked by SAT-44554 to avoid failing runs.