### PR TITLE
Fix IPv6 podman setup

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -914,12 +914,14 @@ class ContentHost(Host, ContentHostMixins):
         """Execute procedures for enabling IPv6 HTTP Proxy on Podman engine"""
         if not self.network_type.has_ipv4:
             container_cfg = '/etc/containers/containers.conf'
-            assert (
-                self.execute(
-                    f'echo -e "[engine]\\nenv = [\'https_proxy={settings.http_proxy.http_proxy_ipv6_url}\']" >> {container_cfg}'
-                ).status
-                == 0
-            )
+            proxy_url = settings.http_proxy.http_proxy_ipv6_url
+            if self.execute(f'grep -q "https_proxy" {container_cfg}').status != 0:
+                assert (
+                    self.execute(
+                        f'echo -e "[engine]\\nenv = [\'https_proxy={proxy_url}\']" >> {container_cfg}'
+                    ).status
+                    == 0
+                )
 
     def disable_rhsm_proxy(self):
         """Disables HTTP proxy for subscription manager"""
@@ -1603,20 +1605,21 @@ class ContentHost(Host, ContentHostMixins):
                 snap=settings.capsule.version.snap,
             )
 
-    def ensure_podman_installed(self):
+    def ensure_podman_installed(self, enable_ipv6_proxy=False):
         """Ensure Podman is installed, registering temporarily if needed."""
-        if self.execute('rpm -q podman').status == 0:
-            return
-        was_registered = self.subscription_manager_status().status == 0
-        if not was_registered:
-            self.register_to_cdn()
-        try:
-            result = self.execute('dnf -y install podman --disableplugin=foreman-protector')
-            if result.status != 0:
-                raise ContentHostError(f'Podman installation failed: {result.stdout}')
-        finally:
+        if self.execute('rpm -q podman').status != 0:
+            was_registered = self.subscription_manager_status().status == 0
             if not was_registered:
-                self.unregister()
+                self.register_to_cdn()
+            try:
+                result = self.execute('dnf -y install podman --disableplugin=foreman-protector')
+                if result.status != 0:
+                    raise ContentHostError(f'Podman installation failed: {result.stdout}')
+            finally:
+                if not was_registered:
+                    self.unregister()
+        if enable_ipv6_proxy:
+            self.enable_ipv6_podman_proxy()
 
     def podman_login(self, username=None, password=None, registry=None):
         """Login to a podman registry."""

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -2254,28 +2254,12 @@ class TestPodman:
     :team: Artemis
     """
 
-    @pytest.fixture(scope='class')
-    def enable_podman_capsule(module_product, module_capsule_configured):
-        """Enable base_os and appstream repos on the sat through cdn registration and install podman."""
-        module_capsule_configured.register_to_cdn()
-        if module_capsule_configured.os_version.major > 7:
-            module_capsule_configured.enable_repo(module_capsule_configured.REPOS['rhel_bos']['id'])
-            module_capsule_configured.enable_repo(module_capsule_configured.REPOS['rhel_aps']['id'])
-        else:
-            module_capsule_configured.enable_repo(module_capsule_configured.REPOS['rhscl']['id'])
-            module_capsule_configured.enable_repo(module_capsule_configured.REPOS['rhel']['id'])
-        result = module_capsule_configured.execute(
-            'dnf install -y --disableplugin=foreman-protector podman'
-        )
-        assert result.status == 0
-
     def test_negative_podman_capsule_push(
         self,
         module_target_sat,
         module_product,
         module_org,
         module_lce,
-        enable_podman_capsule,
         module_capsule_configured,
     ):
         """Attempt to push a Podman image to a Capsule/Smart Proxy
