### PR TITLE
don't install foremanctl from copr but from the regular repository

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2003,20 +2003,19 @@ class Capsule(ContentHost, CapsuleMixins):
         if parameters:
             default_parameters.extend(parameters)
 
-        assert (
-            self.execute(
-                f'foremanctl deploy {" ".join(default_parameters)}',
-                timeout='30m',
-            ).status
-            == 0
+        deploy = self.execute(
+            f'foremanctl deploy {" ".join(default_parameters)}',
+            timeout='30m',
+        )
+        assert deploy.status == 0, f'foremanctl deploy failed:\n{deploy.stderr}'
+
+        deploy_features = self.execute(
+            'foremanctl deploy --add-feature foreman-proxy --add-feature hammer'
+        )
+        assert deploy_features.status == 0, (
+            f'foremanctl deploy --add-feature failed:\n{deploy_features.stderr}'
         )
 
-        assert (
-            self.execute(
-                'foremanctl deploy --add-feature foreman-proxy --add-feature hammer'
-            ).status
-            == 0
-        )
         return
 
     def query_db(self, query, db='foreman', output_format='json'):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1576,12 +1576,6 @@ class ContentHost(Host, ContentHostMixins):
                 satellite_repo=settings.repos.satellite_repo,
                 satmaintenance_repo=settings.repos.satmaintenance_repo,
             )
-        elif settings.server.version.source == 'upstream':
-            self.create_custom_repos(
-                foreman='https://yum.theforeman.org/nightly/el9/x86_64/',
-                foreman_plugins='https://yum.theforeman.org/plugins/nightly/el9/x86_64/',
-                katello='https://yum.theforeman.org/katello/nightly/katello/el9/x86_64/',
-            )
         else:
             # get ohsnap repofile
             self.download_repofile(
@@ -1970,7 +1964,6 @@ class Capsule(ContentHost, CapsuleMixins):
         self.register_to_cdn()
         self.setup_rhel_repos()
         self.setup_satellite_repos()
-        assert self.execute('dnf copr enable -y @theforeman/foremanctl rhel-9-x86_64').status == 0
         assert self.execute('dnf install -y foremanctl').status == 0
 
         if enable_fapolicyd:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1964,6 +1964,16 @@ class Capsule(ContentHost, CapsuleMixins):
         self.register_to_cdn()
         self.setup_rhel_repos()
         self.setup_satellite_repos()
+
+        # Enable Packit repos
+        pull_requests = settings.server.get('deploy_arguments', {}).get('pull_requests', [])
+        if pull_requests:
+            Broker(
+                job_template='upstream-pr-install',
+                target_vm=self.name,
+                pull_requests=pull_requests,
+            ).execute()
+
         assert self.execute('dnf install -y foremanctl').status == 0
 
         if enable_fapolicyd:

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from robottelo.config import settings
 from robottelo.hosts import Satellite
 from robottelo.logging import collection_logger
 
@@ -76,14 +75,3 @@ def ui_session_record_property(request, record_property):
             ):
                 sat = request.getfixturevalue(fixture)
                 sat.record_property = record_property
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_protocol(item, nextitem):
-    """Set version source to upstream for tests marked with foremanctl."""
-    if item.get_closest_marker('foremanctl'):
-        settings.set('server.version.source', 'upstream')
-        yield
-        settings.set('server.version.source', 'internal')
-    else:
-        yield


### PR DESCRIPTION
### Problem Statement

Using a hard-coded copr makes it impossible to use packit builds when testing foremanctl PRs

### Solution

Don't configure the foremanctl copr but rely on the package from the regular repository

Supporting packit builds will require a follow up that enables the packit configuration for the workflows we use to deploy foremanctl based setups

### Related Issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/installer/test_install_foremanctl.py
```

## Summary by Sourcery

Enhancements:
- Remove the hard-coded COPR configuration for foremanctl so it can be sourced from the default or Packit-configured repositories.