### PR TITLE
Use module-scoped fixtures for new_upgrades/test_classparameter.py

### DIFF
--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -302,6 +302,28 @@ def capsule_upgrade_integrated_sat_cap(
     return setup_data
 
 
+@pytest.fixture(scope='module')
+def module_puppet_upgrade_shared_satellite():
+    """Mark tests using this fixture with pytest.mark.puppet_upgrades"""
+    sat_instance = shared_checkout("module_puppet_upgrade")
+    with (
+        SharedResource(
+            "module_puppet_upgrade_enable_puppet",
+            action=sat_instance.enable_puppet_satellite,
+            action_is_recoverable=True,
+        ) as enable_puppet,
+        SharedResource(
+            "module_puppet_upgrade_tests",
+            shared_checkin,
+            sat_instance=sat_instance,
+            action_is_recoverable=True,
+        ) as test_duration,
+    ):
+        enable_puppet.ready()
+        yield sat_instance
+        test_duration.ready()
+
+
 @pytest.fixture
 def puppet_upgrade_shared_satellite():
     """Mark tests using this fixture with pytest.mark.puppet_upgrades"""

--- a/tests/new_upgrades/test_classparameter.py
+++ b/tests/new_upgrades/test_classparameter.py
@@ -13,28 +13,23 @@
 """
 
 import json
-import os
-from time import sleep
 
-from box import Box
 import pytest
 
+from robottelo.config import settings
 from robottelo.utils.shared_resource import SharedResource
 
-
-def _valid_sc_parameters_data():
-    """Returns a list of valid smart class parameter types and values"""
-    return [
-        {'sc_type': 'string', 'value': '\u6120\U000201fc\u3a07\U0002b2cf\u45b9\u7d3c\U00026dea'},
-        {'sc_type': 'boolean', 'value': '1'},
-        {'sc_type': 'boolean', 'value': '0'},
-        {'sc_type': 'integer', 'value': 4541321256269544184},
-        {'sc_type': 'real', 'value': -123.0},
-        {'sc_type': 'array', 'value': "['JkKAxzCvIw', '343532124', 'False']"},
-        {'sc_type': 'hash', 'value': '{"SAEasshgd": "ASDFDdsss"}'},
-        {'sc_type': 'yaml', 'value': 'name=>XYZ'},
-        {'sc_type': 'json', 'value': '{"name": "XYZ"}'},
-    ]
+VALID_SC_PARAMS_DATA = [
+    {'sc_type': 'string', 'value': '\u6120\U000201fc\u3a07\U0002b2cf\u45b9\u7d3c\U00026dea'},
+    {'sc_type': 'boolean', 'value': '1'},
+    {'sc_type': 'boolean', 'value': '0'},
+    {'sc_type': 'integer', 'value': 4541321256269544184},
+    {'sc_type': 'real', 'value': -123.0},
+    {'sc_type': 'array', 'value': "['JkKAxzCvIw', '343532124', 'False']"},
+    {'sc_type': 'hash', 'value': '{"SAEasshgd": "ASDFDdsss"}'},
+    {'sc_type': 'yaml', 'value': 'name=>XYZ'},
+    {'sc_type': 'json', 'value': '{"name": "XYZ"}'},
+]
 
 
 def _validate_value(data, sc_param):
@@ -56,9 +51,10 @@ def _validate_value(data, sc_param):
         assert sc_param.default_value == data['value']
 
 
-@pytest.fixture(params=list(range(1, 10)))
-def puppet_class_parameter_data_and_type_setup(
-    puppet_upgrade_shared_satellite, upgrade_action, request
+@pytest.fixture(scope='module')
+def module_puppet_class_parameter_data_and_type_setup(
+    module_puppet_upgrade_shared_satellite,
+    upgrade_action,
 ):
     """Puppet Class parameters with different data type are created
 
@@ -70,47 +66,38 @@ def puppet_class_parameter_data_and_type_setup(
 
     :expectedresults: The parameters are updated with different data types
     """
-    target_sat = puppet_upgrade_shared_satellite
+    target_sat = module_puppet_upgrade_shared_satellite
     with SharedResource(target_sat.hostname, upgrade_action, target_sat=target_sat) as sat_upgrade:
-        test_data = Box(
-            {
-                'target_sat': target_sat,
-                'count': None,
-            }
-        )
-        repo = 'api_test_classparameters'
-        # Hitting the import_puppetclasses API endpoint multiple times at once causes frequent
-        # 500 ISE errors, so stagger execution of the `create_custom_environment` method. The
-        # Xdist worker number is used as the basis for the splay because a random splay could
-        # still cause collisions. Since the first worker number is 0, we need to add 1 to the
-        # Xdist worker number before multiplying by the length of the splay.
-        xdist_worker_splay = (int(os.environ.get("PYTEST_XDIST_WORKER")[-1]) + 1) * 20
-        sleep(xdist_worker_splay)
-        env_name = target_sat.create_custom_environment(repo=repo)
-        puppet_class = target_sat.api.PuppetClass().search(
-            query={'search': f'name = "{repo}" and environment = "{env_name}"'}
-        )[0]
-        data = _valid_sc_parameters_data()[request.param - 1]
-        sc_param = target_sat.api.SmartClassParameters().search(
-            query={'search': f'parameter="api_classparameters_scp_00{request.param}"'}
-        )[0]
-        sc_param.override = True
-        sc_param.parameter_type = data['sc_type']
-        sc_param.default_value = data['value']
-        sc_param.update(['override', 'parameter_type', 'default_value'])
-        sc_param = sc_param.read()
-        assert sc_param.parameter_type == data['sc_type']
-        _validate_value(data, sc_param)
-        test_data.puppet_class = puppet_class.name
-        test_data.count = request.param
+        target_sat.create_custom_environment(repo='api_test_classparameters')
+
+        for index, data in enumerate(VALID_SC_PARAMS_DATA):
+            sc_param = target_sat.api.SmartClassParameters().search(
+                query={'search': f'parameter="api_classparameters_scp_00{index + 1}"'}
+            )[0]
+
+            sc_param.override = True
+            sc_param.parameter_type = data['sc_type']
+            sc_param.default_value = data['value']
+            sc_param.update(['override', 'parameter_type', 'default_value'])
+            sc_param = sc_param.read()
+
+            assert sc_param.parameter_type == data['sc_type']
+            _validate_value(data, sc_param)
+
         sat_upgrade.ready()
+        target_sat._swap_nailgun(settings.upgrade.to_version)
         target_sat._session = None
-        yield test_data
+        yield target_sat
 
 
 @pytest.mark.puppet_upgrades
+@pytest.mark.parametrize(
+    'sc_data',
+    [p for p in enumerate(VALID_SC_PARAMS_DATA)],
+    ids=range(1, len(VALID_SC_PARAMS_DATA) + 1),
+)
 def test_post_puppet_class_parameter_data_and_type(
-    puppet_class_parameter_data_and_type_setup,
+    module_puppet_class_parameter_data_and_type_setup, sc_data
 ):
     """Puppet Class Parameters value and type is intact post upgrade
 
@@ -128,11 +115,10 @@ def test_post_puppet_class_parameter_data_and_type(
     :expectedresults: The puppet class parameters data and type should be
         intact post upgrade
     """
-    target_sat = puppet_class_parameter_data_and_type_setup.target_sat
-    count = puppet_class_parameter_data_and_type_setup.count
-    data = _valid_sc_parameters_data()[count - 1]
+    target_sat = module_puppet_class_parameter_data_and_type_setup
+    index, my_param = sc_data
     sc_param = target_sat.api.SmartClassParameters().search(
-        query={'search': f'parameter="api_classparameters_scp_00{count}"'}
+        query={'search': f'parameter="api_classparameters_scp_00{index + 1}"'}
     )[0]
-    assert sc_param.parameter_type == data['sc_type']
-    _validate_value(data, sc_param)
+    assert sc_param.parameter_type == my_param['sc_type']
+    _validate_value(my_param, sc_param)


### PR DESCRIPTION
### Problem Statement

- Endeavour Upgrade test suites take a long time to run, with a large number of Satellites deployed
- For example, just the puppet class parameter tests in recent 6.19-to-stream upgrade-scenario CI jobs for team Endeavour  take ~170 minutes total for 9 tests deploying 9 separate Satellites. They are currently all run sequentially, but even with maximum concurrency of 4 xdist workers running 9 tests, that would involve 3 separate Satellite deployments (4 + 4 + 1).

### Solution

Refactor the puppet class parameter tests to use module-scoped fixtures, where all of the puppet imports and initial class parameter setup is done first on a single Satellite, which is then used by all of the tests, whether run in parallel or sequentially by xdist. (See the tests and fixtures in tests/new_upgrades/test_pulp.py for an example of how this is already done.)

```
$ pytest tests/new_upgrades/test_classparameter.py
[...]
=== 9 passed, 36 warnings in 2206.99s (0:36:46) ===
```
### Related Issues

SAT-40414

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Refactor puppet class parameter upgrade tests to use module-scoped fixtures and shared setup to reduce Satellite deployments and speed up execution.

Enhancements:
- Introduce a module-scoped satellite fixture for puppet upgrade tests to reuse a single Satellite instance across tests.
- Centralize valid smart class parameter definitions in a shared constant for reuse and clarity.
- Simplify smart class parameter setup by configuring all parameter types in a single setup flow and swapping the Satellite version once per module.

Tests:
- Rework puppet class parameter upgrade tests to consume module-scoped fixtures and parametrized smart class parameter data instead of per-test setup with xdist-specific splaying.