### PR TITLE
Fix ACS assertion

### DIFF
--- a/tests/foreman/cli/test_acs.py
+++ b/tests/foreman/cli/test_acs.py
@@ -23,7 +23,7 @@ ACS_UPDATED = 'Alternate Content Source updated.'
 ACS_DELETED = 'Alternate Content Source deleted.'
 ACS_NOT_FOUND = 'Could not find alternate_content_source resource with id'
 
-VAL_FAILED = 'Validation failed'
+VAL_FAILED = 'Could not create'
 VAL_CANT_BLANK = 'can\'t be blank'
 VAL_MUST_BLANK = 'must be blank'
 VAL_CANNOT_BE = 'cannot be'


### PR DESCRIPTION
that has recently changed

In our downstream tests these tests started failing recently due to assertion message change.

If the PRT confirms that this is a downstream only problem feel free to close this MR

### Problem Statement
see code

### Solution
see code

### tests to execute

tests/foreman/cli/test_acs.py

## Summary by Sourcery

Tests:
- Adjust ACS validation failure constant in tests to match updated CLI error message.