### PR TITLE
Add tests for removing of content_facet.uuid usage in favor of subscription_facet.uuid

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -154,6 +154,48 @@ def mod_content_hosts(request):
 
 
 @pytest.fixture
+def registered_host(
+    rhel_contenthost,
+    module_target_sat,
+    module_sca_manifest_org,
+    module_activation_key,
+    module_location,
+):
+    """Register a content host and return the host object with its JSON representation.
+
+    This fixture automatically handles host registration using pytest dependency injection.
+    All required fixtures (rhel_contenthost, module_target_sat, etc.) are auto-injected.
+
+    Usage:
+        def test_something(registered_host):
+            contenthost, host, host_json = registered_host
+            # Use contenthost, host, and host_json directly
+
+    Returns:
+        tuple: (contenthost, host, host_json) where contenthost is the rhel content host,
+            host is the API host entity, and host_json contains facet attributes
+
+    Raises:
+        AssertionError: If registration fails
+    """
+    result = rhel_contenthost.api_register(
+        module_target_sat,
+        organization=module_sca_manifest_org,
+        activation_keys=[module_activation_key.name],
+        location=module_location,
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+    # Fetch the registered host
+    host = module_target_sat.api.Host().search(
+        query={'search': f'name={rhel_contenthost.hostname}'}
+    )[0]
+    host_json = host.read_json()
+
+    return rhel_contenthost, host, host_json
+
+
+@pytest.fixture
 def registered_hosts(request, target_sat, module_org, module_ak_with_cv):
     """Fixture that registers content hosts to Satellite, based on rh_cloud setup"""
     with contenthost_factory(request=request, _count=2) as hosts:

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1586,3 +1586,86 @@ class TestHostBulkAction:
         for host_id in host_ids[:-1]:
             with pytest.raises(HTTPError):
                 module_target_sat.api.Host(id=host_id).read()
+
+
+@pytest.mark.rhel_ver_match('N-0')
+def test_positive_uuid_persists_after_unregister_reregister(
+    module_target_sat,
+    module_sca_manifest_org,
+    module_activation_key,
+    module_location,
+    registered_host,
+):
+    """Verify subscription_facet UUID lifecycle: creation, delegation, clearing, and re-registration
+
+    :id: d511b9ee-d657-4dff-a05e-3dcc66b29b60
+
+    :steps:
+        1. Register a content host
+        2. Verify subscription_facet has a valid UUID
+        3. Verify content_facet.uuid delegates to subscription_facet.uuid
+        4. Unregister the host
+        5. Verify UUID is cleared after unregistration
+        6. Re-register the host
+        7. Verify a new UUID is assigned
+
+    :expectedresults:
+        1. Host registration succeeds
+        2. subscription_facet contains a non-null UUID
+        3. content_facet.uuid matches subscription_facet.uuid (delegation)
+        4. After unregistration, UUID is None or subscription_facet is removed
+        5. After re-registration, a new UUID is assigned
+
+    :Verifies: SAT-40424
+    """
+    contenthost, _, host_json = registered_host
+
+    # Verify subscription_facet has UUID
+    assert 'subscription_facet_attributes' in host_json
+    subscription_facet = host_json['subscription_facet_attributes']
+    assert subscription_facet['uuid'] is not None
+    assert len(subscription_facet['uuid']) > 0
+    first_uuid = subscription_facet['uuid']
+
+    # Verify content_facet.uuid delegates to subscription_facet.uuid
+    assert 'content_facet_attributes' in host_json
+    content_facet = host_json['content_facet_attributes']
+    assert content_facet['uuid'] == subscription_facet['uuid']
+
+    # Unregister
+    result = contenthost.unregister()
+    assert result.status == 0
+
+    # Verify UUID is cleared after unregistration
+    def reload_host_json():
+        host = module_target_sat.api.Host().search(
+            query={'search': f'name={contenthost.hostname}'}
+        )[0]
+        return host.read_json()
+
+    host_json = reload_host_json()
+    subscription_facet = host_json.get('subscription_facet_attributes')
+    if subscription_facet:
+        assert subscription_facet.get('uuid') is None
+    else:
+        assert (
+            'subscription_facet_attributes' not in host_json
+            or host_json['subscription_facet_attributes'] is None
+        )
+
+    # Re-register manually
+    result = contenthost.api_register(
+        module_target_sat,
+        organization=module_sca_manifest_org,
+        activation_keys=[module_activation_key.name],
+        location=module_location,
+    )
+    assert result.status == 0, f'Failed to re-register host: {result.stderr}'
+
+    # Get the re-registered host
+    host_json = reload_host_json()
+    second_uuid = host_json['subscription_facet_attributes']['uuid']
+    assert second_uuid is not None
+
+    # UUID should be different after re-registration
+    assert first_uuid != second_uuid


### PR DESCRIPTION
- Adds a `registered_host` fixture to `pytest_fixtures/core/contenthosts.py` that registers a content host and returns `(contenthost, host, host_json)` for use in tests that need a registered host with facet data
- Adds a single consolidated test in `test_host.py` that validates the full `subscription_facet` UUID lifecycle: creation on registration, delegation from `content_facet`, clearing on unregister, and new UUID assignment on re-registration
 

### Related Issues
https://redhat.atlassian.net/browse/SAT-40424

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

