### PR TITLE
[6.19.z] Add openvox-agent testing

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -46,6 +46,9 @@ REPOS:
     RHEL8: replace-with-rhel8-http-link
     RHEL9: replace-with-rhel9-http-link
     RHEL10: replace-with-rhel10-http-link
+  OPENVOX_AGENT_REPO:
+    RHEL8: some-url
+    RHEL9: some-url
   # Downstream Satellite-maintain repo
   SATMAINTENANCE_REPO: replace-with-sat-maintain-repo
   # Software Collection Repo

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1010,9 +1010,7 @@ class ContentHost(Host, ContentHostMixins):
                 f'Failed to put hostname in ssh known_hosts files:\n{result.stderr}'
             )
 
-    def configure_puppet(
-        self, proxy_hostname=None, run_puppet_agent=True, install_puppet_agent7=False
-    ):
+    def configure_puppet(self, proxy_hostname=None, run_agent=True, use_openvox=True):
         """Configures puppet on the virtual machine/Host.
         :param proxy_hostname: external capsule hostname
         :return: None.
@@ -1021,21 +1019,21 @@ class ContentHost(Host, ContentHostMixins):
         if proxy_hostname is None:
             proxy_hostname = settings.server.hostname
 
-        if install_puppet_agent7:
+        self.create_custom_repos(
+            sat_client=settings.repos.satclient_repo[f'RHEL{self.os_version.major}']
+        )
+        if use_openvox:
             self.create_custom_repos(
-                sat_client=settings.repos['SATCLIENT_REPO'][f'RHEL{self.os_version.major}']
-            )
-        else:
-            self.create_custom_repos(
-                sat_client=settings.repos['SATCLIENT2_REPO'][f'RHEL{self.os_version.major}']
+                openvox_agent=settings.repos.openvox_agent_repo[f'RHEL{self.os_version.major}']
             )
 
-        result = self.execute('yum install puppet-agent -y')
-        if result.status != 0:
-            raise ContentHostError('Failed to install the puppet-agent rpm')
+        rpm_name = 'openvox-agent' if use_openvox else 'puppet-agent'
+        if self.execute(f'yum -y install {rpm_name}').status != 0:
+            raise ContentHostError('Failed to install the puppet agent rpm')
 
-        rpm_version = self.execute('rpm -q --qf "%{VERSION}" puppet-agent').stdout
-        assert '7' in rpm_version if install_puppet_agent7 else '7' not in rpm_version
+        assert self.execute(f'rpm -q {rpm_name}').status == 0, (
+            'Puppet agent package is not installed'
+        )
 
         cert_name = self.hostname
         puppet_conf = (
@@ -1062,11 +1060,9 @@ class ContentHost(Host, ContentHostMixins):
         proxy_host = Host(hostname=proxy_hostname, ipv6=self.network_type == NetworkType.IPV6)
         proxy_host.execute(f'puppetserver ca sign --certname {cert_name}')
 
-        if run_puppet_agent:
-            # This particular puppet run would create the host entity under
-            # 'All Hosts' and let's redirect stderr to /dev/null as errors at
-            #  this stage can be ignored.
-            result = self.execute('/opt/puppetlabs/bin/puppet agent -t 2> /dev/null')
+        if run_agent:
+            # This particular puppet run would create the host entity under 'All Hosts'
+            result = self.execute('/opt/puppetlabs/bin/puppet agent -t')
             if result.status:
                 raise ContentHostError('Failed to configure puppet on the content host')
 

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -18,6 +18,7 @@ import pytest
 from wait_for import wait_for
 
 from robottelo.exceptions import CLIReturnCodeError
+from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -51,10 +52,10 @@ def test_positive_CRD_satellite(run_puppet_agent, session_puppet_enabled_sat):
 
 @pytest.mark.e2e
 @pytest.mark.client_release
-@pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.parametrize('client_repo_ver', ['1', '2'], ids=['client1', 'client2'])
+@pytest.mark.rhel_ver_match('[7-9]|10')
+@pytest.mark.parametrize('agent', ['openvox', 'puppet'])
 def test_positive_install_configure_host(
-    session_puppet_enabled_sat, session_puppet_enabled_capsule, content_hosts, client_repo_ver
+    session_puppet_enabled_sat, session_puppet_enabled_capsule, content_hosts, agent
 ):
     """Test that puppet-agent can be installed from the sat-client repo
     and configured to report back to the Satellite.
