### PR TITLE
Fix RHEL7 provisioning tests and remove skip conditions for SAT-41340

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -482,3 +482,47 @@ def configure_secureboot_provisioning(
             sat.execute(f'if [ -e "{_path}" ]; then rm -rf "{_path}"; fi')
     else:
         yield None
+
+
+@pytest.fixture
+def configure_uefi_provisioning_for_older_rhels(
+    request, pxe_loader, module_provisioning_sat, module_provisioning_rhel_content
+):
+    """Fixture for configuring pxe_loader for provisioning of older RHEL versions"""
+    rhel_ver_major = module_provisioning_rhel_content.os.major
+    rhel_ver_minor = module_provisioning_rhel_content.os.minor
+    sat = module_provisioning_sat.sat
+    if (
+        int(rhel_ver_major) <= 7
+        and pxe_loader.vm_firmware == 'uefi'
+        and module_provisioning_sat.sat.network_type != NetworkType.IPV6
+    ):
+        # Set the path for the shim and GRUB2 binaries for the OS of host
+        bootloader_path = f'/var/lib/tftpboot/bootloader-universe/pxegrub2/redhat/{rhel_ver_major}.{rhel_ver_minor}/x86_64'
+
+        # Create the directory to store the shim and GRUB2 binaries for the OS of host
+        sat.execute(f'install -o foreman-proxy -g foreman-proxy -d {bootloader_path}')
+
+        # Fetch and Download SB packages, and extract Grub2 binaries
+        pkg_prefix = 'grub2-efi-x64'
+        url = sat.get_secureboot_packages_with_version(
+            f'{settings.repos.get(f"rhel{rhel_ver_major}_os")}Packages', pkg_prefix
+        )
+        sat.execute(f'curl -o /tmp/{pkg_prefix}.rpm {url}')
+        sat.execute(f'rpm2cpio /tmp/{pkg_prefix}.rpm | cpio -idv --directory /tmp')
+
+        # Make the shim and GRUB2 binaries available for host provisioning:
+        sat.execute(f'cp /tmp/boot/efi/EFI/redhat/grubx64.efi {bootloader_path}/grubx64.efi')
+        sat.execute(f'ln -sr {bootloader_path}/grubx64.efi {bootloader_path}/boot.efi')
+        sat.execute(f'chmod 644 {bootloader_path}/grubx64.efi')
+
+        yield
+        for _path in (
+            os.path.dirname(bootloader_path),
+            '/tmp/boot',
+            '/tmp/etc',
+            '/tmp/grub2-efi-x64.rpm',
+        ):
+            sat.execute(f'if [ -e "{_path}" ]; then rm -rf "{_path}"; fi')
+    else:
+        yield None

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -40,7 +40,6 @@ from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import parametrized
-from robottelo.utils.issue_handlers import is_open
 
 
 def valid_name_desc_data():
@@ -377,6 +376,8 @@ def test_positive_provision_end_to_end(
     module_location,
     provisioning_hostgroup,
     module_provisioning_rhel_content,
+    configure_uefi_provisioning_for_older_rhels,
+    configure_secureboot_provisioning,
 ):
     """Provision a host on Libvirt compute resource with the help of hostgroup.
 
@@ -401,10 +402,6 @@ def test_positive_provision_end_to_end(
 
     :customerscenario: true
     """
-    # Skip test for UEFI and SecureBoot loaders
-    if is_open('SAT-41340') and pxe_loader.vm_firmware in ['uefi', 'uefi_secure_boot']:
-        pytest.skip(f"Test not supported for {pxe_loader.vm_firmware} firmware")
-
     sat = module_libvirt_provisioning_sat.sat
     cr_name = gen_string('alpha')
     hostname = gen_string('alpha').lower()

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -93,6 +93,8 @@ def test_positive_provision_end_to_end(
     provision_method,
     vmware,
     vmwareclient,
+    configure_secureboot_provisioning,
+    configure_uefi_provisioning_for_older_rhels,
 ):
     """Provision a host on vmware compute resource with
     the help of hostgroup.
@@ -112,6 +114,9 @@ def test_positive_provision_end_to_end(
 
     :customerscenario: true
     """
+    if provision_method == 'bootdisk' and pxe_loader.vm_firmware == 'uefi_secure_boot':
+        pytest.skip('Bootdisk + Secureboot provisioning is not yet supported')
+
     sat = module_provisioning_sat.sat
     hostname = gen_string('alpha').lower()
     host = sat.cli.Host.create(


### PR DESCRIPTION
### Problem Statement
We can been skipping the RHEL7 provisioning tests due to SAT-41340

### Solution
Fix RHEL7 provisioning tests by using `bootloader-universe` configuration and remove skip conditions for SAT-41340

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Enable UEFI and Secure Boot provisioning test coverage for older RHEL systems while cleaning up obsolete skips tied to SAT-41340.

New Features:
- Add a reusable fixture to configure UEFI PXE bootloaders for provisioning older RHEL versions (≤7) across test suites.

Bug Fixes:
- Ensure RHEL7 UEFI provisioning tests are properly configured instead of being skipped due to prior SAT-41340 limitations.
- Prevent unsupported combinations such as bootdisk with UEFI Secure Boot on VMware from running by explicitly skipping them.

Enhancements:
- Apply the new UEFI provisioning fixture to PXE, HTTPBoot, FIPS, Libvirt, and VMware provisioning end-to-end tests to broaden coverage and reduce duplication.
- Remove outdated SAT-41340-based skip conditions so relevant provisioning scenarios are now exercised in CI.