### PR TITLE
Block test_global_registration_form_populate

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -299,6 +299,8 @@ def test_global_registration_form_populate(
     :BZ: 2056469, 1994654, 1955421
 
     :customerscenario: true
+
+    :BlockedBy: SAT-44612
     """
     hg_name = gen_string('alpha')
     hg_nested_name = gen_string('alpha')


### PR DESCRIPTION
Test is accessing ActivationKeys HostGroup Tab which is broken by SAT-44612

## Summary by Sourcery

Tests:
- Annotate the global registration form population test with a :BlockedBy: SAT-44612 marker to indicate it cannot currently run.