### PR TITLE
[6.18.z] Increase _swap_nailgun file lock timeout

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2000,8 +2000,8 @@ class Satellite(Capsule, SatelliteMixins):
 
         # Use file locking to prevent race conditions when multiple xdist workers
         # try to install/uninstall nailgun simultaneously
-        lock_file = Path('/tmp/nailgun-install.lock')
-        with FileLock(lock_file):
+        lock_file = Path('/tmp/nailgun-install')
+        with FileLock(lock_file, timeout=120):
             logger.debug('Acquired nailgun install lock, running pip commands')
 
             expected_url = f'https://github.com/SatelliteQE/nailgun/archive/{nailgun_ref}.zip'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21483

### Problem Statement

- `_swap_nailgun` passes a lock file name of `/tmp/nailgun-install.lock` to `broker.helpers.FileLock`, but `FileLock` appends `.lock` to the name, resulting in an actual file named `/tmp/nailgun-install.lock.lock`.
- When using the `--dist load` option [1] for xdist to increase the number of workers using the same `SharedResource`, the default `FileLock` timeout of 10 seconds is too short, resulting in timeout errors like the following:

```
22:21:56  tests/new_upgrades/test_bookmarks.py::test_post_disabled_bookmark 
22:21:56  tests/new_upgrades/test_classparameter.py::test_post_puppet_class_parameter_data_and_type[1] 
22:21:56  tests/new_upgrades/test_classparameter.py::test_post_puppet_class_parameter_data_and_type[3] 
[...]
22:22:06  2026-05-06 02:22:07 - broker.exceptions - ERROR - BrokerError: Timeout while waiting for lock release: /tmp/nailgun-install.lock.lock
22:22:06  2026-05-06 02:22:07 - broker.exceptions - ERROR - BrokerError: Timeout while waiting for lock release: /tmp/nailgun-install.lock.lock
22:22:07  2026-05-06 02:22:08 - robottelo - ERROR - Test phase 'setup' failed for test: tests/new_upgrades/test_bookmarks.py::test_post_disabled_bookmark

22:22:07      robottelo/hosts.py:2091: in _swap_nailgun
22:22:07          with FileLock(lock_file):
22:22:07               ^^^^^^^^^^^^^^^^^^^
22:22:07      ../../lib64/python3.12/site-packages/broker/helpers/file_utils.py:187: in __enter__
22:22:07          self.wait_file()
22:22:07      ../../lib64/python3.12/site-packages/broker/helpers/file_utils.py:177: in wait_file
22:22:07          raise exceptions.BrokerError(
22:22:07      E   broker.exceptions.BrokerError: Timeout while waiting for lock release: /tmp/nailgun-install.lock.lock
```

[1] https://pytest-xdist.readthedocs.io/en/stable/distribution.html

### Solution

- Remove `.lock` from the file name passed to `FileLock`
- Increase `FileLock` timeout to 120 seconds, to allow enough time for all `pip` commands to be run by the worker holding the lock.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Increase robustness of nailgun swapping by adjusting the installation file lock configuration.

Enhancements:
- Extend the nailgun installation file lock timeout to reduce contention failures between parallel workers.
- Change the nailgun installation lock file path to use a non-.lock filename while retaining file-based synchronization.

## Summary by Sourcery

Adjust nailgun installation locking to reduce contention and timeouts during parallel test runs.

Enhancements:
- Change the nailgun installation lock file path to omit the redundant .lock extension while still using file-based synchronization.
- Increase the nailgun installation FileLock timeout to 120 seconds to better accommodate long-running pip operations under xdist.