### PR TITLE
[6.16.z Cherry-pick] Add ansible verbosity to the FAM tests

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -225,6 +225,6 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
 
     # Execute test_playbook
     result = module_target_sat.execute(
-        f'NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 make --directory {FAM_ROOT_DIR} livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.11"'
+        f'NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 FAM_TEST_ANSIBLE_VERBOSITY=1 make --directory {FAM_ROOT_DIR} livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.11"'
     )
     assert result.status == 0, f"{result.status=}\n{result.stdout=}\n{result.stderr=}"


### PR DESCRIPTION
Cherry-pick of #20494 onto `6.16.z`.

Closes #20531

Conflict resolution: The `6.16.z` branch uses inline env vars in the execute command rather than an env list. Added `FAM_TEST_ANSIBLE_VERBOSITY=1` inline to `test_positive_run_modules_and_roles`. Also added the new `test_positive_run_inventory` function adapted to the `6.16.z` style (inline env vars, `module_target_sat`).