### PR TITLE
Fix sync complete message on dashboard

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -314,7 +314,7 @@ def test_positive_sync_yum_repo_and_verify_content_checksum(session, module_org,
         for sync_val in sync_values:
             if 'less than a minute ago' in sync_val['Finished']:
                 assert sync_val['Product'] == product.name
-                assert sync_val['Status'] == SYNC_COMPLETE
+                assert sync_val['Status'] == 'Syncing Complete.'
         result = session.product.verify_content_checksum([product.name])
         assert result['task']['result'] == 'success'
 


### PR DESCRIPTION
### Problem Statement
Sync status page has been rewritten and the "Syncing complete" message has changed there. But it hasn't changed on the Dashboard page, which #21140 did not reflect, so now one test fails with 
```
tests/foreman/ui/test_repository.py:317: in test_positive_sync_yum_repo_and_verify_content_checksum
    assert sync_val['Status'] == SYNC_COMPLETE
E   AssertionError: assert 'Syncing Complete.' == 'Syncing complete'
E     
E     - Syncing complete
E     ?         ^
E     + Syncing Complete.
E     ?         ^       +
```


### Solution
Let this single test check the original message.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_repository.py -k test_positive_sync_yum_repo_and_verify_content_checksum
```

## Summary by Sourcery

Bug Fixes:
- Update repository sync UI test to assert the new "Syncing Complete." status message instead of the legacy constant.