@@ -83,12 +84,21 @@ def test_positive_install_configure_host(
 
     :Verifies: SAT-25418
     """
+    if agent == 'openvox' and content_hosts[0].os_version.major == 10 and is_open('SAT-30237'):
+        pytest.skip('Skipping as openvox-agent for EL10 is still not delivered')
+
+    if agent == 'openvox' and content_hosts[0].os_version.major == 7 and is_open('SAT-44580'):
+        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
+
+    if agent == 'puppet' and content_hosts[0].os_version.major == 10:
+        pytest.skip('Skipping as there is no puppet-agent for EL10')
+
     puppet_infra_host = [session_puppet_enabled_sat, session_puppet_enabled_capsule]
     for client, puppet_proxy in zip(content_hosts, puppet_infra_host, strict=True):
         # Adding IPv6 proxy for IPv6 communication
         client.enable_ipv6_dnf_and_rhsm_proxy()
         client.configure_puppet(
-            proxy_hostname=puppet_proxy.hostname, install_puppet_agent7=(client_repo_ver == '1')
+            proxy_hostname=puppet_proxy.hostname, use_openvox=(agent == 'openvox')
         )
         report = session_puppet_enabled_sat.cli.ConfigReport.list(
             {'search': f'host~{client.hostname}'}
@@ -106,10 +116,10 @@ def test_positive_install_configure_host(
 
 
 @pytest.mark.e2e
-@pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.parametrize('client_repo_ver', ['1', '2'], ids=['client1', 'client2'])
+@pytest.mark.rhel_ver_match('[7-9]|10')
+@pytest.mark.parametrize('agent', ['openvox', 'puppet'])
 def test_positive_run_puppet_agent_generate_report_when_no_message(
-    session_puppet_enabled_sat, rhel_contenthost, client_repo_ver
+    session_puppet_enabled_sat, rhel_contenthost, agent
 ):
     """Verify that puppet-agent can be installed from the sat-client repo
     and configured to report back to the Satellite, and contains the origin
@@ -138,14 +148,23 @@ def test_positive_run_puppet_agent_generate_report_when_no_message(
     :BZ: 2192939, 2257327, 2257314
     :parametrized: yes
     """
+    if agent == 'openvox' and rhel_contenthost.os_version.major == 10 and is_open('SAT-30237'):
+        pytest.skip('Skipping as openvox-agent for EL10 is still not delivered')
+
+    if agent == 'openvox' and rhel_contenthost.os_version.major == 7 and is_open('SAT-44580'):
+        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
+
+    if agent == 'puppet' and rhel_contenthost.os_version.major == 10:
+        pytest.skip('Skipping as there is no puppet-agent for EL10')
+
     sat = session_puppet_enabled_sat
     # Adding IPv6 proxy for IPv6 communication
     rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
     client = rhel_contenthost
     client.configure_puppet(
         proxy_hostname=sat.hostname,
-        run_puppet_agent=False,
-        install_puppet_agent7=(client_repo_ver == '1'),
+        run_agent=False,
+        use_openvox=(agent == 'openvox'),
     )
     # Run either 'puppet agent --detailed-exitcodes' or 'systemctl restart puppet'
     # to generate Puppet config report for host without any messages


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21394

### Problem Statement
There are new client repositories providing OpenVox Agent 8 as a replacement for Puppet Agent 7

### Solution
Change puppet tests `client1`/`client2` client repo parametrization to `puppet`/`openvox` parametrization for installed agent.
Client-2 repo will no longer be needed there is now OpenVox agent repo instead

### Related Issues
[SAT-44510](https://redhat.atlassian.net/browse/SAT-44510)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Add support for installing and configuring either openvox-agent or puppet-agent on content hosts and update CLI tests accordingly.

New Features:
- Allow hosts to install and configure openvox-agent as an alternative to puppet-agent during Puppet setup.

Enhancements:
- Refine Puppet configuration helper to select the agent package and repositories via explicit parameters instead of client repo version flags.
- Update CLI configuration report tests to parameterize over agent type (openvox vs puppet) and use the new Puppet configuration interface.

Tests:
- Adjust existing Puppet configuration and reporting tests to cover both openvox-agent and puppet-agent flows.