### PR TITLE
[6.19.z] Fix puppet plugin enablement test for OpenVox

### DIFF
--- a/tests/foreman/destructive/test_puppetplugin.py
+++ b/tests/foreman/destructive/test_puppetplugin.py
@@ -38,9 +38,12 @@ def assert_puppet_status(server, expected):
     assert ('puppet' in result) is expected
     assert ('puppetca' in result) is expected
 
-    result = server.execute('rpm -q puppetserver')
-    assert (result.status == 0) is expected
-    assert ('package puppetserver is not installed' in result.stdout) is not expected
+    result = server.execute('rpm -q --whatprovides puppetserver')
+    assert (result.status == 0) is expected, (
+        'No package provides puppetserver capability'
+        if expected
+        else 'puppetserver capability is provided when it should not be'
+    )
 
     result = server.execute('systemctl status puppetserver')
     assert ('active (running)' in result.stdout) is expected


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21651

### Problem Statement
With OpenVox puppet plugin enablement test is failing at RPM check:
```
tests/foreman/destructive/test_puppetplugin.py:97: in test_positive_enable_disable_logic
    assert_puppet_status(target_sat, expected=True)
tests/foreman/destructive/test_puppetplugin.py:42: in assert_puppet_status
    assert (result.status == 0) is expected
E   assert (1 == 0) is True
E    +  where 1 = stdout:\npackage puppetserver is not installed\n\nstderr:\n\nstatus: 1.status
```
### Solution
Allow OpenVox or Perforce puppet server to be installed (they both provide `puppetserver`)

### Related Issues
[SAT-44510](https://redhat.atlassian.net/browse/SAT-44510)
[SAT-45007](https://redhat.atlassian.net/browse/SAT-45007)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Fix Puppet plugin enablement test failure on systems where puppetserver is provided by a different package such as OpenVox or Perforce.