### PR TITLE
[6.19.z] [IOP] Add test for advisor iop upgrade scenario

### DIFF
--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -33,15 +33,19 @@ def pytest_configure(config):
         "discovery_upgrades: Discovery upgrade tests that use SharedResource.",
         "capsule_upgrades: Capsule upgrade tests that use SharedResource.",
         "puppet_upgrades: Puppet upgrade tests that use SharedResource.",
+        "iop_upgrades: IOP (Red Hat Lightspeed) upgrade tests that use SharedResource.",
     ]
     for marker in markers:
         config.addinivalue_line("markers", marker)
 
 
-def shared_checkout(shared_name):
+def shared_checkout(shared_name, iop=False):
     Satellite(hostname="blank")._swap_nailgun(settings.UPGRADE.FROM_VERSION)
+    workflow = (
+        settings.server.deploy_workflows.iop if iop else settings.server.deploy_workflows.product
+    )
     bx_inst = Broker(
-        workflow=settings.SERVER.deploy_workflows.product,
+        workflow=workflow,
         deploy_sat_version=settings.UPGRADE.FROM_VERSION,
         deploy_network_type=settings.SERVER.network_type,
         host_class=Satellite,
@@ -55,7 +59,7 @@ def shared_checkout(shared_name):
         sat_checkout.ready()
         sat_instance = bx_inst.from_inventory(
             filter=f'@inv._broker_args.upgrade_group == "{shared_name}_shared_checkout" |'
-            '@inv._broker_args.workflow == "deploy-satellite"'
+            f'@inv._broker_args.workflow == "{workflow}"'
         )
     return sat_instance[0]
 
@@ -180,6 +184,17 @@ def errata_upgrade_shared_satellite():
         "errata_upgrade_tests",
         shared_checkin,
         sat_instance=sat_instance,
+    ) as test_duration:
+        yield sat_instance
+        test_duration.ready()
+
+
+@pytest.fixture
+def iop_upgrade_shared_satellite():
+    """Mark tests using this fixture with pytest.mark.iop_upgrades."""
+    sat_instance = shared_checkout("iop_upgrade", iop=True)
+    with SharedResource(
+        "iop_upgrade_tests", shared_checkin, sat_instance=sat_instance
     ) as test_duration:
         yield sat_instance
         test_duration.ready()

