### PR TITLE
[6.18.z] Fix registration in user jwt test

### DIFF
--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -360,6 +360,7 @@ def test_positive_invalidate_jwt(
             organization=module_org,
             location=module_location,
             activation_keys=[module_activation_key.name],
+            setup_insights=False,
             force=True,
         ).create()
         result = rhel_contenthost.execute(command.strip('\n'))
@@ -378,6 +379,7 @@ def test_positive_invalidate_jwt(
             organization=module_org,
             location=module_location,
             activation_keys=[module_activation_key.name],
+            setup_insights=False,
             force=True,
         ).create()
         result = rhel_contenthost.execute(command.strip('\n'))


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21505

### Problem Statement

- Registration of containerized content host fails because yum/dnf repos are disabled:
```
02:15:28  ___________________ test_positive_invalidate_jwt[rhel8-ipv4] ___________________
02:15:28  tests/foreman/ui/test_user.py:366: in test_positive_invalidate_jwt
02:15:28      assert result.status == 0, f'Failed to register host: {result.stderr}'
02:15:28  E   AssertionError: Failed to register host: This system is currently not registered.
02:15:28  E     Error: There are no enabled repositories in "/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d".
02:15:28  E     
02:15:28  E   assert 1 == 0
02:15:28  E    +  where 1 = stdout:\n#\n# Running registration\n#\nAll local data removed\nsubscription-manager is already installed!\nThe system has been registered with ID: 9546563c-1074-4880-bb87-4928a8877ef5\nThe registered system name is: 9366c78256ac\n# Running [9366c78256ac] host initial configuration\n#\n# Installing Insights client\n#\nUpdating Subscription Management repositories.\nHost [9366c78256ac] initial configuration failed\nSuccessfully updated the system facts.\nHost initialization script failed, see the logs for more information.\nYou can access the script source by running 'cat /root/registration_host_init.sh'\n\nstderr:\nThis system is currently not registered.\nError: There are no enabled repositories in "/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d".\n\nstatus: 1.status
```
- This happens when trying to configure Insights, which is not needed for these hosts or this test
- Our Jenkins CI job for Selenium Grid upgrades picks 1 test at random from tests/foreman/ui/test_user.py, and this particular test fails, causing CI failures

### Solution

- Register with `setup_insights=False`
- Also requires airgun PR https://github.com/SatelliteQE/airgun/pull/2425

### Related Issues

https://github.com/SatelliteQE/airgun/pull/2425

SAT-43368


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Update user JWT invalidation UI test content host registration to disable Insights setup for more accurate coverage.

## Summary by Sourcery

Tests:
- Adjust user JWT invalidation UI test to register content hosts with Insights setup disabled during registration.