### PR TITLE
Add test to verify tabs are present.

### DIFF
--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -75,7 +75,36 @@ def test_positive_module_stream_details_search_in_repo(
         }
         module_stream_details = {
             key: value
-            for key, value in walrus_details['details']['details_table'].items()
+            for key, value in walrus_details['details_table'].items()
             if key in expected_module_details
         }
         assert expected_module_details == module_stream_details
+
+
+def test_positive_module_stream_all_tabs(module_target_sat, module_org):
+    """Verify all 4 tabs render correctly on Module Stream details page.
+
+    :id: 7c5f4e8a-3b2d-4a1f-9e6c-8d7b5a4c3e2f
+
+    :steps:
+        1. Navigate to Content -> Content Types -> Module Streams
+        2. Click on a module stream name
+        3. Verify all 4 tabs render (Details, Repositories, Profiles, Artifacts)
+        4. Verify tab content can be read
+
+    :expectedresults: All tabs are present and accessible
+
+    :CaseImportance: High
+
+    :Verifies: SAT-39267
+    """
+    with module_target_sat.ui_session() as session:
+        session.organization.select(org_name=module_org.name)
+        module_data = session.modulestream.read('walrus', '5.21')
+
+        assert 'details_table' in module_data, 'Details table not found'
+        assert module_data['details_table']['Name'] == 'walrus'
+        assert module_data['details_table']['Stream'] == '5.21'
+        assert 'repositories_tab' in module_data, 'Repositories tab not found'
+        assert 'profiles_tab' in module_data, 'Profiles tab not found'
+        assert 'artifacts_tab' in module_data, 'Artifacts tab not found'

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -84,7 +84,7 @@ def test_positive_module_stream_details_search_in_repo(
 def test_positive_module_stream_all_tabs(module_target_sat, module_org):
     """Verify all 4 tabs render correctly on Module Stream details page.
 
-    :id: 7c5f4e8a-3b2d-4a1f-9e6c-8d7b5a4c3e2f
+    :id: 09c92551-3581-4476-8e9d-c7e4e77a3a24
 
     :steps:
         1. Navigate to Content -> Content Types -> Module Streams
@@ -93,8 +93,6 @@ def test_positive_module_stream_all_tabs(module_target_sat, module_org):
         4. Verify tab content can be read
 
     :expectedresults: All tabs are present and accessible
-
-    :CaseImportance: High
 
     :Verifies: SAT-39267
     """


### PR DESCRIPTION
### Problem Statement
After this PR modulestreams will have new tabs and update to pf5  https://github.com/Katello/katello/pull/11721. This PR adds and extra test case.

### Related Issues.
https://github.com/SatelliteQE/airgun/pull/2439



### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_modulestreams.py
airgun: 2439
```


## Summary by Sourcery

Add coverage to validate module stream details and tabs in the UI.

Tests:
- Add a high-importance UI test that verifies all four module stream details tabs (Details, Repositories, Profiles, Artifacts) render and are accessible.
- Adjust existing module stream details test to match the updated structure of the details data returned by the UI session.