### PR TITLE
Update test_positive_list_with_nested_hostgroup test fix

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -833,12 +833,12 @@ def test_positive_list_with_nested_hostgroup(target_sat):
         name=parent_hg_name,
         organization=[options.organization],
         content_view=content_view,
+        lifecycle_environment=lce,
         ptable=options.ptable,
     ).create()
     nested_hg = target_sat.api.HostGroup(
         architecture=options.architecture,
         domain=options.domain,
-        lifecycle_environment=lce,
         location=[options.location],
         medium=options.medium,
         name=nested_hg_name,


### PR DESCRIPTION
### Problem Statement 
The SAT-38839 (https://github.com/Katello/katello/pull/11707) change introduced a new validation requiring content view and lifecycle environment to both be set or both be empty on hostgroup content facets. 
The test was setting content_view on the parent hostgroup and lifecycle_environment on the nested hostgroup separately, violating this constraint.
                                                                                                                                                                                                     
###  Solution                                                                               
Moved lifecycle_environment from the nested hostgroup to the parent hostgroup so it pairs with content_view, satisfying the new validation. The nested hostgroup inherits both from the parent.    

###  PRT Example                                                                                                                                                                                        
<img width="319" height="67" alt="image" src="https://github.com/user-attachments/assets/b3e3a944-a1d9-4be9-b7c0-6a3a55cb619b" />

```                                                                               
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k 'test_positive_list_with_nested_hostgroup'
```

ERROR was:
```
--------------------------------- Captured Err ---------------------------------
2026-05-06 15:18:03 - nailgun.client - WARNING - Received HTTP 422 response: {
      "error": {"id":null,"errors":{"content_facet.base":["Content view and lifecycle environment must both be set, or both be empty"]},"full_messages":["Base Content view and lifecycle environment must both be set, or both be empty"]}
    }
    
2026-05-06 15:18:03 - robottelo - ERROR - Test phase 'call' failed for test: tests/foreman/cli/test_host.py::test_positive_list_with_nested_hostgroup
2026-05-06 15:18:03 - robottelo - ERROR - Exception thrown:
    tests/foreman/cli/test_host.py:837: in test_positive_list_with_nested_hostgroup
        ).create()
          ^^^^^^^^
    ../../lib64/python3.12/site-packages/nailgun/entities.py:4061: in create
        id=self.create_json(create_missing)['id'],
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ../../lib64/python3.12/site-packages/nailgun/entity_mixins.py:974: in create_json
        raise_for_status_add_to_exception(response)
    ../../lib64/python3.12/site-packages/nailgun/entity_mixins.py:58: in raise_for_status_add_to_exception
        raise e
    ../../lib64/python3.12/site-packages/nailgun/entity_mixins.py:54: in raise_for_status_add_to_exception
        response.raise_for_status()
    ../../lib64/python3.12/site-packages/requests/models.py:1028: in raise_for_status
        raise HTTPError(http_error_msg, response=self)
    E   requests.exceptions.HTTPError: ('422 Client Error: Unprocessable Content for url: https://ip-10-0-217-185.rhos-01.prod.psi.rdu2.redhat.com/api/v2/hostgroups', {'error': {'id': None, 'errors': {'content_facet.base': ['Content view and lifecycle environment must both be set, or both be empty']}, 'full_messages': ['Base Content view and lifecycle environment must both be set, or both be empty']}})
```

## Summary by Sourcery

Tests:
- Update nested hostgroup CLI test to set lifecycle environment on the parent hostgroup so content view and lifecycle environment are configured together.