### PR TITLE
Block most of the Virtwho Tests

### DIFF
--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -10,6 +10,7 @@
 
 :CaseImportance: High
 
+:BlockedBy: SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -8,7 +8,7 @@
 
 :team: Proton
 
-:BlockedBy: SAT-36027
+:BlockedBy: SAT-36027, SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -8,6 +8,7 @@
 
 :team: Proton
 
+:BlockedBy: SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -10,6 +10,7 @@
 
 :CaseImportance: High
 
+:BlockedBy: SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/cli/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/cli/test_hyperv_sca.py
@@ -10,6 +10,7 @@
 
 :CaseImportance: High
 
+:BlockedBy: SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/cli/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt_sca.py
@@ -8,7 +8,7 @@
 
 :team: Proton
 
-:BlockedBy: SAT-36027
+:BlockedBy: SAT-36027, SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/cli/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_libvirt_sca.py
@@ -8,6 +8,7 @@
 
 :team: Proton
 
+:BlockedBy: SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/cli/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/cli/test_nutanix_sca.py
@@ -10,6 +10,7 @@
 
 :CaseImportance: High
 
+:BlockedBy: SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -8,6 +8,7 @@
 
 :team: Proton
 
+:BlockedBy: SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -8,7 +8,7 @@
 
 :team: Proton
 
-:BlockedBy: SAT-36027
+:BlockedBy: SAT-36027, SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -8,6 +8,7 @@
 
 :team: Proton
 
+:BlockedBy: SAT-45010
 """
 
 import pytest

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -8,6 +8,7 @@
 
 :Team: Proton
 
+:BlockedBy: SAT-45010
 """
 
 from fauxfactory import gen_string


### PR DESCRIPTION
Block most of the VirtWho tests as Hyper-V, KubeVirt, Libvirt, Nutanix providers are unavailable.