--- a/tests/new_upgrades/test_rhcloud_iop.py
+++ b/tests/new_upgrades/test_rhcloud_iop.py
@@ -1,0 +1,175 @@
+"""Test for RH Cloud - IOP related Upgrade Scenario's
+
+:Requirement: UpgradedSatellite
+
+:CaseAutomation: Automated
+
+:CaseComponent: Insights-Advisor
+
+:Team: Proton
+
+:CaseImportance: High
+
+"""
+
+from box import Box
+from fauxfactory import gen_alpha
+from manifester import Manifester
+import pytest
+
+from robottelo.config import settings
+from robottelo.constants import OPENSSH_RECOMMENDATION
+from robottelo.utils.shared_resource import SharedResource
+from tests.foreman.ui.test_rhcloud_insights import (
+    create_insights_vulnerability as create_insights_recommendation,
+)
+
+
+@pytest.fixture
+def iop_recommendations_upgrade_setup(
+    iop_upgrade_shared_satellite,
+    rhel_contenthost,
+    upgrade_action,
+):
+    """Before upgrade, set up Satellite with IOP enabled and create conditions that
+    generate advisor recommendations.
+
+    :steps:
+        1. Set up Satellite with IOP enabled.
+        2. Create misconfigured machine to trigger advisor recommendations.
+        3. Verify that recommendations appear on the Satellite.
+        4. Save recommendation name, hostname, and organization for post-upgrade test.
+
+    :expectedresults:
+        1. IOP recommendations are visible in Satellite UI.
+        2. Recommendation data is saved for post-upgrade validation.
+    """
+    target_sat = iop_upgrade_shared_satellite
+    with SharedResource(
+        target_sat.hostname, upgrade_action, target_sat=target_sat, action_is_recoverable=True
+    ) as sat_upgrade:
+        test_name = f'iop_upgrade_{gen_alpha()}'
+        org = target_sat.api.Organization(name=f'{test_name}_org').create()
+
+        manifest = Manifester(manifest_category=settings.manifest.golden_ticket)
+        target_sat.upload_manifest(org.id, manifest.get_manifest().content)
+
+        activation_key = target_sat.api.ActivationKey(
+            name=f'{test_name}_ak',
+            content_view=org.default_content_view,
+            organization=org,
+            environment=target_sat.api.LifecycleEnvironment(id=org.library.id),
+        ).create()
+
+        # Enable RHEL OS repos so insights-client can be installed during registration
+        rhel_ver = rhel_contenthost.os_version.major
+        rhel_repos = getattr(settings.repos, f'rhel{rhel_ver}_os')
+        rhel_contenthost.create_custom_repos(
+            baseos=rhel_repos.baseos,
+            appstream=rhel_repos.appstream,
+        )
+
+        # Register host with insights and REX enabled
+        result = rhel_contenthost.api_register(
+            target_sat,
+            organization=org,
+            activation_keys=[activation_key.name],
+            setup_insights=True,
+            setup_remote_execution=True,
+        )
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+        create_insights_recommendation(rhel_contenthost)
+
+        with target_sat.ui_session() as session:
+            session.organization.select(org_name=org.name)
+
+            # Verify that we can see the rule hit via insights-client
+            result = rhel_contenthost.execute('insights-client --diagnosis')
+            assert result.status == 0
+            assert 'OPENSSH_HARDENING_CONFIG_PERMS' in result.stdout
+
+            # Search for the recommendation and verify it exists
+            result = session.recommendationstab.search(OPENSSH_RECOMMENDATION)
+            assert result[0]['Name'] == OPENSSH_RECOMMENDATION
+
+        test_data = Box(
+            {
+                'recommendation_name': OPENSSH_RECOMMENDATION,
+                'hostname': rhel_contenthost.hostname,
+                'org_name': org.name,
+                'org': org,
+                'satellite': target_sat,
+                'rhel_client': rhel_contenthost,
+            }
+        )
+        sat_upgrade.ready()
+        target_sat._session = None
+        yield test_data
+
+
+@pytest.mark.iop_upgrades
+@pytest.mark.pit_server
+@pytest.mark.pit_client
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('N-1')
+def test_iop_recommendations_upgrade(iop_recommendations_upgrade_setup):
+    """After upgrade, verify IOP recommendations persist, can be searched,
+    and remediation can be applied successfully.
+
+    :id: 3d8a2f5f-ae74-444b-bf14-027c8ab33fca
+
+    :steps:
+        1. After Satellite upgrade, select the pre-upgrade organization.
+        2. Navigate to Red Hat Lightspeed > Recommendations.
+        3. Search for the pre-upgrade recommendation.
+        4. Verify recommendation exists and can be found via search.
+        5. Navigate to host details and verify recommendations are visible.
+        6. Apply remediation from host details page.
+        7. Verify remediation job completes successfully.
+
+    :expectedresults:
+        1. Pre-upgrade IOP recommendations are still visible post-upgrade.
+        2. Search functionality works correctly.
+        3. Host details page shows recommendations.
+        4. Remediation can be applied successfully.
+        5. Job invocation completes with success status.
+    """
+    recommendation_name = iop_recommendations_upgrade_setup.recommendation_name
+    hostname = iop_recommendations_upgrade_setup.hostname
+    org_name = iop_recommendations_upgrade_setup.org_name
+    target_sat = iop_recommendations_upgrade_setup.satellite
+    rhel_client = iop_recommendations_upgrade_setup.rhel_client
+
+    with target_sat.ui_session() as session:
+        session.organization.select(org_name=org_name)
+
+        # Force register host with insights
+        result = rhel_client.execute('insights-client --register --force')
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+        # Search for the recommendation and verify it still exists post-upgrade
+        result = session.recommendationstab.search(recommendation_name)
+        assert result[0]['Name'] == recommendation_name
+
+        # Get recommendations from host details page
+        result = session.host_new.get_recommendations(hostname)
+        assert any(row.get('Description') == recommendation_name for row in result), (
+            f"No row found with Recommendation == {recommendation_name}"
+        )
+
+        # Apply remediation from host details page
+        result = session.host_new.remediate_host_recommendation(
+            hostname,
+            recommendation_name,
+        )
+
+        # Verify that the job succeeded
+        assert result['status']['Succeeded'] != 0
+        assert result['overall_status']['is_success']
+
+        # Verify that the recommendation is no longer listed after remediation
+        result = session.host_new.get_recommendations(hostname)
+        assert not any(row.get('Description') == recommendation_name for row in result), (
+            f"Recommendation should not be present after remediation: {recommendation_name}"
+        )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20042

Adding upgrade scenario for Insights Advisor IOP.

## Summary by Sourcery

Add a new Red Hat Lightspeed (IOP) advisor upgrade scenario test and supporting shared Satellite fixture.

New Features:
- Introduce an IOP (Red Hat Lightspeed) upgrade test validating advisor recommendations persistence and remediation across Satellite upgrades.

Enhancements:
- Extend shared Satellite checkout and fixtures to support IOP-specific upgrade workflows and shared resources.