### PR TITLE
Skip ocpv cli and ui tests if settings not set

### DIFF
--- a/tests/foreman/cli/test_computeresource_ocpv.py
+++ b/tests/foreman/cli/test_computeresource_ocpv.py
@@ -23,6 +23,8 @@ from robottelo.exceptions import CLIReturnCodeError
 from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import parametrized
 
+pytestmark = [pytest.mark.skip_if_not_set('ocpv')]
+
 
 def valid_name_desc_data():
     """Random data for valid name and description"""

--- a/tests/foreman/ui/test_computeresource_ocpv.py
+++ b/tests/foreman/ui/test_computeresource_ocpv.py
@@ -17,6 +17,8 @@ from wait_for import wait_for
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 
+pytestmark = [pytest.mark.skip_if_not_set('ocpv')]
+
 
 @pytest.mark.e2e
 @pytest.mark.on_premises_provisioning


### PR DESCRIPTION
similar to how it is handled in the api tests

### Problem Statement
ocpv tests are executed despite missing settings

### Solution
skip tests if setting is missing

### test to run
tests/foreman/cli/test_computeresource_ocpv.py

## Summary by Sourcery

Skip OCPv CLI compute resource tests when required OCPv settings are not configured.

Bug Fixes:
- Prevent OCPv CLI compute resource tests from running when the required 'ocpv' setting is missing.

Tests:
- Mark OCPv CLI compute resource tests with a conditional skip based on the 'ocpv' configuration setting.