### PR TITLE
[6.19.z] Update all host details inventory status message

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -363,7 +363,10 @@ def test_host_details_page(
         # Verify Insights status of host.
         result = session.host_new.get_host_statuses(rhel_insights_vm.hostname)
         assert result['Red Hat Lightspeed']['Status'] == 'Reporting'
-        assert result['Inventory']['Status'] == 'Host is uploaded and present on console.redhat.com Inventory service'
+        assert (
+            result['Inventory']['Status']
+            == 'Host is uploaded and present on console.redhat.com Inventory service'
+        )
 
         # Verify recommendations exist for host.
         result = session.host_new.search(rhel_insights_vm.hostname)[0]

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -363,7 +363,7 @@ def test_host_details_page(
         # Verify Insights status of host.
         result = session.host_new.get_host_statuses(rhel_insights_vm.hostname)
         assert result['Red Hat Lightspeed']['Status'] == 'Reporting'
-        assert result['Inventory']['Status'] == 'Successfully uploaded to your RH cloud inventory'
+        assert result['Inventory']['Status'] == 'Host is uploaded and present on console.redhat.com Inventory service'
 
         # Verify recommendations exist for host.
         result = session.host_new.search(rhel_insights_vm.hostname)[0]


### PR DESCRIPTION
## Cherry-pick of #21433 to 6.19.z

This PR cherry-picks the inventory status message update from #21433 to the 6.19.z branch.

### Changes
- Updated the expected inventory status message from "Successfully uploaded to your RH cloud inventory" to "Host is uploaded and present on console.redhat.com Inventory service"

### Original PR
- #21433 - Update all host details inventory status message

### Test Updated
- `test_host_details_page` in `tests/foreman/ui/test_rhcloud_insights.py`

### Why This Change
The inventory status message was updated in the Satellite UI to be more descriptive and accurate. This test update ensures the assertion matches the new message format.

---
Cherry-picked from master to 6.19.z