### PR TITLE
set certificate-source=custom_server when deploying with custom certs

### DIFF
--- a/tests/foreman/installer/test_install_foremanctl.py
+++ b/tests/foreman/installer/test_install_foremanctl.py
@@ -173,10 +173,10 @@ def test_positive_install_foremanctl_with_custom_certs(module_sat_foremanctl_cus
     assert_hammer_ping_ok(result)
     # Verify the custom certificate works and there are no errors
     result = sat.execute(
-        f'curl -s -o /dev/null -w "%{{http_code}}" '
-        f'--cacert /root/cacert.crt https://{sat.hostname}/api/v2/ping'
+        'curl --output /dev/null --write-out "%{http_code}" --cacert /root/cacert.crt '
+        f'https://{sat.hostname}/api/v2/ping'
     )
-    assert result.stdout == '200'
+    assert result.stdout == '200', f'Calling API with custom cert failed: {result.stderr}'
 
 
 @pytest.mark.parametrize('module_sat_ready_rhel', ['default'], indirect=True)

--- a/tests/foreman/installer/test_install_foremanctl.py
+++ b/tests/foreman/installer/test_install_foremanctl.py
@@ -142,6 +142,7 @@ def module_sat_foremanctl_custom_certs():
         sat.custom_cert_generate(sat.hostname)
         sat.install_satellite_foremanctl(
             parameters=[
+                '--certificate-source=custom_server',
                 f'--certificate-server-certificate /root/{sat.hostname}/{sat.hostname}.crt',
                 f'--certificate-server-key /root/{sat.hostname}/{sat.hostname}.key',
                 '--certificate-server-ca-certificate /root/cacert.crt',


### PR DESCRIPTION
### Problem Statement

custom certs are only used when the certificate source is set to `custom_server`, which was forgotten in 20ac6cd6ca9b967de403e587d22fa3eee1e31e85

Also, the assertions in the tests does not give any hint what went wrong if something goes wrong.

### Solution

- deploy with `--certificate-source=custom_server`
- Call curl without `--silent`, which allows us to get the error out of stderr

### Related Issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/installer/test_install_foremanctl.py::test_positive_install_foremanctl_with_custom_certs
```

## Summary by Sourcery

Tests:
- Adjust the curl invocation in the custom cert foremanctl installation test to surface HTTP and stderr output and include stderr in the assertion message on failure.