### PR TITLE
Update hammer command tree test data for newly added CLI options

### DIFF
--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -1294,6 +1294,24 @@
               "value": "ENUM"
             },
             {
+              "help": "Debian architectures (e.g., amd64, arm64)",
+              "name": "deb-architectures",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "Debian components (e.g., main, contrib)",
+              "name": "deb-components",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "Debian releases/distributions (e.g., trixie, bookworm)",
+              "name": "deb-releases",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
               "help": "Description for the alternate content source",
               "name": "description",
               "shortname": null,
@@ -1535,6 +1553,24 @@
             {
               "help": "Base URL for finding alternate content",
               "name": "base-url",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "Debian architectures (e.g., amd64, arm64)",
+              "name": "deb-architectures",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "Debian components (e.g., main, contrib)",
+              "name": "deb-components",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
+              "help": "Debian releases/distributions (e.g., trixie, bookworm)",
+              "name": "deb-releases",
               "shortname": null,
               "value": "VALUE"
             },
@@ -14481,6 +14517,12 @@
               "value": "LIST"
             },
             {
+              "help": "Content view environment to reassign orphaned host groups to",
+              "name": "hostgroup-content-view-environment-id",
+              "shortname": null,
+              "value": "NUMBER"
+            },
+            {
               "help": "Content view numeric identifier",
               "name": "id",
               "shortname": null,
@@ -15708,6 +15750,12 @@
               "name": "activation-key-id",
               "shortname": null,
               "value": null
+            },
+            {
+              "help": "Content source identifier to filter by available lifecycle environments",
+              "name": "content-source-id",
+              "shortname": null,
+              "value": "NUMBER"
             },
             {
               "help": "VALUE/NUMBER               Content view identifier",
@@ -26926,6 +26974,18 @@
               "value": null
             },
             {
+              "help": "VALUE/NUMBER Content view environment name/id",
+              "name": "content-view-environment",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "VALUE/NUMBER Content view environment name/id",
+              "name": "content-view-environment-id",
+              "shortname": null,
+              "value": null
+            },
+            {
               "help": "VALUE/NUMBER          Content view name/id",
               "name": "content-view",
               "shortname": null,
@@ -27673,6 +27733,18 @@
             {
               "help": "VALUE/NUMBER        Content source name/id",
               "name": "content-source-id",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "VALUE/NUMBER Content view environment name/id",
+              "name": "content-view-environment",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "VALUE/NUMBER Content view environment name/id",
+              "name": "content-view-environment-id",
               "shortname": null,
               "value": null
             },
@@ -43291,6 +43363,12 @@
               "name": "lifecycle-environment-id",
               "shortname": null,
               "value": null
+            },
+            {
+              "help": "Id of a module stream to find repositories that contain the module stream",
+              "name": "modulemd-id",
+              "shortname": null,
+              "value": "VALUE"
             },
             {
               "help": "Name of the repository",


### PR DESCRIPTION
### Problem Statement
test_positive_all_options failed because Satellite’s Hammer CLI gained new flags and subcommands that were not reflected in Robottelo’s baseline hammer_commands.json. The test compares live hammer full-help output to that JSON snapshot, so any new options show up as “added” until the fixture data is updated.

### Solution
Refresh tests/foreman/data/hammer_commands.json so it includes the newly exposed Hammer options (e.g. alternate content source Debian fields, content view removal / lifecycle environment filtering, host group content-view environment fields, repository list --modulemd-id, etc.) so expectations match the current CLI.

### Related Issues

## Summary by Sourcery

Update Hammer CLI command snapshot data to align with the current CLI help output so baseline comparisons remain accurate.

Bug Fixes:
- Resolve failures in tests that compare Hammer full-help output to the recorded hammer_commands.json snapshot by refreshing the baseline data.

Tests:
- Refresh hammer_commands.json fixture data to include newly added Hammer CLI flags and subcommands used by the comparison tests.