### PR TITLE
Inventory upload, sync recommendation,sync inventory by deleting satelite host

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -18,7 +18,7 @@ import pytest
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.constants import DNF_RECOMMENDATION, OPENSSH_RECOMMENDATION
+from robottelo.constants import DNF_RECOMMENDATION, OPENSSH_RECOMMENDATION, DEFAULT_ORG
 
 
 def create_insights_vulnerability(host):
@@ -591,3 +591,87 @@ def test_host_breadcrumb_switcher_updates_insights_tabs(
             f"After switching back to host1 via breadcrumb, expected host1 recommendations. "
             f"Expected: {host1_titles}, Got: {titles_back_to_host1}"
         )
+
+
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+def test_sync_recommendation_without_satellite_host(
+    rhel_insights_vm,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+):
+    """Synchronize hits data from hosted, verify results are displayed in Satellite, and run remediation.
+
+    :id: 7b2c412d-5f7b-440c-9ddd-2d8dae385210
+
+    :steps:
+        1. Prepare misconfigured machine and upload its data to Insights.
+        2. Go to all host and delete satellite host
+        2. In Satellite UI, go to Insights > Recommendations.
+        3. Run remediation for "OpenSSH config permissions" recommendation against host.
+        4. Verify that the remediation job completed successfully.
+        5. Re-sync recommendations.
+        6. Search for previously remediated issue.
+
+    :expectedresults:
+        1. Insights recommendation related to "OpenSSH config permissions" issue is listed
+            for misconfigured machine.
+        2. Remediation job finished successfully.
+        3. Insights recommendation related to "OpenSSH config permissions" issue is not listed.
+
+    :Verifies: SAT-25889
+
+    :parametrized: yes
+
+    :CaseAutomation: Automated
+    """
+    org_name = rhcloud_manifest_org.name
+
+    # Query for searching the available recommendation
+    REC_QUERY = f'hostname = "{rhel_insights_vm.hostname}" and title = "{OPENSSH_RECOMMENDATION}"'
+
+    # Verify insights-client can update to latest version available from server
+    assert rhel_insights_vm.execute('insights-client --version').status == 0
+
+    # Prepare misconfigured machine and upload data to Insights
+    create_insights_vulnerability(rhel_insights_vm)
+
+    with module_target_sat_insights.ui_session() as session:
+        session.organization.select(org_name=DEFAULT_ORG)
+        session.host_new.delete(module_target_sat_insights.hostname)
+        session.organization.select(org_name=org_name)
+
+        # Sync the recommendations
+        sync_recommendations(session)
+
+        # Verify that we can see the rule hit via insights-client
+        result = rhel_insights_vm.execute('insights-client --diagnosis')
+        assert result.status == 0
+        assert 'OPENSSH_HARDENING_CONFIG_PERMS' in result.stdout
+
+        # Verify that errors are not present in production.log (SAT-36449)
+        result = module_target_sat_insights.execute(
+            'grep "500 Internal Server Error" /var/log/foreman/production.log'
+        )
+        assert result.status != 0
+        result = module_target_sat_insights.execute(
+            'grep "uninitialized constant" /var/log/foreman/production.log'
+        )
+        assert result.status != 0
+
+        # Search for the recommendation.
+        result = session.cloudinsights.search(REC_QUERY)[0]
+        assert result['Hostname'] == rhel_insights_vm.hostname
+        assert result['Recommendation'] == OPENSSH_RECOMMENDATION
+
+        # Run the remediation.
+        session.cloudinsights.remediate(OPENSSH_RECOMMENDATION)
+        session.jobinvocation.wait_job_invocation_state(
+            entity_name='Insights remediations for selected issues',
+            host_name=rhel_insights_vm.hostname,
+        )
+
+        # Re-sync the recommendations
+        sync_recommendations(session)
+
+        # Verify that the recommendation is not listed anymore.
+        assert not session.cloudinsights.search(REC_QUERY)

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -12,10 +12,12 @@
 
 """
 
+import contextlib
 from datetime import UTC, datetime
 
 import pytest
 from wait_for import wait_for
+from widgetastic.exceptions import RowNotFound
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG, DNF_RECOMMENDATION, OPENSSH_RECOMMENDATION
@@ -637,7 +639,9 @@ def test_sync_recommendation_without_satellite_host(
 
     with module_target_sat_insights.ui_session() as session:
         session.organization.select(org_name=DEFAULT_ORG)
-        session.host_new.delete(module_target_sat_insights.hostname)
+        # Delete satellite host if it exists, suppress RowNotFound if already deleted
+        with contextlib.suppress(RowNotFound):
+            session.host_new.delete(module_target_sat_insights.hostname)
         session.organization.select(org_name=org_name)
 
         # Sync the recommendations

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -624,7 +624,6 @@ def test_sync_recommendation_without_satellite_host(
 
     :parametrized: yes
 
-    :CaseAutomation: Automated
     """
     org_name = rhcloud_manifest_org.name
 

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -601,7 +601,7 @@ def test_sync_recommendation_without_satellite_host(
     rhcloud_manifest_org,
     module_target_sat_insights,
 ):
