### PR TITLE
[6.19.z] Fix JIRA is_open() reverse status logging

### DIFF
--- a/robottelo/utils/issue_handlers/__init__.py
+++ b/robottelo/utils/issue_handlers/__init__.py
@@ -22,8 +22,8 @@ def is_open(issue):
     Arguments:
         issue {str} -- A string containing Jira issue id e.g: SAT-12345
     """
-    status = jira.is_open_jira(issue.strip())
+    is_open = jira.is_open_jira(issue.strip())
     logger.debug(
-        f"Is {issue} Jira open? - {'Nope! It is fixed!' if status else 'Yeah. It is still not fixed :('}"
+        f"Is {issue} Jira open? - {'Yeah. It is still not fixed :(' if is_open else 'Nope! It is fixed!'}"
     )
-    return status
+    return is_open


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21523

### Problem Statement
There is a reverse logging for `is_open()`:
```
2026-05-12 11:41:27 - robottelo - DEBUG - SAT-39098 Jira status is 'New' and resolution is ''
2026-05-12 11:41:27 - robottelo - DEBUG - Is SAT-39098 Jira open? - Nope! It is fixed!
```
and
```
2026-05-11 17:58:08 - robottelo - DEBUG - SAT-35513 Jira status is 'Closed' and resolution is 'Done-Errata'
2026-05-11 17:58:08 - robottelo - DEBUG - Is SAT-35513 Jira open? - Yeah. It is still not fixed :(
```

### Solution
Fix reverse logic for logging in `is_open()`

### Related Issues
[freebie](..)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->