### PR TITLE
[6.17.z] Bump cryptography from 47.0.0 to 48.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 apypie==0.8.0
 broker[satlab,docker,ssh2_python]==0.8.6
-cryptography==47.0.0
+cryptography==48.0.0
 deepdiff==9.0.0
 dynaconf[vault]==3.2.13
 fastmcp==3.3.0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21478

Bumps [cryptography](https://github.com/pyca/cryptography) from 47.0.0 to 48.0.0.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst">cryptography's changelog</a>.</em></p>
<blockquote>
<p>48.0.0 - 2026-05-04</p>
<pre><code>
* **BACKWARDS INCOMPATIBLE:** Support for Python 3.8 has been removed.
  ``cryptography`` now requires Python 3.9 or later.
* **BACKWARDS INCOMPATIBLE:** Loading an X.509 CRL whose inner
  ``TBSCertList.signature`` algorithm does not match the outer
  ``signatureAlgorithm`` now raises ``ValueError``. Previously, such CRLs
  were parsed successfully and only rejected during signature validation.
* Added support for :doc:`/hazmat/primitives/asymmetric/mlkem` and
  :doc:`/hazmat/primitives/asymmetric/mldsa` when using OpenSSL 3.5.0 or
  later, in addition to the existing AWS-LC and BoringSSL support. This means
  post-quantum algorithms are now available to users of our wheels.
<ul>
<li><strong>Note:</strong> Going forward, we do not guarantee that all functionality<br />
in <code>cryptography</code> will be available when building against<br />
OpenSSL. See :doc:<code>/statements/state-of-openssl</code> for more information.</li>
</ul>
<p>.. _v47-0-0:<br />
</code></pre></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/pyca/cryptography/commit/8e03e30e3aae01632a697e903e3593c924f0139d"><code>8e03e30</code></a> bump for 48.0.0 release (<a href="https://redirect.github.com/pyca/cryptography/issues/14796">#14796</a>)</li>
<li><a href="https://github.com/pyca/cryptography/commit/295e0d254ef31ab864730aa41312ec355416ee71"><code>295e0d2</code></a> Add AGENTS.md with CLAUDE.md symlink (<a href="https://redirect.github.com/pyca/cryptography/issues/14794">#14794</a>)</li>
<li><a href="https://github.com/pyca/cryptography/commit/104a2de19e268a433e6da92be9cb872dcf0003c8"><code>104a2de</code></a> Bump BoringSSL, OpenSSL, AWS-LC in CI (<a href="https://redirect.github.com/pyca/cryptography/issues/14793">#14793</a>)</li>
<li><a href="https://github.com/pyca/cryptography/commit/67ec1e51988195e17993d2edef5258b27509b926"><code>67ec1e5</code></a> call check_length early on AesSiv::encrypt (<a href="https://redirect.github.com/pyca/cryptography/issues/14792">#14792</a>)</li>
<li><a href="https://github.com/pyca/cryptography/commit/b2da57a0d9e4bfd2b95364299091a18f74127b26"><code>b2da57a</code></a> changelog for mldsa/mlkem for openssl (<a href="https://redirect.github.com/pyca/cryptography/issues/14791">#14791</a>)</li>
<li><a href="https://github.com/pyca/cryptography/commit/3cf44adee25c368d4a136e072fa9f80465d91eb0"><code>3cf44ad</code></a> ML-KEM OpenSSL support (<a href="https://redirect.github.com/pyca/cryptography/issues/14781">#14781</a>)</li>
<li><a href="https://github.com/pyca/cryptography/commit/2e31639666766f846fbab2c605879db0fa64fe83"><code>2e31639</code></a> ML-DSA OpenSSL support (<a href="https://redirect.github.com/pyca/cryptography/issues/14773">#14773</a>)</li>
<li><a href="https://github.com/pyca/cryptography/commit/5affe5a286a986fdf512c4a5cb280d28a96c10e3"><code>5affe5a</code></a> fix rust nightly clippy (<a href="https://redirect.github.com/pyca/cryptography/issues/14790">#14790</a>)</li>
<li><a href="https://github.com/pyca/cryptography/commit/2e73ca448eaf64b6f0d4ffbb794cf96170cef5ec"><code>2e73ca4</code></a> bump rust-openssl dep and update EcPoint::mul_generator to mul_generator2 (<a href="https://redirect.github.com/pyca/cryptography/issues/1">#1</a>...</li>
<li><a href="https://github.com/pyca/cryptography/commit/82ebd3b9f49d49ad5fd8b4b1f1dd02487b6e1466"><code>82ebd3b</code></a> Bump BoringSSL, OpenSSL, AWS-LC in CI (<a href="https://redirect.github.com/pyca/cryptography/issues/14785">#14785</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/pyca/cryptography/compare/47.0.0...48.0.0">compare view</a></li>
</ul>
</details>
<br />

<details>
<summary>Most Recent Ignore Conditions Applied to This Pull Request</summary>

| Dependency Name | Ignore Conditions |
| --- | --- |
| cryptography | [>= 44.dev0, < 45] |
</details>
