### PR TITLE
Add certificate checks against Satellite

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -10,6 +10,8 @@ import json
 from pathlib import Path, PurePath
 import random
 import re
+import socket
+import ssl
 import subprocess
 import sys
 from tempfile import NamedTemporaryFile
@@ -2368,6 +2370,59 @@ class Satellite(Capsule, SatelliteMixins):
         self._cli = type('cli', (), {'_configured': False})
         self._apidoc = None
         self.record_property = None
+
+    def get_foreman_raw_ca(self, verify=settings.server.verify_ca, timeout=60):
+        """Return the PEM-encoded Foreman CA bundle from the public unattended endpoint.
+
+        Issues ``GET {satellite_url}/unattended/public/foreman_raw_ca`` (no authentication).
+
+        :param verify: Passed to ``requests.get`` as ``verify`` (SSL bundle or bool).
+            Defaults to ``settings.server.verify_ca``.
+        :param timeout: Request timeout in seconds.
+        :return: Response body (PEM certificate bundle text).
+        :raises SatelliteHostError: If the request fails or the response status is not successful.
+        """
+        url = f'{self.url}/unattended/public/foreman_raw_ca'
+        try:
+            response = requests.get(url, verify=verify, timeout=timeout)
+            response.raise_for_status()
+        except requests.RequestException as err:
+            raise SatelliteHostError(f'Failed to fetch foreman_raw_ca from {url}') from err
+        return response.text
+
+    def get_server_certificate_from_ssl_socket(self, timeout=60):
+        """Return the leaf TLS server certificate (PEM) presented for ``self.url``.
+
+        Resolves host and port from ``self.url`` (using ``self.port`` when the URL has no
+        explicit port), opens a TCP connection, performs a TLS handshake with Server Name
+        Indication (SNI) set to that host, and returns the peer certificate as PEM text.
+
+        Hostname verification and CA validation are disabled so self-signed Satellite
+        certificates can be retrieved.
+
+        :param timeout: TCP connect timeout in seconds.
+        :return: PEM-encoded leaf server certificate.
+        :raises SatelliteHostError: If connect, handshake, or certificate retrieval fails.
+        """
+        parsed = urlparse(self.url)
+        host = parsed.hostname or self.hostname
+        port = parsed.port if parsed.port is not None else socket.getservbyname(parsed.scheme)
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        try:
+            with (
+                socket.create_connection((host, port), timeout=timeout) as sock,
+                ctx.wrap_socket(sock, server_hostname=host) as tls_sock,
+            ):
+                der = tls_sock.getpeercert(binary_form=True)
+        except OSError as err:
+            raise SatelliteHostError(
+                f'Failed to retrieve TLS server certificate from {host}:{port}'
+            ) from err
+        if not der:
+            raise SatelliteHostError(f'No peer certificate presented by {host}:{port}')
+        return ssl.DER_cert_to_PEM_cert(der)
 
     def _swap_nailgun(self, new_version):
         """Install a different version of nailgun from GitHub and invalidate the module cache."""

--- a/tests/foreman/installer/test_install_foremanctl.py
+++ b/tests/foreman/installer/test_install_foremanctl.py
@@ -13,6 +13,8 @@
 """
 
 from broker import Broker
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
 from fauxfactory import gen_string
 import pytest
 
@@ -306,6 +308,12 @@ def get_cert_fingerprint(sat, cert_path):
     return result.stdout.strip()
 
 
+def cert_fingerprint_openssl_sha256(cert):
+    """SHA256 fingerprint line matching ``openssl x509 -noout -fingerprint -sha256``."""
+    digest = cert.fingerprint(hashes.SHA256())
+    return 'sha256 Fingerprint=' + ':'.join(f'{b:02X}' for b in digest)
+
+
 custom_ca_days = 3650
 custom_cert_days = 365
 
@@ -436,6 +444,13 @@ def test_positive_foremanctl_certificate_custom_validity_and_renewal(module_sat_
         'CA fingerprint changed after --certificate-renew; CA should not be regenerated'
     )
 
+    foreman_ca_pem = sat.get_foreman_raw_ca()
+    foreman_ca_certs = x509.load_pem_x509_certificates(foreman_ca_pem.encode())
+    foreman_ca_fps = {cert_fingerprint_openssl_sha256(c) for c in foreman_ca_certs}
+    assert ca_fp_after in foreman_ca_fps, (
+        'CA from GET /unattended/public/foreman_raw_ca does not match on-disk foremanctl CA'
+    )
+
     # Server/client fingerprints must differ (force: certificates_renew | bool)
     server_fp_after = get_cert_fingerprint(sat, server_cert)
     client_fp_after = get_cert_fingerprint(sat, client_cert)
@@ -444,6 +459,13 @@ def test_positive_foremanctl_certificate_custom_validity_and_renewal(module_sat_
     )
     assert client_fp_after != client_fp_before, (
         'Client cert fingerprint unchanged — renewal did not regenerate it'
+    )
+
+    # Verify the server certificate presented by the TLS socket matches the on-disk server certificate
+    presented_server_pem = sat.get_server_certificate_from_ssl_socket()
+    presented_server_cert = x509.load_pem_x509_certificate(presented_server_pem.encode())
+    assert cert_fingerprint_openssl_sha256(presented_server_cert) == server_fp_after, (
+        'TLS-presented server certificate fingerprint does not match on-disk server cert'
     )
 
     # Renewed certs must still chain to the same CA


### PR DESCRIPTION
### Problem Statement

The certificate tests currently test only against the files that are an intermediate step in the full flow.

### Solution

Add checks against the end result of the mutation.
1. A way to fetch the CA is from the Foreman itself, using the API (`/unattended/public/foreman_raw_ca`)
2. A way to fetch the server certificate that is used for UI and API communication is from the socket directly

### Open question

I wasn't able to find a way to properly test the client certificate.


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Add support for retrieving Satellite CA and server certificates and validate them against on-disk certificates in the Foreman installer certificate renewal flow.

Enhancements:
- Expose helpers on Satellite host objects to fetch the Foreman CA via the public unattended endpoint and to retrieve the active TLS server certificate from the SSL socket.

Tests:
- Extend the Foreman installer certificate renewal test to compare the CA from the unattended API and the TLS-presented server certificate against the regenerated on-disk certificates.