### PR TITLE
Update IOP tests to support multi RHEL versions

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1008,7 +1008,7 @@ VULNERABLE_PACKAGES = {
     8: {
         'rpm': 'mariadb-10.3.39-1.module+el8.8.0+19673+72b0d35f.x86_64',
         'cves': ['CVE-2025-13699'],
-        'erratum': 'RHSA-2026:0137',
+        'erratum': 'RHSA-2026:0225',
     },
     9: {
         'rpm': 'mariadb-3:10.5.29-2.el9_6.x86_64',

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1003,6 +1003,24 @@ RHEL10_VULNERABLE_MARIADB_CVES = ['CVE-2023-52969', 'CVE-2023-52970', 'CVE-2023-
 RHEL10_MARIADB_ERRATUM = 'RHSA-2026:0136'
 # Use the first CVE as the primary one for single-CVE tests
 RHEL10_VULNERABILITY_CVE_ID = RHEL10_VULNERABLE_MARIADB_CVES[0]
+# Per-version vulnerability data for IoP vulnerability testing
+VULNERABLE_PACKAGES = {
+    8: {
+        'rpm': 'mariadb-10.3.39-1.module+el8.8.0+19673+72b0d35f.x86_64',
+        'cves': ['CVE-2025-13699'],
+        'erratum': '',
+    },
+    9: {
+        'rpm': 'mariadb-3:10.5.29-2.el9_6.x86_64',
+        'cves': ['CVE-2025-13699'],
+        'erratum': '',
+    },
+    10: {
+        'rpm': RHEL10_VULNERABLE_MARIADB_RPM,
+        'cves': RHEL10_VULNERABLE_MARIADB_CVES,
+        'erratum': RHEL10_MARIADB_ERRATUM,
+    },
+}
 FAKE_1_YUM_REPOS_COUNT = 32
 FAKE_3_YUM_REPOS_COUNT = 78
 FAKE_9_YUM_SECURITY_ERRATUM = [

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1008,12 +1008,12 @@ VULNERABLE_PACKAGES = {
     8: {
         'rpm': 'mariadb-10.3.39-1.module+el8.8.0+19673+72b0d35f.x86_64',
         'cves': ['CVE-2025-13699'],
-        'erratum': '',
+        'erratum': 'RHSA-2026:0137',
     },
     9: {
         'rpm': 'mariadb-3:10.5.29-2.el9_6.x86_64',
         'cves': ['CVE-2025-13699'],
-        'erratum': '',
+        'erratum': 'RHSA-2026:0137',
     },
     10: {
         'rpm': RHEL10_VULNERABLE_MARIADB_RPM,

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -44,7 +44,7 @@ IOP_SERVICES = [
 
 
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('N-0')
+@pytest.mark.rhel_ver_match('N-2')
 def test_positive_install_iop_custom_certs(
     certs_data,
     sat_ready_rhel,
@@ -173,7 +173,7 @@ def test_positive_install_iop_custom_certs(
 
 
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('N-0')
+@pytest.mark.rhel_ver_match('N-2')
 def test_disable_enable_iop(module_satellite_iop, module_sca_manifest, rhel_contenthost):
     """Disable and re-enable IoP on Satellite.
 

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -253,15 +253,19 @@ def test_rhcloud_insights_vulnerabilities_e2e(
 
         # Wait for applicability to generate on the host after remediation
         def _rex_task_succeeded():
-                session.browser.execute_script('return 1')
-                return (
-                    satellite.api.ForemanTask()
-                    .search(
+            session.browser.execute_script('return 1')
+            return (
+                satellite.api.ForemanTask()
+                .search(
                     query={
                         'search': f'label = Actions::RemoteExecution::RunHostsJob '
                         f'and started_at >= "{timestamp}"'
                     }
-                    )[0].result == 'success')
+                )[0]
+                .result
+                == 'success'
+            )
+
         wait_for(
             _rex_task_succeeded,
             timeout=400,

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -279,7 +279,7 @@ def test_rhcloud_insights_vulnerabilities_e2e(
 @pytest.mark.e2e
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match(r'^(?!7).*')
-@pytest.mark.parametrize('module_target_sat_insights', [True], ids=['local'], indirect=True)
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_edit_business_risk_and_status_individual(
     vulnerable_rhel_host,
     rhcloud_manifest_org,

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -189,7 +189,7 @@ def setup_content_for_iop(module_target_sat_insights, rhcloud_manifest_org):
 @pytest.mark.e2e
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match(r'^(?!7).*')
-@pytest.mark.parametrize('module_target_sat_insights', [True], ids=['local'], indirect=True)
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_rhcloud_insights_vulnerabilities_e2e(
     vulnerable_rhel_host,
     rhcloud_manifest_org,

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -252,22 +252,22 @@ def test_rhcloud_insights_vulnerabilities_e2e(
         )
 
         # Wait for applicability to generate on the host after remediation
-        wait_for(
-            lambda: (
-                satellite.api.ForemanTask()
-                .search(
+        def _rex_task_succeeded():
+                session.browser.execute_script('return 1')
+                return (
+                    satellite.api.ForemanTask()
+                    .search(
                     query={
                         'search': f'label = Actions::RemoteExecution::RunHostsJob '
                         f'and started_at >= "{timestamp}"'
                     }
-                )[0]
-                .result
-                == 'success'
-            ),
+                    )[0].result == 'success')
+        wait_for(
+            _rex_task_succeeded,
             timeout=400,
             delay=15,
-            silent_failure=True,
-            handle_exception=True,
+            silent_failure=False,
+            handle_exception=False,
         )
 
         vulnerabilities = session.host_new.get_vulnerabilities(hostname)

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -108,7 +108,10 @@ def cleanup_stale_insights_state(client):
 def vulnerable_rhel_host(rhel_insights_vm):
     """Fixture to prepare a RHEL host with a vulnerable package"""
     client = rhel_insights_vm
-    # Remove any static repos and update to the latest packages available from the Satellite
+    rhel_ver = client.os_version.major
+    vuln_data = constants.VULNERABLE_PACKAGES[rhel_ver]
+    assert vuln_data['rpm'], f'No vulnerable package defined for RHEL {rhel_ver}'
+
     assert (
         client.execute(
             'find /etc/yum.repos.d/ -type f | grep -vF redhat.repo | xargs -I \'{}\' rm \'{}\''
@@ -117,17 +120,16 @@ def vulnerable_rhel_host(rhel_insights_vm):
     )
     update_result = client.execute('dnf -y update')
     if update_result.status != 0:
-        # Some RHEL 10 snapshots can have transient dependency resolution conflicts.
+        # Some RHEL snapshots can have transient dependency resolution conflicts.
         # Retry with safer solver flags to keep fixture setup stable.
         update_result = client.execute('dnf -y update --nobest --allowerasing')
     assert update_result.status == 0, (
         f'Failed to update packages before vulnerability setup: '
         f'{update_result.stdout}\n{update_result.stderr}'
     )
-    # Install vulnerable mariadb version (dnf install with NEVRA handles install/downgrade)
-    assert client.execute(f'dnf install -y {constants.RHEL10_VULNERABLE_MARIADB_RPM}').status == 0
+    # Install vulnerable package version for the host's RHEL version
+    assert client.execute(f'dnf install -y {vuln_data["rpm"]}').status == 0
     # Run insights-client to report the vulnerabilities to Satellite
-    # If already registered, just collect and upload data; handle stale machine-id by cleaning up first
     result = client.execute('insights-client')
     if result.status != 0 and 'Machine-id found' in result.stdout:
         result = cleanup_stale_insights_state(client)
@@ -146,7 +148,6 @@ def vulnerable_rhel_host_with_recommendations(vulnerable_rhel_host):
     # Add permission misconfiguration to create a recommendation.
     assert client.execute('chmod 777 /etc/shadow').status == 0
     # Run insights-client to report the recommendation to Satellite
-    # No stale state cleanup needed here - vulnerable_rhel_host already handled registration
     result = client.execute('insights-client')
     assert result.status == 0, f'insights-client failed: {result.stdout}'
     return client
@@ -154,31 +155,32 @@ def vulnerable_rhel_host_with_recommendations(vulnerable_rhel_host):
 
 @pytest.fixture(scope='module')
 def setup_content_for_iop(module_target_sat_insights, rhcloud_manifest_org):
-    """Fixture to sync RHEL content repos"""
+    """Fixture to sync RHEL content repos for all supported versions"""
     satellite = module_target_sat_insights
 
-    # Enable and sync BaseOS and AppStram repos
-    for name in ['rhel10_bos', 'rhel10_aps']:
-        # Enable the repository
-        rh_repo_id = satellite.api_factory.enable_rhrepo_and_fetchid(
-            basearch=constants.DEFAULT_ARCHITECTURE,
-            org_id=rhcloud_manifest_org.id,
-            product=constants.REPOS[name]['product'],
-            repo=constants.REPOS[name]['name'],
-            reposet=constants.REPOS[name]['reposet'],
-            releasever=constants.REPOS[name]['releasever'],
-        )
+    for rhel_ver in [8, 9, 10]:
+        for repo_type in ['bos', 'aps']:
+            name = f'rhel{rhel_ver}_{repo_type}'
+            if name not in constants.REPOS:
+                continue
+            rh_repo_id = satellite.api_factory.enable_rhrepo_and_fetchid(
+                basearch=constants.DEFAULT_ARCHITECTURE,
+                org_id=rhcloud_manifest_org.id,
+                product=constants.REPOS[name]['product'],
+                repo=constants.REPOS[name]['name'],
+                reposet=constants.REPOS[name]['reposet'],
+                releasever=constants.REPOS[name]['releasever'],
+            )
 
-        # Sync the repository
-        rh_repo = satellite.api.Repository(id=rh_repo_id).read()
-        task = rh_repo.sync(synchronous=False)
-        satellite.wait_for_tasks(
-            search_query=(f'id = {task["id"]}'),
-            poll_timeout=2500,
-            must_succeed=False,
-        )
-        task_status = satellite.api.ForemanTask(id=task['id']).poll()
-        assert task_status['result'] == 'success'
+            rh_repo = satellite.api.Repository(id=rh_repo_id).read()
+            task = rh_repo.sync(synchronous=False)
+            satellite.wait_for_tasks(
+                search_query=(f'id = {task["id"]}'),
+                poll_timeout=2500,
+                must_succeed=False,
+            )
+            task_status = satellite.api.ForemanTask(id=task['id']).poll()
+            assert task_status['result'] == 'success'
 
     # Manually trigger CVE sync and wait for completion.
     trigger_cve_sync(satellite, assert_start=True)
@@ -186,8 +188,8 @@ def setup_content_for_iop(module_target_sat_insights, rhcloud_manifest_org):
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('10')
-@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+@pytest.mark.rhel_ver_match(r'^(?!7).*')
+@pytest.mark.parametrize('module_target_sat_insights', [True], ids=['local'], indirect=True)
 def test_rhcloud_insights_vulnerabilities_e2e(
     vulnerable_rhel_host,
     rhcloud_manifest_org,
@@ -219,6 +221,9 @@ def test_rhcloud_insights_vulnerabilities_e2e(
     satellite = module_target_sat_insights
     client = vulnerable_rhel_host
     hostname = client.hostname
+    rhel_ver = client.os_version.major
+    vuln_data = constants.VULNERABLE_PACKAGES[rhel_ver]
+    primary_cve = vuln_data['cves'][0]
 
     with satellite.ui_session() as session:
         session.organization.select(org_name=rhcloud_manifest_org.name)
@@ -227,29 +232,23 @@ def test_rhcloud_insights_vulnerabilities_e2e(
         assert status['Red Hat Lightspeed']['Status'] == 'Reporting'
 
         vulnerabilities = session.host_new.get_vulnerabilities(hostname)
-        assert any(
-            vuln.get('CVE ID') == constants.RHEL10_VULNERABILITY_CVE_ID for vuln in vulnerabilities
-        )
+        assert any(vuln.get('CVE ID') == primary_cve for vuln in vulnerabilities)
 
         # Validate the affected Host from the Vulnerability details and list pages
-        affected_host = session.cloudvulnerability.get_affected_hosts_by_cve(
-            constants.RHEL10_VULNERABILITY_CVE_ID
-        )
+        affected_host = session.cloudvulnerability.get_affected_hosts_by_cve(primary_cve)
         assert affected_host[0]['Name'] == hostname
 
         # Validate the Host's Vulnerabilities tab
         vulnerabilities = session.cloudvulnerability.validate_cve_to_host_details_flow(
-            constants.RHEL10_VULNERABILITY_CVE_ID, hostname
+            primary_cve, hostname
         )
-        assert any(
-            vuln.get('CVE ID') == constants.RHEL10_VULNERABILITY_CVE_ID for vuln in vulnerabilities
-        )
+        assert any(vuln.get('CVE ID') == primary_cve for vuln in vulnerabilities)
 
         # Apply the erratum that mitigates the CVEs
         timestamp = (datetime.now(UTC) - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.host_new.apply_erratas(
             entity_name=hostname,
-            search=f'errata_id == {constants.RHEL10_MARIADB_ERRATUM}',
+            search=f'errata_id == {vuln_data["erratum"]}',
         )
 
         # Wait for applicability to generate on the host after remediation
@@ -273,14 +272,14 @@ def test_rhcloud_insights_vulnerabilities_e2e(
 
         vulnerabilities = session.host_new.get_vulnerabilities(hostname)
         cve_ids = [vuln['CVE ID'] for vuln in vulnerabilities]
-        for mariadb_cve in constants.RHEL10_VULNERABLE_MARIADB_CVES:
-            assert mariadb_cve not in cve_ids
+        for cve in vuln_data['cves']:
+            assert cve not in cve_ids
 
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('10')
-@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+@pytest.mark.rhel_ver_match(r'^(?!7).*')
+@pytest.mark.parametrize('module_target_sat_insights', [True], ids=['local'], indirect=True)
 def test_edit_business_risk_and_status_individual(
     vulnerable_rhel_host,
     rhcloud_manifest_org,
@@ -304,35 +303,30 @@ def test_edit_business_risk_and_status_individual(
         2. Status can be edited and persists in the table
     """
     satellite = module_target_sat_insights
+    rhel_ver = vulnerable_rhel_host.os_version.major
+    vuln_data = constants.VULNERABLE_PACKAGES[rhel_ver]
+    primary_cve = vuln_data['cves'][0]
 
     with satellite.ui_session() as session:
         session.organization.select(org_name=rhcloud_manifest_org.name)
 
         # Edit business risk via row kebab menu
-        session.cloudvulnerability.edit_business_risk(
-            constants.RHEL10_VULNERABILITY_CVE_ID, 'High', 'Test justification'
-        )
+        session.cloudvulnerability.edit_business_risk(primary_cve, 'High', 'Test justification')
 
         # Verify business risk in table
         vulns = session.cloudvulnerability.read()
-        cve_row = [row for row in vulns if row['CVE ID'] == constants.RHEL10_VULNERABILITY_CVE_ID]
-        assert len(cve_row) == 1, (
-            f'Expected 1 CVE with ID {constants.RHEL10_VULNERABILITY_CVE_ID}, found {len(cve_row)}'
-        )
+        cve_row = [row for row in vulns if row['CVE ID'] == primary_cve]
+        assert len(cve_row) == 1, f'Expected 1 CVE with ID {primary_cve}, found {len(cve_row)}'
         cve_row = cve_row[0]
         assert cve_row['Business risk'] == 'High'
 
         # Edit status
-        session.cloudvulnerability.edit_status(
-            constants.RHEL10_VULNERABILITY_CVE_ID, 'In review', 'Testing status edit'
-        )
+        session.cloudvulnerability.edit_status(primary_cve, 'In review', 'Testing status edit')
 
         # Verify status in table
         vulns = session.cloudvulnerability.read()
-        cve_row = [row for row in vulns if row['CVE ID'] == constants.RHEL10_VULNERABILITY_CVE_ID]
-        assert len(cve_row) == 1, (
-            f'Expected 1 CVE with ID {constants.RHEL10_VULNERABILITY_CVE_ID}, found {len(cve_row)}'
-        )
+        cve_row = [row for row in vulns if row['CVE ID'] == primary_cve]
+        assert len(cve_row) == 1, f'Expected 1 CVE with ID {primary_cve}, found {len(cve_row)}'
         cve_row = cve_row[0]
         assert cve_row['Status'] == 'In review'
 
@@ -352,9 +346,9 @@ def test_bulk_edit_business_risk_and_status(
     :id: 898904b5-fb95-43f9-8c33-cd107f00c206
 
     :steps:
-        1. Create multiple CVEs by downgrading vulnerable mariadb package
+        1. Create multiple CVEs by downgrading vulnerable package
         2. Navigate to Vulnerabilities page
-        3. Select multiple CVEs (2 of the 3 CVEs created by mariadb)
+        3. Select multiple CVEs (2 of the CVEs created by the package)
         4. Use bulk actions menu to edit business risk
         5. Verify business risk updated for all selected CVEs
         6. Use bulk actions menu to edit status
@@ -366,12 +360,13 @@ def test_bulk_edit_business_risk_and_status(
         3. Bulk status edit applies to all selected CVEs
     """
     satellite = module_target_sat_insights
+    rhel_ver = vulnerable_rhel_host.os_version.major
+    vuln_data = constants.VULNERABLE_PACKAGES[rhel_ver]
 
     with satellite.ui_session() as session:
         session.organization.select(org_name=rhcloud_manifest_org.name)
 
-        # Use the first 2 CVEs from the mariadb package for deterministic bulk edit testing
-        cve_ids = constants.RHEL10_VULNERABLE_MARIADB_CVES[:2]
+        cve_ids = vuln_data['cves'][:2]
 
         # Bulk edit business risk
         session.cloudvulnerability.bulk_edit_business_risk(cve_ids, 'Critical', 'Bulk test')
@@ -398,7 +393,7 @@ def test_bulk_edit_business_risk_and_status(
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('10')
+@pytest.mark.rhel_ver_match(r'^(?!7).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_edit_from_cve_details_page(
     vulnerable_rhel_host,
@@ -425,42 +420,41 @@ def test_edit_from_cve_details_page(
         3. Changes persist and are visible in main vulnerabilities table
     """
     satellite = module_target_sat_insights
+    rhel_ver = vulnerable_rhel_host.os_version.major
+    vuln_data = constants.VULNERABLE_PACKAGES[rhel_ver]
+    primary_cve = vuln_data['cves'][0]
 
     with satellite.ui_session() as session:
         session.organization.select(org_name=rhcloud_manifest_org.name)
 
         # Edit business risk from CVE details page
         session.cloudvulnerability.edit_business_risk_from_details(
-            constants.RHEL10_VULNERABILITY_CVE_ID, 'Low', 'Low priority via details page'
+            primary_cve, 'Low', 'Low priority via details page'
         )
 
         # Verify business risk in main table
         vulns = session.cloudvulnerability.read()
-        cve_row = [row for row in vulns if row['CVE ID'] == constants.RHEL10_VULNERABILITY_CVE_ID]
-        assert len(cve_row) == 1, (
-            f'Expected 1 CVE with ID {constants.RHEL10_VULNERABILITY_CVE_ID}, found {len(cve_row)}'
-        )
+        cve_row = [row for row in vulns if row['CVE ID'] == primary_cve]
+        assert len(cve_row) == 1, f'Expected 1 CVE with ID {primary_cve}, found {len(cve_row)}'
         assert cve_row[0]['Business risk'] == 'Low'
 
         # Edit status from CVE details page
         session.cloudvulnerability.edit_status_from_details(
-            constants.RHEL10_VULNERABILITY_CVE_ID,
+            primary_cve,
             'No action - risk accepted',
             'Risk accepted via details page',
         )
 
         # Verify status in main table
         vulns = session.cloudvulnerability.read()
-        cve_row = [row for row in vulns if row['CVE ID'] == constants.RHEL10_VULNERABILITY_CVE_ID]
-        assert len(cve_row) == 1, (
-            f'Expected 1 CVE with ID {constants.RHEL10_VULNERABILITY_CVE_ID}, found {len(cve_row)}'
-        )
+        cve_row = [row for row in vulns if row['CVE ID'] == primary_cve]
+        assert len(cve_row) == 1, f'Expected 1 CVE with ID {primary_cve}, found {len(cve_row)}'
         assert cve_row[0]['Status'] == 'No action - risk accepted'
 
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('10')
+@pytest.mark.rhel_ver_match(r'^(?!7).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_filter_by_os_version(
     vulnerable_rhel_host,
@@ -475,7 +469,7 @@ def test_filter_by_os_version(
     :steps:
         1. Create a CVE by downgrading a vulnerable package
         2. Navigate to Vulnerabilities page
-        3. Apply OS filter for RHEL 10
+        3. Apply OS filter for the host's RHEL version
         4. Verify filtered results are displayed
         5. Verify CVE appears in filtered results
 
@@ -485,6 +479,9 @@ def test_filter_by_os_version(
         3. The created CVE appears in the filtered results
     """
     satellite = module_target_sat_insights
+    rhel_ver = vulnerable_rhel_host.os_version.major
+    vuln_data = constants.VULNERABLE_PACKAGES[rhel_ver]
+    primary_cve = vuln_data['cves'][0]
 
     with satellite.ui_session() as session:
         session.organization.select(org_name=rhcloud_manifest_org.name)
@@ -493,8 +490,8 @@ def test_filter_by_os_version(
         vulns_before = session.cloudvulnerability.read()
         assert vulns_before, 'No vulnerabilities found before filtering'
 
-        # Apply OS filter for RHEL 10
-        session.cloudvulnerability.filter_by_os(['RHEL 10'])
+        # Apply OS filter for the host's RHEL version
+        session.cloudvulnerability.filter_by_os([f'RHEL {rhel_ver}'])
 
         # Read vulnerabilities after filtering
         vulns_after = session.cloudvulnerability.read()
@@ -507,17 +504,13 @@ def test_filter_by_os_version(
         )
 
         # Verify our CVE appears in the filtered results
-        cve_found = any(
-            row['CVE ID'] == constants.RHEL10_VULNERABILITY_CVE_ID for row in vulns_after
-        )
-        assert cve_found, (
-            f'CVE {constants.RHEL10_VULNERABILITY_CVE_ID} should appear in RHEL 10 filtered results'
-        )
+        cve_found = any(row['CVE ID'] == primary_cve for row in vulns_after)
+        assert cve_found, f'CVE {primary_cve} should appear in RHEL {rhel_ver} filtered results'
 
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('10')
+@pytest.mark.rhel_ver_match(r'^(?!7).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_positive_disable_vulnerability_analysis_for_host(
     vulnerable_rhel_host,
@@ -582,7 +575,7 @@ def test_positive_disable_vulnerability_analysis_for_host(
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('10')
+@pytest.mark.rhel_ver_match(r'^(?!7).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_positive_bulk_disable_vulnerability_analysis(
     vulnerable_rhel_host,
@@ -807,16 +800,18 @@ def test_positive_iop_cve_display_when_repos_exceeding_api_page_limit(
         f'This indicates VMaaS did not paginate beyond the first API page.'
     )
 
+    rhel_ver = vulnerable_rhel_host.os_version.major
+    vuln_data = constants.VULNERABLE_PACKAGES[rhel_ver]
+    primary_cve = vuln_data['cves'][0]
+
     with satellite.ui_session() as session:
         session.organization.select(org_name=rhcloud_manifest_org.name)
 
         # Verify the CVE appears on the Vulnerabilities page and the host is affected
-        affected_hosts = session.cloudvulnerability.get_affected_hosts_by_cve(
-            constants.RHEL10_VULNERABILITY_CVE_ID
-        )
+        affected_hosts = session.cloudvulnerability.get_affected_hosts_by_cve(primary_cve)
         assert any(host['Name'] == hostname for host in affected_hosts), (
             f'Host {hostname} not found in affected hosts for '
-            f'CVE {constants.RHEL10_VULNERABILITY_CVE_ID}. '
+            f'CVE {primary_cve}. '
             f'VMaaS may not have synced repos beyond the first API page (20 repos).'
         )
 

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -557,7 +557,7 @@ def test_positive_disable_vulnerability_analysis_for_host(
         # Search for the registered host and total cves
         table_data = session.all_hosts.search(hostname)
         assert len(table_data) > 0, f"Host {hostname} not found after search"
-        assert int(table_data[0]['Total CVEs']) > 1
+        assert int(table_data[0]['Total CVEs']) >= 1
         host_row = table_data[0]
         assert hostname in table_data[0]['Name'], (
             f"Expected host {hostname}, but got {host_row['Name']}"
@@ -621,7 +621,7 @@ def test_positive_bulk_disable_vulnerability_analysis(
         # Search for the registered host and total cves
         table_data = session.all_hosts.search(hostname)
         assert len(table_data) > 0, f"Host {hostname} not found after search"
-        assert int(table_data[0]['Total CVEs']) > 1
+        assert int(table_data[0]['Total CVEs']) >= 1
         host_row = table_data[0]
         assert hostname in table_data[0]['Name'], (
             f"Expected host {hostname}, but got {host_row['Name']}"

--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -89,7 +89,7 @@ def create_rbac_user(
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match(r'^(?![78]).*')
+@pytest.mark.rhel_ver_match(r'^(?!7).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_iop_recommendations_e2e(
     rhel_insights_vm,
@@ -274,7 +274,7 @@ def test_iop_rhcloud_inventory_e2e(
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match(r'^(?![78]).*')
+@pytest.mark.rhel_ver_match(r'^(?!7).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_iop_recommendations_remediate_multiple_hosts(
     rhel_insights_vms,
@@ -348,7 +348,7 @@ def test_iop_recommendations_remediate_multiple_hosts(
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match(r'^(?![78]).*')
+@pytest.mark.rhel_ver_match(r'^(?!7).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_iop_recommendations_host_details_e2e(
     rhel_insights_vm,
@@ -436,8 +436,8 @@ def test_iop_negative_rhcloud_inventory_upload_not_displayed(module_target_sat_i
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('10')
-@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+@pytest.mark.rhel_ver_match(r'^(?!7).*')
+@pytest.mark.parametrize('module_target_sat_insights', [True], ids=['local'], indirect=True)
 def test_iop_recommendations_remediation_type_and_status(
     rhel_insights_vm,
     rhcloud_manifest_org,

--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -437,7 +437,7 @@ def test_iop_negative_rhcloud_inventory_upload_not_displayed(module_target_sat_i
 @pytest.mark.e2e
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match(r'^(?!7).*')
-@pytest.mark.parametrize('module_target_sat_insights', [True], ids=['local'], indirect=True)
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
 def test_iop_recommendations_remediation_type_and_status(
     rhel_insights_vm,
     rhcloud_manifest_org,


### PR DESCRIPTION
SAT-44051

Update IOP tests to support RHEL 8 9 and 10. 

Added in Vulnerability packages for RHEL 8 and 9. 

Updated tests.

## Summary by Sourcery

Generalize RH Cloud IoP vulnerability and recommendations tests to support multiple RHEL major versions instead of only RHEL 10.

New Features:
- Introduce per-RHEL-version vulnerability metadata to drive IoP vulnerability scenarios across RHEL 8, 9, and 10.

Enhancements:
- Update test fixtures and flows to derive vulnerable packages, CVEs, errata, and OS filters dynamically from the host's RHEL version.
- Expand content sync setup to enable and sync BaseOS/AppStream repositories for all supported RHEL versions.
- Relax RHEL version matching on IoP UI and CLI tests to cover all supported versions except RHEL 7 and adjust Satellite/Insights deployment modes accordingly.
- Adjust CLI IoP installation tests to run against an older (N-2) RHEL version baseline.