### PR TITLE
Allow `host_conf` usage w/o request fixture

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -21,18 +21,18 @@ def host_conf(request):
     conf = params = {}
     if hasattr(request, 'param'):
         params = request.param
+    elif hasattr(request, 'get'):
+        params = request.get('param', {})
     distro = params.get('distro', 'rhel')
     network = params.get('network', settings.content_host.network_type)
     _rhelver = f"{distro}{params.get('rhel_version', settings.content_host.default_rhel_version)}"
 
     # check to see if no-containers is passed as an argument to pytest
     deploy_kwargs = {}
-    if not any(
-        [
-            request.config.getoption('no_containers'),
-            params.get('no_containers'),
-            request.node.get_closest_marker('no_containers'),
-        ]
+    if not (
+        params.get('no_containers')
+        or request.config.getoption('no_containers')
+        or request.node.get_closest_marker('no_containers')
     ):
         deploy_kwargs = settings.content_host.get(_rhelver).to_dict().get('container', {})
         if deploy_kwargs and network:


### PR DESCRIPTION
### Problem Statement
`contenthost_factory` always requires the fixture to be parametrized:
```
@pytest.fixture(params=[{'rhel_version': 8, 'no_containers': True}])
def external_server(request):
    with contenthost_factory(request=request) as host:
```

Removing unnecessary fixture parametrization w/o removing `contenthost_factory` is not possible:
```
@pytest.fixture
def external_server():
    with contenthost_factory(request={'param': {'rhel_version': 9, 'no_containers': True}}) as host:
```
^ impossible code

### Solution
In `host_conf()` add handling of dictionary object mimicking `request` in order to allow unparametrized fixtures to still use `contenthost_factory`

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Allow content host configuration fixture to be used without a pytest request object and update external puppet server provisioning to RHEL 9 with revised test conditions.

Bug Fixes:
- Enable host_conf fixture to accept configuration via plain parameter dictionaries in addition to pytest request objects.

Enhancements:
- Simplify no-containers option handling in host_conf to use clearer boolean logic.
- Update external_puppet_server fixture to provision RHEL 9 content hosts and install the corresponding Puppet repository.
- Adjust provisioning test markers and skip conditions to cover RHEL 7–10 and reflect current openvox-agent availability issues.

## Summary by Sourcery

Allow content host configuration to accept plain parameter dictionaries in addition to pytest request objects when used by fixtures.

Bug Fixes:
- Enable host_conf to read parameters from a dictionary with a 'param' key, allowing use of contenthost_factory without a parametrized pytest request fixture.

Enhancements:
- Simplify no-containers handling in host_conf by using clearer boolean logic when deciding whether to configure container deployment.