### PR TITLE
Fix content_view and lifecycle_environment validation in nested hostgroup test

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -833,11 +833,13 @@ def test_positive_list_with_nested_hostgroup(target_sat):
         name=parent_hg_name,
         organization=[options.organization],
         content_view=content_view,
+        lifecycle_environment=lce,
         ptable=options.ptable,
     ).create()
     nested_hg = target_sat.api.HostGroup(
         architecture=options.architecture,
         domain=options.domain,
+        content_view=content_view,
         lifecycle_environment=lce,
         location=[options.location],
         medium=options.medium,


### PR DESCRIPTION
## Problem Statement

The `test_positive_list_with_nested_hostgroup` test was failing with an HTTP 422 error when attempting to create host groups:

```
requests.exceptions.HTTPError: ('422 Client Error: Unprocessable Content for url: https://.../api/v2/hostgroups', 
{'error': {'id': None, 'errors': {'content_facet.base': ['Content view and lifecycle environment must both be set, or both be empty']}, 
'full_messages': ['Base Content view and lifecycle environment must both be set, or both be empty']}})
```

The root cause was that Satellite API requires `content_view` and `lifecycle_environment` to be paired together - both must be set or both must be empty. The test was creating:
- Parent hostgroup with `content_view` but **without** `lifecycle_environment`
- Nested hostgroup with `lifecycle_environment` but **without** `content_view`

## Solution

Added the missing parameters to satisfy the API validation:
- Added `lifecycle_environment=lce` to parent hostgroup creation (line 835)
- Added `content_view=content_view` to nested hostgroup creation (line 841)

## Test Results

✅ Test now passes successfully:
```
tests/foreman/cli/test_host.py::test_positive_list_with_nested_hostgroup PASSED
1 passed, 73 deselected, 1 warning in 86.65s
```

## Verification

The test properly validates:
- Creating parent and nested host groups with content management settings
- Host creation using nested hostgroup
- Proper inheritance of content_view and lifecycle_environment from parent to nested hostgroup
- Correct display of hostgroup hierarchy in host listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix nested hostgroup creation test by aligning content view and lifecycle environment configuration with Satellite API validation requirements.

Bug Fixes:
- Ensure parent hostgroup is created with both content view and lifecycle environment set to satisfy API pairing requirements.
- Ensure nested hostgroup is created with both content view and lifecycle environment set to satisfy API pairing requirements.