### PR TITLE
[6.17.z] Fix duplicate Broker kwargs in contenthost_factory

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -85,7 +85,8 @@ def contenthost_factory(request, **kwargs):
     host_params = host_conf(request)
     post_configs = host_params.pop("post_configs", [])
     host_class = kwargs.pop("host_class", ContentHost)
-    with Broker(**host_params, host_class=host_class, **kwargs) as host:
+    broker_args = {**host_params, **kwargs}
+    with Broker(host_class=host_class, **broker_args) as host:
         if post_configs:
             hosts = host if isinstance(host, list) else [host]
             for config_name in post_configs:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21520

# Problem Statement

`contenthost_factory`  fixture called:

    Broker(**host_params, host_class=host_class, **kwargs)

Both `host_params` (returned by `host_conf()`) and `kwargs` could contain the same key, such as `workflow`. When this happened, Python raised:

    TypeError: Broker() got multiple values for keyword argument 'workflow'

This error occurred before `Broker` was initialized, causing fixture setup to fail in:

`tests/foreman/maintain/test_upgrade.py::test_negative_pre_update_tuning_profile_check`

# Solution

Merge `host_params` and `kwargs` into a single dictionary before calling `Broker`:

    broker_args = {**host_params, **kwargs}
    Broker(host_class=host_class, **broker_args)

If the same key exists in both dictionaries, the value from `kwargs` overrides the value from `host_params`.

# Related Issues

None.

# PRT Test Case

trigger: test-robottelo
pytest: tests/foreman/maintain/test_upgrade.py::test_negative_pre_update_tuning_profile_check


<!--
PRT usage reference:
https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Prevent TypeError in contenthost_factory by merging host configuration and kwargs into a single Broker argument dict where explicit kwargs take precedence.