### PR TITLE
feat(ui/azurerm): make VM deletion verification robust and cleanup be…

### DIFF
--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -14,6 +14,7 @@
 
 from fauxfactory import gen_string
 import pytest
+from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import (
@@ -136,18 +137,25 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
                 # Host Delete
                 with sat_azure.api_factory.satellite_setting('destroy_vm_on_host_delete=True'):
                     session.host.delete(fqdn)
-                assert not session.host.search(fqdn)
-
-                # AzureRm Cloud assertion
-                assert not azurecloud_vm.exists
+                wait_for(
+                    lambda: (
+                        not session.host.search(fqdn)
+                        and not azurermclient.find_vms(name=hostname.lower())
+                    ),
+                    timeout=300,
+                    delay=10,
+                )
 
         except Exception as error:
             azure_vm = sat_azure.api.Host().search(query={'search': f'name={fqdn}'})
             if azure_vm:
                 azure_vm[0].delete(synchronous=False)
-            azurecloud_vm = azurermclient.get_vm(name=hostname.lower())
-            if azurecloud_vm.exists:
-                azurecloud_vm.delete()
+            try:
+                matching_vms = azurermclient.find_vms(name=hostname.lower())
+                if matching_vms:
+                    matching_vms[0].delete()
+            except Exception:
+                pass
             raise error
 
 


### PR DESCRIPTION
### Problem Statement
End-to-end AzureRM host provisioning test intermittently fails during deletion verification because the existence check raises on “not found,” causing false negatives

### Solution
Replace brittle VM deletion assertion using azurecloud_vm.exists with a resilient poll based on azurermclient.find_vms(name=...), which returns an empty list when the VM is gone and never raises.
Make teardown cleanup best-effort (wrap Azure lookups/deletes in try/except) so cleanup errors don’t mask root failures.

### Rationale
wrapanapi.entities.vm.Vm.exists only treats NotFoundError as absence, but the Azure path raises VMInstanceNotFound/Azure ResourceNotFoundError on 404, which bubbles out and fails the test despite successful deletion. Polling find_vms avoids exception paths and handles Azure’s eventual consistency.

## Summary by Sourcery

Strengthen AzureRM end-to-end host provisioning test deletion verification and make teardown cleanup best-effort to reduce flaky failures.

Tests:
- Update AzureRM host deletion wait condition to also poll Azure for absence of the VM instead of asserting on azurecloud_vm.exists.
- Increase deletion verification timeout and interval to accommodate Azure eventual consistency.
- Wrap Azure VM lookup/deletion in teardown in a best-effort try/except block so cleanup issues do not mask the original test failure.