### PR TITLE
SRPM cases cleanup

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -703,35 +703,6 @@ class TestRepository:
         repo.remove_content(data={'ids': [srpm_detail[0].id], 'content_type': 'srpm'})
         assert repo.read().content_counts['srpm'] == 0
 
-    @pytest.mark.upgrade
-    @pytest.mark.skip('Uses deprecated SRPM repository')
-    @pytest.mark.skipif(
-        (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
-    )
-    @pytest.mark.parametrize(
-        'repo_options',
-        [{'url': repo_constants.FAKE_YUM_SRPM_REPO}],
-        ids=['yum_fake'],
-        indirect=True,
-    )
-    def test_positive_create_delete_srpm_repo(self, repo, target_sat):
-        """Create a repository, sync SRPM contents and remove repo
-
-        :id: e091a725-042f-43ca-99cc-c017c450ced9
-
-        :parametrized: yes
-
-        :expectedresults: The repository's contents include SRPM and able to remove repo
-
-        :CaseImportance: Critical
-        """
-        repo.sync()
-        assert repo.read().content_counts['srpm'] == 3
-        assert len(target_sat.api.Srpms().search(query={'repository_id': repo.id})) == 3
-        repo.delete()
-        with pytest.raises(HTTPError):
-            repo.read()
-
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -2154,6 +2125,34 @@ class TestDockerRepository:
 
 class TestSRPMRepository:
     """Tests specific to using repositories containing source RPMs."""
+
+    @pytest.mark.upgrade
+    @pytest.mark.skipif(
+        (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
+    )
+    @pytest.mark.parametrize(
+        'repo_options',
+        [{'url': repo_constants.FAKE_YUM_SRPM_REPO}],
+        ids=['yum_fake'],
+        indirect=True,
+    )
+    def test_positive_create_delete_srpm_repo(self, repo, target_sat):
+        """Create a repository, sync SRPM contents and remove repo
+
+        :id: e091a725-042f-43ca-99cc-c017c450ced9
+
+        :parametrized: yes
+
+        :expectedresults: The repository's contents include SRPM and able to remove repo
+
+        :CaseImportance: Critical
+        """
+        repo.sync()
+        assert repo.read().content_counts['srpm'] == 3
+        assert len(target_sat.api.Srpms().search(query={'repository_id': repo.id})) == 3
+        repo.delete()
+        with pytest.raises(HTTPError):
+            repo.read()
 
     @pytest.mark.upgrade
     def test_positive_srpm_upload_publish_promote_cv(

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -41,7 +41,6 @@ from robottelo.constants.repos import (
     CUSTOM_RPM_SHA,
     FAKE_5_YUM_REPO,
     FAKE_YUM_MD5_REPO,
-    FAKE_YUM_SRPM_REPO,
 )
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.logging import logger
@@ -52,7 +51,6 @@ from robottelo.utils.datafactory import (
     valid_docker_repository_names,
     valid_http_credentials,
 )
-from tests.foreman.api.test_contentview import content_view
 
 YUM_REPOS = (
     settings.repos.yum_0.url,
@@ -2092,91 +2090,6 @@ class TestRepository:
 #         Repository.delete({'id': repo['id']})
 #         with pytest.raises(CLIReturnCodeError):
 #             Repository.info({'id': repo['id']})
-
-
-class TestSRPMRepository:
-    """Tests specific to using repositories containing source RPMs."""
-
-    @pytest.mark.skip("Uses deprecated SRPM repository")
-    @pytest.mark.parametrize(
-        'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
-    )
-    def test_positive_sync(self, repo, module_org, module_product, target_sat):
-        """Synchronize repository with SRPMs
-
-        :id: eb69f840-122d-4180-b869-1bd37518480c
-
-        :parametrized: yes
-
-        :expectedresults: srpms can be listed in repository
-        """
-        target_sat.cli.Repository.synchronize({'id': repo['id']})
-        result = target_sat.execute(
-            f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
-            f"/custom/{module_product.label}/{repo['label']}/Packages/t/ | grep .src.rpm"
-        )
-        assert result.status == 0
-        assert result.stdout
-
-    @pytest.mark.skip("Uses deprecated SRPM repository")
-    @pytest.mark.parametrize(
-        'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
-    )
-    def test_positive_sync_publish_cv(self, module_org, module_product, repo, target_sat):
-        """Synchronize repository with SRPMs, add repository to content view
-        and publish content view
-
-        :id: 78cd6345-9c6c-490a-a44d-2ad64b7e959b
-
-        :parametrized: yes
-
-        :expectedresults: srpms can be listed in content view
-        """
-        target_sat.cli.Repository.synchronize({'id': repo['id']})
-        cv = target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
-        target_sat.cli.ContentView.add_repository({'id': cv['id'], 'repository-id': repo['id']})
-        target_sat.cli.ContentView.publish({'id': cv['id']})
-        result = target_sat.execute(
-            f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/content_views/"
-            f"{cv['label']}/1.0/custom/{module_product.label}/{repo['label']}/Packages/t/"
-            " | grep .src.rpm"
-        )
-        assert result.status == 0
-        assert result.stdout
-
-    @pytest.mark.upgrade
-    @pytest.mark.skip("Uses deprecated SRPM repository")
-    @pytest.mark.parametrize(
-        'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
-    )
-    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, target_sat):
-        """Synchronize repository with SRPMs, add repository to content view,
-        publish and promote content view to lifecycle environment
-
-        :id: 3d197118-b1fa-456f-980e-ad1a517bc769
-
-        :parametrized: yes
-
-        :expectedresults: srpms can be listed in content view in proper
-            lifecycle environment
-        """
-        lce = target_sat.cli_factory.make_lifecycle_environment({'organization-id': module_org.id})
-        target_sat.cli.Repository.synchronize({'id': repo['id']})
-        cv = target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
-        target_sat.cli.ContentView.add_repository({'id': cv['id'], 'repository-id': repo['id']})
-        target_sat.cli.ContentView.publish({'id': cv['id']})
-        target_sat.cli.content_view = target_sat.cli.ContentView.info({'id': cv['id']})
-        cvv = content_view['versions'][0]
-        target_sat.cli.ContentView.version_promote(
-            {'id': cvv['id'], 'to-lifecycle-environment-id': lce['id']}
-        )
-        result = target_sat.execute(
-            f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/{lce['label']}/"
-            f"{cv['label']}/custom/{module_product.label}/{repo['label']}/Packages/t"
-            " | grep .src.rpm"
-        )
-        assert result.status == 0
-        assert result.stdout
 
 
 class TestAnsibleCollectionRepository:


### PR DESCRIPTION
### Problem Statement
Currently we have a weird mix of SRPM tests - some are executed and other ones are skipped (allegedly deprecated) across different components.

The truth about the skipped tests is that they are actually testing pulp2 functionality (distribution paths on filesystem), which is not a thing since Satellite 6.10 and above runs pulp3. Thus I feel quite comfortable to remove them completely. Another skipped test should be good for execution, it should be just placed in the `TestSRPMRepository` class.


### Solution
This PR.


### PRT test Cases example
```
trigger: test-robottelo
network_type: ipv6
pytest: tests/foreman/api/test_repository.py::TestSRPMRepository
```

## Summary by Sourcery

Clean up SRPM-related tests by removing deprecated pulp2-based scenarios and consolidating SRPM repository coverage under the API test suite.

Enhancements:
- Remove obsolete SRPM CLI tests that relied on deprecated filesystem-based pulp2 distribution paths.
- Eliminate an unused import from the CLI repository tests module.

Tests:
- Move and enable the SRPM repository create/sync/delete test under TestSRPMRepository in the API test suite, keeping SRPM test coverage focused and up to date.