### PR TITLE
Verify -add-feature and --remove-feature in foremanctl

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2026,6 +2026,19 @@ class Capsule(ContentHost, CapsuleMixins):
         )
         return
 
+    def list_foremanctl_features(self, enabled=False):
+        """Get the list of features as a set of feature names"""
+        if enabled:
+            result = self.execute('foremanctl features --list-enabled')
+        else:
+            result = self.execute('foremanctl features')
+        assert result.status == 0, f'foremanctl features command failed: {result.stderr}'
+        return {
+            p[0]
+            for line in result.stdout.splitlines()
+            if (p := line.split()) and p[0].lower() != 'feature'
+        }
+
     def query_db(self, query, db='foreman', output_format='json'):
         """Execute a PostgreSQL query and return the result.
 

--- a/tests/foreman/installer/test_install_foremanctl.py
+++ b/tests/foreman/installer/test_install_foremanctl.py
@@ -442,3 +442,44 @@ def test_positive_foremanctl_certificate_custom_validity_and_renewal(module_sat_
     # API: Verify CRUD still works with renewed certificates
     org = sat.api.Organization(id=org.id).read()
     assert org.name == org_name
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize('module_sat_ready_rhel', ['default'], indirect=True)
+def test_foremanctl_deploy_add_remove_feature(module_sat_ready_rhel):
+    """Verify foremanctl deploy --add-feature and --remove-feature work correctly.
+
+    :id: ec1e8b03-5b29-450a-887d-3a75ab707336
+
+    :steps:
+        1. Deploy Satellite with remote-execution feature
+        2. Verify the remote-execution feature is enabled
+        3. Remove 'remote-execution' feature
+        4. Verify the remote-execution feature is disabled
+
+    :expectedresults:
+        1. The remote-execution feature is enabled
+        2. The remote-execution feature is disabled
+    """
+    FEATURE_NAME = 'remote-execution'
+    sat = module_sat_ready_rhel
+    result = sat.execute(
+        f'foremanctl deploy --add-feature {FEATURE_NAME}',
+        timeout='30m',
+    )
+    assert result.status == 0, (
+        f'foremanctl deploy --add-feature {FEATURE_NAME} failed: {result.stderr}'
+    )
+
+    assert FEATURE_NAME in sat.list_foremanctl_features(enabled=True), (
+        f'{FEATURE_NAME} is not enabled'
+    )
+
+    result = sat.execute(f'foremanctl deploy --remove-feature {FEATURE_NAME}', timeout='30m')
+    assert result.status == 0, (
+        f'foremanctl deploy --remove-feature {FEATURE_NAME} failed: {result.stderr}'
+    )
+
+    assert FEATURE_NAME not in sat.list_foremanctl_features(enabled=True), (
+        f'{FEATURE_NAME} is still enabled'
+    )


### PR DESCRIPTION
### Problem Statement
missing add tests for add-feature and remove-feature options in foremanctl
### Solution

Added add-feature and remove-feature test
### Related Issues

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/installer/test_install_foremanctl.py -k 'test_foremanctl_deploy_add_remove_feature'

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Add test coverage for foremanctl deploy feature enable/disable operations.

Tests:
- Add end-to-end test verifying `foremanctl deploy --add-feature` and `--remove-feature` correctly enable and disable features.
- Introduce reusable helper to fetch enabled features from `foremanctl features` output in tests.