### PR TITLE
[6.19.z] Update RHEL9 & RHEL10 version in constants

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -624,32 +624,32 @@ REPOS = {
         },
         'rhel9_bos': {
             'id': 'rhel-9-for-x86_64-baseos-kickstart',
-            'name': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Kickstart 9.7',
-            'version': '9.7',
+            'name': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Kickstart 9.8',
+            'version': '9.8',
             'reposet': REPOSET['kickstart']['rhel9_bos'],
             'product': PRDS['rhel9'],
             'distro': 'rhel9',
         },
         'rhel9_aps': {
             'id': 'rhel-9-for-x86_64-appstream-kickstart',
-            'name': 'Red Hat Enterprise Linux 9 for x86_64 - AppStream Kickstart 9.7',
-            'version': '9.7',
+            'name': 'Red Hat Enterprise Linux 9 for x86_64 - AppStream Kickstart 9.8',
+            'version': '9.8',
             'reposet': REPOSET['kickstart']['rhel9_aps'],
             'product': PRDS['rhel9'],
             'distro': 'rhel9',
         },
         'rhel10_bos': {
             'id': 'rhel-10-for-x86_64-baseos-kickstart',
-            'name': 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS Kickstart 10.1',
-            'version': '10.1',
+            'name': 'Red Hat Enterprise Linux 10 for x86_64 - BaseOS Kickstart 10.2',
+            'version': '10.2',
             'reposet': REPOSET['kickstart']['rhel10_bos'],
             'product': PRDS['rhel10'],
             'distro': 'rhel10',
         },
         'rhel10_aps': {
             'id': 'rhel-10-for-x86_64-appstream-kickstart',
-            'name': 'Red Hat Enterprise Linux 10 for x86_64 - AppStream Kickstart 10.1',
-            'version': '10.1',
+            'name': 'Red Hat Enterprise Linux 10 for x86_64 - AppStream Kickstart 10.2',
+            'version': '10.2',
             'reposet': REPOSET['kickstart']['rhel10_aps'],
             'product': PRDS['rhel10'],
             'distro': 'rhel10',
@@ -768,8 +768,8 @@ REPOS = {
 # RHEL versions for LEAPP testing
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
-RHEL9_VER = '9.7'
-RHEL10_VER = '10.1'
+RHEL9_VER = '9.8'
+RHEL10_VER = '10.2'
 
 BULK_REPO_LIST = [
     REPOS['rhel7_optional'],


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21635

Update RHEL9 and RHEL10 versions as RHEL 9.8 and RHEL 10.2 is released now

## Summary by Sourcery

Update constants to use RHEL 9.8 as the default RHEL 9 kickstart and LEAPP testing version.

Enhancements:
- Bump RHEL 9 BaseOS and AppStream kickstart identifiers to version 9.8.
- Set the RHEL9 version constant for LEAPP testing to 9.8.