### PR TITLE
reproducer for SAT-35949

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1211,6 +1211,24 @@ class TestRexUsers:
 class TestPullProviderRex:
     """Tests related to remote execution via pull provider (mqtt)"""
 
+    def test_reproduce_capsule_mismatch(
+        self,
+        module_org,
+        smart_proxy_location,
+        module_target_sat,
+        module_capsule_configured_mqtt,
+    ):
+        """Run custom template on host converted to mqtt"""
+        # Update module_capsule_configured_mqtt to include module_org/smart_proxy_location
+        module_target_sat.cli.Capsule.update(
+            {
+                'name': module_capsule_configured_mqtt.hostname,
+                'organization-ids': module_org.id,
+                'location-ids': smart_proxy_location.id,
+            }
+        )
+        breakpoint()  # noqa
+
     @pytest.mark.upgrade
     @pytest.mark.no_containers
     @pytest.mark.client_release


### PR DESCRIPTION
### Problem Statement
not to be merged!

### Solution

This should help reproduce the issue for verification of https://github.com/theforeman/foreman/pull/10952

1. have a packit patched machine with changes from https://github.com/theforeman/foreman/pull/10952 
2. checkout this PR from your local robottelo setup
```
git fetch <remote> pull/<PR_ID>/head:<NEW_BRANCHNAME>
git checkout NEW_BRANCHNAME
```
3. run the test against the packit machine
```
pytest tests/foreman/cli/test_remoteexecution.py -k capsule_mismatch
```
4. Let the test execute up until the breakpoint. Then go the the satellite UI, check capsules under *Any org*/*Any loc* see the newly created capsule assigned to the custom org, try to edit taxonomies -- Default org/Default loc are there marked as used by a host
5. after you release the breakpoint the capsule machine probably won't clean up itself, so you'll have to check it in via broker

## Summary by Sourcery

Tests:
- Introduce a remote execution pull provider test that updates capsule taxonomies and pauses execution to facilitate manual reproduction and verification of the capsule mismatch issue.