### PR TITLE
Add blocker to inventory settings test

### DIFF
--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -254,6 +254,8 @@ def test_rh_cloud_inventory_settings(
 
     :BZ: 1852594, 1889690, 1852594
 
+    :BlockedBy: SAT-35600
+
     :CaseAutomation: Automated
     """
     org = rhcloud_manifest_org


### PR DESCRIPTION
Adding missed blocker tag to test_rh_cloud_inventory_settings test

## Summary by Sourcery

Tests:
- Tag the RH Cloud inventory settings UI test with a blocker reference to SAT-35600.