### PR TITLE
[6.18.z] Update logic of ContentHost's network_type method

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -155,7 +155,11 @@ class ContentHost(Host, ContentHostMixins):
     @property
     def network_type(self):
         if not hasattr(self, '_net_type'):
-            self._net_type = NetworkType(settings.content_host.network_type)
+            broker_args = getattr(self, '_broker_args', None) or {}
+            if nt := broker_args.get('net_type'):
+                self._net_type = NetworkType(nt)
+            else:
+                self._net_type = NetworkType(settings.content_host.network_type)
         return self._net_type
 
     @classmethod


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21620

### Problem statement
In dualstack scenarios, all IPv6-parametrized tests that depend on proxy configuration (e.g., `test_subscription_manager_install_from_repository[rhel*-ipv6]`) fail because the IPv6 content host never gets its dnf/rhsm proxy configured.

The broker container provider's construct_host only passes hostname, name, and broker_settings to the ContentHost constructor — the net_type kwarg is stored in _broker_args but never reaches __init__, so _net_type is never set. 
The network_type property then falls back to settings.content_host.network_type, which in a dualstack scenario resolves to NetworkType.DUALSTACK. 
Since DUALSTACK.has_ipv4 == True, the proxy setup in enable_ipv6_dnf_and_rhsm_proxy() is silently skipped, and the IPv6 container cannot reach external HTTP resources like download.devel.redhat.com.

### Solution
Update the ContentHost.network_type property to recover net_type from _broker_args (where broker actually stores the per-host network type) before falling back to the global setting. 
This ensures IPv6 content hosts in dualstack scenarios are correctly identified and get their proxy configured.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_registration.py::test_subscription_manager_install_from_repository
network_type: dualstack
```

## Summary by Sourcery

Bug Fixes:
- Ensure IPv6 content hosts in dualstack environments correctly derive their network type so proxy configuration is applied as expected.