### PR TITLE
Fix pip and logging in upgrade tests

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -10,6 +10,8 @@ import json
 from pathlib import Path, PurePath
 import random
 import re
+import subprocess
+import sys
 from tempfile import NamedTemporaryFile
 import time
 from urllib.parse import urljoin, urlparse, urlunsplit
@@ -17,6 +19,7 @@ from urllib.parse import urljoin, urlparse, urlunsplit
 import apypie
 from box import Box
 from broker import Broker
+from broker.helpers import FileLock
 from broker.hosts import Host
 from dynaconf.vendor.box.exceptions import BoxKeyError
 from fauxfactory import gen_alpha, gen_string
@@ -2082,15 +2085,51 @@ class Satellite(Capsule, SatelliteMixins):
 
     def _swap_nailgun(self, new_version):
         """Install a different version of nailgun from GitHub and invalidate the module cache."""
-        import sys
 
-        from pip._internal import main as pip_main
+        logger.debug(f'Installing nailgun for new_version: {new_version}')
+        nailgun_ref = 'master' if new_version == 'stream' else f'{new_version}.z'
 
-        pip_main(['uninstall', '-y', 'nailgun'])
-        pip_main(['install', f'https://github.com/SatelliteQE/nailgun/archive/{new_version}.zip'])
+        # Use file locking to prevent race conditions when multiple xdist workers
+        # try to install/uninstall nailgun simultaneously
+        lock_file = Path('/tmp/nailgun-install.lock')
+        with FileLock(lock_file):
+            logger.debug('Acquired nailgun install lock, running pip commands')
+
+            expected_url = f'https://github.com/SatelliteQE/nailgun/archive/{nailgun_ref}.zip'
+            # Check if correct version already installed
+            result = subprocess.run(
+                [sys.executable, '-m', 'pip', 'freeze'], capture_output=True, text=True, check=True
+            )
+            is_installed = any(
+                line.startswith('nailgun') and expected_url in line
+                for line in result.stdout.split('\n')
+            )
+            if is_installed:
+                logger.debug(f'Nailgun {new_version} already installed, skipping pip install')
+            else:
+                logger.debug(f'Nailgun {new_version} not already installed, running pip install')
+                subprocess.run(
+                    [sys.executable, '-m', 'pip', 'uninstall', '-y', 'nailgun'], check=True
+                )
+                subprocess.run(
+                    [
+                        sys.executable,
+                        '-m',
+                        'pip',
+                        'install',
+                        expected_url,
+                    ],
+                    check=True,
+                )
+            logger.debug('Nailgun pip commands complete, releasing lock')
+
+        # Clear module cache after lock is released (each worker clears its own cache).
+        # Run this even if the worker didn't need to reinstall nailgun,
+        # to make sure it has the correct api.
         self._api = type('api', (), {'_configured': False})
         to_clear = [k for k in sys.modules if 'nailgun' in k]
-        [sys.modules.pop(k) for k in to_clear]
+        for k in to_clear:
+            sys.modules.pop(k)
 
     @property
     def api(self):

