### PR TITLE
Fix GCE available_images test after GCP list pagination

### DIFF
--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -75,19 +75,24 @@ class TestGCEComputeResourceTestCases:
 
         :BZ: 2164989
 
+        :verifies: SAT-45130
+
         :expectedresults: RHEL images from GCP are available to select in GCE CR
 
         """
         satgce_images = module_gce_compute.available_images()
-        googleclient_images = googleclient.list_templates(
-            include_public=True, public_projects=GCE_RHEL_CLOUD_PROJECTS
-        )
-        googleclient_image_names = [img.name for img in googleclient_images]
-        # Validating GCE_CR images in Google CR
-        sat_available_images = [satgce_images[i]['name'] for i in range(len(satgce_images))]
+        sat_available_images = [item['name'] for item in satgce_images]
+
         for image in sat_available_images:
-            assert image in googleclient_image_names
-            # Validate only rhel-images exist in GCE_CR
+            # list_templates() only returns the first page per project (~500 images); Satellite can
+            # list newer names that are not on that page. Resolve each name with a filtered lookup.
+            matches = googleclient.find_templates(
+                name=image,
+                include_public=True,
+                public_projects=GCE_RHEL_CLOUD_PROJECTS,
+            )
+            assert matches, f'Image {image!r} not found in GCP (service project + public RHEL)'
+            assert matches[0].name == image
             assert image.startswith('rhel-')
 
     def test_positive_check_available_networks(self, module_gce_compute, googleclient):


### PR DESCRIPTION
Problem Statement
test_positive_check_available_images compared every Satellite available_images name to a set built from googleclient.list_templates(). Wrapanapi’s list_templates only performs a single images.list call per project and does not paginate with nextPageToken, so only the first ~500 images per project appear. Valid RHEL image names (for example rhel-9-arm64-v20260428) can exist in GCP and in Satellite’s list but be missing from that truncated set, causing a false failure.

Solution
For each name from module_gce_compute.available_images(), call googleclient.find_templates(name=image, include_public=True, public_projects=GCE_RHEL_CLOUD_PROJECTS) so GCP filters by image name. Assert a non-empty match and that the name still starts with rhel-. Replace the range(len(...)) list build with a list comprehension over satgce_images.