### PR TITLE
[6.18.z] Add blocker to inventory settings test

### DIFF
--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -247,6 +247,8 @@ def test_rh_cloud_inventory_settings(
 
     :BZ: 1852594, 1889690, 1852594
 
+    :BlockedBy: SAT-35600
+
     :CaseAutomation: Automated
     """
     org = rhcloud_manifest_org


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21460

Adding missed blocker tag to test_rh_cloud_inventory_settings test

## Summary by Sourcery

Tests:
- Tag the RH Cloud inventory settings UI test with a blocker reference to SAT-35600.