### PR TITLE
reduced the wait time after service restart

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -2034,7 +2034,7 @@ class TestContentViewSync:
         )
         timestamp = datetime.now(UTC)
         target_sat.cli.Service.restart()
-        sleep(30)
+        sleep(10)
         # Assert that the initial import task did not succeed and CVV was removed
         assert (
             target_sat.api.ForemanTask()
@@ -2044,6 +2044,7 @@ class TestContentViewSync:
             .result
             != 'success'
         )
+        sleep(10)
         target_sat.wait_for_tasks(
             search_query=f'label = Actions::Katello::ContentView::Remove and started_at >= "{timestamp}"',
             search_rate=10,


### PR DESCRIPTION
### Problem Statement
Test failing in jenkins build with below error
```
tests/foreman/cli/test_satellitesync.py:2047: in test_positive_export_rerun_failed_import
    target_sat.wait_for_tasks(
robottelo/host_helpers/capsule_mixins.py:70: in wait_for_tasks
    raise AssertionError(f"No task was found using query '{search_query}'")
E   AssertionError: No task was found using query 'label = Actions::Katello::ContentView::Remove and started_at >= "2026-05-19 06:04:04.701266+00:00"'
```
while running locally it is failing with below error
```
            # Assert that the initial import task did not succeed and CVV was removed
    >       assert (
                target_sat.api.ForemanTask()
                .search(
                    query={'search': f'Actions::Katello::ContentViewVersion::Import and id = {task_id}'}
                )[0]
                .result
                != 'success'
            )
    E       AssertionError: assert 'success' != 'success'
```


### Solution
Reduced the wait time after service restart from 30 to 10 seconds in the export rerun failed import test. The test now passes because the 10 second wait correctly catches the import task in a failed warning state before it recovers. The change successfully fixed the test. (disable recaps in /config)

### Related Issues
N/A

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py -k 'test_positive_export_rerun_failed_import'
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Update the satellite sync export rerun failed import test to wait 10 seconds instead of 30 after service restart.