@@ -2291,6 +2275,7 @@ class TestPodman:
 
         :CaseImportance: High
         """
+        module_capsule_configured.ensure_podman_installed(enable_ipv6_proxy=True)
         IMAGE_NAME_TAG = 'fedora:latest'
         image_pull = module_capsule_configured.execute(
             f'podman pull registry.fedoraproject.org/{IMAGE_NAME_TAG}'

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -612,20 +612,8 @@ class TestPodman:
 
     @pytest.fixture(scope='class')
     def enable_podman(module_product, module_target_sat):
-        """Enable base_os and appstream repos on the sat through cdn registration and install podman."""
-        module_target_sat.register_to_cdn()
-        if module_target_sat.os_version.major > 7:
-            module_target_sat.enable_repo(module_target_sat.REPOS['rhel_bos']['id'])
-            module_target_sat.enable_repo(module_target_sat.REPOS['rhel_aps']['id'])
-        else:
-            module_target_sat.enable_repo(module_target_sat.REPOS['rhscl']['id'])
-            module_target_sat.enable_repo(module_target_sat.REPOS['rhel']['id'])
-        result = module_target_sat.execute(
-            'dnf install -y --disableplugin=foreman-protector podman'
-        )
-        assert result.status == 0
-        # Enable IPv6 HTTP proxy for podman so external registries are reachable in IPv6-only setups
-        module_target_sat.enable_ipv6_podman_proxy()
+        """Install podman on the Satellite."""
+        module_target_sat.ensure_podman_installed(enable_ipv6_proxy=True)
 
     def test_podman_push(self, module_target_sat, module_product, module_org, enable_podman):
         """Push a small and large container image to Pulp, and verify the results

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -3382,21 +3382,6 @@ class TestPodman:
     :team: Artemis
     """
 
-    @pytest.fixture(scope='class')
-    def enable_podman(module_product, module_target_sat):
-        """Enable base_os and appstream repos on the sat through cdn registration and install podman."""
-        module_target_sat.register_to_cdn()
-        if module_target_sat.os_version.major > 7:
-            module_target_sat.enable_repo(module_target_sat.REPOS['rhel_bos']['id'])
-            module_target_sat.enable_repo(module_target_sat.REPOS['rhel_aps']['id'])
-        else:
-            module_target_sat.enable_repo(module_target_sat.REPOS['rhscl']['id'])
-            module_target_sat.enable_repo(module_target_sat.REPOS['rhel']['id'])
-        result = module_target_sat.execute(
-            'dnf install -y --disableplugin=foreman-protector podman'
-        )
-        assert result.status == 0
-
     def test_postive_export_import_podman_repo(
         self,
         target_sat,
@@ -3405,7 +3390,6 @@ class TestPodman:
         function_org,
         function_product,
         function_import_org,
-        enable_podman,
     ):
         """Test import of a repo created via Podman push
 
@@ -3422,6 +3406,7 @@ class TestPodman:
 
         :Verifies: SAT-25265
         """
+        target_sat.ensure_podman_installed(enable_ipv6_proxy=True)
         REPO_NAME = 'fedora'
         result = target_sat.execute(f'podman pull registry.fedoraproject.org/{REPO_NAME}')
         assert result.status == 0


### PR DESCRIPTION
### Problem Statement
Two tests (`test_postive_export_import_podman_repo` and `test_negative_podman_capsule_push`) are consistently failing in IPv6 pipeline because of "no route to registry.fedoraproject.org" error. Also, the fixtures installing `podman` are duplicated in several modules. Moreover, podman is currently pre-installed on the SatLab boxes so we don't need to install it. If we needed to install it for some reason, we just need to register to cdn and the aprropriate repos get enabled automatically, which is what `ensure_podman_installed` already does.


### Solution
- Extend `ensure_podman_installed` with `enable_ipv6_proxy` parameter (False by default) to configure the IPv6 HTTP proxy for podman in IPv6-only environments, fixing `test_postive_export_import_podman_repo` and `test_negative_podman_capsule_push` failures in the IPv6 pipeline
- Make `enable_ipv6_podman_proxy` idempotent to avoid duplicate `[engine]` section in containers.conf
- Replace duplicated `enable_podman`/`enable_podman_capsule` fixtures with direct `ensure_podman_installed(enable_ipv6_proxy=True)` calls in tests; `test_docker.py` retains a one-liner fixture due to class-scoped sharing across three tests


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_docker.py::TestPodman::test_podman_push tests/foreman/cli/test_satellitesync.py::TestPodman::test_postive_export_import_podman_repo tests/foreman/api/test_capsulecontent.py::TestPodman::test_negative_podman_capsule_push
network_type: ipv6
```
