### PR TITLE
[6.18.z] Fix PXE Provisioning tests for miscelleneous CI

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -366,24 +366,29 @@ def configure_secureboot_provisioning(
     request, pxe_loader, module_provisioning_sat, module_provisioning_rhel_content
 ):
     """Fixture for configuring Secureboot pxe_loader for provisioning, when hosts RHEL version > Satellites RHEL version"""
-    rhel_ver = module_provisioning_rhel_content.os.major
+    rhel_ver_major = module_provisioning_rhel_content.os.major
+    rhel_ver_minor = module_provisioning_rhel_content.os.minor
     sat = module_provisioning_sat.sat
     if (
-        int(rhel_ver) > sat.os_version.major
-        and pxe_loader.vm_firmware == 'uefi_secure_boot'
+        pxe_loader.vm_firmware == 'uefi_secure_boot'
         and module_provisioning_sat.sat.network_type != NetworkType.IPV6
     ):
         # Set the path for the shim and GRUB2 binaries for the OS of host
-        bootloader_path = '/var/lib/tftpboot/bootloader-universe/pxegrub2/redhat/default/x86_64'
+        bootloader_path = f'/var/lib/tftpboot/bootloader-universe/pxegrub2/redhat/{rhel_ver_major}.{rhel_ver_minor}/x86_64'
 
         # Create the directory to store the shim and GRUB2 binaries for the OS of host
         sat.execute(f'install -o foreman-proxy -g foreman-proxy -d {bootloader_path}')
 
         # Fetch and Download SB packages, and extract Shim/Grub2 binaries
         for prefix in ['grub2-efi-x64', 'shim-x64']:
-            url = sat.get_secureboot_packages_with_version(
-                f'{settings.repos.get(f"rhel{rhel_ver}_os").baseos}/Packages', prefix
-            )
+            if int(rhel_ver_major) > 7:
+                url = sat.get_secureboot_packages_with_version(
+                    f'{settings.repos.get(f"rhel{rhel_ver_major}_os").baseos}/Packages', prefix
+                )
+            else:
+                url = sat.get_secureboot_packages_with_version(
+                    f'{settings.repos.get(f"rhel{rhel_ver_major}_os")}Packages', prefix
+                )
             sat.execute(f'curl -o /tmp/{prefix}.rpm {url}')
             sat.execute(f'rpm2cpio /tmp/{prefix}.rpm | cpio -idv --directory /tmp')
 
@@ -394,6 +399,13 @@ def configure_secureboot_provisioning(
         sat.execute(f'ln -sr {bootloader_path}/shimx64.efi {bootloader_path}/boot-sb.efi')
         sat.execute(f'chmod 644 {bootloader_path}/grubx64.efi {bootloader_path}/shimx64.efi')
         yield
-        sat.execute(f'rm -rf {bootloader_path}')
+        for _path in (
+            os.path.dirname(bootloader_path),
+            '/tmp/boot',
+            '/tmp/etc',
+            '/tmp/grub2-efi-x64.rpm',
+            '/tmp/shim-x64.rpm',
+        ):
+            sat.execute(f'if [ -e "{_path}" ]; then rm -rf "{_path}"; fi')
     else:
         yield None

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -71,6 +71,12 @@ def test_rhel_pxe_provisioning(
         and module_provisioning_sat.sat.network_type == NetworkType.IPV6
     ):
         pytest.skip('Test cannot be run on BIOS as its not supported')
+    if (
+        is_open('SAT-41340')
+        and module_provisioning_rhel_content.os.major == '7'
+        and pxe_loader.vm_firmware == 'uefi'
+    ):
+        pytest.skip('RHEL 7 is not compatible with UEFI')
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat
     # Configure the grubx64.efi image to setup the interface and use TFTP to load the configuration
@@ -105,7 +111,7 @@ def test_rhel_pxe_provisioning(
     # the result of the installation. Wait until Satellite reports that the host is installed.
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
-        timeout=1500,
+        timeout=1800,
         delay=10,
     )
     host = host.read()
@@ -360,6 +366,13 @@ def test_rhel_httpboot_provisioning(
 
     :Verifies: SAT-20684
     """
+    # rhel7 and firmware is uefi then it is not supported
+    if (
+        is_open('SAT-41340')
+        and module_provisioning_rhel_content.os.major == '7'
+        and pxe_loader.vm_firmware == 'uefi'
+    ):
+        pytest.skip('RHEL 7 is not compatible with UEFI.')
     sat = module_provisioning_sat.sat
     # Configure the grubx64.efi image to setup the interface and use TFTP to load the configuration
     # update grub2-efi package
@@ -400,7 +413,7 @@ def test_rhel_httpboot_provisioning(
     # the result of the installation. Wait until Satellite reports that the host is installed.
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
-        timeout=1500,
+        timeout=1800,
         delay=10,
     )
     host = host.read()
@@ -534,7 +547,7 @@ def test_rhel_pxe_provisioning_fips_enabled(
     # the result of the installation. Wait until Satellite reports that the host is installed.
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
-        timeout=1500,
+        timeout=1800,
         delay=10,
     )
     host = host.read()
@@ -614,6 +627,7 @@ def test_rhel_pxe_provisioning_secureboot_enabled(
     module_location,
     module_provisioning_rhel_content,
     provisioning_hostgroup,
+    configure_secureboot_provisioning,
 ):
     """Simulate Secureboot baremetal provisioning of a RHEL system via PXE on vCenter provider
 
@@ -659,7 +673,7 @@ def test_rhel_pxe_provisioning_secureboot_enabled(
     # the result of the installation. Wait until Satellite reports that the host is installed.
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
-        timeout=1500,
+        timeout=1800,
         delay=10,
     )
     host = host.read()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21183

### Problem Statement

PXE Provisioning tests are failing for 2 reasons.

RHEL7 : it is incompatible/ unsupported with UEFI. (SAT-41340)

Other RHEL Versions: not enough time provided to move status from pending to installed.

### Solution

1. Skip RHEL7 test with UEFI untill SAT-41340 is resolved.
2. Time taken to move PXE Provisioning status from `Pending Installation` to `Installed` is around 28-29 minutes, for safe-side, Increasing the wait time to 35 minutes.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->