### PR TITLE
Rename remediations_count in condensed report

### DIFF
--- a/tests/foreman/cli/test_usage_report.py
+++ b/tests/foreman/cli/test_usage_report.py
@@ -82,7 +82,7 @@ def test_positive_max_age(module_target_sat):
     :expectedresults: Max age setting takes effect
 
     """
-    key = 'advisor_on_prem_remediations_count'
+    key = 'iop_remediations_count'
     key_cond = f'foreman.{key}'
     server_value = int(module_target_sat.get_reported_condensed_value(key_cond))
     test_value = (server_value + 1) * 2

--- a/tests/foreman/data/usage_report_condensed.yml
+++ b/tests/foreman/data/usage_report_condensed.yml
@@ -1,1 +1,1 @@
-{"foreman.advisor_on_prem_remediations_count":0,"foreman.rhel_ai_workload_host_count":0,"foreman.host_rhel_count":1,"foreman.host_redhat_without_rhel_count":0,"foreman.host_other_count":0,"foreman.image_mode_host_count":0,"foreman.use_dualstack":false,"foreman.use_ipv6":false}
+{"foreman.iop_remediations_count":0,"foreman.rhel_ai_workload_host_count":0,"foreman.host_rhel_count":1,"foreman.host_redhat_without_rhel_count":0,"foreman.host_other_count":0,"foreman.image_mode_host_count":0,"foreman.use_dualstack":false,"foreman.use_ipv6":false}


### PR DESCRIPTION
### Problem Statement
Reporting tests fail with:
```
E   Failed: Report field mismatch: added items: {'foreman.iop_remediations_count'}, removed items: {'foreman.advisor_on_prem_remediations_count'}
```
Apparently the field was renamed in the condensed report

### Solution
Rename `foreman.advisor_on_prem_remediations_count` to `foreman.iop_remediations_count`

### Related Issues
[SAT-45333](https://redhat.atlassian.net/browse/SAT-45333)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Rename the remediations count field in condensed usage report fixture to match the current report schema.