### PR TITLE
Add test for IoP Vulnerability export

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -12,7 +12,9 @@
 
 """
 
+import csv
 from datetime import UTC, datetime, timedelta
+import json
 
 import pytest
 from wait_for import wait_for
@@ -706,3 +708,70 @@ def test_positive_iop_cve_display_when_repos_exceeding_api_page_limit(
             f'CVE {constants.RHEL10_VULNERABILITY_CVE_ID}. '
             f'VMaaS may not have synced repos beyond the first API page (20 repos).'
         )
+
+
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+def test_export_vulnerability_data(
+    vulnerable_rhel_host,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+    setup_content_for_iop,
+):
+    """Verify that vulnerability data can be exported as CSV or JSON
+
+    :id: 52164a99-41cf-439a-a8f5-6b5de7310f57
+
+    :steps:
+
+        1. Register a host to Satellite and create a vulnerability on the host.
+        2. On the Lightspeed > Vulnerability page, export data as both JSON and CSV.
+        3. Load the data from the exported files into memory.
+        4. Extract the data for the CVE created on the host.
+
+    :expectedResults:
+
+        Values in both export formats match the expected values for CVE.
+    """
+    satellite = module_target_sat_insights
+
+    # From the webUI, export vulnerability data as both JSON and CSV
+    with satellite.ui_session() as session:
+        session.organization.select(org_name=rhcloud_manifest_org.name)
+        csv_export_path = session.cloudvulnerability.export()
+        json_export_path = session.cloudvulnerability.export(export_format='json')
+
+    export_paths = [csv_export_path, json_export_path]
+
+    # Extract the export formats from the downloaded files,
+    # then load the contents of those files into memory.
+    for path in export_paths:
+        export_format = path.split('.')[-1]
+
+        if export_format == 'csv':
+            with open(path, newline='') as csvfile:
+                csv_data = [row for row in csv.reader(csvfile)]
+        elif export_format == 'json':
+            with open(path) as jsonfile:
+                json_data = json.load(jsonfile)
+
+    # Extract the MariaDB vulnerability from the JSON data
+    for cve in json_data:
+        if constants.RHEL10_VULNERABILITY_CVE_ID in cve['attributes'].values():
+            json_cve = cve['attributes']
+
+    # Extract the MariaDB vulnerability from the CSV data,
+    # then zip it with the CSV column headers
+    for cve in csv_data:
+        if constants.RHEL10_VULNERABILITY_CVE_ID in cve:
+            csv_cve = dict(zip(csv_data[0], cve, strict=True))
+
+    # Since CSV values are all strings, we need to cast some of the
+    # values to different types in order to make valid assertions.
+    for cve in [json_cve, csv_cve]:
+        assert int(cve['systems_affected']) > 0
+        assert cve['synopsis'] == constants.RHEL10_VULNERABILITY_CVE_ID
+        assert cve['impact'] == 'Moderate'
+        assert bool(cve['advisory_available'])
+        assert vulnerable_rhel_host.os_distribution_version in cve['rhel_versions']


### PR DESCRIPTION
This PR adds test coverage for exporting vulnerability data via the Lightspeed > Vulnerability page of the Satellite webUI. This coverage implements SAT-44422. It requires https://github.com/SatelliteQE/airgun/pull/2428.

## Summary by Sourcery

Tests:
- Add end-to-end test that exports vulnerability data as CSV and JSON and validates consistency of key CVE fields across formats.