### PR TITLE
[6.17.z] Also use shortened hostname in parametrized_enrolled_sat fixture

### DIFF
--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -500,6 +500,10 @@ def sessions_tear_down(parametrized_enrolled_sat):
     parametrized_enrolled_sat.execute(
         f'rm -f {HAMMER_SESSIONS}/https_{parametrized_enrolled_sat.hostname}'
     )
+    if hasattr(parametrized_enrolled_sat, 'shortened_hostname'):
+        parametrized_enrolled_sat.execute(
+            f'rm -f {HAMMER_SESSIONS}/https_{parametrized_enrolled_sat.shortened_hostname}'
+        )
 
 
 @pytest.fixture

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -295,7 +295,9 @@ def parametrized_enrolled_sat(
         yield new_sat
         ipa_host.disenroll_idm()
     else:
-        new_sat.enroll_ad_and_configure_external_auth(ad_data)
+        shortened_hostname = new_sat.enroll_ad_and_configure_external_auth(ad_data)
+        if shortened_hostname is not None:
+            new_sat.shortened_hostname = shortened_hostname
         yield new_sat
     new_sat.unregister()
     new_sat.teardown()

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -857,6 +857,10 @@ def test_positive_negotiate_logout(
         2. Hammer command fails after log out.
         3. Proper messages are returned in all cases.
     """
+    hostname = (
+        getattr(parametrized_enrolled_sat, 'shortened_hostname', None)
+        or parametrized_enrolled_sat.hostname
+    )
     auth_type = request.node.callspec.params['parametrized_enrolled_sat']
     user = (
         settings.ipa.user
@@ -873,9 +877,7 @@ def test_positive_negotiate_logout(
     # Log out, verify the hammer sessions was closed
     result = parametrized_enrolled_sat.cli.Auth.logout()
     assert 'Logged out.' in str(result)
-    result = parametrized_enrolled_sat.execute(
-        f'cat {HAMMER_SESSIONS}/https_{parametrized_enrolled_sat.hostname}'
-    )
+    result = parametrized_enrolled_sat.execute(f'cat {HAMMER_SESSIONS}/https_{hostname}')
     assert '"id":null' in result.stdout
     result = parametrized_enrolled_sat.cli.Auth.status()
     assert NO_SESSION_BUT_KERB_MSG in str(result)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21640

### Problem Statement
When a Satellite is enrolled with AD, enroll_ad_and_configure_external_auth may return a shortened hostname. The hammer session file is created using this short name, but the test and teardown look it up using the full FQDN, causing a mismatch.

### Solution
- Capture the shortened hostname returned by enroll_ad_and_configure_external_auth and store it on the satellite object as shortened_hostname.
- Use the shortened hostname (when available) in test_positive_negotiate_logout when checking hammer session files.
- Clean up the shortened-hostname session file in sessions_tear_down.

### Related Issues
https://github.com/SatelliteQE/robottelo/pull/20735

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Handle shortened hostnames for AD-enrolled Satellites when managing hammer session files in tests and fixtures.

Bug Fixes:
- Ensure hammer session files are checked using the shortened hostname when AD enrollment returns one.
- Ensure teardown removes hammer session files created with either full or shortened hostnames.

Enhancements:
- Capture and store the shortened hostname returned from AD enrollment on the Satellite fixture when available.