### PR TITLE
[6.17.z] Fix weekly_checks github action workflow (#21509)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,13 +42,13 @@ jobs:
             uv-${{ runner.os }}
 
       - name: Restore Jira Status Cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v5
         with:
           # If the path is changed in the validator or jira.yaml.template, it should be changed here too
           path: jira_status_cache.json
-          key: jira-status-cache-global
+          key: jira-status-cache-global-${{ github.run_id }}
           restore-keys: |
-            jira-status-cache-global
+            jira-status-cache-global-
 
       - name: Install Dependencies
         run: |
@@ -97,11 +97,3 @@ jobs:
       - name: Analysis (git diff)
         if: failure()
         run: git diff
-
-      - name: Save Jira Status Cache
-        if: always()
-        uses: actions/cache@v4
-        with:
-          # If the path is changed in the validator or jira.yaml.template, it should be changed here too
-          path: jira_status_cache.json
-          key: jira-status-cache-global

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -4,9 +4,12 @@ name: weekly_checks
 on:
   schedule:
     - cron: 0 0 * * 0
+  workflow_dispatch:
 
 env:
     PYCURL_SSL_LIBRARY: openssl
+    ROBOTTELO_JIRA__API_KEY: ${{ secrets.JIRA_KEY }}
+    ROBOTTELO_JIRA__EMAIL: ${{ secrets.JIRA_EMAIL }}
 
 jobs:
   customerscenario_tags:
@@ -39,15 +42,6 @@ jobs:
             uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
             uv-${{ runner.os }}
 
-      - name: Restore Jira Status Cache
-        uses: actions/cache@v4
-        with:
-          # If the path is changed in the validator or jira.yaml.template, it should be changed here too
-          path: jira_status_cache.json
-          key: jira-status-cache-global
-          restore-keys: |
-            jira-status-cache-global
-
       - name: Install Dependencies
         run: |
           sudo apt update
@@ -66,42 +60,16 @@ jobs:
 
       - name: Repopulate jira status cache
         run: |
-          python scripts/populate_jira_cache.py --fresh
-
-      - name: Customer scenario check
-        run: |
-          touch .env.md
-          echo "---" >> .env.md
-          echo "title: Add missing customerscenario tags" >> .env.md
-          echo "assignees: pondrejk " >> .env.md
-          echo "labels: Documentation" >> .env.md
-          echo "---" >> .env.md
-          echo CS_TAGS="$(make customer-scenario-check-jira)" >> .env.md
-          if grep 'The following tests need customerscenario tags' .env.md; then
-            echo "::set-output name=result::0"
-          fi
-        id: cscheck
-        env:
-          ROBOTTELO_JIRA__API_KEY: ${{ secrets.JIRA_KEY }}
-          ROBOTTELO_JIRA__EMAIL: ${{ secrets.JIRA_EMAIL }}
-
-      - name: Customer scenario status
-        run: |
-          cat .env.md
-
-      - name: Create an issue for customerscenatio tag addition
-        uses: JasonEtco/create-an-issue@v2
-        if: ${{ env.CS_CHECK_RESULT }}
-        with:
-          filename: .env.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CS_CHECK_RESULT: ${{ steps.cscheck.outputs.result}}
+          python scripts/populate_jira_cache.py --fresh tests
 
       - name: Save Jira Status Cache
         if: always()
-        uses: actions/cache@v4
+        uses: actions/cache/save@v5
         with:
           # If the path is changed in the validator or jira.yaml.template, it should be changed here too
           path: jira_status_cache.json
-          key: jira-status-cache-global
+          key: jira-status-cache-global-${{ github.run_id }}
+
+      - name: Check for missing CustomerScenario tags and create a Jira issue if any are found
+        run: |
+          python scripts/customer_scenarios.py --jira --create-jira

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ TESTIMONY_OPTIONS=--config testimony.yaml
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  docs                       to make documentation in the default format"
+	@echo "  customer-scenario-check-jira Find tests without customerscenario tags"
 	@echo "  docs-clean                 to remove docs and doc build artifacts"
 	@echo "  test-docstrings            to check whether docstrings are good quality"
 	@echo "  test-robottelo             to run internal robottelo tests"
@@ -154,7 +155,7 @@ clean-cache:
 clean-all: docs-clean logs-clean pyc-clean clean-cache clean-shared
 
 customer-scenario-check-jira:
-	@scripts/customer_scenarios.py --jira
+	@scripts/customer_scenarios.py --jira $(EXTRA_ARGS)
 
 vault-login:
 	@scripts/vault_login.py --login

--- a/conf/jira.yaml.template
+++ b/conf/jira.yaml.template
@@ -11,3 +11,10 @@ JIRA:
   ISSUE_STATUS: ["Testing", "Release Pending"]
   CACHE_FILE: jira_status_cache.json
   CACHE_TTL_DAYS: 7
+  SFDC_COUNTER_FIELD: "customfield_10978"
+  TEAM_FIELD: "customfield_10606"
+  STORY_POINTS_FIELD: "customfield_10028"
+  PROJECT: "SAT"
+  TEAM: "sat-jpl"
+  STORY_POINTS: 1
+

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2012,6 +2012,7 @@ JIRA_WONTFIX_RESOLUTIONS = (
     "Not a Bug",
     "MirrorOrphan",
 )
+JIRA_COMMON_FIELDS = ['key', 'status', 'labels', 'resolution']
 
 GROUP_MEMBERSHIP_MAPPER = {
     "config": {

--- a/robottelo/utils/issue_handlers/jira.py
+++ b/robottelo/utils/issue_handlers/jira.py
@@ -11,19 +11,21 @@ from wait_for import TimedOutError, wait_for
 from robottelo.config import settings
 from robottelo.constants import (
     JIRA_CLOSED_STATUSES,
+    JIRA_COMMON_FIELDS,
     JIRA_ONQA_STATUS,
     JIRA_OPEN_STATUSES,
     JIRA_WONTFIX_RESOLUTIONS,
 )
 from robottelo.logging import logger
 
-common_jira_fields = ['key', 'status', 'labels', 'resolution']
-
 FIELD_EXTRACTORS = {
     "key": lambda issue: issue.key,
     "status": lambda issue: issue.fields.status.name if issue.fields.status else "",
     "labels": lambda issue: list(issue.fields.labels or []),
     "resolution": lambda issue: issue.fields.resolution.name if issue.fields.resolution else "",
+    "customfield_10978": lambda issue: (
+        issue.renderedFields.customfield_10978 if issue.renderedFields else ""
+    ),
 }
 
 
@@ -188,13 +190,17 @@ def _jira_client():
     )
 
 
-def get_jira(jql, fields=None):
-    """Accepts the jql to retrieve the data from Jira for the given fields
+def get_jira(issue_ids, fields=None, expand='renderedFields', max_results=100):
+    """Retrieve Jira issues for the given list of issue keys/IDs and fields.
 
-    :param jql: The query for retrieving the issue(s) details from jira
-    :type jql: str
+    :param issue_ids: Jira issue ids to get data for
+    :type issue_ids: list
     :param fields: The custom fields in query to retrieve the data for
     :type fields: list
+    :param expand: extra information to fetch inside each resource
+    :type fields: str
+    :param max_results: Maximum number of issues to return.
+    :type max_results: int
     :returns: List of Issue objects from the jira library
     :rtype: list
     """
@@ -203,8 +209,15 @@ def get_jira(jql, fields=None):
     def _make_request():
         try:
             jira = _jira_client()
-            issues = jira.search_issues(jql_str=jql, fields=fields_str)
-            return list(issues)
+            all_issues = []
+            for i in range(0, len(issue_ids), max_results):
+                batch = issue_ids[i : i + max_results]
+                jql = ' OR '.join([f"id = {issue_id}" for issue_id in batch])
+                issues = jira.search_issues(
+                    jql_str=jql, fields=fields_str, expand=expand, maxResults=max_results
+                )
+                all_issues.extend(issues)
+            return all_issues
         except JIRAError as err:
             if getattr(err, 'status_code', None) == 429:
                 logger.warning("Hit Jira API rate limit (429). Will retry after wait period.")
@@ -236,7 +249,7 @@ def get_data_jira(issue_ids, cached_data=None, jira_fields=None):  # pragma: no 
     :rtype: list of dict
     """
     if not jira_fields:
-        jira_fields = common_jira_fields
+        jira_fields = JIRA_COMMON_FIELDS
 
     if not issue_ids:
         return []
@@ -288,8 +301,7 @@ def get_data_jira(issue_ids, cached_data=None, jira_fields=None):  # pragma: no 
     # Generate jql
     if isinstance(remaining_issues, str):
         remaining_issues = [issue_id.strip() for issue_id in remaining_issues.split(',')]
-    jql = ' OR '.join([f"id = {issue_id}" for issue_id in remaining_issues])
-    issues = get_jira(jql, jira_fields)
+    issues = get_jira(remaining_issues, jira_fields)
     fetched_data = [
         _issue_to_flat_dict(issue, jira_fields) for issue in issues if issue is not None
     ]

--- a/scripts/customer_scenarios.py
+++ b/scripts/customer_scenarios.py
@@ -9,8 +9,11 @@
 # ///
 
 import click
+from jira import JIRA
 import testimony
 
+from robottelo.config import settings
+from robottelo.constants import JIRA_COMMON_FIELDS
 from robottelo.utils.issue_handlers.jira import get_data_jira
 
 
@@ -19,8 +22,16 @@ def main():
     pass
 
 
+def _jira_client():
+    """Create a JIRA client with basic auth (email and api_key)."""
+    return JIRA(
+        server=settings.jira.url,
+        basic_auth=(settings.jira.email, settings.jira.api_key),
+    )
+
+
 def make_path_list(path_list):
-    targets = ['tests/foreman', 'tests/upgrades']
+    targets = ['tests/foreman', 'tests/new_upgrades']
     if path_list:
         paths = path_list.split(',')
         paths = [path for path in paths if any(target in path for target in targets)]
@@ -62,26 +73,71 @@ def query_jira(data):
          data {dict} -- The list of test modules and tests without customerscenario tags
     """
     output = []
-    sfdc_counter_field = 'customfield_12313440'
+    jira_fields_with_sfdc = JIRA_COMMON_FIELDS + [settings.jira.sfdc_counter_field]
     with click.progressbar(data.items()) as bar:
         for path, tests in bar:
             for test in tests:
-                jira_data = get_data_jira(test[1], jira_fields=[sfdc_counter_field])
+                issues = [str(issue.strip()) for issue in test[1].split(',')]
+                jira_data = get_data_jira(issues, jira_fields=jira_fields_with_sfdc)
                 for data in jira_data:
-                    customer_cases = int(float(data[sfdc_counter_field]))
+                    customer_cases = int(data[settings.jira.sfdc_counter_field])
                     if customer_cases and customer_cases >= 1:
                         output.append(f'{path} {test}')
                         break
-    return set(output)
+    return output
+
+
+def create_jira_issue(comment):
+    """Create jira issues based on missing customerscenario token
+
+    Arguments:
+         issue_data {dict} -- The list of test modules, tests without customerscenario tags and other jira fields.
+    """
+    jira = _jira_client()
+    summary = "Add missing CustomerScenario tags for Robottelo tests"
+    jql = f"summary ~ '{summary}' AND status != Closed ORDER BY created DESC"
+    comment = 'The following tests need customerscenario tags:\n' + "\n".join(comment).strip()
+    jira_fields_with_description = JIRA_COMMON_FIELDS + ['description']
+    issues = jira.search_issues(jql_str=jql, fields=jira_fields_with_description, maxResults=1)
+    if issues:
+        issue = issues[0]
+        if issue.fields.description.strip() != comment:
+            click.echo(
+                f'Found open issue {issue} for missing CustomerScenario tags. Updating the description.'
+            )
+            issue.update(fields={"description": comment})
+        else:
+            click.echo(
+                f'Found open issue {issue} for missing CustomerScenario tags with same tests. Skipping update.'
+            )
+        return issue
+    issue_data = {
+        "project": settings.jira.project,
+        "summary": summary,
+        "issuetype": {"name": "Task"},
+        "description": comment,
+        "labels": ["qe-automation"],
+        settings.jira.team_field: {"value": settings.jira.team},
+        "components": [{"name": 'JPL - Tooling'}],
+        settings.jira.story_points_field: 1,
+        "security": {"name": settings.jira.comment_visibility},
+    }
+    click.echo('Creating JIRA issue for missing CustomerScenario tags')
+    issue = jira.create_issue(issue_data)
+    click.echo(f"Created {issue} JIRA issue for missing CustomerScenario tags")
+    return issue
 
 
 @main.command()
 @click.option('--jira', is_flag=True, help='Run the customer scripting for Jira')
-def run(jira, paths=None):
+@click.option(
+    '--create-jira', is_flag=True, help='Create jira issues based on missing customerscenario token'
+)
+def run(jira, create_jira, paths=None):
     if jira:
         path_list = make_path_list(paths)
         values = get_tests_path_without_customer_tag(path_list)
-        results = query_jira(values)
+        results = sorted(set(query_jira(values)))
 
     if len(results) == 0:
         click.echo('No action needed for customerscenario tags')
@@ -89,6 +145,8 @@ def run(jira, paths=None):
         click.echo('The following tests need customerscenario tags:')
         for result in results:
             click.echo(result)
+        if create_jira:
+            create_jira_issue(results)
 
 
 if __name__ == '__main__':

--- a/scripts/populate_jira_cache.py
+++ b/scripts/populate_jira_cache.py
@@ -9,13 +9,21 @@ import re
 
 import click
 
+from robottelo.config import settings
+from robottelo.constants import JIRA_COMMON_FIELDS
 from robottelo.utils.issue_handlers.jira import get_data_jira, jira_cache
 
-# Regex patterns to find Jira issues in docstrings
-JIRA_PATTERNS = [
-    r':BlockedBy:\s+(SAT-\d+)',
-    r':Verifies:\s+(SAT-\d+)',
-]
+blocked_by_regex = re.compile(
+    # To match :BlockedBy: SAT-32932
+    r'\s*:BlockedBy:\s*(?P<blocked_by>.*\S*)',
+    re.IGNORECASE,
+)
+
+verifies_regex = re.compile(
+    # To match :Verifies: SAT-32932
+    r'\s*:Verifies:\s*(?P<verifies>.*\S*)',
+    re.IGNORECASE,
+)
 
 
 @click.command()
@@ -29,9 +37,12 @@ def populate_jira_cache(tests_dir, fresh):
         content = Path(file_path).read_text()
 
         issues = []
-        for pattern in JIRA_PATTERNS:
-            issues.extend(re.findall(pattern, content))
-
+        blocked_by = blocked_by_regex.findall(content)
+        verifies = verifies_regex.findall(content)
+        if blocked_by:
+            issues.extend(issue.strip() for match in blocked_by for issue in match.split(','))
+        if verifies:
+            issues.extend(issue.strip() for match in verifies for issue in match.split(','))
         return issues
 
     def scan_test_directory(directory_path):
@@ -42,7 +53,6 @@ def populate_jira_cache(tests_dir, fresh):
         for file_path in directory.glob('**/test_*.py'):
             issues = extract_jira_issues_from_file(file_path)
             all_issues.update(issues)
-
         return all_issues
 
     click.echo(f"Scanning {tests_dir} for Jira issues...")
@@ -68,7 +78,8 @@ def populate_jira_cache(tests_dir, fresh):
             return
 
     click.echo(f"Fetching data for {len(new_issues)} issues...")
-    jira_data = get_data_jira(list(new_issues))
+    jira_fields_with_sfdc = JIRA_COMMON_FIELDS + [settings.jira.sfdc_counter_field]
+    jira_data = get_data_jira(list(new_issues), jira_fields=jira_fields_with_sfdc)
 
     # Update cache with new data
     for issue in jira_data:

--- a/tests/robottelo/test_issue_handlers_jira.py
+++ b/tests/robottelo/test_issue_handlers_jira.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import JIRA_WONTFIX_RESOLUTIONS
+from robottelo.constants import JIRA_COMMON_FIELDS, JIRA_WONTFIX_RESOLUTIONS
 from robottelo.utils.issue_handlers import jira
 
 
@@ -29,7 +29,7 @@ class TestJiraIssueHandler:
         mock_issue.fields.status.name = 'Closed'
         mock_issue.fields.labels = ['bug']
         mock_issue.fields.resolution.name = 'Done'
-        out = jira._issue_to_flat_dict(mock_issue, jira.common_jira_fields)
+        out = jira._issue_to_flat_dict(mock_issue, JIRA_COMMON_FIELDS)
         assert out['key'] == 'SAT-456'
         assert out['status'] == 'Closed'
         assert out['resolution'] == 'Done'
@@ -118,10 +118,13 @@ class TestJiraIssueHandler:
             m_jira = mock.Mock()
             m_jira.search_issues.return_value = mock_issues
             m_client.return_value = m_jira
-            result = jira.get_jira('id = SAT-1 OR id = SAT-2', ['key', 'status'])
+            result = jira.get_jira(['SAT-1', 'SAT-2'], ['key', 'status'])
         assert result == mock_issues
         m_jira.search_issues.assert_called_once_with(
-            jql_str='id = SAT-1 OR id = SAT-2', fields='key,status'
+            jql_str='id = SAT-1 OR id = SAT-2',
+            fields='key,status',
+            expand='renderedFields',
+            maxResults=100,
         )
 
     def test_get_data_jira_empty_ids_returns_empty_list(self):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21509
Fixes https://github.com/SatelliteQE/robottelo/issues/21630 

### Problem Statement
weekly_checks github action workflow has been failing for a long time with the following error:
```
Run python scripts/populate_jira_cache.py --fresh
2026-04-26 03:23:50 - robottelo - ERROR - The Ohsnap URL is invalid! Post-configuration hooks will not run. Default configuration will be used.
Usage: populate_jira_cache.py [OPTIONS] TESTS_DIR
Try 'populate_jira_cache.py --help' for help.

Error: Missing argument 'TESTS_DIR'.
```
After fixing this the workflow fails throws error for the customer scenario check(without failing) with following error:
```
KeyError: 'customfield_12313440'
make: *** [Makefile:157: customer-scenario-check-jira] Error 1
```

There are a few more issues to get the workflow in a working state with the right code logic.

### Solution
- Add the missing parameter for the populate_jira_cache script
- Add `workflow_dispatch` on `weekly_checks` so it can be triggered manually if needed
- Don't do Jira cache restore in `weekly_checks` as it'll invalidate the populate script part. Only do save operation.
- Use `${{ github.run_id }}` to differentiate new cache from old, so only the new one is used by Robottelo checks, and the older one gets invalidated/deleted by GitHub after no use for a week.
- Fix the customer scenario tag check by using new `sfdc_counter_field` jira field.
- Add the code for creating jira task for the missing customer scenario tags. Issue will be filed for `JPL - Tooling` team.
- Fix regex in the `scripts/populate_jira_cache.py`
- Fix max batch issue in Jira issue handler.
- Only use restore cache for `Robottelo - CI` checks, as it's creating unnecessary cache for each PR

### Related Issues
- SAT-43252
- ANTSE-215

### Results
- It's not possible to trigger this workflow with the forked repo MR as Github doesn't pass the secrets. See https://github.com/jameerpathan111/robottelo/actions/runs/26166538401/job/76972137219 instead, which was run against my own fork.