### PR TITLE
fix:Move Azure VM asserts outside ui_session in UD provision test

### DIFF
--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -196,11 +196,10 @@ def test_positive_azurerm_host_provision_ud(
     fqdn = f'{hostname}.{sat_azure_domain.name}'.lower()
     cloudimg_image = module_azurerm_cloudimg.name
 
-    with sat_azure.ui_session() as session:
-        session.organization.select(org_name=sat_azure_org.name)
-        session.location.select(loc_name=sat_azure_loc.name)
-        # Provision Host
-        try:
+    try:
+        with sat_azure.ui_session() as session:
+            session.organization.select(org_name=sat_azure_org.name)
+            session.location.select(loc_name=sat_azure_loc.name)
             with sat_azure.skip_yum_update_during_provisioning(
                 template='Kickstart default user data'
             ):
@@ -221,21 +220,21 @@ def test_positive_azurerm_host_provision_ud(
                     == module_azure_hg.name
                 )
 
-                # AzureRm Cloud assertion
-                azurecloud_vm = azurermclient.get_vm(name=hostname.lower())
-                assert azurecloud_vm
-                assert azurecloud_vm.is_running
-                assert azurecloud_vm.name == hostname.lower()
-                assert (
-                    azurecloud_vm.ip
-                    == host_page['overview']['details']['details'][
-                        f'{settings.server.NETWORK_TYPE}_address'
-                    ]
-                )
-                assert azurecloud_vm.type == AZURERM_VM_SIZE_DEFAULT
+        # After ui_session: Azure SDK does not use WebDriver (avoids Grid idle-session teardown).
+        azurecloud_vm = azurermclient.get_vm(name=hostname.lower())
+        assert azurecloud_vm
+        assert azurecloud_vm.is_running
+        assert azurecloud_vm.name == hostname.lower()
+        assert (
+            azurecloud_vm.ip
+            == host_page['overview']['details']['details'][
+                f'{settings.server.NETWORK_TYPE}_address'
+            ]
+        )
+        assert azurecloud_vm.type == AZURERM_VM_SIZE_DEFAULT
 
-        finally:
-            azure_vm = sat_azure.api.Host().search(query={'search': f'name={fqdn}'})
-            if azure_vm:
-                with sat_azure.api_factory.satellite_setting('destroy_vm_on_host_delete=True'):
-                    azure_vm[0].delete(synchronous=False)
+    finally:
+        azure_vm = sat_azure.api.Host().search(query={'search': f'name={fqdn}'})
+        if azure_vm:
+            with sat_azure.api_factory.satellite_setting('destroy_vm_on_host_delete=True'):
+                azure_vm[0].delete(synchronous=False)


### PR DESCRIPTION
### Problem Statement
test_positive_azurerm_host_provision_ud keeps a Selenium session open while calling azurermclient.get_vm(). The Azure SDK does not send WebDriver traffic, so Selenium Grid treats the session as idle, removes it (session timed out due to inactivity), and teardown fails with InvalidSessionIdException when Airgun calls webdriver.quit(). The failure appears on context exit, not on a Satellite UI assertion, which makes triage noisy and can mask the real timing issue.



### Solution
Run all Satellite UI steps inside with sat_azure.ui_session() (org/loc, host create, host status/details and UI assertions), then exit the UI session so the browser is closed cleanly. Perform Azure VM cross-checks (get_vm and related asserts) after the session ends, using data already read from the UI (e.g. host_page). Keep existing API-based cleanup in finally so resources are still removed if the test fails.

### Related Issues
None

## Summary by Sourcery

Adjust Azure VM UD host provisioning UI test to avoid keeping the Selenium UI session open during Azure SDK VM assertions.

Bug Fixes:
- Prevent Selenium Grid idle-session timeouts and InvalidSessionIdException in the Azure UD host provisioning test by moving Azure VM assertions outside the UI session context.

Tests:
- Reorganize the Azure UD host provisioning UI test flow so all Satellite UI interactions run inside the UI session and Azure VM cross-checks run afterward while preserving API-based cleanup logic.