--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -2,7 +2,6 @@
 This module is intended to be used for upgrade tests that have a single run stage.
 """
 
-import datetime
 import json
 from tempfile import mkstemp
 
@@ -19,20 +18,8 @@ from robottelo.constants import (
 )
 from robottelo.exceptions import GCECertNotFoundError, SatelliteHostError
 from robottelo.hosts import Capsule, Satellite
+from robottelo.logging import logger
 from robottelo.utils.shared_resource import SharedResource
-
-
-def log(message, level="DEBUG"):
-    """Pytest has a limitation to use logging.logger from conftest.py
-    so we need to emulate the logger by std-out the output
-    """
-    now = datetime.datetime.now()
-    full_message = "{date} - conftest - {level} - {message}\n".format(
-        date=now.strftime("%Y-%m-%d %H:%M:%S"), level=level, message=message
-    )
-    print(full_message)  # noqa
-    with open('robottelo.log', 'a') as log_file:
-        log_file.write(full_message)
 
 
 def pytest_configure(config):
@@ -52,7 +39,7 @@ def pytest_configure(config):
 
 
 def shared_checkout(shared_name):
-    Satellite(hostname="blank")._swap_nailgun(f"{settings.UPGRADE.FROM_VERSION}.z")
+    Satellite(hostname="blank")._swap_nailgun(settings.UPGRADE.FROM_VERSION)
     bx_inst = Broker(
         workflow=settings.SERVER.deploy_workflows.product,
         deploy_sat_version=settings.UPGRADE.FROM_VERSION,
@@ -100,7 +87,7 @@ def shared_checkin(sat_instance):
         resource_name=sat_instance.hostname + "_checkin",
         action=Broker(hosts=[sat_instance]).checkin,
     ) as sat_checkin:
-        log(f'Running sat_checkin.ready() for {sat_instance.hostname} ')
+        logger.debug(f'Running sat_checkin.ready() for {sat_instance.hostname}')
         sat_checkin.ready()
 
 

--- a/tests/new_upgrades/test_activation_key.py
+++ b/tests/new_upgrades/test_activation_key.py
@@ -95,7 +95,7 @@ def test_ak_upgrade_scenario(ak_upgrade_setup):
     :BlockedBy: SAT-28048, SAT-28990
     """
     target_sat = ak_upgrade_setup.target_sat
-    target_sat._swap_nailgun(f"{settings.UPGRADE.TO_VERSION}.z")
+    target_sat._swap_nailgun(settings.UPGRADE.TO_VERSION)
     org = target_sat.api.Organization().search(
         query={'search': f'name={ak_upgrade_setup.org.name}'}
     )[0]

--- a/tests/new_upgrades/test_capsulecontent.py
+++ b/tests/new_upgrades/test_capsulecontent.py
@@ -93,7 +93,7 @@ def capsule_sync_setup(capsule_upgrade_integrated_sat_cap, upgrade_action):
             }
         )
         sat_upgrade.ready()
-        target_sat._swap_nailgun(f"{settings.UPGRADE.TO_VERSION}.z")
+        target_sat._swap_nailgun(settings.UPGRADE.TO_VERSION)
         cap_upgrade.ready()
         target_sat._session = None
         capsule._session = None

--- a/tests/new_upgrades/test_client.py
+++ b/tests/new_upgrades/test_client.py
@@ -169,10 +169,7 @@ def test_post_scenario_post_client_package_installation(pre_client_package_insta
     rhel_client.execute('subscription-manager unregister')
     rhel_client.execute('subscription-manager clean')
     target_sat = pre_client_package_installation_setup.satellite
-    if settings.UPGRADE.TO_VERSION == 'stream':
-        target_sat._swap_nailgun('master')
-    else:
-        target_sat._swap_nailgun(f"{settings.UPGRADE.TO_VERSION}.z")
+    target_sat._swap_nailgun(settings.UPGRADE.TO_VERSION)
     org = target_sat.api.Organization(id=pre_client_package_installation_setup.org.id).read()
     location = target_sat.api.Location(id=pre_client_package_installation_setup.location.id).read()
     lce = target_sat.api.LifecycleEnvironment(

--- a/tests/new_upgrades/test_puppet.py
+++ b/tests/new_upgrades/test_puppet.py
@@ -34,7 +34,7 @@ def puppet_upgrade_setup(puppet_upgrade_integrated_sat_cap, upgrade_action):
             }
         )
         sat_upgrade.ready()
-        satellite._swap_nailgun(f'{settings.UPGRADE.TO_VERSION}.z')
+        satellite._swap_nailgun(settings.UPGRADE.TO_VERSION)
         cap_upgrade.ready()
         satellite._session = None
         capsule._session = None


### PR DESCRIPTION
### Problem Statement

