### PR TITLE
Update tests for deprecated CV/LCE param removal

### DIFF
--- a/pytest_fixtures/component/activationkey.py
+++ b/pytest_fixtures/component/activationkey.py
@@ -7,9 +7,12 @@ from robottelo.cli.repository import Repository
 @pytest.fixture(scope='module')
 def module_activation_key(module_sca_manifest_org, module_target_sat):
     """Create activation key using default CV and library environment."""
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+        module_sca_manifest_org.default_content_view,
+        module_sca_manifest_org.library,
+    )
     return module_target_sat.api.ActivationKey(
-        content_view=module_sca_manifest_org.default_content_view.id,
-        environment=module_sca_manifest_org.library.id,
+        content_view_environment_ids=[cvenv_id],
         organization=module_sca_manifest_org,
     ).create()
 
@@ -17,9 +20,12 @@ def module_activation_key(module_sca_manifest_org, module_target_sat):
 @pytest.fixture
 def function_activation_key(function_sca_manifest_org, target_sat):
     """Create activation key using default CV and library environment."""
+    cvenv_id = target_sat.api_factory.get_cvenv_id(
+        function_sca_manifest_org.default_content_view,
+        function_sca_manifest_org.library,
+    )
     return target_sat.api.ActivationKey(
-        content_view=function_sca_manifest_org.default_content_view.id,
-        environment=function_sca_manifest_org.library.id,
+        content_view_environment_ids=[cvenv_id],
         organization=function_sca_manifest_org,
     ).create()
 
@@ -33,27 +39,27 @@ def module_ak(module_org, module_target_sat):
 
 @pytest.fixture(scope='module')
 def module_ak_with_cv(module_lce, module_org, module_promoted_cv, module_target_sat):
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(module_promoted_cv, module_lce)
     return module_target_sat.api.ActivationKey(
-        content_view=module_promoted_cv,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
         organization=module_org,
     ).create()
 
 
 @pytest.fixture
 def function_ak_with_cv(function_lce, function_org, function_promoted_cv, target_sat):
+    cvenv_id = target_sat.api_factory.get_cvenv_id(function_promoted_cv, function_lce)
     return target_sat.api.ActivationKey(
-        content_view=function_promoted_cv,
-        environment=function_lce,
+        content_view_environment_ids=[cvenv_id],
         organization=function_org,
     ).create()
 
 
 @pytest.fixture(scope='module')
 def module_ak_with_cv_repo(module_lce, module_org, module_cv_repo, module_target_sat):
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(module_cv_repo, module_lce)
     return module_target_sat.api.ActivationKey(
-        content_view=module_cv_repo,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
         organization=module_org,
     ).create()
 
@@ -79,8 +85,11 @@ def module_ak_with_synced_repo(module_sca_manifest_org, module_target_sat):
 
 @pytest.fixture(scope='module')
 def module_default_ak(module_target_sat, module_org):
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+        module_org.default_content_view,
+        module_org.library,
+    )
     return module_target_sat.api.ActivationKey(
         organization=module_org,
-        content_view=module_org.default_content_view.id,
-        environment=module_org.library.id,
+        content_view_environment_ids=[cvenv_id],
     ).create()

