### PR TITLE
Make test_positive_task_status faster and more robust

### DIFF
--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -132,11 +132,10 @@ def test_positive_task_status(session, target_sat):
 
     :BZ: 1718889
     """
-    url = 'www.non_existent_repo_url.org'
     org = target_sat.api.Organization().create()
     product = target_sat.api.Product(organization=org).create()
     repo = target_sat.api.Repository(
-        url=f'http://{url}', product=product, content_type='yum'
+        url='http://doesnotexist.invalid', product=product, content_type='yum'
     ).create()
     with pytest.raises(TaskFailedError):
         repo.sync()
@@ -157,13 +156,6 @@ def test_positive_task_status(session, target_sat):
         assert tasks['table'][0]['Action'] == task_name
         assert tasks['table'][0]['State'] == 'stopped'
         assert tasks['table'][0]['Result'] == 'warning'
-        session.dashboard.action({'LatestFailedTasks': {'name': 'Synchronize'}})
-        values = session.task.read(task_name)
-        assert values['task']['result'] == 'warning'
-        assert values['task']['errors'] in [
-            f"500, message='Internal Server Error', url='http://{url}'",
-            f'Cannot connect to host {url}:80 ssl:default [Domain name not found]',
-        ]
 
 
 @pytest.mark.upgrade


### PR DESCRIPTION
Switched the repository URL from 'www.non_existent_repo_url.org' to
'doesnotexist.invalid'. The .invalid TLD (RFC 2606) is guaranteed to
return NXDOMAIN immediately from any DNS resolver, eliminating DNS
timeout variance and thus making the task fail faster.

Removed the LatestFailedTasks navigation and task details read that
followed it. The TaskDetails navigator always re-navigates to the tasks
list via the menu and searches for the task independently, so the call
provided no coverage for whether the dashboard link itself worked
correctly. The task result assertion it enabled was also deterministic.
'warning' and 'error' were achieved respectively in PRT and local
environment, making it a source of flakiness rather than meaningful
coverage.

Made with Cursor.

Depends on: https://github.com/SatelliteQE/airgun/pull/2441

## Summary by Sourcery

Improve the reliability and speed of the dashboard task status UI test when syncing an invalid repository.

Bug Fixes:
- Use a reserved .invalid TLD for the test repository URL to avoid DNS timeout variability and make the failing sync complete faster.
- Adjust the dashboard task status assertion to rely on the task result state rather than brittle backend error message text.