-    """Synchronize hits data from hosted, verify results are displayed in Satellite, and run remediation.
+    """Synchronize hits data from hosted Insights, verify results are displayed in Satellite, and run remediation.
 
     :id: 7b2c412d-5f7b-440c-9ddd-2d8dae385210
 

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -18,7 +18,7 @@ import pytest
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.constants import DNF_RECOMMENDATION, OPENSSH_RECOMMENDATION, DEFAULT_ORG
+from robottelo.constants import DEFAULT_ORG, DNF_RECOMMENDATION, OPENSSH_RECOMMENDATION
 
 
 def create_insights_vulnerability(host):

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -606,11 +606,11 @@ def test_sync_recommendation_without_satellite_host(
     :steps:
         1. Prepare misconfigured machine and upload its data to Insights.
         2. Go to all host and delete satellite host
-        2. In Satellite UI, go to Insights > Recommendations.
-        3. Run remediation for "OpenSSH config permissions" recommendation against host.
-        4. Verify that the remediation job completed successfully.
-        5. Re-sync recommendations.
-        6. Search for previously remediated issue.
+        3. In Satellite UI, go to Insights > Recommendations.
+        4. Run remediation for "OpenSSH config permissions" recommendation against host.
+        5. Verify that the remediation job completed successfully.
+        6. Re-sync recommendations.
+        7. Search for previously remediated issue.
 
     :expectedresults:
         1. Insights recommendation related to "OpenSSH config permissions" issue is listed

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -719,7 +719,6 @@ def test_sync_inventory_status_without_satellite_host(
 
     :Verifies: SAT-25889
 
-    :CaseAutomation: Automated
     """
     org = rhcloud_manifest_org
     inventory_sync_task = 'InventorySync::Async::InventoryFullSync'

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -711,7 +711,7 @@ def test_sync_inventory_status_without_satellite_host(
     :steps:
         1. Register 2 hosts to Satellite to an org with a manifest imported and set up Lightspeed.
         2. Delete satellite host from all host page in default org
-        2. Sync the Lightspeed inventory for the org.
+        3. Sync the Lightspeed inventory for the org.
 
     :expectedresults: Inventory status is successfully synced for the hosts.
 
@@ -758,6 +758,7 @@ def test_inventory_upload_without_satellite_host(
     rhcloud_registered_hosts,
 ):
     """Generate report and verify its basic properties in case we delete satellite host
+
     :id: bfc5b566-c695-46a6-a543-c4f049ce96b6
 
     :expectedresults:
@@ -771,6 +772,8 @@ def test_inventory_upload_without_satellite_host(
         7. Host counts in metadata matches host counts in slices
 
     :Verifies: SAT-25889
+
+    :CaseAutomation: Automated
     """
 
     org = rhcloud_manifest_org

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -701,7 +701,9 @@ def test_sync_inventory_status(rhcloud_manifest_org, rhcloud_registered_hosts, m
 
 
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
-def test_sync_inventory_status_without_satellite_host(rhcloud_manifest_org, rhcloud_registered_hosts, target_sat):
+def test_sync_inventory_status_without_satellite_host(
+    rhcloud_manifest_org, rhcloud_registered_hosts, target_sat
+):
     """Test syncing Lightspeed inventory status after deleting satellite host
 
     :id: 3ac7a238-6d71-4504-ba23-4774950ece4f
@@ -746,6 +748,7 @@ def test_sync_inventory_status_without_satellite_host(rhcloud_manifest_org, rhcl
         )
         assert task_output[0].output['host_statuses']['sync'] == 2
         assert task_output[0].output['host_statuses']['disconnect'] == 0
+
 
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_inventory_upload_without_satellite_host(

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -12,12 +12,14 @@
 
 """
 
+import contextlib
 from datetime import UTC, datetime, timedelta
 import os
 import tempfile
 
 import pytest
 from wait_for import wait_for
+from widgetastic.exceptions import RowNotFound
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_LOC, DEFAULT_ORG
@@ -725,7 +727,9 @@ def test_sync_inventory_status_without_satellite_host(
 
     with target_sat.ui_session() as session:
         session.organization.select(org_name=DEFAULT_ORG)
-        session.host_new.delete(target_sat.hostname)
+        # Delete satellite host if it exists, suppress RowNotFound if already deleted
+        with contextlib.suppress(RowNotFound):
+            session.host_new.delete(target_sat.hostname)
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         session.cloudinventory.sync_inventory_status()
@@ -779,7 +783,9 @@ def test_inventory_upload_without_satellite_host(
     org = rhcloud_manifest_org
     with target_sat.ui_session() as session:
         session.organization.select(org_name=DEFAULT_ORG)
-        session.host_new.delete(target_sat.hostname)
+        # Delete satellite host if it exists, suppress RowNotFound if already deleted
+        with contextlib.suppress(RowNotFound):
+            session.host_new.delete(target_sat.hostname)
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
 

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -700,6 +700,109 @@ def test_sync_inventory_status(rhcloud_manifest_org, rhcloud_registered_hosts, m
         assert task_output[0].output['host_statuses']['disconnect'] == 0
 
 
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+def test_sync_inventory_status_without_satellite_host(rhcloud_manifest_org, rhcloud_registered_hosts, target_sat):
+    """Test syncing Lightspeed inventory status after deleting satellite host
+
+    :id: 3ac7a238-6d71-4504-ba23-4774950ece4f
+
+    :steps:
+        1. Register 2 hosts to Satellite to an org with a manifest imported and set up Lightspeed.
+        2. Delete satellite host from all host page in default org
+        2. Sync the Lightspeed inventory for the org.
+
+    :expectedresults: Inventory status is successfully synced for the hosts.
+
+    :Verifies: SAT-25889
+
+    :CaseAutomation: Automated
+    """
+    org = rhcloud_manifest_org
+    inventory_sync_task = 'InventorySync::Async::InventoryFullSync'
+    timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
+
+    with target_sat.ui_session() as session:
+        session.organization.select(org_name=DEFAULT_ORG)
+        session.host_new.delete(target_sat.hostname)
+        session.organization.select(org_name=org.name)
+        session.location.select(loc_name=DEFAULT_LOC)
+        session.cloudinventory.sync_inventory_status()
+        wait_for(
+            lambda: (
+                target_sat.api.ForemanTask()
+                .search(query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'})[
+                    0
+                ]
+                .result
+                == 'success'
+            ),
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
+        )
+        task_output = target_sat.api.ForemanTask().search(
+            query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'}
+        )
+        assert task_output[0].output['host_statuses']['sync'] == 2
+        assert task_output[0].output['host_statuses']['disconnect'] == 0
+
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+def test_inventory_upload_without_satellite_host(
+    target_sat,
+    inventory_settings,
+    rhcloud_manifest_org,
+    rhcloud_registered_hosts,
+):
+    """Generate report and verify its basic properties in case we delete satellite host
+    :id: bfc5b566-c695-46a6-a543-c4f049ce96b6
+
+    :expectedresults:
+
+        1. Report can be generated
+        2. Report can be downloaded
+        3. Report has non-zero size
+        4. Report can be extracted
+        5. JSON files inside report can be parsed
+        6. metadata.json lists all and only slice JSON files in tar
+        7. Host counts in metadata matches host counts in slices
+
+    :Verifies: SAT-25889
+    """
+
+    org = rhcloud_manifest_org
+    with target_sat.ui_session() as session:
+        session.organization.select(org_name=DEFAULT_ORG)
+        session.host_new.delete(target_sat.hostname)
+        session.organization.select(org_name=org.name)
+        session.location.select(loc_name=DEFAULT_LOC)
+
+        timestamp = (datetime.now(UTC) - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
+        session.cloudinventory.generate_and_upload_report(org.name)
+        # wait_for_tasks report generation task to finish.
+        wait_for(
+            lambda: (
+                target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::HostInventoryReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
+        )
+        report_path = session.cloudinventory.download_report_only(org.name)
+        inventory_data = session.cloudinventory.read(org.name)
+        # Verify that generated archive is valid.
+        common_assertion(report_path, inventory_data, org, target_sat)
+
+
 @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
 def test_positive_inventory_sync_check_host_status_categories(
     request,

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -777,7 +777,6 @@ def test_inventory_upload_without_satellite_host(
 
     :Verifies: SAT-25889
 
-    :CaseAutomation: Automated
     """
 
     org = rhcloud_manifest_org


### PR DESCRIPTION
### Problem Statement
When we delete satellite host and perform operation like 

1. Try to generate/upload inventory reports
2. Sync all inventory status
3. Sync recommendations
4. Enable Cloud Connector

 We get below error message
`can't find record with friendly id: 'satellite.example.com'
and 
Recommendation sync has failed: Error: Request failed with status code 404
`
### Solution
Added automation to perform above operations after deleting satellite host.

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_inventory.py -k "test_inventory_upload_without_satellite_host or test_sync_inventory_status_without_satellite_host"
theforeman:
    foreman_rh_cloud: 1205

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Add automated UI test coverage to validate Lightspeed inventory upload, inventory status sync, and Insights recommendation sync flows after the Satellite host has been deleted.

Tests:
- Add inventory status sync test to ensure Lightspeed inventory sync succeeds when the Satellite host record has been removed.
- Add inventory upload test to verify reports can still be generated, uploaded, downloaded, and validated after deleting the Satellite host.
- Add Insights recommendations test to ensure syncing, viewing, remediating, and re-syncing recommendations works correctly when the Satellite host is deleted.