--- a/pytest_fixtures/component/contentview.py
+++ b/pytest_fixtures/component/contentview.py
@@ -61,9 +61,9 @@ def module_ak_cv_lce(module_org, module_lce, module_published_cv, module_target_
     content_view_version = module_published_cv.version[0]
     content_view_version.promote(data={'environment_ids': module_lce.id})
     module_published_cv = module_published_cv.read()
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(module_published_cv, module_lce)
     return module_target_sat.api.ActivationKey(
-        content_view=module_published_cv,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
         organization=module_org,
     ).create()
 

--- a/pytest_fixtures/component/host.py
+++ b/pytest_fixtures/component/host.py
@@ -27,7 +27,6 @@ def setup_rhst_repo(module_target_sat):
     cv = module_target_sat.api.ContentView(organization=org).create()
     lce = module_target_sat.api.LifecycleEnvironment(organization=org).create()
     ak = module_target_sat.api.ActivationKey(
-        environment=lce,
         organization=org,
     ).create()
     repo_name = 'rhst7'

--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -102,9 +102,9 @@ def function_leapp_ak(
     module_leapp_lce,
     module_sca_manifest_org,
 ):
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(function_leapp_cv, module_leapp_lce)
     return module_target_sat.api.ActivationKey(
-        content_view=function_leapp_cv,
-        environment=module_leapp_lce,
+        content_view_environment_ids=[cvenv_id],
         organization=module_sca_manifest_org,
     ).create()
 

--- a/pytest_fixtures/component/provision_capsule_pxe.py
+++ b/pytest_fixtures/component/provision_capsule_pxe.py
@@ -127,9 +127,10 @@ def capsule_provisioning_hostgroup(
         architecture=default_architecture,
         domain=capsule_provisioning_sat.domain,
         content_source=capsule.id,
-        content_view=capsule_provisioning_rhel_content.cv,
+        content_view_environment_id=capsule_provisioning_sat.sat.api_factory.get_cvenv_id(
+            capsule_provisioning_rhel_content.cv, module_lce_library
+        ),
         kickstart_repository=capsule_provisioning_rhel_content.ksrepo,
-        lifecycle_environment=module_lce_library,
         root_pass=settings.provisioning.host_root_password,
         operatingsystem=capsule_provisioning_rhel_content.os,
         ptable=default_partitiontable,
@@ -257,10 +258,10 @@ def capsule_provisioning_rhel_content(
     content_view = sat.api.ContentView(
         organization=module_sca_manifest_org, name=content_view.name
     ).search()[0]
+    cvenv_id = sat.api_factory.get_cvenv_id(content_view, module_lce_library)
     ak = sat.api.ActivationKey(
         organization=module_sca_manifest_org,
-        content_view=content_view,
-        environment=module_lce_library,
+        content_view_environment_ids=[cvenv_id],
     ).create()
 
     # Ensure client repo is enabled in the activation key

--- a/pytest_fixtures/component/provision_ocpv.py
+++ b/pytest_fixtures/component/provision_ocpv.py
@@ -100,10 +100,11 @@ def module_ocpv_hostgroup(
         location=[module_location],
         architecture=default_architecture,
         content_source=module_provisioning_capsule.id,
-        content_view=module_org.default_content_view,
+        content_view_environment_id=module_ocpv_sat.api_factory.get_cvenv_id(
+            module_org.default_content_view, module_lce_library
+        ),
         compute_resource=module_ocpv_cr,
         domain=domain,
-        lifecycle_environment=module_lce_library,
         root_pass=settings.provisioning.host_root_password,
         operatingsystem=module_ocpv_image.os,
     ).create()

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -137,10 +137,10 @@ def module_provisioning_rhel_content(
     )
     assert task_status[0].result == 'success'
     # create new activation key for provisioning
+    cvenv_id = sat.api_factory.get_cvenv_id(content_view, module_lce_library)
     ak = sat.api.ActivationKey(
         organization=module_sca_manifest_org,
-        content_view=content_view,
-        environment=module_lce_library,
+        content_view_environment_ids=[cvenv_id],
     ).create()
     # enable all custom repos in the activation key
     product_content = ak.product_content(data={'content_access_mode_all': '1'})['results']
@@ -312,9 +312,10 @@ def provisioning_hostgroup(
         architecture=default_architecture,
         domain=module_provisioning_sat.domain,
         content_source=module_provisioning_capsule.id,
-        content_view=module_provisioning_rhel_content.cv,
+        content_view_environment_id=module_provisioning_sat.sat.api_factory.get_cvenv_id(
+            module_provisioning_rhel_content.cv, module_lce_library
+        ),
         kickstart_repository=module_provisioning_rhel_content.ksrepo,
-        lifecycle_environment=module_lce_library,
         root_pass=settings.provisioning.host_root_password,
         operatingsystem=module_provisioning_rhel_content.os,
         ptable=default_partitiontable,

--- a/pytest_fixtures/component/provision_vmware.py
+++ b/pytest_fixtures/component/provision_vmware.py
@@ -62,10 +62,11 @@ def module_vmware_hostgroup(
         architecture=default_architecture,
         domain=module_provisioning_sat.domain,
         content_source=module_provisioning_capsule.id,
-        content_view=module_provisioning_rhel_content.cv,
+        content_view_environment_id=module_provisioning_sat.sat.api_factory.get_cvenv_id(
+            module_provisioning_rhel_content.cv, module_lce_library
+        ),
         compute_resource=module_vmware_cr,
         kickstart_repository=module_provisioning_rhel_content.ksrepo,
-        lifecycle_environment=module_lce_library,
         root_pass=settings.provisioning.host_root_password,
         operatingsystem=module_provisioning_rhel_content.os,
         ptable=default_partitiontable,

--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -88,8 +88,9 @@ def setup_content(module_target_sat, module_org):
     cv.publish()
     cvv = cv.read().version[0].read()
     cvv.promote(data={'environment_ids': lce.id, 'force': False})
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(cv, lce)
     ak = module_target_sat.api.ActivationKey(
-        content_view=cv, max_hosts=100, organization=org, environment=lce
+        content_view_environment_ids=[cvenv_id], max_hosts=100, organization=org
     ).create()
     return ak, org, custom_repo
 

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -69,9 +69,7 @@ def rhcloud_activation_key(module_target_sat_insights, rhcloud_manifest_org):
     """A module-level fixture to create an Activation key in rhcloud_manifest_org"""
     cvenv_id = module_target_sat_insights.api_factory.get_cvenv_id(
         rhcloud_manifest_org.default_content_view,
-        module_target_sat_insights.api.LifecycleEnvironment(
-            id=rhcloud_manifest_org.library.id
-        ),
+        module_target_sat_insights.api.LifecycleEnvironment(id=rhcloud_manifest_org.library.id),
     )
     return module_target_sat_insights.api.ActivationKey(
         content_view_environment_ids=[cvenv_id],
@@ -87,9 +85,7 @@ def activation_key_with_els_manifest_org(module_target_sat_insights, module_els_
     """A module-level fixture to create an Activation key in module_els_manifest_org"""
     cvenv_id = module_target_sat_insights.api_factory.get_cvenv_id(
         module_els_manifest_org.default_content_view,
-        module_target_sat_insights.api.LifecycleEnvironment(
-            id=module_els_manifest_org.library.id
-        ),
+        module_target_sat_insights.api.LifecycleEnvironment(id=module_els_manifest_org.library.id),
     )
     return module_target_sat_insights.api.ActivationKey(
         content_view_environment_ids=[cvenv_id],

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -67,12 +67,15 @@ def rhcloud_manifest_org(module_target_sat_insights, module_sca_manifest):
 @pytest.fixture(scope='module')
 def rhcloud_activation_key(module_target_sat_insights, rhcloud_manifest_org):
     """A module-level fixture to create an Activation key in rhcloud_manifest_org"""
-    return module_target_sat_insights.api.ActivationKey(
-        content_view=rhcloud_manifest_org.default_content_view,
-        organization=rhcloud_manifest_org,
-        environment=module_target_sat_insights.api.LifecycleEnvironment(
+    cvenv_id = module_target_sat_insights.api_factory.get_cvenv_id(
+        rhcloud_manifest_org.default_content_view,
+        module_target_sat_insights.api.LifecycleEnvironment(
             id=rhcloud_manifest_org.library.id
         ),
+    )
+    return module_target_sat_insights.api.ActivationKey(
+        content_view_environment_ids=[cvenv_id],
+        organization=rhcloud_manifest_org,
         service_level='Self-Support',
         purpose_usage='test-usage',
         purpose_role='test-role',
@@ -82,12 +85,15 @@ def rhcloud_activation_key(module_target_sat_insights, rhcloud_manifest_org):
 @pytest.fixture(scope='module')
 def activation_key_with_els_manifest_org(module_target_sat_insights, module_els_manifest_org):
     """A module-level fixture to create an Activation key in module_els_manifest_org"""
-    return module_target_sat_insights.api.ActivationKey(
-        content_view=module_els_manifest_org.default_content_view,
-        organization=module_els_manifest_org,
-        environment=module_target_sat_insights.api.LifecycleEnvironment(
+    cvenv_id = module_target_sat_insights.api_factory.get_cvenv_id(
+        module_els_manifest_org.default_content_view,
+        module_target_sat_insights.api.LifecycleEnvironment(
             id=module_els_manifest_org.library.id
         ),
+    )
+    return module_target_sat_insights.api.ActivationKey(
+        content_view_environment_ids=[cvenv_id],
+        organization=module_els_manifest_org,
     ).create()
 
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -212,11 +212,14 @@ def registered_hosts(request, target_sat, module_org, module_ak_with_cv):
 def katello_host_tools_host(target_sat, module_org, rhel_contenthost):
     """Register content host to Satellite and install katello-host-tools on the host."""
     repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
+    cvenv_id = target_sat.api_factory.get_cvenv_id(
+        module_org.default_content_view,
+        target_sat.api.LifecycleEnvironment(id=module_org.library.id),
+    )
     ak = target_sat.api.ActivationKey(
-        content_view=module_org.default_content_view,
+        content_view_environment_ids=[cvenv_id],
         max_hosts=100,
         organization=module_org,
-        environment=target_sat.api.LifecycleEnvironment(id=module_org.library.id),
     ).create()
     rhel_contenthost.register(module_org, None, ak.name, target_sat, repo_data=f'repo={repo}')
     rhel_contenthost.install_katello_host_tools()

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -41,6 +41,12 @@ class APIFactory:
         result = self._satellite.api.ContentViewEnvironment().list_content_view_environments(
             params={'content_view_id': cv_id, 'lifecycle_environment_id': lce_id}
         )
+        if not result['results']:
+            raise ValueError(
+                f'No ContentViewEnvironment found for content_view_id={cv_id}, '
+                f'lifecycle_environment_id={lce_id}. '
+                f'Has the content view been published and promoted to this environment?'
+            )
         return result['results'][0]['id']
 
     def make_http_proxy(self, org, http_proxy_type, use_ip=False):

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -33,7 +33,11 @@ class APIFactory:
     def get_cvenv_id(self, content_view, lifecycle_environment):
         """Look up a ContentViewEnvironment ID from a CV + LCE pair."""
         cv_id = content_view.id if hasattr(content_view, 'id') else content_view
-        lce_id = lifecycle_environment.id if hasattr(lifecycle_environment, 'id') else lifecycle_environment
+        lce_id = (
+            lifecycle_environment.id
+            if hasattr(lifecycle_environment, 'id')
+            else lifecycle_environment
+        )
         result = self._satellite.api.ContentViewEnvironment().list_content_view_environments(
             params={'content_view_id': cv_id, 'lifecycle_environment_id': lce_id}
         )

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -30,6 +30,15 @@ class APIFactory:
         self._satellite = satellite
         self.__dict__.update(initiate_repo_helpers(self._satellite))
 
+    def get_cvenv_id(self, content_view, lifecycle_environment):
+        """Look up a ContentViewEnvironment ID from a CV + LCE pair."""
+        cv_id = content_view.id if hasattr(content_view, 'id') else content_view
+        lce_id = lifecycle_environment.id if hasattr(lifecycle_environment, 'id') else lifecycle_environment
+        result = self._satellite.api.ContentViewEnvironment().list_content_view_environments(
+            params={'content_view_id': cv_id, 'lifecycle_environment_id': lce_id}
+        )
+        return result['results'][0]['id']
+
     def make_http_proxy(self, org, http_proxy_type, use_ip=False):
         """
         Creates HTTP proxy.
@@ -649,21 +658,20 @@ class APIFactory:
             # updated entities after promoting
             entities = {k: v.read() for k, v in entities.items()}
 
-        updates = []
-        if (  # assign env to ak if not present
-            entities['ActivationKey'].environment is None
-            or entities['ActivationKey'].environment.id != entities['LifecycleEnvironment'].id
+        ak = entities['ActivationKey']
+        ak_cv = ak.content_view
+        ak_lce = ak.environment
+        desired_cv = entities['ContentView']
+        desired_lce = entities['LifecycleEnvironment']
+        if (
+            ak_cv is None
+            or ak_lce is None
+            or ak_cv.id != desired_cv.id
+            or ak_lce.id != desired_lce.id
         ):
-            entities['ActivationKey'].environment = entities['LifecycleEnvironment']
-            updates.append('environment')
-        if (  # assign cv to ak if not present
-            entities['ActivationKey'].content_view is None
-            or entities['ActivationKey'].content_view.id != entities['ContentView'].id
-        ):
-            entities['ActivationKey'].content_view = entities['ContentView']
-            updates.append('content_view')
-        if updates:
-            entities['ActivationKey'].update(['content_view', 'environment'])  # both needed anyway
+            cvenv_id = self.get_cvenv_id(desired_cv, desired_lce)
+            ak.content_view_environment_ids = [cvenv_id]
+            ak.update(['content_view_environment_ids'])
 
         entities = {k: v.read() for k, v in entities.items()}
         if enable_repos:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1108,9 +1108,9 @@ class ContentHost(Host, ContentHostMixins):
         :param bool register: Whether to register to the Satellite. Keyexchange done regardless
         """
         if register:
+            cvenv_id = satellite.api_factory.get_cvenv_id(org.default_content_view, org.library)
             ak = satellite.api.ActivationKey(
-                content_view=org.default_content_view.id,
-                environment=org.library.id,
+                content_view_environment_ids=[cvenv_id],
                 organization=org,
             ).create()
             self.register(
@@ -1183,9 +1183,9 @@ class ContentHost(Host, ContentHostMixins):
         # attempt to register host
         if register:
             if not activation_key:
+                cvenv_id = satellite.api_factory.get_cvenv_id(org.default_content_view, org.library)
                 activation_key = satellite.api.ActivationKey(
-                    content_view=org.default_content_view.id,
-                    environment=org.library.id,
+                    content_view_environment_ids=[cvenv_id],
                     organization=org,
                 ).create()
             self.register(
@@ -2586,9 +2586,11 @@ class Satellite(Capsule, SatelliteMixins):
             assert task_status['result'] == 'success'
 
         # register contenthost
+        cvenv_id = self.api_factory.get_cvenv_id(
+            module_org.default_content_view, module_org.library
+        )
         ak = self.api.ActivationKey(
-            content_view=module_org.default_content_view.id,
-            environment=module_org.library.id,
+            content_view_environment_ids=[cvenv_id],
             organization=module_org,
         ).create()
         register = rhel_contenthost.register(module_org, None, ak.name, self)

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -344,10 +344,10 @@ def get_activation_key(org, target_sat):
         query={'search': f'name="Default Organization View" AND organization_id={org_obj.id}'}
     )[0]
     # Create activation key with lifecycle environment and content view
+    cvenv_id = target_sat.api_factory.get_cvenv_id(default_cv, library_env)
     ak = target_sat.api.ActivationKey(
         organization=org_obj,
-        environment=library_env,
-        content_view=default_cv,
+        content_view_environment_ids=[cvenv_id],
         name=f'virtwho_ak_{gen_string("alpha", 6)}',
     ).create()
     return ak.name

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -427,8 +427,9 @@ def test_positive_fetch_product_content(
     cvv = cv.version[0]
     cvv.promote(data={'environment_ids': module_lce.id})
 
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(cv, module_lce)
     ak = module_target_sat.api.ActivationKey(
-        content_view=cv.id, organization=module_org.id, environment=module_lce.id
+        content_view_environment_ids=[cvenv_id], organization=module_org.id
     ).create()
     ak_content = ak.product_content()['results']
     assert {custom_repo.product.id, rh_repo.product.id} == {
@@ -484,11 +485,13 @@ def test_positive_search_by_environment(target_sat):
     cv.version[0].promote(data={'environment_ids': lce_dev.id})
     cv.version[0].promote(data={'environment_ids': lce_qa.id})
 
+    cvenv_dev_id = target_sat.api_factory.get_cvenv_id(cv, lce_dev)
+    cvenv_qa_id = target_sat.api_factory.get_cvenv_id(cv, lce_qa)
     ak_dev = target_sat.api.ActivationKey(
-        organization=org, environment=lce_dev, content_view=cv
+        organization=org, content_view_environment_ids=[cvenv_dev_id]
     ).create()
     ak_qa = target_sat.api.ActivationKey(
-        organization=org, environment=lce_qa, content_view=cv
+        organization=org, content_view_environment_ids=[cvenv_qa_id]
     ).create()
 
     for lce, expected_ak in [(lce_dev, ak_dev), (lce_qa, ak_qa)]:

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -130,10 +130,10 @@ class TestContentView:
         # Check that no host associated to just created content view
         assert class_cv.content_host_count == 0
         assert len(class_promoted_cv.version) == 1
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(class_cv, module_lce)
         host = module_target_sat.api.Host(
             content_facet_attributes={
-                'content_view_id': class_cv.id,
-                'lifecycle_environment_id': module_lce.id,
+                'content_view_environment_ids': [cvenv_id],
             },
             organization=module_org.id,
         ).create()
@@ -688,17 +688,16 @@ class TestRollingContentView:
         rolling_cv.update(['environment'])
         library = module_org.library.read()
         # Create new activation key providing rolling CV
+        cvenv_id = target_sat.api_factory.get_cvenv_id(rolling_cv, library)
         ak = target_sat.api.ActivationKey(
             organization=module_org,
-            content_view=rolling_cv,
-            environment=library,
+            content_view_environment_ids=[cvenv_id],
         ).create()
         assert ak.content_view.read() == rolling_cv
         assert ak.environment.read() == library
         # Update an existing activation key with CVE
-        module_ak.content_view = rolling_cv
-        module_ak.environment = library
-        module_ak.update(['content_view', 'environment'])
+        module_ak.content_view_environment_ids = [cvenv_id]
+        module_ak.update(['content_view_environment_ids'])
         module_ak = module_ak.read()
         assert module_ak.content_view.read() == rolling_cv
         assert module_ak.environment.read() == library
@@ -708,8 +707,8 @@ class TestRollingContentView:
         with pytest.raises(HTTPError):
             rolling_cv.delete()
         ak.delete()
-        module_ak.content_view = module_ak.environment = None
-        module_ak.update(['content_view', 'environment'])
+        module_ak.content_view_environment_ids = []
+        module_ak.update(['content_view_environment_ids'])
         rolling_cv.delete_from_environment(library.id)
         rolling_cv.delete()
         with pytest.raises(HTTPError):
@@ -1171,10 +1170,11 @@ class TestRollingContentView:
         rolling_cv.update(['repository'])
         rolling_cv = rolling_cv.read()
         # create the AK with the rolling cv
+        lce_library = rolling_cv.environment[0].read()  # Library
+        cvenv_id = target_sat.api_factory.get_cvenv_id(rolling_cv, lce_library)
         ak = target_sat.api.ActivationKey(
             organization=org,
-            content_view=rolling_cv,
-            environment=rolling_cv.environment[0].read(),  # Library
+            content_view_environment_ids=[cvenv_id],
         ).create()
         # Hammer CLI: override the repos to enabled for AK
         override = target_sat.cli_factory.override_repos_for_activation_key(

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -66,10 +66,10 @@ def activation_key_rhel(
     module_target_sat, module_els_sca_manifest_org, module_lce, module_promoted_cv
 ):
     """Create activation key that will be used after conversion for registration"""
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(module_promoted_cv, module_lce)
     return module_target_sat.api.ActivationKey(
         organization=module_els_sca_manifest_org,
-        content_view=module_promoted_cv,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
     ).create()
 
 
@@ -141,10 +141,10 @@ def centos(
     cv = update_cv(
         module_target_sat, module_promoted_cv, module_lce, enable_rhel_subscriptions + [repo]
     )
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(cv, module_lce)
     ak = module_target_sat.api.ActivationKey(
         organization=module_els_sca_manifest_org,
-        content_view=cv,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
     ).create()
     # Ensure C2R repo is enabled in the activation key
     all_content = ak.product_content(data={'content_access_mode_all': '1'})['results']
@@ -237,10 +237,10 @@ def oracle(
     cv = update_cv(
         module_target_sat, module_promoted_cv, module_lce, enable_rhel_subscriptions + [repo]
     )
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(cv, module_lce)
     ak = module_target_sat.api.ActivationKey(
         organization=module_els_sca_manifest_org,
-        content_view=cv,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
     ).create()
     # Ensure C2R repo is enabled in the activation key
     all_content = ak.product_content(data={'content_access_mode_all': '1'})['results']

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -512,8 +512,9 @@ class TestDockerActivationKey:
             key
         """
         content_view = content_view_publish_promote
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(content_view, module_lce)
         ak = module_target_sat.api.ActivationKey(
-            content_view=content_view, environment=module_lce, organization=module_org
+            content_view_environment_ids=[cvenv_id], organization=module_org
         ).create()
         assert ak.content_view.id == content_view.id
         assert ak.content_view.read().repository[0].id == repo.id
@@ -531,12 +532,13 @@ class TestDockerActivationKey:
 
         """
         content_view = content_view_publish_promote
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(content_view, module_lce)
         ak = module_target_sat.api.ActivationKey(
-            content_view=content_view, environment=module_lce, organization=module_org
+            content_view_environment_ids=[cvenv_id], organization=module_org
         ).create()
         assert ak.content_view.id == content_view.id
-        ak.content_view_environments = None
-        assert ak.update(['content_view_environments']).content_view is None
+        ak.content_view_environment_ids = []
+        assert ak.update(['content_view_environment_ids']).content_view is None
 
     def test_positive_add_docker_repo_ccv(
         self, content_view_version, module_lce, module_org, module_target_sat
@@ -563,8 +565,9 @@ class TestDockerActivationKey:
         comp_cvv = comp_content_view.read().version[0].read()
         comp_cvv.promote(data={'environment_ids': module_lce.id, 'force': False})
 
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(comp_content_view, module_lce)
         ak = module_target_sat.api.ActivationKey(
-            content_view=comp_content_view, environment=module_lce, organization=module_org
+            content_view_environment_ids=[cvenv_id], organization=module_org
         ).create()
         assert ak.content_view.id == comp_content_view.id
 
@@ -594,12 +597,13 @@ class TestDockerActivationKey:
         comp_cvv = comp_content_view.read().version[0].read()
         comp_cvv.promote(data={'environment_ids': module_lce.id, 'force': False})
 
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(comp_content_view, module_lce)
         ak = module_target_sat.api.ActivationKey(
-            content_view=comp_content_view, environment=module_lce, organization=module_org
+            content_view_environment_ids=[cvenv_id], organization=module_org
         ).create()
         assert ak.content_view.id == comp_content_view.id
-        ak.content_view_environments = None
-        assert ak.update(['content_view_environments']).content_view is None
+        ak.content_view_environment_ids = []
+        assert ak.update(['content_view_environment_ids']).content_view is None
 
 
 class TestPodman:

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -79,10 +79,10 @@ def activation_key(module_sca_manifest_org, module_cv, module_lce, module_target
         module_cv,
         module_lce,
     )['content-view']
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(_cv, module_lce)
     return module_target_sat.api.ActivationKey(
         organization=module_sca_manifest_org,
-        environment=module_lce,
-        content_view=_cv,
+        content_view_environment_ids=[cvenv_id],
     ).create()
 
 
@@ -1494,10 +1494,10 @@ def test_positive_incremental_update_apply_to_envs_cvs(
 
     # Create AK with the CV and the last LCE.
     host_lce = lces[-1].read()
+    cvenv_id = target_sat.api_factory.get_cvenv_id(host_cv, host_lce)
     ak = target_sat.api.ActivationKey(
         organization=function_org,
-        environment=host_lce,
-        content_view=host_cv,
+        content_view_environment_ids=[cvenv_id],
     ).create()
 
     # Register the content host with the AK.
@@ -1823,10 +1823,12 @@ def test_positive_bulk_erratum_applicable_vs_installable(
     assert rhel_contenthost.subscribed
 
     # Register the second content host to the Library LCE
+    library_cvenv_id = target_sat.api_factory.get_cvenv_id(
+        function_org.default_content_view, function_lce_library
+    )
     library_ak = target_sat.api.ActivationKey(
         organization=function_org,
-        environment=function_lce_library,
-        content_view=function_org.default_content_view,
+        content_view_environment_ids=[library_cvenv_id],
     ).create()
     lbl = library_ak.product_content(data={'content_access_mode_all': '1'})['results'][0]['label']
     library_ak.content_override(data={'content_overrides': [{'content_label': lbl, 'value': '1'}]})

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -220,8 +220,9 @@ def test_positive_create_and_update_with_hostgroup(
         location=module_location,
         organization=module_org,
         content_facet_attributes={
-            'content_view_id': module_published_cv.id,
-            'lifecycle_environment_id': module_lce.id,
+            'content_view_environment_ids': [
+                module_target_sat.api_factory.get_cvenv_id(module_published_cv, module_lce)
+            ],
         },
     ).create()
     assert host.hostgroup.read().name == hostgroup.name
@@ -230,8 +231,9 @@ def test_positive_create_and_update_with_hostgroup(
     ).create()
     host.hostgroup = new_hostgroup
     host.content_facet_attributes = {
-        'content_view_id': module_published_cv.id,
-        'lifecycle_environment_id': module_lce.id,
+        'content_view_environment_ids': [
+            module_target_sat.api_factory.get_cvenv_id(module_published_cv, module_lce)
+        ],
     }
     host = host.update(['hostgroup', 'content_facet_attributes'])
     assert host.hostgroup.read().name == new_hostgroup.name
@@ -250,9 +252,11 @@ def test_positive_create_inherit_lce_cv(
 
     :BZ: 1391656
     """
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+        module_default_org_view, module_lce_library
+    )
     hostgroup = module_target_sat.api.HostGroup(
-        content_view=module_default_org_view,
-        lifecycle_environment=module_lce_library,
+        content_view_environment_id=cvenv_id,
         organization=[module_org],
     ).create()
     host = module_target_sat.api.Host(hostgroup=hostgroup, organization=module_org).create()
@@ -728,16 +732,20 @@ def test_positive_create_and_update_with_content_view(
         organization=module_org,
         location=module_location,
         content_facet_attributes={
-            'content_view_id': module_default_org_view.id,
-            'lifecycle_environment_id': module_lce_library.id,
+            'content_view_environment_ids': [
+                module_target_sat.api_factory.get_cvenv_id(
+                    module_default_org_view, module_lce_library
+                )
+            ],
         },
     ).create()
     assert host.content_facet_attributes['content_view']['id'] == module_default_org_view.id
     assert host.content_facet_attributes['lifecycle_environment']['id'] == module_lce_library.id
 
     host.content_facet_attributes = {
-        'content_view_id': module_default_org_view.id,
-        'lifecycle_environment_id': module_lce_library.id,
+        'content_view_environment_ids': [
+            module_target_sat.api_factory.get_cvenv_id(module_default_org_view, module_lce_library)
+        ],
     }
     host = host.update(['content_facet_attributes'])
     assert host.content_facet_attributes['content_view']['id'] == module_default_org_view.id
@@ -1063,8 +1071,9 @@ def test_positive_read_content_source_id(
         location=module_location,
         content_facet_attributes={
             'content_source_id': proxy.id,
-            'content_view_id': module_published_cv.id,
-            'lifecycle_environment_id': module_lce.id,
+            'content_view_environment_ids': [
+                target_sat.api_factory.get_cvenv_id(module_published_cv, module_lce)
+            ],
         },
     ).create()
     content_facet_attributes = host.content_facet_attributes
@@ -1095,8 +1104,9 @@ def test_positive_update_content_source_id(
         organization=module_org,
         location=module_location,
         content_facet_attributes={
-            'content_view_id': module_published_cv.id,
-            'lifecycle_environment_id': module_lce.id,
+            'content_view_environment_ids': [
+                target_sat.api_factory.get_cvenv_id(module_published_cv, module_lce)
+            ],
         },
     ).create()
     host.content_facet_attributes['content_source_id'] = proxy.id
@@ -1154,8 +1164,9 @@ def test_positive_read_enc_information(
         environment=module_env_search,
         puppetclass=module_puppet_classes,
         content_facet_attributes={
-            'content_view_id': cv.id,
-            'lifecycle_environment_id': lce.id,
+            'content_view_environment_ids': [
+                session_puppet_enabled_sat.api_factory.get_cvenv_id(cv, lce)
+            ],
         },
         host_parameters_attributes=host_parameters_attributes,
         puppet_proxy=session_puppet_enabled_proxy,

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -143,8 +143,9 @@ class TestHostGroup:
             location=location,
             organization=org,
             content_facet_attributes={
-                'content_view_id': content_view.id,
-                'lifecycle_environment_id': lc_env.id,
+                'content_view_environment_ids': [
+                    session_puppet_enabled_sat.api_factory.get_cvenv_id(content_view, lc_env)
+                ],
             },
             name=gen_string('alpha'),
         ).create(False)
@@ -174,8 +175,9 @@ class TestHostGroup:
             organization=module_org,
             managed=True,
             content_facet_attributes={
-                'content_view_id': content_view.id,
-                'lifecycle_environment_id': lce.id,
+                'content_view_environment_ids': [
+                    module_target_sat.api_factory.get_cvenv_id(content_view, lce)
+                ],
             },
         ).create()
         # TODO: use host that can also rebuild the SSH_Nic, SSH_Host, and Content_Host_Status
@@ -271,13 +273,13 @@ class TestHostGroup:
             organization=module_puppet_org
         ).create()
         content_view.version[0].promote(data={'environment_ids': lce.id, 'force': False})
+        cvenv_id = session_puppet_enabled_sat.api_factory.get_cvenv_id(content_view, lce)
         hostgroup = session_puppet_enabled_sat.api.HostGroup(
             architecture=arch,
             content_source=proxy,
-            content_view=content_view,
+            content_view_environment_id=cvenv_id,
             domain=domain,
             environment=env,
-            lifecycle_environment=lce,
             location=[module_puppet_loc],
             medium=media,
             operatingsystem=os,
@@ -330,12 +332,12 @@ class TestHostGroup:
             operatingsystem=[os], location=[new_loc], organization=[new_org]
         ).create()
         new_cv.version[0].promote(data={'environment_ids': new_lce.id, 'force': False})
+        new_cvenv_id = session_puppet_enabled_sat.api_factory.get_cvenv_id(new_cv, new_lce)
 
         # update itself
         hostgroup.organization = [new_org]
         hostgroup.location = [new_loc]
-        hostgroup.lifecycle_environment = new_lce
-        hostgroup.content_view = new_cv
+        hostgroup.content_view_environment_id = new_cvenv_id
         hostgroup.domain = new_domain
         hostgroup.architecture = new_arch
         hostgroup.operatingsystem = new_os
@@ -353,8 +355,7 @@ class TestHostGroup:
                 'ptable',
                 'subnet',
                 'domain',
-                'content_view',
-                'lifecycle_environment',
+                'content_view_environment_id',
                 'location',
                 'organization',
                 'medium',

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -212,10 +212,10 @@ def test_positive_install_content_with_http_proxy(
     content_view = content_view.read()
     content_view.version[-1].promote(data={'environment_ids': lce.id})
 
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(content_view, lce)
     activation_key = module_target_sat.api.ActivationKey(
-        content_view=content_view,
+        content_view_environment_ids=[cvenv_id],
         organization=org,
-        environment=lce,
     ).create()
     activation_key.content_override(
         data={

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -766,13 +766,15 @@ def test_capsule_pxe_provisioning(
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = capsule_provisioning_sat.sat
     cap = module_capsule_configured
+    cvenv_id = sat.api_factory.get_cvenv_id(
+        capsule_provisioning_rhel_content.cv, module_lce_library
+    )
     host = sat.api.Host(
         hostgroup=capsule_provisioning_hostgroup,
         organization=module_sca_manifest_org,
         location=module_location,
         content_facet_attributes={
-            'content_view_id': capsule_provisioning_rhel_content.cv.id,
-            'lifecycle_environment_id': module_lce_library.id,
+            'content_view_environment_ids': [cvenv_id],
         },
         name=gen_string('alpha').lower(),
         mac=host_mac_addr,

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -138,9 +138,7 @@ def test_host_provisioning_with_external_puppetserver(
     puppet_env = 'production'
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat
-    cvenv_id = sat.api_factory.get_cvenv_id(
-        module_provisioning_rhel_content.cv, module_lce_library
-    )
+    cvenv_id = sat.api_factory.get_cvenv_id(module_provisioning_rhel_content.cv, module_lce_library)
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
         organization=module_sca_manifest_org,

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -138,13 +138,15 @@ def test_host_provisioning_with_external_puppetserver(
     puppet_env = 'production'
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat
+    cvenv_id = sat.api_factory.get_cvenv_id(
+        module_provisioning_rhel_content.cv, module_lce_library
+    )
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
         organization=module_sca_manifest_org,
         location=module_location,
         content_facet_attributes={
-            'content_view_id': module_provisioning_rhel_content.cv.id,
-            'lifecycle_environment_id': module_lce_library.id,
+            'content_view_environment_ids': [cvenv_id],
         },
         name=gen_string('alpha').lower(),
         mac=host_mac_addr,

--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -264,6 +264,9 @@ class TestProvisioningTemplate:
         """
         macaddress = gen_mac(multicast=False)
         capsule = module_target_sat.nailgun_smart_proxy
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+            module_default_org_view, module_lce_library
+        )
         host = module_target_sat.api.Host(
             organization=module_sca_manifest_org,
             location=module_location,
@@ -276,8 +279,7 @@ class TestProvisioningTemplate:
             ptable=default_partitiontable,
             content_facet_attributes={
                 'content_source_id': capsule.id,
-                'content_view_id': module_default_org_view.id,
-                'lifecycle_environment_id': module_lce_library.id,
+                'content_view_environment_ids': [cvenv_id],
             },
         ).create()
         request.addfinalizer(lambda: host.delete())
@@ -320,6 +322,9 @@ class TestProvisioningTemplate:
         identifier = gen_string('alphanumeric')
         tag = gen_string('numeric', length=4)
         # create a host with vlan enabled interface
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+            module_default_org_view, module_lce_library
+        )
         host = module_target_sat.api.Host(
             organization=module_sca_manifest_org,
             location=module_location,
@@ -329,8 +334,7 @@ class TestProvisioningTemplate:
             ptable=default_partitiontable,
             content_facet_attributes={
                 'content_source_id': capsule.id,
-                'content_view_id': module_default_org_view.id,
-                'lifecycle_environment_id': module_lce_library.id,
+                'content_view_environment_ids': [cvenv_id],
             },
             interfaces_attributes=[
                 {
@@ -509,6 +513,9 @@ class TestProvisioningTemplate:
             {'name': 'ansible_job_template_id', 'value': template_id, 'parameter_type': 'integer'},
             {'name': 'ansible_extra_vars', 'value': extra_vars_dict, 'parameter_type': 'string'},
         ]
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+            module_default_org_view, module_lce_library
+        )
         host = module_target_sat.api.Host(
             organization=module_sca_manifest_org,
             location=module_location,
@@ -520,8 +527,7 @@ class TestProvisioningTemplate:
             ptable=default_partitiontable,
             content_facet_attributes={
                 'content_source_id': module_target_sat.nailgun_smart_proxy.id,
-                'content_view_id': module_default_org_view.id,
-                'lifecycle_environment_id': module_lce_library.id,
+                'content_view_environment_ids': [cvenv_id],
             },
             host_parameters_attributes=host_params,
         ).create()
@@ -567,6 +573,9 @@ class TestProvisioningTemplate:
         macaddress = gen_mac(multicast=False)
         rex_user = gen_string('alpha')
         ssh_key = gen_string('alphanumeric')
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+            module_default_org_view, module_lce_library
+        )
         host = module_target_sat.api.Host(
             organization=module_sca_manifest_org,
             location=module_location,
@@ -579,8 +588,7 @@ class TestProvisioningTemplate:
             ptable=default_partitiontable,
             content_facet_attributes={
                 'content_source_id': module_provisioning_capsule.id,
-                'content_view_id': module_default_org_view.id,
-                'lifecycle_environment_id': module_lce_library.id,
+                'content_view_environment_ids': [cvenv_id],
             },
             host_parameters_attributes=[
                 {
@@ -707,6 +715,9 @@ class TestProvisioningTemplate:
         :parametrized: yes
         """
         host_params = [{'name': 'fips_enabled', 'value': 'true', 'parameter_type': 'boolean'}]
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+            module_default_org_view, module_lce_library
+        )
         host = module_target_sat.api.Host(
             organization=module_sca_manifest_org,
             location=module_location,
@@ -718,8 +729,7 @@ class TestProvisioningTemplate:
             ptable=default_partitiontable,
             content_facet_attributes={
                 'content_source_id': module_target_sat.nailgun_smart_proxy.id,
-                'content_view_id': module_default_org_view.id,
-                'lifecycle_environment_id': module_lce_library.id,
+                'content_view_environment_ids': [cvenv_id],
             },
             host_parameters_attributes=host_params,
         ).create()

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -74,8 +74,9 @@ def setup_content(module_sca_manifest_org, module_target_sat):
     cv.publish()
     cvv = cv.read().version[0].read()
     cvv.promote(data={'environment_ids': lce.id, 'force': False})
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(cv, lce)
     ak = module_target_sat.api.ActivationKey(
-        content_view=cv, max_hosts=100, organization=org, environment=lce
+        content_view_environment_ids=[cvenv_id], max_hosts=100, organization=org
     ).create()
     all_content = ak.product_content(data={'content_access_mode_all': '1'})['results']
     content_label = [repo['label'] for repo in all_content if repo['name'] == custom_repo.name][0]
@@ -1066,8 +1067,9 @@ def test_positive_installed_products(
     }
     repo_id = target_sat.api_factory.enable_sync_redhat_repo(rh_repo, org.id)
     cv = target_sat.api_factory.cv_publish_promote(cv_name, lce_name, repo_id, org.id)
+    cvenv_id = target_sat.api_factory.get_cvenv_id(cv, cv.environment[-1])
     ak = target_sat.api.ActivationKey(
-        content_view=cv, organization=org, environment=cv.environment[-1]
+        content_view_environment_ids=[cvenv_id], organization=org
     ).create()
 
     rhel_contenthost.register(org, default_location, ak.name, target_sat)

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -59,13 +59,14 @@ def custom_repo(rh_repo, module_sca_manifest_org, module_target_sat):
 @pytest.fixture(scope='module')
 def module_ak(module_sca_manifest_org, rh_repo, custom_repo, module_target_sat):
     """rh_repo and custom_repo are included here to ensure their execution before the AK"""
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+        module_sca_manifest_org.default_content_view,
+        module_sca_manifest_org.library,
+    )
     return module_target_sat.api.ActivationKey(
-        content_view=module_sca_manifest_org.default_content_view,
+        content_view_environment_ids=[cvenv_id],
         max_hosts=100,
         organization=module_sca_manifest_org,
-        environment=module_target_sat.api.LifecycleEnvironment(
-            id=module_sca_manifest_org.library.id
-        ),
     ).create()
 
 
@@ -228,9 +229,9 @@ def test_sca_end_to_end(
     content_view.publish()
     assert len(content_view.repository) == 2
     host = rhel_contenthost.nailgun_host
+    cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, module_ak.environment)
     host.content_facet_attributes = {
-        'content_view_id': content_view.id,
-        'lifecycle_environment_id': module_ak.environment.id,
+        'content_view_environment_ids': [cvenv_id],
     }
     host.update(['content_facet_attributes'])
     rhel_contenthost.run(r'subscription-manager repos --enable \*')
@@ -270,11 +271,14 @@ def test_positive_expired_SCA_cert_handling(module_sca_manifest_org, rhel_conten
 
     :CaseImportance: High
     """
+    cvenv_id = target_sat.api_factory.get_cvenv_id(
+        module_sca_manifest_org.default_content_view,
+        module_sca_manifest_org.library,
+    )
     ak = target_sat.api.ActivationKey(
-        content_view=module_sca_manifest_org.default_content_view,
+        content_view_environment_ids=[cvenv_id],
         max_hosts=100,
         organization=module_sca_manifest_org,
-        environment=target_sat.api.LifecycleEnvironment(id=module_sca_manifest_org.library.id),
     ).create()
     # registering the content host with no content enabled/synced in the org
     # should create a client SCA cert with no content

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1637,9 +1637,9 @@ def test_syspurpose_end_to_end(
     """
     # Create an activation key with test values
     # purpose_addons = "test-addon1, test-addon2"
+    cvenv_id = target_sat.api_factory.get_cvenv_id(module_promoted_cv, module_lce)
     activation_key = target_sat.api.ActivationKey(
-        content_view=module_promoted_cv,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
         organization=module_org,
         # purpose_addons=[purpose_addons],
         purpose_role="test-role",

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -1071,10 +1071,10 @@ def test_sync_consume_flatpak_repo_via_cv(
     module_capsule_configured.wait_for_sync(start_time=timestamp)
 
     # Create an AK assigned with one content view environment only.
+    cvenv_id = sat.api_factory.get_cvenv_id(cv1, function_lce)
     ak_cv = sat.api.ActivationKey(
         organization=function_org,
-        content_view=cv1,
-        environment=function_lce,
+        content_view_environment_ids=[cvenv_id],
     ).create()
 
     # Register a content host using the AK via Capsule.

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -63,9 +63,9 @@ def rh_repo_setup_ak(module_sca_manifest_org, module_rhel_contenthost, module_ta
     # promote the last version published into the module lce
     cv.version[-1].promote(data={'environment_ids': lce.id, 'force': False})
 
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(cv, lce)
     ak = module_target_sat.api.ActivationKey(
-        content_view=cv,
-        environment=lce,
+        content_view_environment_ids=[cvenv_id],
         organization=module_sca_manifest_org,
     ).create()
     # Ensure tools repo is enabled in the activation key

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1174,9 +1174,11 @@ def test_positive_check_errata_dates(module_sca_manifest_org, module_target_sat)
 def new_module_ak(
     module_sca_manifest_org, rh_repo_module_manifest, module_lce_library, module_target_sat
 ):
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+        module_sca_manifest_org.default_content_view, module_lce_library
+    )
     new_module_ak = module_target_sat.api.ActivationKey(
-        environment=module_lce_library,
-        content_view=module_sca_manifest_org.default_content_view,
+        content_view_environment_ids=[cvenv_id],
         organization=module_sca_manifest_org,
     ).create()
     # Ensure tools repo is enabled in the activation key

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -501,10 +501,10 @@ def test_sync_consume_flatpak_repo_via_cv(
         cv.read().version[0].promote(data={'environment_ids': function_lce.id})
 
     # 3. Create an AK assigned with one content view environment only.
+    cvenv_id = sat.api_factory.get_cvenv_id(cv1, function_lce)
     ak = sat.api.ActivationKey(
         organization=function_org,
-        content_view=cv1,
-        environment=function_lce,
+        content_view_environment_ids=[cvenv_id],
     ).create()
 
     # 4. Register a content host using the AK.

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -670,9 +670,9 @@ def test_positive_config_on_sat_without_network_protocol(
         rh_repo.sync(timeout=2000)
 
     # Create an activation key for Satellite self-registration
+    cvenv_id = target_sat.api_factory.get_cvenv_id(cv, lce)
     ac_key = target_sat.api.ActivationKey(
-        content_view=cv,
-        environment=lce,
+        content_view_environment_ids=[cvenv_id],
         organization=function_org,
     ).create()
 

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -143,10 +143,12 @@ def test_positive_install_iop_custom_certs(
     org = satellite.api.Organization().create()
     satellite.upload_manifest(org.id, module_sca_manifest.content)
 
+    cvenv_id = satellite.api_factory.get_cvenv_id(
+        org.default_content_view, satellite.api.LifecycleEnvironment(id=org.library.id)
+    )
     activation_key = satellite.api.ActivationKey(
-        content_view=org.default_content_view,
+        content_view_environment_ids=[cvenv_id],
         organization=org,
-        environment=satellite.api.LifecycleEnvironment(id=org.library.id),
         service_level='Self-Support',
         purpose_usage='test-usage',
         purpose_role='test-role',
@@ -197,10 +199,12 @@ def test_disable_enable_iop(module_satellite_iop, module_sca_manifest, rhel_cont
     org = satellite.api.Organization().create()
     satellite.upload_manifest(org.id, module_sca_manifest.content)
 
+    cvenv_id = satellite.api_factory.get_cvenv_id(
+        org.default_content_view, satellite.api.LifecycleEnvironment(id=org.library.id)
+    )
     activation_key = satellite.api.ActivationKey(
-        content_view=org.default_content_view,
+        content_view_environment_ids=[cvenv_id],
         organization=org,
-        environment=satellite.api.LifecycleEnvironment(id=org.library.id),
         service_level='Self-Support',
         purpose_usage='test-usage',
         purpose_role='test-role',

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -215,8 +215,11 @@ def test_infoblox_end_to_end(
         ptable=default_partitiontable,
         content_facet_attributes={
             'content_source_id': module_provisioning_capsule.id,
-            'content_view_id': module_default_org_view.id,
-            'lifecycle_environment_id': module_lce_library.id,
+            'content_view_environment_ids': [
+                module_target_sat.api_factory.get_cvenv_id(
+                    module_default_org_view, module_lce_library
+                )
+            ],
         },
     ).create()
     # check if A Record is created for the host IP on Infoblox

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1162,8 +1162,9 @@ class TestEndToEnd:
 
         # step 2.12: Create a new activation key
         activation_key_name = gen_string('alpha')
+        cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, le1)
         activation_key = target_sat.api.ActivationKey(
-            name=activation_key_name, environment=le1, organization=org, content_view=content_view
+            name=activation_key_name, content_view_environment_ids=[cvenv_id], organization=org
         ).create()
 
         # step 2.13: Enable product content

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1178,8 +1178,9 @@ class TestEndToEnd:
         # content view and last lifecycle where it exists
         content_host = target_sat.api.Host(
             content_facet_attributes={
-                'content_view_id': content_view.id,
-                'lifecycle_environment_id': le1.id,
+                'content_view_environment_ids': [
+                    target_sat.api_factory.get_cvenv_id(content_view, le1)
+                ],
             },
             organization=org,
         ).create()

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -388,8 +388,9 @@ def test_capsule_installation(
     # Create capsule certs and activation key
     file, _, cmd_args = sat_fapolicyd_install.capsule_certs_generate(cap_ready_rhel)
     sat_fapolicyd_install.session.remote_copy(file, cap_ready_rhel)
+    cvenv_id = sat_fapolicyd_install.api_factory.get_cvenv_id(org.default_content_view, org.library)
     ak = sat_fapolicyd_install.api.ActivationKey(
-        organization=org, environment=org.library, content_view=org.default_content_view
+        organization=org, content_view_environment_ids=[cvenv_id]
     ).create()
     sync_capsule_repos(sat_fapolicyd_install, cap_ready_rhel, org, ak)
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -100,9 +100,9 @@ def module_ak(
     module_sca_manifest_org, module_cv, custom_repo, module_lce_library, module_target_sat
 ):
     """Create a module AK in Library LCE"""
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(module_cv, module_lce_library)
     ak = module_target_sat.api.ActivationKey(
-        content_view=module_cv,
-        environment=module_lce_library,
+        content_view_environment_ids=[cvenv_id],
         organization=module_sca_manifest_org,
     ).create()
     # Fetch available subscriptions

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -119,10 +119,10 @@ def activation_key(module_target_sat, module_org, lifecycle_env):
         assert len(content_view.version) == 1, "CV not published"
         version = content_view.version[0].read()
         version.promote(data={'environment_ids': lifecycle_env.id, 'force': True})
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(content_view, lifecycle_env)
         activation_key = module_target_sat.api.ActivationKey(
             name=repo.get('akname'),
-            environment=lifecycle_env,
-            content_view=content_view,
+            content_view_environment_ids=[cvenv_id],
             organization=module_org,
         ).create()
         # Setup org for a custom repo for RHEL6, RHEL7 and RHEL8.

--- a/tests/foreman/sys/test_capsule_loadbalancer.py
+++ b/tests/foreman/sys/test_capsule_loadbalancer.py
@@ -61,9 +61,9 @@ def content_for_client(module_target_sat, module_sca_manifest_org, module_lce, m
     cvv = module_cv.version[0]
     cvv.promote(data={'environment_ids': module_lce.id})
     module_cv = module_cv.read()
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(module_cv, module_lce)
     ak = module_target_sat.api.ActivationKey(
-        content_view=module_cv,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
         organization=module_sca_manifest_org,
     ).create()
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -866,9 +866,9 @@ def test_positive_add_host(
 
     :parametrized: yes
     """
+    cvenv_id = target_sat.api_factory.get_cvenv_id(module_promoted_cv, module_lce)
     ak = target_sat.api.ActivationKey(
-        content_view=module_promoted_cv,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
         organization=module_org,
     ).create()
     result = rhel_contenthost.register(module_org, None, ak.name, target_sat)
@@ -1034,9 +1034,12 @@ def test_positive_host_associations(session, target_sat):
         {'url': settings.repos.yum_1.url, 'organization-id': org.id}
     )
     ak1 = target_sat.api.ActivationKey(id=org_entities['activationkey-id']).read()
+    cvenv_id = target_sat.api_factory.get_cvenv_id(
+        org_entities['content-view-id'],
+        org_entities['lifecycle-environment-id'],
+    )
     ak2 = target_sat.api.ActivationKey(
-        content_view=org_entities['content-view-id'],
-        environment=org_entities['lifecycle-environment-id'],
+        content_view_environment_ids=[cvenv_id],
         organization=org.id,
     ).create()
     with Broker(

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -631,7 +631,10 @@ def test_positive_fetch_product_content(target_sat, function_sca_manifest_org, s
     cv.publish()
     cvv = cv.read().version[0].read()
     cvv.promote(data={'environment_ids': lce.id, 'force': True})
-    ak = target_sat.api.ActivationKey(content_view=cv, organization=org, environment=lce).create()
+    cvenv_id = target_sat.api_factory.get_cvenv_id(cv, lce)
+    ak = target_sat.api.ActivationKey(
+        content_view_environment_ids=[cvenv_id], organization=org
+    ).create()
     with session:
         session.organization.select(org.name)
         ak = session.activationkey.read(ak.name, widget_names='repository_sets')

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -1084,9 +1084,9 @@ def test_positive_filter_by_environment(
         host = (
             target_sat.api.Host().search(query={'search': f'name={clients[0].hostname}'})[0].read()
         )
+        cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, new_lce)
         host.content_facet_attributes = {
-            'content_view_id': content_view.id,
-            'lifecycle_environment_id': new_lce.id,
+            'content_view_environment_ids': [cvenv_id],
         }
         host.update(['content_facet_attributes'])
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2238,8 +2238,9 @@ def change_content_source_prep(
     content_view.publish()
     content_view.read().version[0].promote(data={'environment_ids': lce.id})
 
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(content_view, lce)
     ak = module_target_sat.api.ActivationKey(
-        content_view=content_view, organization=org.id, environment=lce.id
+        content_view_environment_ids=[cvenv_id], organization=org.id
     ).create()
 
     # Edit capsule's taxonomies
@@ -2416,10 +2417,10 @@ def test_manage_content_source_with_multi_cv(
     cv_version2.promote(data={'environment_ids': lce2.id})
 
     # Step 3 & 4: Create activation key and register host
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(module_cv, module_org.library)
     ak = module_target_sat.api.ActivationKey(
         organization=module_org.id,
-        content_view=module_cv.id,
-        environment=module_org.library.id,
+        content_view_environment_ids=[cvenv_id],
     ).create()
     result = rhel_contenthost.register(module_org, None, ak.name, module_target_sat)
     assert result.status == 0, f'Failed to register host: {result.stderr}'
@@ -3010,11 +3011,11 @@ def test_positive_manage_repository_sets(
     cv_version.promote(data={'environment_ids': module_lce.id})
 
     # Update activation key
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(content_view, module_lce)
     module_ak = module_target_sat.api.ActivationKey(
         id=module_ak.id,
         organization=module_sca_manifest_org,
-        content_view=content_view,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
     ).update()
 
     # Register hosts and collect repo names
@@ -4065,9 +4066,9 @@ def test_positive_all_hosts_manage_system_purpose(
     content_view = content_view.read()
     cvv = content_view.version[0].read()
     cvv.promote(data={'environment_ids': module_lce.id})
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(content_view, module_lce)
     ak = module_target_sat.api.ActivationKey(
-        content_view=content_view,
-        environment=module_lce,
+        content_view_environment_ids=[cvenv_id],
         organization=module_sca_manifest_org,
     ).create()
 
@@ -4314,10 +4315,10 @@ def test_assign_multi_cv_from_host_page(
 
     :verifies: SAT-25846
     """
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(module_cv_repo, module_org.library)
     ak = module_target_sat.api.ActivationKey(
         organization=module_org.id,
-        content_view=module_cv_repo.id,
-        environment=module_org.library.id,
+        content_view_environment_ids=[cvenv_id],
     ).create()
     result = rhel_contenthost.register(module_org, None, ak.name, module_target_sat)
     assert result.status == 0
@@ -4363,10 +4364,10 @@ def test_assign_different_cv_from_same_env(
     :verifies: SAT-25846
     """
     # Create activation key and register host
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(module_cv_repo, module_org.library)
     ak = module_target_sat.api.ActivationKey(
         organization=module_org.id,
-        content_view=module_cv_repo.id,
-        environment=module_org.library.id,
+        content_view_environment_ids=[cvenv_id],
     ).create()
     result = rhel_contenthost.register(module_org, None, ak.name, module_target_sat)
     assert result.status == 0

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -890,10 +890,12 @@ def test_negative_remove_parameter_non_admin_user(
         default_organization=module_org,
         default_location=smart_proxy_location,
     ).create()
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+        module_org.default_content_view, module_org.library
+    )
     host = module_target_sat.api.Host(
         content_facet_attributes={
-            'content_view_id': module_org.default_content_view.id,
-            'lifecycle_environment_id': module_org.library.id,
+            'content_view_environment_ids': [cvenv_id],
         },
         location=smart_proxy_location,
         organization=module_org,
@@ -1961,6 +1963,9 @@ def test_positive_set_multi_line_and_with_spaces_parameter_value(
         'password-auth\r\n'
         'account     include                  password-auth'
     )
+    cvenv_id = session_puppet_enabled_sat.api_factory.get_cvenv_id(
+        module_puppet_published_cv, module_puppet_lce_library
+    )
     host = session_puppet_enabled_sat.api.Host(
         organization=host_template.organization,
         architecture=host_template.architecture,
@@ -1972,8 +1977,7 @@ def test_positive_set_multi_line_and_with_spaces_parameter_value(
         ptable=host_template.ptable,
         root_pass=host_template.root_pass,
         content_facet_attributes={
-            'content_view_id': module_puppet_published_cv.id,
-            'lifecycle_environment_id': module_puppet_lce_library.id,
+            'content_view_environment_ids': [cvenv_id],
         },
     ).create()
     with session_puppet_enabled_sat.ui_session() as session:
@@ -2103,13 +2107,13 @@ def test_all_hosts_bulk_cve_reassign(
     module_cv = target_sat.api.ContentView(id=module_cv.id).read()
     module_cv = cv_publish_promote(target_sat, module_org, module_cv, module_lce)['content-view']
     module_cv = cv_publish_promote(target_sat, module_org, module_cv, lce2)['content-view']
+    cvenv_id = target_sat.api_factory.get_cvenv_id(module_cv, module_lce)
     for _ in range(3):
         target_sat.api.Host(
             organization=module_org,
             location=module_location,
             content_facet_attributes={
-                'content_view_id': module_cv.id,
-                'lifecycle_environment_id': module_lce.id,
+                'content_view_environment_ids': [cvenv_id],
             },
         ).create()
     with target_sat.ui_session() as session:

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -359,9 +359,7 @@ def test_positive_add_host(session, module_target_sat):
         organization=org,
         location=loc,
         content_facet_attributes={
-            'content_view_environment_ids': [
-                module_target_sat.api_factory.get_cvenv_id(cv, lce)
-            ],
+            'content_view_environment_ids': [module_target_sat.api_factory.get_cvenv_id(cv, lce)],
         },
     ).create()
     with session:

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -358,7 +358,11 @@ def test_positive_add_host(session, module_target_sat):
     host = module_target_sat.api.Host(
         organization=org,
         location=loc,
-        content_facet_attributes={'content_view_id': cv.id, 'lifecycle_environment_id': lce.id},
+        content_facet_attributes={
+            'content_view_environment_ids': [
+                module_target_sat.api_factory.get_cvenv_id(cv, lce)
+            ],
+        },
     ).create()
     with session:
         session.organization.select(org_name=org.name)
@@ -665,8 +669,9 @@ def test_negative_hosts_limit(module_target_sat, module_org_with_parameter, smar
                 organization=module_org_with_parameter,
                 location=smart_proxy_location,
                 content_facet_attributes={
-                    'content_view_id': cv.id,
-                    'lifecycle_environment_id': lce.id,
+                    'content_view_environment_ids': [
+                        module_target_sat.api_factory.get_cvenv_id(cv, lce)
+                    ],
                 },
             ).create()
         )

--- a/tests/foreman/ui/test_imagemode.py
+++ b/tests/foreman/ui/test_imagemode.py
@@ -257,10 +257,10 @@ def test_positive_oscap_remediation_bootc(module_org, default_smart_proxy, targe
     assert len(content_view.version) == 1, "CV not published"
     version = content_view.version[0].read()
     version.promote(data={'environment_ids': lifecycle_env.id, 'force': True})
+    cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lifecycle_env)
     activation_key = target_sat.api.ActivationKey(
         name=ak_name,
-        environment=lifecycle_env,
-        content_view=content_view,
+        content_view_environment_ids=[cvenv_id],
         organization=module_org,
     ).create()
     # Setup org for a custom repo for RHEL10

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -61,13 +61,13 @@ def test_positive_check_dashboard(
     content_view.publish()
     content_view = content_view.read()
     content_view.version[0].promote(data={'environment_ids': lce.id})
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(content_view, lce)
     module_target_sat.api.Host(
         hostgroup=module_host_group,
         location=default_location,
         organization=default_org,
         content_facet_attributes={
-            'content_view_id': content_view.id,
-            'lifecycle_environment_id': lce.id,
+            'content_view_environment_ids': [cvenv_id],
         },
     ).create()
     module_target_sat.api.ScapContents(

--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -322,9 +322,12 @@ def test_global_registration_form_populate(
     ).create()
     target_sat.api.HostGroup(name=hg_nested_name, parent=parent_hg).create()
     new_org = target_sat.api.Organization().create()
+    cvenv_id = target_sat.api_factory.get_cvenv_id(
+        new_org.default_content_view,
+        target_sat.api.LifecycleEnvironment(id=new_org.library.id),
+    )
     new_ak = target_sat.api.ActivationKey(
-        content_view=new_org.default_content_view,
-        environment=target_sat.api.LifecycleEnvironment(id=new_org.library.id),
+        content_view_environment_ids=[cvenv_id],
         organization=new_org,
     ).create()
     with target_sat.ui_session() as session:
@@ -693,8 +696,9 @@ def test_global_registration_with_capsule_host(
 
     assert len(cv.version) == 1
 
+    cvenv_id = target_sat.api_factory.get_cvenv_id(cv, module_lce_library)
     activation_key = target_sat.api.ActivationKey(
-        content_view=cv, environment=module_lce_library, organization=module_org
+        content_view_environment_ids=[cvenv_id], organization=module_org
     ).create()
 
     # Assert that a task to sync lifecycle environment to the capsule

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -67,8 +67,9 @@ def module_setup_content(module_sca_manifest_org, module_target_sat):
     cv.publish()
     cvv = cv.read().version[0].read()
     cvv.promote(data={'environment_ids': lce.id})
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(cv, lce)
     ak = module_target_sat.api.ActivationKey(
-        content_view=cv, organization=org, environment=lce
+        content_view_environment_ids=[cvenv_id], organization=org
     ).create()
     all_content = ak.product_content(data={'content_access_mode_all': '1'})['results']
     content_label = [repo['label'] for repo in all_content if repo['name'] == custom_repo.name][0]

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -106,11 +106,14 @@ def fixture_setup_rhc_satellite(
         ).create()
         content_view.publish()
         # Create Activation key
+        cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+            content_view,
+            module_target_sat.api.LifecycleEnvironment(id=module_rhc_org.library.id),
+        )
         ak = module_target_sat.api.ActivationKey(
             name=settings.rh_cloud.activation_key or gen_string('alpha'),
-            content_view=content_view,
+            content_view_environment_ids=[cvenv_id],
             organization=module_rhc_org,
-            environment=module_target_sat.api.LifecycleEnvironment(id=module_rhc_org.library.id),
         ).create()
         logger.debug(
             f"Activation key: {ak} \n CV: {content_view} \n Organization: {module_rhc_org}"

--- a/tests/new_upgrades/test_activation_key.py
+++ b/tests/new_upgrades/test_activation_key.py
@@ -63,8 +63,9 @@ def ak_upgrade_setup(content_upgrade_shared_satellite, upgrade_action):
         cv = target_sat.publish_content_view(org, [custom_repo], f'{test_name}_cv')
         assert len(cv.read_json()['versions']) == 1
         test_data.cv = cv
+        cvenv_id = target_sat.api_factory.get_cvenv_id(cv, org.library)
         ak = target_sat.api.ActivationKey(
-            content_view=cv, organization=org, environment=org.library.id, name=f'{test_name}_ak'
+            content_view_environment_ids=[cvenv_id], organization=org, name=f'{test_name}_ak'
         ).create()
         test_data.ak = ak
         ak.host_collection.append(

--- a/tests/new_upgrades/test_capsulecontent.py
+++ b/tests/new_upgrades/test_capsulecontent.py
@@ -75,8 +75,9 @@ def capsule_sync_setup(capsule_upgrade_integrated_sat_cap, upgrade_action):
         content_view = target_sat.publish_content_view(org, repo, f'{test_name}_content_view')
         content_view.version[0].promote(data={'environment_ids': [lce.id]})
         content_view_env_id = [env.id for env in content_view.read().environment]
+        cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lce)
         ak = target_sat.api.ActivationKey(
-            name=f'{test_name}_ak', organization=org.id, environment=lce, content_view=content_view
+            name=f'{test_name}_ak', organization=org.id, content_view_environment_ids=[cvenv_id]
         ).create()
         assert lce.id in content_view_env_id
         test_data = Box(

--- a/tests/new_upgrades/test_capsulecontent.py
+++ b/tests/new_upgrades/test_capsulecontent.py
@@ -218,11 +218,11 @@ def test_post_user_scenario_capsule_sync_yum_repo(capsule_sync_setup):
     content_view = target_sat.publish_content_view(org.id, repo, 'post_upgrade_sync_content_view')
     content_view.version[0].promote(data={'environment_ids': lce.id})
     content_view_env_id = [env.id for env in content_view.read().environment]
+    cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lce)
     ak = target_sat.api.ActivationKey(
         name='post_upgrade_sync_ak',
         organization=org.id,
-        environment=lce.id,
-        content_view=content_view,
+        content_view_environment_ids=[cvenv_id],
     ).create()
     ak_env = ak.environment.read()
     assert ak_env.id in content_view_env_id

--- a/tests/new_upgrades/test_client.py
+++ b/tests/new_upgrades/test_client.py
@@ -88,8 +88,9 @@ def pre_client_package_installation_setup(
         ).create()
         content_view = target_sat.publish_content_view(org, [repo], f'{test_name}_cv')
         content_view.version[0].promote(data={'environment_ids': lce.id})
+        cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lce)
         ak = target_sat.api.ActivationKey(
-            name=f'{test_name}_ak', organization=org.id, environment=lce, content_view=content_view
+            name=f'{test_name}_ak', organization=org.id, content_view_environment_ids=[cvenv_id]
         ).create()
         result = rhel_contenthost.api_register(
             target_sat,
@@ -186,11 +187,11 @@ def test_post_scenario_post_client_package_installation(pre_client_package_insta
     target_sat.api.Repository.sync(repo)
     content_view = target_sat.publish_content_view(org, [repo], f'{test_name}_cv_post_upgrade')
     content_view.version[0].promote(data={'environment_ids': lce.id})
+    cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lce)
     ak = target_sat.api.ActivationKey(
         name=f'{test_name}_ak_post_upgrade',
         organization=org.id,
-        environment=lce,
-        content_view=content_view,
+        content_view_environment_ids=[cvenv_id],
     ).create()
     result = rhel_client.api_register(
         target_sat,

--- a/tests/new_upgrades/test_errata.py
+++ b/tests/new_upgrades/test_errata.py
@@ -157,11 +157,11 @@ def generate_errata_for_client_setup(
         ]
         content_view = target_sat.publish_content_view(org, repolist, f'{test_name}_cv')
         test_data.content_view_id = content_view.id
+        cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, environment)
         ak = target_sat.api.ActivationKey(
             name=f'{test_name}_ak',
-            content_view=content_view,
+            content_view_environment_ids=[cvenv_id],
             organization=org.id,
-            environment=environment,
         ).create()
         test_data.activation_key = ak.name
         # Override/enable all AK repos (disabled by default since 6.15)

--- a/tests/new_upgrades/test_hostcontent.py
+++ b/tests/new_upgrades/test_hostcontent.py
@@ -54,10 +54,10 @@ def db_seed_host_mismatch_setup(
         default_location = target_sat.api.Location().search(
             query={'search': f'name="{DEFAULT_LOC}"'}
         )[0]
+        cvenv_id = target_sat.api_factory.get_cvenv_id(org.default_content_view, org.library)
         ak = target_sat.api.ActivationKey(
             name=f'{test_name}_ak',
-            content_view=org.default_content_view.id,
-            environment=org.library.id,
+            content_view_environment_ids=[cvenv_id],
             organization=org,
         ).create()
         rhel_contenthost.api_register(

--- a/tests/new_upgrades/test_remoteexecution.py
+++ b/tests/new_upgrades/test_remoteexecution.py
@@ -65,8 +65,9 @@ def remote_execution_external_capsule_setup(
         capsule.nailgun_capsule.content_add_lifecycle_environment(data={'environment_id': lce.id})
         content_view = target_sat.publish_content_view(org, [], f'{test_name}_cv')
         content_view.version[0].promote(data={'environment_ids': lce.id})
+        cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lce)
         ak = target_sat.api.ActivationKey(
-            name=f'{test_name}_ak', organization=org.id, environment=lce, content_view=content_view
+            name=f'{test_name}_ak', organization=org.id, content_view_environment_ids=[cvenv_id]
         ).create()
         test_data = Box(
             {
@@ -181,8 +182,9 @@ def remote_execution_satellite_setup(
         ).create()
         content_view = target_sat.publish_content_view(org, [], f'{test_name}_cv')
         content_view.version[0].promote(data={'environment_ids': lce.id})
+        cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lce)
         ak = target_sat.api.ActivationKey(
-            name=f'{test_name}_ak', organization=org.id, environment=lce, content_view=content_view
+            name=f'{test_name}_ak', organization=org.id, content_view_environment_ids=[cvenv_id]
         ).create()
         result = rhel_contenthost.api_register(
             target_sat,

--- a/tests/new_upgrades/test_repository.py
+++ b/tests/new_upgrades/test_repository.py
@@ -76,8 +76,9 @@ def custom_repo_check_setup(sat_upgrade_chost, content_upgrade_shared_satellite,
         content_view = target_sat.publish_content_view(org, repo, test_name)
         test_data.content_view = content_view
         content_view.version[0].promote(data={'environment_ids': lce.id})
+        cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lce)
         ak = target_sat.api.ActivationKey(
-            content_view=content_view, organization=org.id, environment=lce, name=test_name
+            content_view_environment_ids=[cvenv_id], organization=org.id, name=test_name
         ).create()
         sat_upgrade_chost.api_register(
             target_sat, organization=org, activation_keys=[ak.name], location=None

--- a/tests/new_upgrades/test_rhcloud_iop.py
+++ b/tests/new_upgrades/test_rhcloud_iop.py
@@ -54,11 +54,14 @@ def iop_recommendations_upgrade_setup(
         manifest = Manifester(manifest_category=settings.manifest.golden_ticket)
         target_sat.upload_manifest(org.id, manifest.get_manifest().content)
 
+        cvenv_id = target_sat.api_factory.get_cvenv_id(
+            org.default_content_view,
+            target_sat.api.LifecycleEnvironment(id=org.library.id),
+        )
         activation_key = target_sat.api.ActivationKey(
             name=f'{test_name}_ak',
-            content_view=org.default_content_view,
+            content_view_environment_ids=[cvenv_id],
             organization=org,
-            environment=target_sat.api.LifecycleEnvironment(id=org.library.id),
         ).create()
 
         # Enable RHEL OS repos so insights-client can be installed during registration

--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -40,8 +40,9 @@ class TestActivationKey:
         lce = target_sat.api.LifecycleEnvironment(organization=org).search(
             query={'search': 'name=Library'}
         )[0]
+        cvenv_id = target_sat.api_factory.get_cvenv_id(cv, lce)
         ak = target_sat.api.ActivationKey(
-            content_view=cv, environment=lce, organization=org, name=f"{request.param}_ak"
+            content_view_environment_ids=[cvenv_id], organization=org, name=f"{request.param}_ak"
         ).create()
         return {'org': org, 'cv': cv, 'ak': ak, 'custom_repo': custom_repo}
 

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -147,8 +147,9 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
             *synced_repos,
         ]
         content_view = target_sat.publish_content_view(function_org, repolist)
+        cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, environment)
         ak = target_sat.api.ActivationKey(
-            content_view=content_view, organization=function_org, environment=environment
+            content_view_environment_ids=[cvenv_id], organization=function_org
         ).create()
         # Override/enable all AK repos (disabled by default since 6.15)
         c_labels = [

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -55,9 +55,11 @@ class TestScenarioDBseedHostMismatch:
 
         :customerscenario: true
         """
-        ak = self.api.ActivationKey(
-            content_view=function_org.default_content_view.id,
-            environment=function_org.library.id,
+        cvenv_id = target_sat.api_factory.get_cvenv_id(
+            function_org.default_content_view, function_org.library
+        )
+        ak = target_sat.api.ActivationKey(
+            content_view_environment_ids=[cvenv_id],
             organization=function_org,
         ).create()
         rhel7_contenthost_module.register(function_org, function_location, ak.name, target_sat)

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -143,8 +143,9 @@ class TestScenarioCustomRepoCheck:
         repo.sync()
         content_view = target_sat.publish_content_view(org, repo)
         content_view.version[0].promote(data={'environment_ids': lce.id})
+        cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lce)
         ak = target_sat.api.ActivationKey(
-            content_view=content_view, organization=org.id, environment=lce
+            content_view_environment_ids=[cvenv_id], organization=org.id
         ).create()
         # Override/enable all AK repos (disabled by default since 6.15)
         c_labels = [


### PR DESCRIPTION
### Problem Statement

Katello 4.21 removes the deprecated separate `content_view_id` and `lifecycle_environment_id` API parameters from activation keys, hosts, and hostgroups. These were replaced by `content_view_environment_ids` / `content_view_environment_id` in 6.19.

### Solution

- Add `get_cvenv_id()` helper to `api_factory` for looking up ContentViewEnvironment IDs from CV+LCE pairs
- Update all activation key creations to use `content_view_environment_ids=[cvenv_id]` instead of `content_view=cv, environment=lce`
- Update all host `content_facet_attributes` to use `content_view_environment_ids` instead of separate `content_view_id`/`lifecycle_environment_id`
- Update all hostgroup creations to use `content_view_environment_id=cvenv_id` instead of separate `content_view`/`lifecycle_environment`

Read-side assertions (`ak.content_view.id`, `ak.environment.read()`, etc.) are preserved via nailgun backward-compat properties.

### Related Issues

- Depends on nailgun PR: https://github.com/SatelliteQE/nailgun/pull/1419
- Katello PR: https://github.com/Katello/katello/pull/11753

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrate tests and helpers to use content view environment IDs instead of separate content view and lifecycle environment parameters.

New Features:
- Add an API factory helper to look up ContentViewEnvironment IDs from content view and lifecycle environment pairs.

Enhancements:
- Update activation key, host, and hostgroup helpers to set content_view_environment_ids consistently when registering or provisioning resources.

Tests:
- Refresh API and UI tests, fixtures, and provisioning scenarios to create and update entities via content_view_environment_ids rather than deprecated content_view_id and lifecycle_environment_id fields.