### PR TITLE
Block test_sync_AC_without_deadlock by SAT-44202

### DIFF
--- a/tests/foreman/destructive/test_capsulecontent.py
+++ b/tests/foreman/destructive/test_capsulecontent.py
@@ -230,7 +230,9 @@ def test_sync_AC_without_deadlock(
 
     :customerscenario: true
 
-    :Verifies: SAT-34271
+    :Verifies: SAT-34271, SAT-44202
+
+    :BlockedBy: SAT-44202
 
     """
     # Set capsule to immediate download policy


### PR DESCRIPTION
### Problem Statement
The `test_sync_AC_without_deadlock` test fails due to unresolved https://redhat.atlassian.net/browse/SAT-44202.


### Solution
Block it until the issue is resolved and use it for its verification.


### Related Issues
https://redhat.atlassian.net/browse/SAT-44202


### PRT test Cases example
Not applicable for a block.

## Summary by Sourcery

Enhancements:
- Update test metadata to reference SAT-44202 and mark the test as blocked by this issue.