### PR TITLE
Fix convert2rhel target_os fact assert for EL7 and EL8

### DIFF
--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -364,8 +364,14 @@ def test_convert2rhel_oracle_with_pre_conversion_template_check(
     convert2rhel_facts = json.loads(oracle.execute('cat /etc/rhsm/facts/convert2rhel.facts').stdout)
     assert convert2rhel_facts['conversions.env.CONVERT2RHEL_THROUGH_FOREMAN'] == '1'
     # https://issues.redhat.com/browse/RHELC-1737
-    target_os_name = 'Oracle Linux Server' if is_open('RHELC-1737') else 'Red Hat'
-    assert target_os_name in convert2rhel_facts['conversions.target_os.name']
+    source_os = convert2rhel_facts['conversions.source_os.name']
+    target_os = convert2rhel_facts['conversions.target_os.name']
+    if is_open('RHELC-1737') and source_os == target_os:
+        assert 'Oracle Linux Server' in target_os
+    else:
+        assert 'Red Hat' in target_os, (
+            f'unexpected conversions.target_os.name after conversion: {target_os!r}'
+        )
     assert convert2rhel_facts['conversions.success'] is True
 
 
@@ -466,6 +472,12 @@ def test_convert2rhel_centos_with_pre_conversion_template_check(
     convert2rhel_facts = json.loads(centos.execute('cat /etc/rhsm/facts/convert2rhel.facts').stdout)
     assert convert2rhel_facts['conversions.env.CONVERT2RHEL_THROUGH_FOREMAN'] == '1'
     # https://issues.redhat.com/browse/RHELC-1737
-    target_os_name = 'CentOS Linux' if is_open('RHELC-1737') else 'Red Hat'
-    assert target_os_name in convert2rhel_facts['conversions.target_os.name']
+    source_os = convert2rhel_facts['conversions.source_os.name']
+    target_os = convert2rhel_facts['conversions.target_os.name']
+    if is_open('RHELC-1737') and source_os == target_os:
+        assert 'CentOS Linux' in target_os
+    else:
+        assert 'Red Hat' in target_os, (
+            f'unexpected conversions.target_os.name after conversion: {target_os!r}'
+        )
     assert convert2rhel_facts['conversions.success'] is True


### PR DESCRIPTION
# Problem Statement

`test_convert2rhel_oracle_with_pre_conversion_template_check` and
`test_convert2rhel_centos_with_pre_conversion_template_check` validate
`conversions.target_os.name` from `/etc/rhsm/facts/convert2rhel.facts`.

The value of `target_os.name` is not consistent across convert2rhel streams.
In some builds, especially on EL8, the conversion succeeds but the facts still
contain the original source OS name (for example, `Oracle Linux Server` or
`CentOS Linux`). In other builds, the value is updated to `Red Hat`.

Because of this, assertions based only on `is_open("RHELC-1737")` or only on
`"Red Hat"` caused false failures when the Jira status and the actual facts did
not match.

# Solution

- If `RHELC-1737` is still open and `source_os.name == target_os.name`,
  assert the legacy source OS string in `target_os.name`.
- Otherwise, accept either:
  - `Red Hat` in `target_os.name`
This keeps the tests stable across EL7 and EL8 regardless of the Jira state,
until convert2rhel facts are updated consistently.

# Related Issues

- RHELC-1737

# PRT Test Case Example

```bash
trigger: test-robottelo
pytest: tests/foreman/api/test_convert2rhel.py -k 'pre_conversion_template_check'

## Summary by Sourcery

Tests:
- Adjust Oracle and CentOS pre-conversion template tests to assert target_os.name based on source_os.name and Jira RHELC-1737 state, improving stability across EL7 and EL8.