### PR TITLE
Add ArfReport to BOOKMARK_ENTITIES_SELECTION for API bookmark coverage

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2088,7 +2088,7 @@ BOOKMARK_ENTITIES_SELECTION = [
         'name': 'ArfReport',
         'controller': 'arf_reports',
         'session_name': 'arfreport',
-        'skip_for_ui': True,
+        'skip_for_ui': True,  # search bar is only available when reports exist; otherwise the welcome page renders
     },
 ]
 

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2084,6 +2084,12 @@ BOOKMARK_ENTITIES_SELECTION = [
         'controller': 'provisioning_templates',
         'session_name': 'provisioningtemplate',
     },
+    {
+        'name': 'ArfReport',
+        'controller': 'arf_reports',
+        'session_name': 'arfreport',
+        'skip_for_ui': True,
+    },
 ]
 
 STRING_TYPES = ['alpha', 'numeric', 'alphanumeric', 'latin1', 'utf8', 'cjk', 'html']


### PR DESCRIPTION
Adds ArfReport with skip_for_ui to enable API-level bookmark tests against the arf_reports controller. UI tests are skipped because the ARF reports page requires an existing report for the search bar to appear.

### Problem Statement
Bookmarks could not be saved for arf_reports.

### Solution
https://github.com/theforeman/foreman_openscap/pull/610 , this just verifies the behaviour.

### Related Issues
https://redhat.atlassian.net/browse/SAT-44574


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

New Features:
- Configure ARF reports as a bookmarkable entity for API-level tests.