### PR TITLE
Migrate 10 tests to use module_import_sat instead of target_sat

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -96,14 +96,6 @@ def function_import_org_with_manifest(target_sat, function_import_org):
     return function_import_org
 
 
-@pytest.fixture
-def function_import_org_at_isat_with_manifest(module_import_sat, function_import_org_at_isat):
-    """Creates an Organization with a brand-new manifest on the import Satellite."""
-    with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
-        module_import_sat.upload_manifest(function_import_org_at_isat.id, manifest.content)
-    return function_import_org_at_isat
-
-
 @pytest.fixture(scope='module')
 def module_synced_custom_repo(module_target_sat, module_org, module_product):
     repo = module_target_sat.cli_factory.make_repository(
@@ -289,9 +281,12 @@ def module_import_sat(request, module_target_sat):
 
     Returns a separate Satellite when settings.iss.separate_import_sat is True,
     or the exporting Satellite when False (for local debugging).
+    An air-gapped import Satellite has subscription_connection_enabled set to No.
     """
     if settings.iss.separate_import_sat:
-        return request.getfixturevalue('module_satellite_host')
+        sat = request.getfixturevalue('module_satellite_host')
+        sat.cli.Settings.set({'name': 'subscription_connection_enabled', 'value': 'No'})
+        return sat
     return module_target_sat
 
 
@@ -299,6 +294,14 @@ def module_import_sat(request, module_target_sat):
 def function_import_org_at_isat(module_import_sat):
     """Creates an Organization for content import."""
     return module_import_sat.api.Organization().create()
+
+
+@pytest.fixture
+def function_import_org_at_isat_with_manifest(module_import_sat, function_import_org_at_isat):
+    """Creates an Organization with a brand-new manifest on the import Satellite."""
+    with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
+        module_import_sat.upload_manifest(function_import_org_at_isat.id, manifest.content)
+    return function_import_org_at_isat
 
 
 @pytest.fixture
@@ -1012,9 +1015,6 @@ class TestExportImport:
         assert len(exported_lib_packages)
         assert exported_lib_packages == cv_packages
         # Import and verify content of library
-        module_import_sat.cli.Settings.set(
-            {'name': 'subscription_connection_enabled', 'value': 'No'}
-        )
         module_import_sat.cli.ContentImport.library(
             {
                 'organization-id': function_import_org_at_isat_with_manifest.id,
@@ -1103,10 +1103,6 @@ class TestExportImport:
         )
 
         # Import section
-        # set disconnected mode
-        module_import_sat.cli.Settings.set(
-            {'name': 'subscription_connection_enabled', 'value': 'No'}
-        )
         # check that files are present in import_path
         result = module_import_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
@@ -1270,9 +1266,6 @@ class TestExportImport:
         exported_packages = target_sat.cli.Package.list({'content-view-version-id': cvv['id']})
         assert len(exported_packages)
         # Import and verify content
-        module_import_sat.cli.Settings.set(
-            {'name': 'subscription_connection_enabled', 'value': 'No'}
-        )
         module_import_sat.cli.ContentImport.version(
             {'organization-id': function_import_org_at_isat_with_manifest.id, 'path': import_path},
             timeout='2h',
@@ -1794,10 +1787,14 @@ class TestExportImport:
         exporting_cvv = target_sat.cli.ContentView.version_info(
             {'id': exporting_cv['versions'][0]['id']}
         )
-        exported_packages = target_sat.cli.Package.list(
-            {'content-view-version-id': exporting_cvv['id']}
-        )
-        exported_files = target_sat.cli.File.list({'content-view-version-id': exporting_cvv['id']})
+        exported_packages = {
+            p['filename']
+            for p in target_sat.cli.Package.list({'content-view-version-id': exporting_cvv['id']})
+        }
+        exported_files = {
+            f['name']
+            for f in target_sat.cli.File.list({'content-view-version-id': exporting_cvv['id']})
+        }
 
         # Export CV version contents in syncable format
         assert target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR) == ''
@@ -1830,14 +1827,28 @@ class TestExportImport:
             len(exporting_cvv['repositories']) == len(importing_cvv['repositories']) == len(repos)
         ), 'Repositories count does not match'
 
-        imported_packages = module_import_sat.cli.Package.list(
-            {'content-view-version-id': importing_cvv['id']}
+        imported_packages = {
+            p['filename']
+            for p in module_import_sat.cli.Package.list(
+                {'content-view-version-id': importing_cvv['id']}
+            )
+        }
+        imported_files = {
+            f['name']
+            for f in module_import_sat.cli.File.list(
+                {'content-view-version-id': importing_cvv['id']}
+            )
+        }
+        assert exported_packages == imported_packages, (
+            f'Imported RPMs do not match the export.\n'
+            f'Only in export: {sorted(exported_packages - imported_packages)}\n'
+            f'Only in import: {sorted(imported_packages - exported_packages)}'
         )
-        imported_files = module_import_sat.cli.File.list(
-            {'content-view-version-id': importing_cvv['id']}
+        assert exported_files == imported_files, (
+            f'Imported Files do not match the export.\n'
+            f'Only in export: {sorted(exported_files - imported_files)}\n'
+            f'Only in import: {sorted(imported_files - exported_files)}'
         )
-        assert exported_packages == imported_packages, 'Imported RPMs do not match the export'
-        assert exported_files == imported_files, 'Imported Files do not match the export'
 
         # Check the import history
         import_list = module_import_sat.cli.ContentImport.list(
@@ -2232,10 +2243,12 @@ class TestExportImport:
     def test_negative_import_redhat_cv_without_manifest(
         self,
         target_sat,
-        export_import_cleanup_function,
+        complete_export_import_cleanup,
         config_export_import_settings,
         function_sca_manifest_org,
         function_synced_rh_repo,
+        module_import_sat,
+        function_import_org_at_isat,
     ):
         """Redhat content can't be imported into satellite/organization without manifest
 
@@ -2257,15 +2270,10 @@ class TestExportImport:
                importing content."
         """
         # Create cv and publish
-        cv_name = gen_string('alpha')
         cv = target_sat.cli_factory.make_content_view(
-            {'name': cv_name, 'organization-id': function_sca_manifest_org.id}
-        )
-        target_sat.cli.ContentView.add_repository(
             {
-                'id': cv['id'],
                 'organization-id': function_sca_manifest_org.id,
-                'repository-id': function_synced_rh_repo['id'],
+                'repository-ids': [function_synced_rh_repo['id']],
             }
         )
         target_sat.cli.ContentView.publish({'id': cv['id']})
@@ -2278,18 +2286,17 @@ class TestExportImport:
         export = target_sat.cli.ContentExport.completeVersion(
             {'id': cvv['id'], 'organization-id': function_sca_manifest_org.id}
         )
-        import_path = target_sat.move_pulp_archive(function_sca_manifest_org, export['message'])
+        import_path = target_sat.move_pulp_archive(
+            function_sca_manifest_org, export['message'], target=module_import_sat
+        )
         # check that files are present in import_path
-        result = target_sat.execute(f'ls {import_path}')
+        result = module_import_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
 
-        # importing portion
-        importing_org = target_sat.cli_factory.make_org()
-        # set disconnected mode
-        target_sat.cli.Settings.set({'name': 'subscription_connection_enabled', 'value': "No"})
+        # importing portion — org has no manifest, import must fail
         with pytest.raises(CLIReturnCodeError) as error:
-            target_sat.cli.ContentImport.version(
-                {'organization-id': importing_org['id'], 'path': import_path}
+            module_import_sat.cli.ContentImport.version(
+                {'organization-id': function_import_org_at_isat.id, 'path': import_path}
             )
         assert (
             'Could not import the archive.:\n  No manifest found. Import a manifest with the '
@@ -2512,7 +2519,9 @@ class TestExportImport:
             }
         )
         target_sat.cli.Repository.synchronize({'id': repo.id})
-        exported_packages = target_sat.cli.Package.list({'repository-id': repo.id})
+        exported_packages = {
+            p['filename'] for p in target_sat.cli.Package.list({'repository-id': repo.id})
+        }
 
         # Export the repository, import it and verify the prod and repo names match the export.
         export = target_sat.cli.ContentExport.completeRepository(
@@ -2531,8 +2540,14 @@ class TestExportImport:
         )
 
         # Verify the imported content matches the export.
-        imported_packages = target_sat.cli.Package.list({'repository-id': import_repo['id']})
-        assert imported_packages == exported_packages, 'Imported content does not match the export'
+        imported_packages = {
+            p['filename'] for p in target_sat.cli.Package.list({'repository-id': import_repo['id']})
+        }
+        assert exported_packages == imported_packages, (
+            f'Imported content does not match the export.\n'
+            f'Only in export: {sorted(exported_packages - imported_packages)}\n'
+            f'Only in import: {sorted(imported_packages - exported_packages)}'
+        )
 
         # Create CV with a long name, add the repo and publish.
         exporting_cv = target_sat.cli_factory.make_content_view(
@@ -2564,10 +2579,17 @@ class TestExportImport:
         assert len(importing_cv['versions']) == 1
 
         # Verify the imported content matches the export.
-        imported_packages = target_sat.cli.Package.list(
-            {'content-view-version-id': importing_cv['versions'][0]['id']}
+        imported_packages = {
+            p['filename']
+            for p in target_sat.cli.Package.list(
+                {'content-view-version-id': importing_cv['versions'][0]['id']}
+            )
+        }
+        assert exported_packages == imported_packages, (
+            f'Imported content does not match the export.\n'
+            f'Only in export: {sorted(exported_packages - imported_packages)}\n'
+            f'Only in import: {sorted(imported_packages - exported_packages)}'
         )
-        assert exported_packages == imported_packages
 
     def test_postive_export_import_large_cv(
         self,

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -96,6 +96,14 @@ def function_import_org_with_manifest(target_sat, function_import_org):
     return function_import_org
 
 
+@pytest.fixture
+def function_import_org_at_isat_with_manifest(module_import_sat, function_import_org_at_isat):
+    """Creates an Organization with a brand-new manifest on the import Satellite."""
+    with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
+        module_import_sat.upload_manifest(function_import_org_at_isat.id, manifest.content)
+    return function_import_org_at_isat
+
+
 @pytest.fixture(scope='module')
 def module_synced_custom_repo(module_target_sat, module_org, module_product):
     repo = module_target_sat.cli_factory.make_repository(
@@ -934,12 +942,13 @@ class TestExportImport:
     def test_positive_export_import_default_org_view(
         self,
         target_sat,
-        export_import_cleanup_function,
+        complete_export_import_cleanup,
         config_export_import_settings,
         function_sca_manifest_org,
-        function_import_org_with_manifest,
         function_synced_custom_repo,
         function_synced_rh_repo,
+        module_import_sat,
+        function_import_org_at_isat_with_manifest,
     ):
         """Export Default Organization View version contents in directory and Import them.
 
@@ -965,31 +974,17 @@ class TestExportImport:
         :customerscenario: true
         """
         # Create cv and publish
-        cv_name = gen_string('alpha')
         cv = target_sat.cli_factory.make_content_view(
-            {'name': cv_name, 'organization-id': function_sca_manifest_org.id}
-        )
-        target_sat.cli.ContentView.add_repository(
             {
-                'id': cv['id'],
                 'organization-id': function_sca_manifest_org.id,
-                'repository-id': function_synced_custom_repo['id'],
-            }
-        )
-        target_sat.cli.ContentView.add_repository(
-            {
-                'id': cv['id'],
-                'organization-id': function_sca_manifest_org.id,
-                'repository-id': function_synced_rh_repo['id'],
+                'repository-ids': [
+                    function_synced_custom_repo['id'],
+                    function_synced_rh_repo['id'],
+                ],
             }
         )
         target_sat.cli.ContentView.publish({'id': cv['id']})
-        content_view = target_sat.cli.ContentView.info(
-            {
-                'name': cv_name,
-                'organization-id': function_sca_manifest_org.id,
-            }
-        )
+        content_view = target_sat.cli.ContentView.info({'id': cv['id']})
         # Verify packages
         default_cvv_id = content_view['versions'][0]['id']
         cv_packages = target_sat.cli.Package.list({'content-view-version-id': default_cvv_id})
@@ -1001,7 +996,9 @@ class TestExportImport:
             {'organization-id': function_sca_manifest_org.id}
         )
         # Verify 'export-library' is created and packages are there
-        import_path = target_sat.move_pulp_archive(function_sca_manifest_org, export['message'])
+        import_path = target_sat.move_pulp_archive(
+            function_sca_manifest_org, export['message'], target=module_import_sat
+        )
         export_lib_cv = target_sat.cli.ContentView.info(
             {
                 'name': EXPORT_LIBRARY_NAME,
@@ -1015,15 +1012,23 @@ class TestExportImport:
         assert len(exported_lib_packages)
         assert exported_lib_packages == cv_packages
         # Import and verify content of library
-        target_sat.cli.Settings.set({'name': 'subscription_connection_enabled', 'value': "No"})
-        target_sat.cli.ContentImport.library(
-            {'organization-id': function_import_org_with_manifest.id, 'path': import_path}
+        module_import_sat.cli.Settings.set(
+            {'name': 'subscription_connection_enabled', 'value': 'No'}
         )
-        importing_cvv = target_sat.cli.ContentView.info(
-            {'name': DEFAULT_CV, 'organization-id': function_import_org_with_manifest.id}
+        module_import_sat.cli.ContentImport.library(
+            {
+                'organization-id': function_import_org_at_isat_with_manifest.id,
+                'path': import_path,
+            }
+        )
+        importing_cvv = module_import_sat.cli.ContentView.info(
+            {
+                'name': DEFAULT_CV,
+                'organization-id': function_import_org_at_isat_with_manifest.id,
+            }
         )['versions']
         assert len(importing_cvv) >= 1
-        imported_packages = target_sat.cli.Package.list(
+        imported_packages = module_import_sat.cli.Package.list(
             {'content-view-version-id': importing_cvv[0]['id']}
         )
         assert len(imported_packages)
@@ -1032,10 +1037,12 @@ class TestExportImport:
     def test_positive_export_import_filtered_cvv(
         self,
         module_synced_custom_repo,
-        export_import_cleanup_module,
+        complete_export_import_cleanup,
         config_export_import_settings,
         target_sat,
         module_org,
+        module_import_sat,
+        function_import_org_at_isat,
     ):
         """CV Version with filtered contents is the only one that gets exported and imported
 
@@ -1057,15 +1064,10 @@ class TestExportImport:
             2. Filtered exported custom contents has been imported in org/satellite
 
         """
-        cv_name = gen_string('alpha')
         cv = target_sat.cli_factory.make_content_view(
-            {'name': cv_name, 'organization-id': module_org.id}
-        )
-        target_sat.cli.ContentView.add_repository(
             {
-                'id': cv['id'],
                 'organization-id': module_org.id,
-                'repository-id': module_synced_custom_repo['id'],
+                'repository-ids': [module_synced_custom_repo['id']],
             }
         )
         filter_name = gen_string('alphanumeric')
@@ -1096,24 +1098,27 @@ class TestExportImport:
         export = target_sat.cli.ContentExport.completeVersion(
             {'id': exporting_cvv_id, 'organization-id': module_org.id}
         )
-        import_path = target_sat.move_pulp_archive(module_org, export['message'])
+        import_path = target_sat.move_pulp_archive(
+            module_org, export['message'], target=module_import_sat
+        )
 
         # Import section
-        importing_org = target_sat.cli_factory.make_org()
         # set disconnected mode
-        target_sat.cli.Settings.set({'name': 'subscription_connection_enabled', 'value': "No"})
+        module_import_sat.cli.Settings.set(
+            {'name': 'subscription_connection_enabled', 'value': 'No'}
+        )
         # check that files are present in import_path
-        result = target_sat.execute(f'ls {import_path}')
+        result = module_import_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import file and verify content
-        target_sat.cli.ContentImport.version(
-            {'organization-id': importing_org['id'], 'path': import_path}
+        module_import_sat.cli.ContentImport.version(
+            {'organization-id': function_import_org_at_isat.id, 'path': import_path}
         )
-        importing_cvv = target_sat.cli.ContentView.info(
-            {'name': cv_name, 'organization-id': importing_org['id']}
+        importing_cvv = module_import_sat.cli.ContentView.info(
+            {'name': cv['name'], 'organization-id': function_import_org_at_isat.id}
         )['versions']
         assert len(importing_cvv) >= 1
-        imported_packages = target_sat.cli.Package.list(
+        imported_packages = module_import_sat.cli.Package.list(
             {'content-view-version-id': importing_cvv[0]['id']}
         )
         assert len(imported_packages) == 1
@@ -1208,11 +1213,12 @@ class TestExportImport:
     def test_positive_export_import_redhat_cv(
         self,
         target_sat,
-        export_import_cleanup_function,
+        complete_export_import_cleanup,
         config_export_import_settings,
         function_sca_manifest_org,
-        function_import_org_with_manifest,
         function_synced_rh_repo,
+        module_import_sat,
+        function_import_org_at_isat_with_manifest,
     ):
         """Export CV version with RedHat contents in directory and import them.
 
@@ -1238,15 +1244,10 @@ class TestExportImport:
 
         """
         # Create cv and publish
-        cv_name = gen_string('alpha')
         cv = target_sat.cli_factory.make_content_view(
-            {'name': cv_name, 'organization-id': function_sca_manifest_org.id}
-        )
-        target_sat.cli.ContentView.add_repository(
             {
-                'id': cv['id'],
                 'organization-id': function_sca_manifest_org.id,
-                'repository-id': function_synced_rh_repo['id'],
+                'repository-ids': [function_synced_rh_repo['id']],
             }
         )
         target_sat.cli.ContentView.publish({'id': cv['id']})
@@ -1263,20 +1264,24 @@ class TestExportImport:
         # Verify export directory is not empty
         assert target_sat.validate_pulp_filepath(function_sca_manifest_org, PULP_EXPORT_DIR) != ''
 
-        import_path = target_sat.move_pulp_archive(function_sca_manifest_org, export['message'])
+        import_path = target_sat.move_pulp_archive(
+            function_sca_manifest_org, export['message'], target=module_import_sat
+        )
         exported_packages = target_sat.cli.Package.list({'content-view-version-id': cvv['id']})
         assert len(exported_packages)
         # Import and verify content
-        target_sat.cli.Settings.set({'name': 'subscription_connection_enabled', 'value': "No"})
-        target_sat.cli.ContentImport.version(
-            {'organization-id': function_import_org_with_manifest.id, 'path': import_path},
+        module_import_sat.cli.Settings.set(
+            {'name': 'subscription_connection_enabled', 'value': 'No'}
+        )
+        module_import_sat.cli.ContentImport.version(
+            {'organization-id': function_import_org_at_isat_with_manifest.id, 'path': import_path},
             timeout='2h',
         )
-        importing_cvv = target_sat.cli.ContentView.info(
-            {'name': cv_name, 'organization-id': function_import_org_with_manifest.id}
+        importing_cvv = module_import_sat.cli.ContentView.info(
+            {'name': cv['name'], 'organization-id': function_import_org_at_isat_with_manifest.id}
         )['versions']
         assert len(importing_cvv) >= 1
-        imported_packages = target_sat.cli.Package.list(
+        imported_packages = module_import_sat.cli.Package.list(
             {'content-view-version-id': importing_cvv[0]['id']}
         )
         assert len(imported_packages)
@@ -1288,11 +1293,11 @@ class TestExportImport:
                 'organization-id': function_sca_manifest_org.id,
             }
         )
-        imported_repo = target_sat.cli.Repository.info(
+        imported_repo = module_import_sat.cli.Repository.info(
             {
                 'name': function_synced_rh_repo['name'],
                 'product': function_synced_rh_repo['product']['name'],
-                'organization-id': function_import_org_with_manifest.id,
+                'organization-id': function_import_org_at_isat_with_manifest.id,
             }
         )
         assert exported_repo['content-counts'] == imported_repo['content-counts'], (
@@ -1572,7 +1577,7 @@ class TestExportImport:
         importing_cv = module_import_sat.cli.ContentView.info(
             {'name': exporting_cv['name'], 'organization-id': function_import_org_at_isat.id}
         )
-        assert all([exporting_cv[key] == importing_cv[key] for key in ['label', 'name']]), (
+        assert all(exporting_cv[key] == importing_cv[key] for key in ['label', 'name']), (
             'Imported CV name/label does not match the export'
         )
         assert len(exporting_cv['versions']) == len(importing_cv['versions']) == 1, (
@@ -1745,12 +1750,13 @@ class TestExportImport:
 
     def test_postive_export_import_cv_with_mixed_content_syncable(
         self,
-        export_import_cleanup_function,
+        complete_export_import_cleanup,
         target_sat,
         function_org,
         function_synced_custom_repo,
         function_synced_file_repo,
-        function_import_org,
+        module_import_sat,
+        function_import_org_at_isat,
     ):
         """Export and import CV with mixed content in the syncable format.
 
@@ -1776,19 +1782,13 @@ class TestExportImport:
 
         """
         # Create CV, add all setup repos and publish
-        cv = target_sat.cli_factory.make_content_view({'organization-id': function_org.id})
-        repos = [
-            function_synced_custom_repo,
-            function_synced_file_repo,
-        ]
-        for repo in repos:
-            target_sat.cli.ContentView.add_repository(
-                {
-                    'id': cv['id'],
-                    'organization-id': function_org.id,
-                    'repository-id': repo['id'],
-                }
-            )
+        repos = [function_synced_custom_repo, function_synced_file_repo]
+        cv = target_sat.cli_factory.make_content_view(
+            {
+                'organization-id': function_org.id,
+                'repository-ids': [repo['id'] for repo in repos],
+            }
+        )
         target_sat.cli.ContentView.publish({'id': cv['id']})
         exporting_cv = target_sat.cli.ContentView.info({'id': cv['id']})
         exporting_cvv = target_sat.cli.ContentView.version_info(
@@ -1807,36 +1807,42 @@ class TestExportImport:
         assert target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR) != ''
 
         # Import the syncable export, check the content
-        import_path = target_sat.move_pulp_archive(function_org, export['message'])
-        target_sat.cli.ContentImport.version(
-            {'organization-id': function_import_org.id, 'path': import_path}
+        import_path = target_sat.move_pulp_archive(
+            function_org, export['message'], target=module_import_sat
         )
-        importing_cv = target_sat.cli.ContentView.info(
-            {'name': exporting_cv['name'], 'organization-id': function_import_org.id}
+        module_import_sat.cli.ContentImport.version(
+            {'organization-id': function_import_org_at_isat.id, 'path': import_path}
         )
-        assert all([exporting_cv[key] == importing_cv[key] for key in ['label', 'name']]), (
+        importing_cv = module_import_sat.cli.ContentView.info(
+            {'name': exporting_cv['name'], 'organization-id': function_import_org_at_isat.id}
+        )
+        assert all(exporting_cv[key] == importing_cv[key] for key in ['label', 'name']), (
             'Imported CV name/label does not match the export'
         )
         assert len(exporting_cv['versions']) == len(importing_cv['versions']) == 1, (
             'CV versions count does not match'
         )
 
-        importing_cvv = target_sat.cli.ContentView.version_info(
+        importing_cvv = module_import_sat.cli.ContentView.version_info(
             {'id': importing_cv['versions'][0]['id']}
         )
         assert (
             len(exporting_cvv['repositories']) == len(importing_cvv['repositories']) == len(repos)
         ), 'Repositories count does not match'
 
-        imported_packages = target_sat.cli.Package.list(
+        imported_packages = module_import_sat.cli.Package.list(
             {'content-view-version-id': importing_cvv['id']}
         )
-        imported_files = target_sat.cli.File.list({'content-view-version-id': importing_cvv['id']})
+        imported_files = module_import_sat.cli.File.list(
+            {'content-view-version-id': importing_cvv['id']}
+        )
         assert exported_packages == imported_packages, 'Imported RPMs do not match the export'
         assert exported_files == imported_files, 'Imported Files do not match the export'
 
         # Check the import history
-        import_list = target_sat.cli.ContentImport.list({'organization-id': function_import_org.id})
+        import_list = module_import_sat.cli.ContentImport.list(
+            {'organization-id': function_import_org_at_isat.id}
+        )
         assert len(import_list) == 1, 'Only 1 import expected within the Organization'
         assert import_list[0]['path'] == import_path
         assert import_list[0]['content-view-version'] == importing_cvv['name']
@@ -2024,9 +2030,10 @@ class TestExportImport:
         self,
         target_sat,
         config_export_import_settings,
-        export_import_cleanup_function,
+        complete_export_import_cleanup,
         function_org,
-        function_import_org,
+        module_import_sat,
+        function_import_org_at_isat,
     ):
         """Exporting and Importing library with ansible collection
 
@@ -2061,21 +2068,25 @@ class TestExportImport:
         target_sat.cli.Repository.synchronize({'id': ansible_repo['id']})
         # Export library
         export = target_sat.cli.ContentExport.completeLibrary({'organization-id': function_org.id})
-        import_path = target_sat.move_pulp_archive(function_org, export['message'])
+        import_path = target_sat.move_pulp_archive(
+            function_org, export['message'], target=module_import_sat
+        )
         # Check that files are present in import_path
-        result = target_sat.execute(f'ls {import_path}')
+        result = module_import_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import files and verify content
-        target_sat.cli.ContentImport.library(
-            {'organization-id': function_import_org.id, 'path': import_path}
+        module_import_sat.cli.ContentImport.library(
+            {'organization-id': function_import_org_at_isat.id, 'path': import_path}
         )
-        assert target_sat.cli.Product.list({'organization-id': function_import_org.id})
-        import_product = target_sat.cli.Product.info(
+        assert module_import_sat.cli.Product.list(
+            {'organization-id': function_import_org_at_isat.id}
+        )
+        import_product = module_import_sat.cli.Product.info(
             {
-                'organization-id': function_import_org.id,
-                'id': target_sat.cli.Product.list({'organization-id': function_import_org.id})[0][
-                    'id'
-                ],
+                'organization-id': function_import_org_at_isat.id,
+                'id': module_import_sat.cli.Product.list(
+                    {'organization-id': function_import_org_at_isat.id}
+                )[0]['id'],
             }
         )
         assert import_product['name'] == export_product['name']
@@ -2086,10 +2097,11 @@ class TestExportImport:
         self,
         target_sat,
         config_export_import_settings,
-        export_import_cleanup_function,
+        complete_export_import_cleanup,
         function_org,
         function_synced_custom_repo,
-        function_import_org,
+        module_import_sat,
+        function_import_org_at_isat,
     ):
         """Test export and import of a repository with GPG key
 
@@ -2124,26 +2136,28 @@ class TestExportImport:
         export = target_sat.cli.ContentExport.completeRepository(
             {'id': function_synced_custom_repo.id}
         )
-        import_path = target_sat.move_pulp_archive(function_org, export['message'])
-        target_sat.cli.ContentImport.repository(
+        import_path = target_sat.move_pulp_archive(
+            function_org, export['message'], target=module_import_sat
+        )
+        module_import_sat.cli.ContentImport.repository(
             {
-                'organization-id': function_import_org.id,
+                'organization-id': function_import_org_at_isat.id,
                 'path': import_path,
             }
         )
         # Check the imported repo has the GPG key assigned.
-        imported_repo = target_sat.cli.Repository.info(
+        imported_repo = module_import_sat.cli.Repository.info(
             {
                 'name': function_synced_custom_repo.name,
                 'product': function_synced_custom_repo.product.name,
-                'organization-id': function_import_org.id,
+                'organization-id': function_import_org_at_isat.id,
             }
         )
         assert int(imported_repo['content-counts']['packages'])
         assert imported_repo['gpg-key']['name'] == gpg_key.name
         # Check the GPG key is imported to the importing org too.
-        imported_gpg = target_sat.cli.ContentCredential.info(
-            {'organization-id': function_import_org.id, 'name': gpg_key.name}
+        imported_gpg = module_import_sat.cli.ContentCredential.info(
+            {'organization-id': function_import_org_at_isat.id, 'name': gpg_key.name}
         )
         assert imported_gpg
         assert imported_gpg['content'] == gpg_key.content
@@ -2558,11 +2572,12 @@ class TestExportImport:
     def test_postive_export_import_large_cv(
         self,
         request,
-        export_import_cleanup_function,
+        complete_export_import_cleanup,
         target_sat,
         function_org,
         function_synced_large_file_repo,
-        function_import_org,
+        module_import_sat,
+        function_import_org_at_isat,
     ):
         """Export and import CV with 100k files and check both operations succeeded.
 
@@ -2585,12 +2600,10 @@ class TestExportImport:
         :customerscenario: true
         """
         # Create CV, add the repository and publish
-        cv = target_sat.cli_factory.make_content_view({'organization-id': function_org.id})
-        target_sat.cli.ContentView.add_repository(
+        cv = target_sat.cli_factory.make_content_view(
             {
-                'id': cv['id'],
                 'organization-id': function_org.id,
-                'repository-id': function_synced_large_file_repo['id'],
+                'repository-ids': [function_synced_large_file_repo['id']],
             }
         )
         target_sat.cli.ContentView.publish({'id': cv['id']})
@@ -2607,16 +2620,18 @@ class TestExportImport:
         assert '1.0' in target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR)
 
         # Import the exported CV, check the files count.
-        import_path = target_sat.move_pulp_archive(function_org, export['message'])
-        target_sat.cli.ContentImport.version(
-            {'organization-id': function_import_org.id, 'path': import_path}, timeout='90m'
+        import_path = target_sat.move_pulp_archive(
+            function_org, export['message'], target=module_import_sat
         )
-        importing_cv = target_sat.cli.ContentView.info(
-            {'name': exporting_cv['name'], 'organization-id': function_import_org.id}
+        module_import_sat.cli.ContentImport.version(
+            {'organization-id': function_import_org_at_isat.id, 'path': import_path}, timeout='90m'
+        )
+        importing_cv = module_import_sat.cli.ContentView.info(
+            {'name': exporting_cv['name'], 'organization-id': function_import_org_at_isat.id}
         )
         assert len(importing_cv['versions']) == 1
         assert (
-            target_sat.api.ContentViewVersion(id=importing_cv['versions'][0]['id'])
+            module_import_sat.api.ContentViewVersion(id=importing_cv['versions'][0]['id'])
             .read()
             .file_count
             == settings.repos.large_file_type_repo.files_count
@@ -2720,11 +2735,12 @@ class TestExportImport:
     def test_positive_export_import_incremental_yum_repo(
         self,
         target_sat,
-        export_import_cleanup_function,
+        complete_export_import_cleanup,
         config_export_import_settings,
         function_org,
-        function_import_org,
         function_synced_custom_repo,
+        module_import_sat,
+        function_import_org_at_isat,
     ):
         """Export and import custom YUM repo contents incrementally.
 
@@ -2759,13 +2775,15 @@ class TestExportImport:
 
         # Run import and verify the product and repo is created
         # in the importing org and the content counts match.
-        import_path = target_sat.move_pulp_archive(function_org, export['message'])
-        target_sat.cli.ContentImport.repository(
-            {'organization-id': function_import_org.id, 'path': import_path}
+        import_path = target_sat.move_pulp_archive(
+            function_org, export['message'], target=module_import_sat
         )
-        import_repo = target_sat.cli.Repository.info(
+        module_import_sat.cli.ContentImport.repository(
+            {'organization-id': function_import_org_at_isat.id, 'path': import_path}
+        )
+        import_repo = module_import_sat.cli.Repository.info(
             {
-                'organization-id': function_import_org.id,
+                'organization-id': function_import_org_at_isat.id,
                 'name': function_synced_custom_repo.name,
                 'product': function_synced_custom_repo.product.name,
             }
@@ -2786,13 +2804,15 @@ class TestExportImport:
         assert '2.0' in target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR)
 
         # Run the import and verify the content counts match the updated counts.
-        import_path = target_sat.move_pulp_archive(function_org, export['message'])
-        target_sat.cli.ContentImport.repository(
-            {'organization-id': function_import_org.id, 'path': import_path}
+        import_path = target_sat.move_pulp_archive(
+            function_org, export['message'], target=module_import_sat
         )
-        import_repo = target_sat.cli.Repository.info(
+        module_import_sat.cli.ContentImport.repository(
+            {'organization-id': function_import_org_at_isat.id, 'path': import_path}
+        )
+        import_repo = module_import_sat.cli.Repository.info(
             {
-                'organization-id': function_import_org.id,
+                'organization-id': function_import_org_at_isat.id,
                 'name': function_synced_custom_repo.name,
                 'product': function_synced_custom_repo.product.name,
             }
@@ -3026,11 +3046,12 @@ class TestExportImport:
     def test_positive_export_import_consume_incremental_yum_repo(
         self,
         target_sat,
-        export_import_cleanup_function,
+        complete_export_import_cleanup,
         config_export_import_settings,
         function_org,
-        function_import_org,
         function_synced_custom_repo,
+        module_import_sat,
+        function_import_org_at_isat,
         rhel_contenthost,
     ):
         """Export and import custom repo incrementally and consume it on a content host.
@@ -3084,41 +3105,50 @@ class TestExportImport:
         assert '1.0' in target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR)
 
         # On the importing side import version 1, check the package count.
-        import_path1 = target_sat.move_pulp_archive(function_org, export_1['message'])
-        target_sat.cli.ContentImport.version(
-            {'organization-id': function_import_org.id, 'path': import_path1}
+        import_path1 = target_sat.move_pulp_archive(
+            function_org, export_1['message'], target=module_import_sat
         )
-        imp_cv = target_sat.cli.ContentView.info(
-            {'name': exp_cv['name'], 'organization-id': function_import_org.id}
+        module_import_sat.cli.ContentImport.version(
+            {'organization-id': function_import_org_at_isat.id, 'path': import_path1}
+        )
+        imp_cv = module_import_sat.cli.ContentView.info(
+            {'name': exp_cv['name'], 'organization-id': function_import_org_at_isat.id}
         )
         assert len(imp_cv['versions']) == 1
         imp_cvv = imp_cv['versions'][0]
-        assert target_sat.api.ContentViewVersion(id=imp_cvv['id']).read().package_count == pkg_cnt_1
+        assert (
+            module_import_sat.api.ContentViewVersion(id=imp_cvv['id']).read().package_count
+            == pkg_cnt_1
+        )
 
         # Create an AK with the imported CV, register the content host and check
         # the package count available to install. Filtered package should be missing.
-        cvenv_id = target_sat.api_factory.get_cvenv_id(imp_cv['id'], function_import_org.library)
-        ak = target_sat.cli_factory.make_activation_key(
+        cvenv_id = module_import_sat.api_factory.get_cvenv_id(
+            imp_cv['id'], function_import_org_at_isat.library
+        )
+        ak = module_import_sat.cli_factory.make_activation_key(
             {
                 'content-view-environment-ids': cvenv_id,
-                'organization-id': function_import_org.id,
+                'organization-id': function_import_org_at_isat.id,
             }
         )
-        repo_content_label = target_sat.cli.Repository.info(
+        repo_content_label = module_import_sat.cli.Repository.info(
             {
                 'name': function_synced_custom_repo['name'],
                 'product': function_synced_custom_repo['product']['name'],
-                'organization-id': function_import_org.id,
+                'organization-id': function_import_org_at_isat.id,
             }
         )['content-label']
-        target_sat.cli.ActivationKey.content_override(
+        module_import_sat.cli.ActivationKey.content_override(
             {
                 'id': ak.id,
                 'content-label': repo_content_label,
                 'value': 'true',
             }
         )
-        res = rhel_contenthost.register(function_import_org, None, ak.name, target_sat)
+        res = rhel_contenthost.register(
+            function_import_org_at_isat, None, ak.name, module_import_sat
+        )
         assert res.status == 0, (
             f'Failed to register host: {rhel_contenthost.hostname}\n'
             f'StdOut: {res.stdout}\nStdErr: {res.stderr}'
@@ -3152,12 +3182,14 @@ class TestExportImport:
         assert '2.0' in target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR)
 
         # Import version 2, check the package count.
-        import_path2 = target_sat.move_pulp_archive(function_org, export_2['message'])
-        target_sat.cli.ContentImport.version(
-            {'organization-id': function_import_org.id, 'path': import_path2}
+        import_path2 = target_sat.move_pulp_archive(
+            function_org, export_2['message'], target=module_import_sat
         )
-        imp_cv = target_sat.cli.ContentView.info(
-            {'name': exp_cv['name'], 'organization-id': function_import_org.id}
+        module_import_sat.cli.ContentImport.version(
+            {'organization-id': function_import_org_at_isat.id, 'path': import_path2}
+        )
+        imp_cv = module_import_sat.cli.ContentView.info(
+            {'name': exp_cv['name'], 'organization-id': function_import_org_at_isat.id}
         )
         assert len(imp_cv['versions']) == 2
         imp_cvv = max(imp_cv['versions'], key=lambda x: int(x['id']))
@@ -3173,7 +3205,7 @@ class TestExportImport:
             )['content-counts']['packages']
         )
         assert (
-            target_sat.api.ContentViewVersion(id=imp_cvv['id']).read().package_count
+            module_import_sat.api.ContentViewVersion(id=imp_cvv['id']).read().package_count
             == pkg_cnt_2
             == package_count
         ), 'Unexpected package count after second import'
@@ -3193,10 +3225,11 @@ class TestExportImport:
         self,
         target_sat,
         config_export_import_settings,
-        export_import_cleanup_function,
+        complete_export_import_cleanup,
         function_org,
         function_product,
-        function_import_org,
+        module_import_sat,
+        function_import_org_at_isat,
     ):
         """Test export/import of a repo created via Podman push
 
@@ -3235,21 +3268,25 @@ class TestExportImport:
         assert target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR) == ''
         export = target_sat.cli.ContentExport.completeRepository({'id': repo['id']})
         assert '1.0' in target_sat.validate_pulp_filepath(function_org, PULP_EXPORT_DIR)
-        import_path = target_sat.move_pulp_archive(function_org, export['message'])
+        import_path = target_sat.move_pulp_archive(
+            function_org, export['message'], target=module_import_sat
+        )
         # Check that files are present in import_path
-        result = target_sat.execute(f'ls {import_path}')
+        result = module_import_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import files and verify content
-        target_sat.cli.ContentImport.library(
-            {'organization-id': function_import_org.id, 'path': import_path}
+        module_import_sat.cli.ContentImport.library(
+            {'organization-id': function_import_org_at_isat.id, 'path': import_path}
         )
-        assert target_sat.cli.Product.list({'organization-id': function_import_org.id})
-        import_repo = target_sat.cli.Repository.info(
+        assert module_import_sat.cli.Product.list(
+            {'organization-id': function_import_org_at_isat.id}
+        )
+        import_repo = module_import_sat.cli.Repository.info(
             {
-                'organization-id': function_import_org.id,
-                'id': target_sat.cli.Repository.list({'organization-id': function_import_org.id})[
-                    0
-                ]['id'],
+                'organization-id': function_import_org_at_isat.id,
+                'id': module_import_sat.cli.Repository.list(
+                    {'organization-id': function_import_org_at_isat.id}
+                )[0]['id'],
             }
         )
         assert import_repo['name'] == repo['name']


### PR DESCRIPTION
### Problem Statement
Currently we the the vast majority of the ISS export+import tests runs against the same Satellite instance for both - export and import (just into another organization), which does not quite follow the user case and may miss some important issues.


### Solution
After merge of https://github.com/SatelliteQE/robottelo/pull/21600 we should be ready to migrate the tests to use a separate Satellite instance for imports. In this PR I'm migrating 10 of them where it makes sense the most. Others may follow.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py -k 'test_postive_export_import_cv_with_mixed_content_syncable or test_postive_export_import_repo_with_GPG or test_positive_export_import_incremental_yum_repo or test_positive_export_import_consume_incremental_yum_repo or test_positive_export_import_default_org_view or test_postive_export_import_podman_repo or test_postive_export_import_ansible_collection_repo or test_positive_export_import_redhat_cv or test_positive_export_import_filtered_cvv or test_postive_export_import_large_cv'
env:
    ROBOTTELO_iss__separate_import_sat: true
```
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py -k 'test_postive_export_import_cv_with_mixed_content_syncable or test_postive_export_import_repo_with_GPG or test_positive_export_import_incremental_yum_repo or test_positive_export_import_consume_incremental_yum_repo or test_positive_export_import_default_org_view or test_postive_export_import_podman_repo or test_postive_export_import_ansible_collection_repo or test_positive_export_import_redhat_cv or test_positive_export_import_filtered_cvv or test_postive_export_import_large_cv'
env:
    ROBOTTELO_iss__separate_import_sat: false
```

## Summary by Sourcery

Migrate several content export/import CLI tests to use a dedicated import Satellite instance instead of the primary target Satellite.

Tests:
- Update ten ISS export/import scenarios to perform imports against module_import_sat and import-specific organizations/fixtures.
- Adjust content view and repository setup in tests to use bulk repository-ids arguments and align with new cleanup fixtures.
- Extend test coverage of import-side behavior by validating imported entities (packages, files, products, repositories, credentials) on the separate Satellite instance.