### PR TITLE
Update admin username and password params in foremanctl deploy

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2002,8 +2002,8 @@ class Capsule(ContentHost, CapsuleMixins):
         # Install Satellite and return result
 
         default_parameters = [
-            f'--foreman-initial-admin-username {settings.server.admin_username}',
-            f'--foreman-initial-admin-password {settings.server.admin_password}',
+            f'--initial-admin-username {settings.server.admin_username}',
+            f'--initial-admin-password {settings.server.admin_password}',
         ]
 
         parameters = [] if parameters is None else parameters


### PR DESCRIPTION
### Problem Statement


### Solution
Update admin username and password params in foremanctl deploy command as per the latest changes done in theforeman/foremanctl#490


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Align foremanctl admin username and password parameters with the latest expected flags to prevent deployment failures.