### PR TITLE
[6.16.z] Fix test_positive_global_registration_end_to_end flakiness

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -11,7 +11,7 @@
 :Team: Proton
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import re
 
 from airgun.exceptions import DisabledWidgetError
@@ -222,12 +222,17 @@ def test_positive_global_registration_end_to_end(
         assert result.status == 0
     result = rhel_contenthost.execute('subscription-manager identity')
     assert result.status == 0
-    # Assert that a yum update was made this day ("Update" or "I, U" in history)
+    # Assert that a yum update was made today ("Update" or "I, U" in history)
     timezone_offset = rhel_contenthost.execute('date +"%:z"').stdout.strip()
     tzinfo = datetime.strptime(timezone_offset, '%z').tzinfo
     result = rhel_contenthost.execute('yum history | grep -E "I|U"')
     assert result.status == 0
-    assert datetime.now(tzinfo).strftime('%Y-%m-%d') in result.stdout
+    now = datetime.now(tzinfo)
+    today = now.strftime('%Y-%m-%d')
+    yesterday = (now - timedelta(days=1)).strftime('%Y-%m-%d')
+    assert today in result.stdout or yesterday in result.stdout, (
+        f'Expected yum history to contain {today} or {yesterday}, got:\n{result.stdout}'
+    )
     # Set "Connect to host using IP address"
     module_target_sat.api.Parameter(
         host=rhel_contenthost.hostname,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21668

### Problem Statement
The `test_positive_global_registration_end_to_end` test fails intermittently due to a date-boundary race condition. 
The test asserts that today's date appears in yum history output, but when the test runs
near midnight in the content host's local timezone, the yum operations can complete just before midnight (e.g., 2026-05-14 23:59) while the assertion executes just after midnight (e.g., 2026-05-15 00:00:53). 
This causes the date check to fail because datetime.now() returns the next day's date, which doesn't match any entry in yum history.

### Solution
Accept either today's or yesterday's date in the yum history assertion, accounting for the possibility that operations span the midnight boundary in the content host's timezone.

### Error message 
```
<section class="jenkins-section" style="box-sizing: inherit; border-top: 1.25px solid color(srgb 0.893047 0.91414 0.943708); max-width: 1800px; padding: 26px 0px 0px; color: oklch(0.05 0.075 256.91); font-family: system-ui, &quot;Segoe UI&quot;, roboto, &quot;Noto Sans&quot;, oxygen, ubuntu, cantarell, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(254, 254, 254); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
--------------------------------- Captured Err --------------------------------- 2026-05-15 04:00:53 - robottelo - ERROR - Test phase 'call' failed for test: tests/foreman/ui/test_registration.py::test_positive_global_registration_end_to_end[rhel9-ipv4] 2026-05-15 04:00:53 - robottelo - ERROR - Exception thrown:     tests/foreman/ui/test_registration.py:232: in test_positive_global_registration_end_to_end         assert datetime.now(tzinfo).strftime('%Y-%m-%d') in result.stdout     E   AssertionError: assert '2026-05-15' in 'Updating Subscription Management repositories.\nID     \| Command line             \| Date and time    \| Action(s)      \| Altered\n     9 \| -y update                \| 2026-05-14 23:59 \| C, E, I, U     \|   18   \n     8 \| install -y insights-clie \| 2026-05-14 23:58 \| Upgrade        \|    1   \n     7 \| install -y rabbit-1.5.6- \| 2026-05-14 23:58 \| Install        \|    1   \n     6 \|                          \| 2026-05-14 23:56 \| Install        \|    1 EE\n     5 \|                          \| 2026-05-09 09:15 \| Install        \|    4   \n     4 \|                          \| 2026-05-09 09:15 \| Install        \|   13 EE\n     3 \|                          \| 2026-05-09 09:11 \| I, U           \|  115 EE\n     2 \|                          \| 2025-11-18 11:02 \| Install        \|   24   \n     1 \|                          \| 2025-11-18 11:00 \| I, U           \|   27   \n'     E    +  where '2026-05-15' = <built-in method strftime of datetime.datetime object at 0x7f8d11d05f20>('%Y-%m-%d')     E    +    where <built-in method strftime of datetime.datetime object at 0x7f8d11d05f20> = datetime.datetime(2026, 5, 15, 0, 0, 53, 645387, tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=72000))).strftime     E    +      where datetime.datetime(2026, 5, 15, 0, 0, 53, 645387, tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=72000))) = <built-in method now of type object at 0x7f8d23c62820>(datetime.timezone(datetime.timedelta(days=-1, seconds=72000)))     E    +        where <built-in method now of type object at 0x7f8d23c62820> = datetime.now     E    +  and   'Updating Subscription Management repositories.\nID     \| Command line             \| Date and time    \| Action(s)      \| Altered\n     9 \| -y update                \| 2026-05-14 23:59 \| C, E, I, U     \|   18   \n     8 \| install -y insights-clie \| 2026-05-14 23:58 \| Upgrade        \|    1   \n     7 \| install -y rabbit-1.5.6- \| 2026-05-14 23:58 \| Install        \|    1   \n     6 \|                          \| 2026-05-14 23:56 \| Install        \|    1 EE\n     5 \|                          \| 2026-05-09 09:15 \| Install        \|    4   \n     4 \|                          \| 2026-05-09 09:15 \| Install        \|   13 EE\n     3 \|                          \| 2026-05-09 09:11 \| I, U           \|  115 EE\n     2 \|                          \| 2025-11-18 11:02 \| Install        \|   24   \n     1 \|                          \| 2025-11-18 11:00 \| I, U           \|   27   \n' = stdout:\nUpdating Subscription Management repositories.\nID     \| Command line             \| Date and time    \| Action(s)      \| Altered\n     9 \| -y update                \| 2026-05-14 23:59 \| C, E, I, U     \|   18   \n     8 \| install -y insights-clie \| 2026-05-14 23:58 \| Upgrade        \|    1   \n     7 \| install -y rabbit-1.5.6- \| 2026-05-14 23:58 \| Install        \|    1   \n     6 \|                          \| 2026-05-14 23:56 \| Install        \|    1 EE\n     5 \|                          \| 2026-05-09 09:15 \| Install        \|    4   \n     4 \|                          \| 2026-05-09 09:15 \| Install        \|   13 EE\n     3 \|                          \| 2026-05-09 09:11 \| I, U           \|  115 EE\n     2 \|                          \| 2025-11-18 11:02 \| Install        \|   24   \n     1 \|                          \| 2025-11-18 11:00 \| I, U           \|   27   \n\nstderr:\n\nstatus: 0.stdout
--


</section><section class="jenkins-section" style="box-sizing: inherit; border-top: 1.25px solid color(srgb 0.893047 0.91414 0.943708); max-width: 1800px; padding: 26px 0px 0px; color: oklch(0.05 0.075 256.91); font-family: system-ui, &quot;Segoe UI&quot;, roboto, &quot;Noto Sans&quot;, oxygen, ubuntu, cantarell, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(254, 254, 254); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"></section><br class="Apple-interchange-newline">
```

### PRT test Cases example
<img width="395" height="129" alt="image" src="https://github.com/user-attachments/assets/2248646a-52b4-49f0-865b-526d38988e0d" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_registration.py::test_positive_global_registration_end_to_end
```

## Summary by Sourcery

Tests:
- Update the global registration end-to-end UI test to accept either today’s or yesterday’s date in yum history output to handle operations spanning midnight.