### PR TITLE
[6.17.z] Add no_containers mark to failing Insights tests

### DIFF
--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -55,6 +55,7 @@ def common_assertion(report_path, inventory_data, org, satellite):
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.run_in_one_thread
+@pytest.mark.no_containers
 def test_rhcloud_inventory_e2e(
     inventory_settings,
     rhcloud_manifest_org,
@@ -381,6 +382,7 @@ def test_rhcloud_inventory_disabled_local_insights(module_target_sat_insights):
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.run_in_one_thread
+@pytest.mark.no_containers
 def test_rhcloud_global_parameters(
     inventory_settings,
     rhcloud_manifest_org,


### PR DESCRIPTION
This PR adds the `no_containers` pytest mark to two tests that are failing without it and passing locally with the mark added.