### PR TITLE
Use slim (client-only) fastmcp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ broker[satlab,docker,ssh2_python]==0.8.7
 cryptography==48.0.0
 deepdiff==9.0.0
 dynaconf[vault]==3.2.13
-fastmcp==3.3.1
+fastmcp-slim[client]==3.3.1
 fauxfactory==4.2.1
 jira==3.10.5
 jinja2==3.1.6


### PR DESCRIPTION
### Problem Statement
There is now client-only `fastmcp` package called `fastmcp-slim`

### Solution
Use `fastmcp-slim[client]` [client-only package](https://gofastmcp.com/clients/client-only-package) instead of full fledged `fastmcp`


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->