### PR TITLE
Fix timing issue in test_positive_erratum_installable

### DIFF
--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -181,6 +181,8 @@ def test_positive_erratum_installable(vm, module_target_sat):
     :CaseImportance: Critical
     """
     errata_id = REAL_RHEL10_ERRATA_ID if vm.os_version.major == 10 else REAL_RHEL9_ERRATA_ID
+    host_id = module_target_sat.cli.Host.info({'name': vm.hostname})['id']
+    module_target_sat.cli.Host.errata_recalculate({'host-id': host_id})
     # check that package errata is applicable
     for _ in range(30):
         erratum = module_target_sat.cli.Host.errata_list(


### PR DESCRIPTION
## Summary
- Fixes CI timing failure where `test_positive_erratum_installable` was failing to find expected erratum
- Added explicit `Host.errata_recalculate()` call before polling for errata

## Problem
The test was relying on errata recalculation from the module fixture, which could complete well before the test runs in CI environments. The delay between fixture setup and test execution caused errata applicability data to become stale.

## Solution
Added explicit `Host.errata_recalculate()` call immediately before polling, matching the pattern used in `test_positive_list_installable_updates`.

## Test plan
- [x] Test passes locally with the fix applied
- [x] Both RHEL 9 and RHEL 10 variants pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent intermittent CI failures in the erratum installable test by forcing a host errata recalculation before polling for results.