### PR TITLE
[6.19.z] Update Insights E2E Task Search

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -36,11 +36,18 @@ def create_insights_vulnerability(host):
     assert result.status == 0
 
 
-def sync_recommendations(session):
+def sync_recommendations(session, satellite):
     timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
     session.cloudinsights.sync_hits()
     wait_for(
-        lambda: session.task.search(f'Insights full sync and started_at >= "{timestamp}"'),
+        lambda: (
+            satellite.api.ForemanTask()
+            .search(
+                query={'search': f'Red Hat Lightspeed full sync and started_at >= "{timestamp}"'}
+            )[0]
+            .result
+            == 'success'
+        ),
         timeout=180,
         delay=15,
         handle_exception=True,
@@ -102,7 +109,7 @@ def test_rhcloud_insights_e2e(
         session.organization.select(org_name=org_name)
 
         # Sync the recommendations
-        sync_recommendations(session)
+        sync_recommendations(session, module_target_sat_insights)
 
         # Verify that we can see the rule hit via insights-client
         result = rhel_insights_vm.execute('insights-client --diagnosis')
@@ -132,7 +139,7 @@ def test_rhcloud_insights_e2e(
         )
 
         # Re-sync the recommendations
-        sync_recommendations(session)
+        sync_recommendations(session, module_target_sat_insights)
 
         # Verify that the recommendation is not listed anymore.
         assert not session.cloudinsights.search(REC_QUERY)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21602

During our most recent 6.19.1 test run, the Insights end-to-end test regressed due to a change in the name of the task created when syncing recommendations. However, updating this alone did not allow the test to pass, as there appears to be an issue with the Airgun task search entity method.

This PR updates the name of the task so the test can find the correct task to wait for while syncing recommendations. Additionally, this PR converts the `sync_recommendations()` helper method to use an API task search instead of a UI task search. This results in a more performant test, as the API search is noticeably faster than the UI search. A UI task search is also not required for this test's functionality, as the only purpose of the search is to ensure that the recommendation sync has completed.

## Summary by Sourcery

Update the Insights end-to-end test to use an API-based task search and the current task name when waiting for recommendation sync to complete.

Enhancements:
- Replace the UI task search with an API task search in the Insights recommendation sync helper for faster and more reliable completion checks.

Tests:
- Adjust the Insights E2E test helper to accept the Satellite API client, use the updated task name, and ensure recommendation sync waits on a successful task result before continuing.