### PR TITLE
Add a test case for loadbalanced flatpak content

### DIFF
--- a/tests/foreman/data/haproxy.cfg
+++ b/tests/foreman/data/haproxy.cfg
@@ -38,7 +38,7 @@ frontend https
 
 backend f-proxy-https
    option tcp-check
-   balance roundrobin
+   balance source
    mode tcp
    server f-proxy-https-2 CAPSULE_1:443 check
    server f-proxy-https-3 CAPSULE_2:443 check

--- a/tests/foreman/sys/test_capsule_loadbalancer.py
+++ b/tests/foreman/sys/test_capsule_loadbalancer.py
@@ -417,7 +417,6 @@ def test_loadbalancer_container(
 
 @pytest.mark.e2e
 @pytest.mark.rhel_ver_match('10')
-@pytest.mark.parametrize('cert_login', [False, True], ids=['podman_login', 'cert_login'])
 def test_loadbalancer_flatpak(
     request,
     setup_haproxy,
@@ -428,29 +427,26 @@ def test_loadbalancer_flatpak(
     module_flatpak_contenthost,
     function_host_cleanup,
     flatpak_content_for_lb,
-    cert_login,
 ):
     """Verify flatpak repository workflow end to end via CV through a load balancer.
 
     :id: 937674f3-3d0b-4346-8d9f-844d72a5c8e7
-
-    :parametrized: yes
 
     :setup:
         1. Two capsules set up with a load balancer (HAProxy).
         2. Flatpak repos mirrored, two CVs published and promoted, capsules synced.
 
     :steps:
-        1. Register the content host via the load balancer.
+        1. Register the content host via the load balancer with certificate authentication.
         2. Configure the content host to use the load balancer's flatpak index.
-        3. Ensure only the proper Apps are available (exclusion for cert-based auth only).
+        3. Ensure only the proper Apps are available (CV isolation).
         4. Install flatpak app from cv1, ensure it succeeded.
-        5. Try to install flatpak app from cv2, ensure it failed for cert-based login.
+        5. Try to install flatpak app from cv2, ensure it failed.
         6. Verify flatpak still works when only one capsule is available (failover).
 
     :expectedresults:
         1. Flatpak repos published in a CV are installable on a host via the CV through LB.
-        2. Other flatpak repos published in a different CV are isolated (cert-based only).
+        2. Other flatpak repos published in a different CV are isolated.
         3. Flatpak installation works even when one of the capsules is unavailable.
 
     :Verifies: SAT-36752, SAT-44752
@@ -470,7 +466,7 @@ def test_loadbalancer_flatpak(
         activation_keys=ak.name,
         target=setup_capsules[0],
         force=True,
-        setup_container_certs=cert_login,
+        setup_container_certs=True,
     )
     assert result.status == 0, (
         f'Failed to register host: {host.hostname}\nStdOut: {result.stdout}\nStdErr: {result.stderr}'
@@ -481,31 +477,17 @@ def test_loadbalancer_flatpak(
     remote_name = f'LB-remote-{gen_string("alpha")}'
     inputs = (
         f'Remote Name={remote_name}, '
-        f'Flatpak registry URL={settings.server.scheme}://{setup_haproxy.hostname}/'
+        f'Flatpak registry URL={settings.server.scheme}://{setup_haproxy.hostname}/, '
+        'Set up certificate authentication=true'
     )
-    if cert_login:
-        inputs = f'{inputs}, Set up certificate authentication=true'
 
-        @request.addfinalizer
-        def _finalize():
-            host.reset_podman_cert_auth(setup_capsules[0])
-            host.execute(f'flatpak remote-delete {remote_name}')
-            host.execute(f'flatpak uninstall {cv1_app} com.redhat.Platform -y')
-            for capsule in setup_capsules:
-                capsule.power_control(state=VmState.RUNNING, ensure=True)
-
-    else:
-        inputs = (
-            f'{inputs}, Username={settings.server.admin_username}, '
-            f'Password={settings.server.admin_password}'
-        )
-
-        @request.addfinalizer
-        def _finalize():
-            host.execute(f'flatpak remote-delete {remote_name}')
-            host.execute(f'flatpak uninstall {cv1_app} com.redhat.Platform -y')
-            for capsule in setup_capsules:
-                capsule.power_control(state=VmState.RUNNING, ensure=True)
+    @request.addfinalizer
+    def _finalize():
+        host.reset_podman_cert_auth()
+        host.execute(f'flatpak remote-delete {remote_name}')
+        host.execute(f'flatpak uninstall {cv1_app} com.redhat.Platform -y')
+        for capsule in setup_capsules:
+            capsule.power_control(state=VmState.RUNNING, ensure=True)
 
     job = sat.cli_factory.job_invocation(
         {
@@ -520,11 +502,10 @@ def test_loadbalancer_flatpak(
     res = host.execute('flatpak remotes')
     assert remote_name in res.stdout
 
-    # 3. Ensure only the proper Apps are available (exclusion for cert-based auth only).
+    # 3. Ensure only the proper Apps are available (CV isolation).
     res = host.execute(f'flatpak remote-ls {remote_name}')
     assert all(app_name in res.stdout for app_name in ['Thunderbird', 'Platform'])
-    if cert_login:
-        assert 'firefox' not in res.stdout.lower()
+    assert 'firefox' not in res.stdout.lower()
 
     # 4. Install flatpak app from cv1, ensure it succeeded.
     opts = {
@@ -545,20 +526,19 @@ def test_loadbalancer_flatpak(
     assert 'succeeded' in res['status']
     assert cv1_app in host.execute('flatpak list').stdout
 
-    # 5. Try to install flatpak app from cv2, ensure it failed for cert-based login.
-    if cert_login:
-        with pytest.raises(CLIFactoryError) as error:
-            sat.cli_factory.job_invocation(
-                opts
-                | {
-                    'inputs': (
-                        f'Flatpak remote name={remote_name}, Application name={cv2_app}, '
-                        'Launch a session bus instance=true'
-                    )
-                },
-            )
-        assert 'A sub task failed' in error.value.args[0]
-        assert cv2_app not in host.execute('flatpak list').stdout
+    # 5. Try to install flatpak app from cv2, ensure it failed.
+    with pytest.raises(CLIFactoryError) as error:
+        sat.cli_factory.job_invocation(
+            opts
+            | {
+                'inputs': (
+                    f'Flatpak remote name={remote_name}, Application name={cv2_app}, '
+                    'Launch a session bus instance=true'
+                )
+            },
+        )
+    assert 'A sub task failed' in error.value.args[0]
+    assert cv2_app not in host.execute('flatpak list').stdout
 
     # 6. Verify flatpak still works when only one capsule is available (failover).
     host.execute(f'flatpak uninstall {cv1_app} com.redhat.Platform -y')

--- a/tests/foreman/sys/test_capsule_loadbalancer.py
+++ b/tests/foreman/sys/test_capsule_loadbalancer.py
@@ -432,6 +432,8 @@ def test_loadbalancer_flatpak(
 
     :id: 937674f3-3d0b-4346-8d9f-844d72a5c8e7
 
+    :Team: Artemis
+
     :setup:
         1. Two capsules set up with a load balancer (HAProxy).
         2. Flatpak repos mirrored, two CVs published and promoted, capsules synced.

--- a/tests/foreman/sys/test_capsule_loadbalancer.py
+++ b/tests/foreman/sys/test_capsule_loadbalancer.py
@@ -12,13 +12,16 @@
 
 """
 
+from datetime import UTC, datetime
+
 import pytest
 from wait_for import wait_for
 from wrapanapi import VmState
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.constants import CLIENT_PORT, DataFile
+from robottelo.constants import CLIENT_PORT, FLATPAK_REMOTES, FLATPAK_RHEL_RELEASE_VER, DataFile
+from robottelo.exceptions import CLIFactoryError
 from robottelo.utils.datafactory import gen_string
 from robottelo.utils.installer import InstallerCommand
 
@@ -320,6 +323,283 @@ def test_loadbalancer_container(
     )
     assert rhel_contenthost.execute(f'podman pull {registry_repo}').status == 0
     assert rhel_contenthost.execute('podman rmi -a').status == 0
+
+
+@pytest.fixture(scope='module')
+def flatpak_content_for_lb(module_target_sat, module_org, setup_capsules):
+    """Mirror flatpak repos, create two CVs, promote to a dedicated LCE, sync capsules.
+
+    :return: dict with activation key (cv1), cv1_app and cv2_app names.
+    """
+    sat = module_target_sat
+
+    # Create a dedicated LCE and associate it to both capsules.
+    lce = sat.api.LifecycleEnvironment(organization=module_org).create()
+    for capsule in setup_capsules:
+        capsule_id = next(c['id'] for c in sat.cli.Capsule.list() if c['name'] == capsule.hostname)
+        sat.cli.Capsule.content_add_lifecycle_environment(
+            {
+                'id': capsule_id,
+                'organization-id': module_org.id,
+                'lifecycle-environment': lce.name,
+            }
+        )
+
+    # Create a flatpak remote, scan it, and mirror the required repos.
+    remote_config = FLATPAK_REMOTES['RedHat']
+    create_opts = {
+        'organization-id': module_org.id,
+        'url': remote_config['url'],
+        'name': gen_string('alpha'),
+    }
+    if remote_config['authenticated']:
+        create_opts['username'] = settings.container_repo.registries.redhat.username
+        create_opts['token'] = settings.container_repo.registries.redhat.password
+    fr = sat.cli.FlatpakRemote().create(create_opts)
+    sat.cli.FlatpakRemote().scan({'id': fr['id']})
+    all_repos = sat.cli.FlatpakRemote().repository_list({'flatpak-remote-id': fr['id']})
+
+    ver = FLATPAK_RHEL_RELEASE_VER
+    repo_names = [
+        f'rhel{ver}/firefox-flatpak',
+        f'rhel{ver}/flatpak-runtime',  # runtime is dependency
+        f'rhel{ver}/thunderbird-flatpak',
+    ]
+    remote_repos = [r for r in all_repos if r['name'] in repo_names]
+    assert len(repo_names) == len(remote_repos), 'Testing repos are missing from remote index.'
+
+    product = sat.api.Product(organization=module_org).create()
+    for repo in remote_repos:
+        sat.cli.FlatpakRemote().repository_mirror(
+            {
+                'flatpak-remote-id': fr['id'],
+                'id': repo['id'],
+                'product-id': product.id,
+            }
+        )
+    local_repos = sat.cli.Repository.list({'product-id': product.id})
+    assert set([r['name'] for r in local_repos]) == set(repo_names), (
+        'Required repo(s) were not scanned or mirrored'
+    )
+    for repo in local_repos:
+        sat.cli.Repository.synchronize({'id': repo['id']})
+
+    # Create two CVs with different repos, publish and promote them to LCE.
+    # cv1: thunderbird + runtime (Last 2); cv2: firefox + runtime (First 2).
+    cv1 = sat.api.ContentView(
+        organization=module_org,
+        repository=[r['id'] for r in local_repos if r['name'] in repo_names[-2:]],
+    ).create()
+    cv2 = sat.api.ContentView(
+        organization=module_org,
+        repository=[r['id'] for r in local_repos if r['name'] in repo_names[:2]],
+    ).create()
+    timestamp = datetime.now(UTC)
+    for cv in [cv1, cv2]:
+        cv.publish()
+        cv.read().version[0].promote(data={'environment_ids': lce.id})
+    for capsule in setup_capsules:
+        capsule.wait_for_sync(start_time=timestamp)
+
+    ak = sat.api.ActivationKey(
+        organization=module_org,
+        content_view=cv1,
+        environment=lce,
+    ).create()
+
+    return {
+        'ak': ak,
+        'cv1_app': 'org.mozilla.Thunderbird',
+        'cv2_app': 'org.mozilla.firefox',
+    }
+
+
+@pytest.mark.e2e
+@pytest.mark.rhel_ver_match('10')
+@pytest.mark.parametrize('cert_login', [False, True], ids=['podman_login', 'cert_login'])
+def test_loadbalancer_flatpak(
+    request,
+    setup_haproxy,
+    setup_capsules,
+    module_target_sat,
+    module_org,
+    module_location,
+    module_flatpak_contenthost,
+    function_host_cleanup,
+    flatpak_content_for_lb,
+    cert_login,
+):
+    """Verify flatpak repository workflow end to end via CV through a load balancer.
+
+    :id: 937674f3-3d0b-4346-8d9f-844d72a5c8e7
+
+    :parametrized: yes
+
+    :setup:
+        1. Two capsules set up with a load balancer (HAProxy).
+        2. Flatpak repos mirrored, two CVs published and promoted, capsules synced.
+
+    :steps:
+        1. Register the content host via the load balancer.
+        2. Configure the content host to use the load balancer's flatpak index.
+        3. Ensure only the proper Apps are available (exclusion for cert-based auth only).
+        4. Install flatpak app from cv1, ensure it succeeded.
+        5. Try to install flatpak app from cv2, ensure it failed for cert-based login.
+        6. Verify flatpak still works when only one capsule is available (failover).
+
+    :expectedresults:
+        1. Flatpak repos published in a CV are installable on a host via the CV through LB.
+        2. Other flatpak repos published in a different CV are isolated (cert-based only).
+        3. Flatpak installation works even when one of the capsules is unavailable.
+
+    :Verifies: SAT-36752, SAT-44752
+
+    :BlockedBy: SAT-44752
+
+    """
+    sat, host = module_target_sat, module_flatpak_contenthost
+    ak = flatpak_content_for_lb['ak']
+    cv1_app = flatpak_content_for_lb['cv1_app']
+    cv2_app = flatpak_content_for_lb['cv2_app']
+
+    # 1. Register the content host via the load balancer.
+    result = host.register(
+        org=module_org,
+        loc=module_location,
+        activation_keys=ak.name,
+        target=setup_capsules[0],
+        force=True,
+        setup_container_certs=cert_login,
+    )
+    assert result.status == 0, (
+        f'Failed to register host: {host.hostname}\nStdOut: {result.stdout}\nStdErr: {result.stderr}'
+    )
+    assert host.subscribed
+
+    # 2. Configure the content host to use the load balancer's flatpak index.
+    remote_name = f'LB-remote-{gen_string("alpha")}'
+    inputs = (
+        f'Remote Name={remote_name}, '
+        f'Flatpak registry URL={settings.server.scheme}://{setup_haproxy.hostname}/'
+    )
+    if cert_login:
+        inputs = f'{inputs}, Set up certificate authentication=true'
+
+        @request.addfinalizer
+        def _finalize():
+            host.reset_podman_cert_auth(setup_capsules[0])
+            host.execute(f'flatpak remote-delete {remote_name}')
+            host.execute(f'flatpak uninstall {cv1_app} com.redhat.Platform -y')
+            for capsule in setup_capsules:
+                capsule.power_control(state=VmState.RUNNING, ensure=True)
+
+    else:
+        inputs = (
+            f'{inputs}, Username={settings.server.admin_username}, '
+            f'Password={settings.server.admin_password}'
+        )
+
+        @request.addfinalizer
+        def _finalize():
+            host.execute(f'flatpak remote-delete {remote_name}')
+            host.execute(f'flatpak uninstall {cv1_app} com.redhat.Platform -y')
+            for capsule in setup_capsules:
+                capsule.power_control(state=VmState.RUNNING, ensure=True)
+
+    job = sat.cli_factory.job_invocation(
+        {
+            'organization': module_org.name,
+            'job-template': 'Flatpak - Set up remote on host',
+            'inputs': inputs,
+            'search-query': f'name = {host.hostname}',
+        }
+    )
+    res = sat.cli.JobInvocation.info({'id': job.id})
+    assert 'succeeded' in res['status']
+    res = host.execute('flatpak remotes')
+    assert remote_name in res.stdout
+
+    # 3. Ensure only the proper Apps are available (exclusion for cert-based auth only).
+    res = host.execute(f'flatpak remote-ls {remote_name}')
+    assert all(app_name in res.stdout for app_name in ['Thunderbird', 'Platform'])
+    if cert_login:
+        assert 'firefox' not in res.stdout.lower()
+
+    # 4. Install flatpak app from cv1, ensure it succeeded.
+    opts = {
+        'organization': module_org.name,
+        'job-template': 'Flatpak - Install application on host',
+        'search-query': f'name = {host.hostname}',
+    }
+    job = sat.cli_factory.job_invocation(
+        opts
+        | {
+            'inputs': (
+                f'Flatpak remote name={remote_name}, Application name={cv1_app}, '
+                'Launch a session bus instance=true'
+            )
+        },
+    )
+    res = sat.cli.JobInvocation.info({'id': job.id})
+    assert 'succeeded' in res['status']
+    assert cv1_app in host.execute('flatpak list').stdout
+
+    # 5. Try to install flatpak app from cv2, ensure it failed for cert-based login.
+    if cert_login:
+        with pytest.raises(CLIFactoryError) as error:
+            sat.cli_factory.job_invocation(
+                opts
+                | {
+                    'inputs': (
+                        f'Flatpak remote name={remote_name}, Application name={cv2_app}, '
+                        'Launch a session bus instance=true'
+                    )
+                },
+            )
+        assert 'A sub task failed' in error.value.args[0]
+        assert cv2_app not in host.execute('flatpak list').stdout
+
+    # 6. Verify flatpak still works when only one capsule is available (failover).
+    host.execute(f'flatpak uninstall {cv1_app} com.redhat.Platform -y')
+    setup_capsules[0].power_control(state=VmState.STOPPED, ensure=True)
+    wait_for(
+        lambda: 'Thunderbird' in host.execute(f'flatpak remote-ls {remote_name}').stdout,
+        timeout=30,
+        delay=5,
+    )
+    job = sat.cli_factory.job_invocation(
+        opts
+        | {
+            'inputs': (
+                f'Flatpak remote name={remote_name}, Application name={cv1_app}, '
+                'Launch a session bus instance=true'
+            )
+        },
+    )
+    res = sat.cli.JobInvocation.info({'id': job.id})
+    assert 'succeeded' in res['status']
+    assert cv1_app in host.execute('flatpak list').stdout
+
+    setup_capsules[0].power_control(state=VmState.RUNNING, ensure=True)
+    setup_capsules[1].power_control(state=VmState.STOPPED, ensure=True)
+    wait_for(
+        lambda: 'Thunderbird' in host.execute(f'flatpak remote-ls {remote_name}').stdout,
+        timeout=30,
+        delay=5,
+    )
+    host.execute(f'flatpak uninstall {cv1_app} com.redhat.Platform -y')
+    job = sat.cli_factory.job_invocation(
+        opts
+        | {
+            'inputs': (
+                f'Flatpak remote name={remote_name}, Application name={cv1_app}, '
+                'Launch a session bus instance=true'
+            )
+        },
+    )
+    res = sat.cli.JobInvocation.info({'id': job.id})
+    assert 'succeeded' in res['status']
+    assert cv1_app in host.execute('flatpak list').stdout
 
 
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])