- `_swap_nailgun` calls `pip` API methods, which break robottelo's logging config (no activity logged to logs/robottelo.log after uninstall / reinstall of nailgun)
- pip documentation recommends using `subprocess` instead: https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program
- some calls to `_swap_nailgun` pass `{version}.z` as the version to install, which doesn't work for `master` branch / `stream` version
- custom legacy `log` method writes to `stdout` and directly to `robottelo.log` (not `logs/robottelo.log`), instead of using `robottelo.logging.logger`.
- simultaneous attempts to run `_swap_nailgun` by parallel xdist workers raise errors:

```
2026-04-30 19:59:40 - robottelo - ERROR - Test phase 'setup' failed for test: tests/new_upgrades/test_bookmarks.py::test_post_disabled_bookmark
2026-04-30 19:59:40 - robottelo - ERROR - Exception thrown:
    fixturedef = <FixtureDef argname='search_upgrade_shared_satellite' scope='function' baseid='tests/new_upgrades'>
    request = <Su[bRequest 'search_upgrade_shared_satellite' for <Function test_post_disabled_bookmark>>
    
        @pytest.hookimpl(wrapper=True)
        def pytest_fixture_setup(fixturedef: FixtureDef, request) -> object | None:
[...]
    >               return (yield)
                            ^^^^^
    
    ../../Python/venv_robottelo/lib64/python3.12/site-packages/pytest_asyncio/plugin.py:728: 
    _ _ _ _
    tests/new_upgrades/conftest.py:143: in search_upgrade_shared_satellite
        sat_instance = shared_checkout("search_upgrade")
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    tests/new_upgrades/conftest.py:42: in shared_checkout
        Satellite(hostname="blank")._swap_nailgun(settings.UPGRADE.FROM_VERSION)
    robottelo/hosts.py:2093: in _swap_nailgun
        subprocess.run([sys.executable, '-m', 'pip', 'uninstall', '-y', 'nailgun'], check=True)
```

### Solution

Update `_swap_nailgun`:
- use the recommended method for running pip commands via `subprocess`
- consistently accept the Satellite/nailgun version to install, not the branch/ref name
- use LockFile from broker to ensure pip commands aren't run simultaneously

Update `new_upgrades` fixtures to use `robottelo.logging.logger`, which works despite comments claiming otherwise in the legacy `log` method. (A similar fix was already done for shared resources in #21055 .)

### Related Issues

```
trigger: test-robottelo
pytest: tests/new_upgrades/test_bookmarks.py -n2 --dist load
```
(Use `--dist load` to distribute the two tests in the module across the two workers simultaneously.)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Improve upgrade test reliability and logging by updating nailgun upgrade handling and pytest fixtures.

Bug Fixes:
- Prevent shared resource error handling from crashing when the resource file has been deleted by the action.
- Ensure upgrade job failures from Broker are re-raised as SatelliteHostError so upgrade tests fail correctly.

Enhancements:
- Switch nailgun swap logic to invoke pip via subprocess using the Python executable, avoiding interference with robottelo logging configuration.
- Replace custom stdout-based logging in new_upgrades conftest with the standard robottelo logger for consistent logging behavior across tests.

## Summary by Sourcery

Update nailgun swap logic in upgrade tests to use a safer pip invocation and shared locking while aligning version handling and logging with the standard robottelo logger.

Bug Fixes:
- Prevent nailgun reinstall operations from breaking robottelo logging by avoiding direct use of pip internals.
- Ensure nailgun installation works for both numeric Satellite versions and the stream/master case by separating version and Git ref handling.
- Avoid race conditions and errors when multiple xdist workers run nailgun swap operations concurrently.

Enhancements:
- Invoke nailgun installation and uninstallation via subprocess using the Python executable, following pip’s recommended usage pattern.
- Use a filesystem lock to serialize pip operations across parallel test workers during nailgun swaps.
- Standardize new_upgrades fixtures to use the shared robottelo.logger instead of a custom stdout-based logging helper.
- Simplify upgrade tests by passing the Satellite upgrade version directly into _swap_nailgun rather than pre-formatted ref strings.