### PR TITLE
[6.19.z] Satellite upgrade fixture and shared resource fixes (#21435)

### DIFF
--- a/robottelo/utils/shared_resource.py
+++ b/robottelo/utils/shared_resource.py
@@ -258,21 +258,27 @@ class SharedResource:
                 os.environ.get('PYTEST_XDIST_WORKER'),
             )
             raise exc_value
-        if exc_type is None:
-            logger.debug('Setting status to done')
-            self.done()
-            if self.is_main:
-                self._wait_for_status("done")
-                logger.debug("All workers done, removing resource file")
-                self.resource_file.unlink()
-        else:
-            self._update_status("error")
-            if self.is_main:
-                if self._check_all_status("error"):
-                    # All have failed, delete the file
-                    logger.warning("All workers FAILED, removing resource file")
-                    self.resource_file.unlink()
-                else:
-                    logger.warning("Setting main status to ERROR")
-                    self._update_main_status("error")
+        if exc_type:
+            # Only try to update status if the resource file still exists
+            # It may have been deleted by act() if the action was non-recoverable
+            try:
+                self._update_status("error")
+                if self.is_main:
+                    if self._check_all_status("error"):
+                        # All have failed, delete the file
+                        logger.warning("All workers FAILED, removing resource file")
+                        self.resource_file.unlink()
+                    else:
+                        logger.warning("Setting main status to ERROR")
+                        self._update_main_status("error")
+            except FileNotFoundError:
+                logger.debug(
+                    "Resource file was deleted during error handling, skipping status update"
+                )
             raise exc_value
+        logger.debug('Setting status to done')
+        self.done()
+        if self.is_main:
+            self._wait_for_status("done")
+            logger.debug("All workers done, removing resource file")
+            self.resource_file.unlink()

--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -8,6 +8,7 @@ from tempfile import mkstemp
 
 from box import Box
 from broker import Broker
+from broker.exceptions import ProviderError
 import pytest
 from wrapanapi.systems.google import GoogleCloudSystem
 
@@ -16,7 +17,7 @@ from robottelo.constants import (
     GCE_RHEL_CLOUD_PROJECTS,
     GCE_TARGET_RHEL_IMAGE_NAME,
 )
-from robottelo.exceptions import GCECertNotFoundError
+from robottelo.exceptions import GCECertNotFoundError, SatelliteHostError
 from robottelo.hosts import Capsule, Satellite
 from robottelo.utils.shared_resource import SharedResource
 
@@ -106,13 +107,23 @@ def shared_checkin(sat_instance):
 @pytest.fixture(scope='session')
 def upgrade_action():
     def _upgrade_action(target_sat):
-        Broker(
+
+        result = Broker(
             job_template=settings.UPGRADE.SATELLITE_UPGRADE_JOB_TEMPLATE,
             target_vm=target_sat.name,
             sat_version=settings.UPGRADE.TO_VERSION,
             upgrade_path="ystream",
             tower_inventory=target_sat.tower_inventory,
         ).execute()
+
+        # Broker catches ProviderError and returns it instead of raising.
+        # We need to re-raise so that the error propagates correctly.
+        if isinstance(result, ProviderError):
+            # extract the message from Broker
+            broker_msg = getattr(result, 'message', str(result))
+            raise SatelliteHostError(f"Satellite upgrade job failed:\n{broker_msg}") from result
+
+        return result
 
     return _upgrade_action
 


### PR DESCRIPTION
Cherry-pick of #21435 

### Problem Statement

Improperly-handled exceptions in the `upgrade_action` fixture and `SharedResource` context manager cleanup end up obscuring the real issue when the `satellite-upgrade` job fails during upgrade tests:

- `FileNotFoundError` during shared resource cleanup
```
[...]
During handling of the above exception, another exception occurred:

search_upgrade_shared_satellite = Satellite(omitting_credentials=False, port=22, blank=False, hostname=satellite.example.com,...ServerConfig(url='https://satellite.example.com', auth=('admin', 'XXX'), verify=False))
upgrade_action = <function upgrade_action.<locals>._upgrade_action at 0x7fa5206cafc0>

    @pytest.fixture
    def disabled_bookmark_setup(search_upgrade_shared_satellite, upgrade_action):
[...]
        target_sat = search_upgrade_shared_satellite
>       with SharedResource(target_sat.hostname, upgrade_action, target_sat=target_sat) as sat_upgrade:
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/new_upgrades/test_bookmarks.py:46: 
_ _ _ _ _ _ _ _ _ _
robottelo/utils/shared_resource.py:269: in __exit__
    self._update_status("error")
robottelo/utils/shared_resource.py:97: in _update_status
    curr_data = json.loads(self.resource_file.read_text())
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib64/python3.12/pathlib.py:1027: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _

self = PosixPath('/tmp/satellite.example.com.shared'), mode = 'r', buffering = -1, encoding = 'locale', errors = None, newline = None

    def open(self, mode='r', buffering=-1, encoding=None,
             errors=None, newline=None):
        """
        Open the file pointed to by this path and return a file object, as
        the built-in open() function does.
        """
        if "b" not in mode:
            encoding = io.text_encoding(encoding)
>       return io.open(self, mode, buffering, encoding, errors, newline)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       FileNotFoundError: [Errno 2] No such file or directory: '/tmp/satellite.example.com.shared'

[...]
ERROR tests/new_upgrades/test_bookmarks.py::test_post_disabled_bookmark - FileNotFoundError: [Errno 2] No such file or directory: '/tmp/satellite.example.com.shared'
```

- Fixing the above error uncovered an issue in which the `upgrade_action` fixture did not raise an error if the `satellite-upgrade` AAP job failed, because broker catches the exception and returns it instead. The fixture needs to check whether broker returned an exception-valued value instead of a string-valued job result.

### Solution

- Catch `FileNotFoundError` exceptions when the satellite-upgrade job fails and the shared resource cleanup method tries to read from the resource file, which has already been deleted

- Raise the exception in the `upgrade_action` fixture when the job has failed and broker returned an exception instead of a valid job result.

### Related Issues

- SAT-40409
- https://github.com/SatelliteQE/broker/pull/496
- https://github.com/SatelliteQE/broker/pull/497

### PRT test cases

The failed PRT test runs below were triggered by passing an invalid value for `settings.upgrade.to_version`. The failed upgrade job no longer triggers the `FileNotFoundError`, showing the `JobExecutionError` from broker instead.

I've also included a successful PRT test run, using the valid `to_version` value.

## Summary by Sourcery

Handle shared resource cleanup failures more robustly and ensure satellite upgrade test fixtures surface underlying broker job errors.

Bug Fixes:
- Prevent FileNotFoundError in SharedResource cleanup when the underlying resource file has already been removed during error handling.
- Ensure the satellite upgrade_action test fixture raises broker ProviderError when the satellite-upgrade job fails instead of silently treating it as a successful result.