--- a/tests/foreman/sys/test_capsule_loadbalancer.py
+++ b/tests/foreman/sys/test_capsule_loadbalancer.py
@@ -74,6 +74,95 @@ def content_for_client(module_target_sat, module_sca_manifest_org, module_lce, m
 
 
 @pytest.fixture(scope='module')
+def flatpak_content_for_lb(module_target_sat, module_org, setup_capsules):
+    """Mirror flatpak repos, create two CVs, promote to a dedicated LCE, sync capsules.
+
+    :return: dict with activation key (cv1), cv1_app and cv2_app names.
+    """
+    sat = module_target_sat
+
+    # Create a dedicated LCE and associate it to both capsules.
+    lce = sat.api.LifecycleEnvironment(organization=module_org).create()
+    for capsule in setup_capsules:
+        capsule_id = next(c['id'] for c in sat.cli.Capsule.list() if c['name'] == capsule.hostname)
+        sat.cli.Capsule.content_add_lifecycle_environment(
+            {
+                'id': capsule_id,
+                'organization-id': module_org.id,
+                'lifecycle-environment': lce.name,
+            }
+        )
+
+    # Create a flatpak remote, scan it, and mirror the required repos.
+    remote_config = FLATPAK_REMOTES['RedHat']
+    create_opts = {
+        'organization-id': module_org.id,
+        'url': remote_config['url'],
+        'name': gen_string('alpha'),
+    }
+    if remote_config['authenticated']:
+        create_opts['username'] = settings.container_repo.registries.redhat.username
+        create_opts['token'] = settings.container_repo.registries.redhat.password
+    fr = sat.cli.FlatpakRemote().create(create_opts)
+    sat.cli.FlatpakRemote().scan({'id': fr['id']})
+    all_repos = sat.cli.FlatpakRemote().repository_list({'flatpak-remote-id': fr['id']})
+
+    ver = FLATPAK_RHEL_RELEASE_VER
+    repo_names = [
+        f'rhel{ver}/firefox-flatpak',
+        f'rhel{ver}/flatpak-runtime',  # runtime is dependency
+        f'rhel{ver}/thunderbird-flatpak',
+    ]
+    remote_repos = [r for r in all_repos if r['name'] in repo_names]
+    assert len(repo_names) == len(remote_repos), 'Testing repos are missing from remote index.'
+
+    product = sat.api.Product(organization=module_org).create()
+    for repo in remote_repos:
+        sat.cli.FlatpakRemote().repository_mirror(
+            {
+                'flatpak-remote-id': fr['id'],
+                'id': repo['id'],
+                'product-id': product.id,
+            }
+        )
+    local_repos = sat.cli.Repository.list({'product-id': product.id})
+    assert set([r['name'] for r in local_repos]) == set(repo_names), (
+        'Required repo(s) were not scanned or mirrored'
+    )
+    for repo in local_repos:
+        sat.cli.Repository.synchronize({'id': repo['id']})
+
+    # Create two CVs with different repos, publish and promote them to LCE.
+    # cv1: thunderbird + runtime (Last 2); cv2: firefox + runtime (First 2).
+    cv1 = sat.api.ContentView(
+        organization=module_org,
+        repository=[r['id'] for r in local_repos if r['name'] in repo_names[-2:]],
+    ).create()
+    cv2 = sat.api.ContentView(
+        organization=module_org,
+        repository=[r['id'] for r in local_repos if r['name'] in repo_names[:2]],
+    ).create()
+    timestamp = datetime.now(UTC)
+    for cv in [cv1, cv2]:
+        cv.publish()
+        cv.read().version[0].promote(data={'environment_ids': lce.id})
+    for capsule in setup_capsules:
+        capsule.wait_for_sync(start_time=timestamp)
+
+    ak = sat.api.ActivationKey(
+        organization=module_org,
+        content_view=cv1,
+        environment=lce,
+    ).create()
+
+    return {
+        'ak': ak,
+        'cv1_app': 'org.mozilla.Thunderbird',
+        'cv2_app': 'org.mozilla.firefox',
+    }
+
+
+@pytest.fixture(scope='module')
 def setup_capsules(
     module_org,
     module_location,
@@ -323,95 +412,6 @@ def test_loadbalancer_container(
     )
     assert rhel_contenthost.execute(f'podman pull {registry_repo}').status == 0
     assert rhel_contenthost.execute('podman rmi -a').status == 0
-
-
-@pytest.fixture(scope='module')
-def flatpak_content_for_lb(module_target_sat, module_org, setup_capsules):
-    """Mirror flatpak repos, create two CVs, promote to a dedicated LCE, sync capsules.
-
-    :return: dict with activation key (cv1), cv1_app and cv2_app names.
-    """
-    sat = module_target_sat
-
-    # Create a dedicated LCE and associate it to both capsules.
-    lce = sat.api.LifecycleEnvironment(organization=module_org).create()
-    for capsule in setup_capsules:
-        capsule_id = next(c['id'] for c in sat.cli.Capsule.list() if c['name'] == capsule.hostname)
-        sat.cli.Capsule.content_add_lifecycle_environment(
-            {
-                'id': capsule_id,
-                'organization-id': module_org.id,
-                'lifecycle-environment': lce.name,
-            }
-        )
-
-    # Create a flatpak remote, scan it, and mirror the required repos.
-    remote_config = FLATPAK_REMOTES['RedHat']
-    create_opts = {
-        'organization-id': module_org.id,
-        'url': remote_config['url'],
-        'name': gen_string('alpha'),
-    }
-    if remote_config['authenticated']:
-        create_opts['username'] = settings.container_repo.registries.redhat.username
-        create_opts['token'] = settings.container_repo.registries.redhat.password
-    fr = sat.cli.FlatpakRemote().create(create_opts)
-    sat.cli.FlatpakRemote().scan({'id': fr['id']})
-    all_repos = sat.cli.FlatpakRemote().repository_list({'flatpak-remote-id': fr['id']})
-
-    ver = FLATPAK_RHEL_RELEASE_VER
-    repo_names = [
-        f'rhel{ver}/firefox-flatpak',
-        f'rhel{ver}/flatpak-runtime',  # runtime is dependency
-        f'rhel{ver}/thunderbird-flatpak',
-    ]
-    remote_repos = [r for r in all_repos if r['name'] in repo_names]
-    assert len(repo_names) == len(remote_repos), 'Testing repos are missing from remote index.'
-
-    product = sat.api.Product(organization=module_org).create()
-    for repo in remote_repos:
-        sat.cli.FlatpakRemote().repository_mirror(
-            {
-                'flatpak-remote-id': fr['id'],
-                'id': repo['id'],
-                'product-id': product.id,
-            }
-        )
-    local_repos = sat.cli.Repository.list({'product-id': product.id})
-    assert set([r['name'] for r in local_repos]) == set(repo_names), (
-        'Required repo(s) were not scanned or mirrored'
-    )
-    for repo in local_repos:
-        sat.cli.Repository.synchronize({'id': repo['id']})
-
-    # Create two CVs with different repos, publish and promote them to LCE.
-    # cv1: thunderbird + runtime (Last 2); cv2: firefox + runtime (First 2).
-    cv1 = sat.api.ContentView(
-        organization=module_org,
-        repository=[r['id'] for r in local_repos if r['name'] in repo_names[-2:]],
-    ).create()
-    cv2 = sat.api.ContentView(
-        organization=module_org,
-        repository=[r['id'] for r in local_repos if r['name'] in repo_names[:2]],
-    ).create()
-    timestamp = datetime.now(UTC)
-    for cv in [cv1, cv2]:
-        cv.publish()
-        cv.read().version[0].promote(data={'environment_ids': lce.id})
-    for capsule in setup_capsules:
-        capsule.wait_for_sync(start_time=timestamp)
-
-    ak = sat.api.ActivationKey(
-        organization=module_org,
-        content_view=cv1,
-        environment=lce,
-    ).create()
-
-    return {
-        'ak': ak,
-        'cv1_app': 'org.mozilla.Thunderbird',
-        'cv2_app': 'org.mozilla.firefox',
-    }
 
 
 @pytest.mark.e2e

--- a/tests/foreman/sys/test_capsule_loadbalancer.py
+++ b/tests/foreman/sys/test_capsule_loadbalancer.py
@@ -24,6 +24,7 @@ from robottelo.constants import CLIENT_PORT, FLATPAK_REMOTES, FLATPAK_RHEL_RELEA
 from robottelo.exceptions import CLIFactoryError
 from robottelo.utils.datafactory import gen_string
 from robottelo.utils.installer import InstallerCommand
+from robottelo.utils.issue_handlers import is_open
 
 pytestmark = [pytest.mark.no_containers]
 
@@ -149,10 +150,10 @@ def flatpak_content_for_lb(module_target_sat, module_org, setup_capsules):
     for capsule in setup_capsules:
         capsule.wait_for_sync(start_time=timestamp)
 
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(cv1, lce)
     ak = sat.api.ActivationKey(
+        content_view_environment_ids=[cvenv_id],
         organization=module_org,
-        content_view=cv1,
-        environment=lce,
     ).create()
 
     return {
@@ -567,6 +568,9 @@ def test_loadbalancer_flatpak(
         timeout=30,
         delay=5,
     )
+    # workaround for flatpak caching
+    if is_open('SAT-46580'):
+        host.execute(f'rm -f /var/lib/flatpak/oci/{remote_name}.index.gz')
     job = sat.cli_factory.job_invocation(
         opts
         | {
@@ -588,6 +592,9 @@ def test_loadbalancer_flatpak(
         delay=5,
     )
     host.execute(f'flatpak uninstall {cv1_app} com.redhat.Platform -y')
+    # workaround for flatpak caching
+    if is_open('SAT-46580'):
+        host.execute(f'rm -f /var/lib/flatpak/oci/{remote_name}.index.gz')
     job = sat.cli_factory.job_invocation(
         opts
         | {


### PR DESCRIPTION
### Problem Statement
The two related issues linked bellow propose the flatpak content should be tested as consumable from behind a load balancer.

I agree, but there are currently several issues:
1. Broken pulpcore_registry index [SAT-44554](https://redhat.atlassian.net/browse/SAT-44554) in stream will prevent Satellite to serve flatpak repos and PRT from pass (this will be fixed soon, upstream PR is already up).
2. HA Proxy misconfiguration - balance needs to be set to `source` for port 443 as per the [documentation](https://docs.redhat.com/en/documentation/red_hat_satellite/6.18/html/configuring_capsules_with_a_load_balancer/installing-and-configuring-the-load-balancer) (which says so explicitly since 6.4).
3. Not only the content on both Capsules needs to be identical, also DB content for container_gateway needs to be consistent on both instances - this will be addressed by [SAT-44752](https://redhat.atlassian.net/browse/SAT-44752)


### Solution
This PR proposes an E2E test case for the flatpak behind loadbalancer. With patch for 1. and fix for 2. it passes down to the line 590, and then fails in the last `flatpak install`, which should be addressed by SAT-44752. Thus I am hooking this test case on it with `:BlockedBy:` and proposing it to help with its verification.


### Related Issues
https://redhat.atlassian.net/browse/SAT-36752
https://redhat.atlassian.net/browse/SAT-44752


### PRT test Cases example
Not applicable until the issues are in Testing or Closed (`:BlockedBy: SAT-44752`)

Otherwise 
```
trigger: test-robottelo
pytest: tests/foreman/sys/test_capsule_loadbalancer.py -k test_loadbalancer_flatpak
```

## Summary by Sourcery

Add an end-to-end test that verifies Flatpak content can be consumed via a load-balanced pair of capsules and update the HAProxy configuration to use source-based balancing on HTTPS traffic.

Bug Fixes:
- Adjust the HAProxy backend configuration to use source-based balancing for HTTPS, aligning test behavior with documented requirements.

Tests:
- Introduce a fixture that prepares Flatpak repositories, content views, activation keys, and capsule sync for load balancer testing.
- Add an E2E test that registers a host through the load balancer, configures a Flatpak remote, validates app visibility and isolation under different auth modes, and verifies failover when capsules are stopped in turn.