### PR TITLE
[6.17.z] Multiple new_upgrades fixes

### DIFF
--- a/conf/upgrade.yaml.template
+++ b/conf/upgrade.yaml.template
@@ -7,6 +7,8 @@ UPGRADE:
   OS: rhel9
   # The job template Broker should use to upgrade a Satellite
   SATELLITE_UPGRADE_JOB_TEMPLATE: satellite-upgrade
+  # The upgrade path to use when upgrading Satellite (< ystream | zstream >)
+  UPGRADE_PATH: ystream
   # Capsule's activation key will only be available when we spawn the VM using upgrade template.
   CAPSULE_AK:
     RHEL8: rhel8_capsule_ak

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -679,18 +679,18 @@ class ContentHost(Host, ContentHostMixins):
             'update-packages': str(update_packages).lower(),
         }
         if org is not None:
-            if isinstance(org, entities.Organization):
-                options['organization-id'] = org.id
-            elif isinstance(org, dict):
+            if isinstance(org, dict):
                 options['organization-id'] = org['id']
+            elif hasattr(org, 'id'):
+                options['organization-id'] = org.id
             else:
                 raise ValueError('org must be a dict or an Organization object')
 
         if loc is not None:
-            if isinstance(loc, entities.Location):
-                options['location-id'] = loc.id
-            elif isinstance(loc, dict):
+            if isinstance(loc, dict):
                 options['location-id'] = loc['id']
+            elif hasattr(loc, 'id'):
+                options['location-id'] = loc.id
             else:
                 raise ValueError('loc must be a dict or a Location object')
 
@@ -1593,9 +1593,12 @@ class ContentHost(Host, ContentHostMixins):
                 snap=settings.server.version.snap,
             )
 
-    def setup_capsule_repos(self):
+    def setup_capsule_repos(self, release=None):
         """Setup Capsule repositories on host
         requires registered host if ga source has to be enabled
+
+        Args:
+            release: Override capsule version release (Default: settings.capsule.version.release)
         """
         if settings.capsule.version.source == "ga":
             # enable cdn repos
@@ -1608,8 +1611,8 @@ class ContentHost(Host, ContentHostMixins):
         else:
             self.download_repofile(
                 product='capsule',
-                release=settings.capsule.version.release,
-                snap=settings.capsule.version.snap,
+                release=release or settings.capsule.version.release,
+                snap='' if release else settings.capsule.version.snap,
             )
 
 
@@ -1756,12 +1759,21 @@ class Capsule(ContentHost, CapsuleMixins):
         """Get capsule features"""
         return requests.get(f'https://{self.hostname}:9090/features', verify=False).text
 
-    def capsule_setup(self, sat_host=None, capsule_cert_opts=None, **installer_kwargs):
-        """Prepare the host and run the capsule installer"""
+    def capsule_setup(
+        self, sat_host=None, capsule_cert_opts=None, release=None, **installer_kwargs
+    ):
+        """Prepare the host and run the capsule installer
 
+        Args:
+            sat_host: Satellite host object
+            capsule_cert_opts: Certificate options for capsule
+            release: Override capsule version release for upgrade testing (Default: settings.capsule.version.release)
+        Kwargs:
+            installer_kwargs: Additional installer arguments
+        """
         self.register_to_cdn()
         self.setup_rhel_repos()
-        self.setup_capsule_repos()
+        self.setup_capsule_repos(release=release)
 
         # After capsule registration to cdn, it should be initialized with the Satellite.
         self._satellite = sat_host or Satellite()

--- a/robottelo/utils/shared_resource.py
+++ b/robottelo/utils/shared_resource.py
@@ -76,7 +76,7 @@ class SharedResource:
         """
         self.resource_name = resource_name
         self.resource_file = Path(f"/tmp/{resource_name}.shared")
-        self.lock_file = FileLock(self.resource_file)
+        self.lock_file = FileLock(self.resource_file, timeout=120)
         self.id = str(uuid4().fields[-1])
         self.action = action
         self.action_validator = action_validator
@@ -183,7 +183,7 @@ class SharedResource:
 
     def unregister(self):
         """Unregisters the current process as a watcher."""
-        logger.debug("Unregistering %s", os.environ.get('PYTEST_XDIST_WORKER'))
+        logger.debug("Unregistering %s", os.environ.get('PYTEST_XDIST_WORKER', 'worker'))
         with self.lock_file:
             curr_data = json.loads(self.resource_file.read_text())
             logger.debug("Removing watcher ID from resource file")
@@ -254,8 +254,8 @@ class SharedResource:
 
         if exc_type is FileNotFoundError:
             logger.warning(
-                '%s did not find resource file. has it already been deleted?',
-                os.environ.get('PYTEST_XDIST_WORKER'),
+                '%s did not find resource file. Has it already been deleted?',
+                os.environ.get('PYTEST_XDIST_WORKER', 'Worker'),
             )
             raise exc_value
         if exc_type:

--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -25,14 +25,20 @@ from robottelo.utils.shared_resource import SharedResource
 def pytest_configure(config):
     """Register custom markers to avoid warnings."""
     markers = [
-        "content_upgrades: Content upgrade tests that use SharedResource.",
-        "search_upgrades: Search upgrade tests that use SharedResource.",
-        "hostgroup_upgrades: Host group upgrade tests that use SharedResource.",
-        "errata_upgrades: Errata upgrade tests that use SharedResource.",
-        "perf_tuning_upgrades: Performance tuning upgrade tests that use SharedResource.",
-        "discovery_upgrades: Discovery upgrade tests that use SharedResource.",
         "capsule_upgrades: Capsule upgrade tests that use SharedResource.",
+        "capsule_puppet_upgrades: Capsule puppet upgrade tests that use SharedResource.",
+        "client_upgrades: Client upgrade tests that use SharedResource.",
+        "content_upgrades: Content upgrade tests that use SharedResource.",
+        "discovery_upgrades: Discovery upgrade tests that use SharedResource.",
+        "errata_upgrades: Errata upgrade tests that use SharedResource.",
+        "hostgroup_upgrades: Host group upgrade tests that use SharedResource.",
+        "perf_tuning_upgrades: Performance tuning upgrade tests that use SharedResource.",
         "puppet_upgrades: Puppet upgrade tests that use SharedResource.",
+        "search_upgrades: Search upgrade tests that use SharedResource.",
+        "subscription_upgrades: Subscription upgrade tests that use SharedResource.",
+        "sync_plan_upgrades: Sync plan upgrade tests that use SharedResource.",
+        "usergroup_upgrades: User group upgrade tests that use SharedResource.",
+        "virt_who_upgrades: Virt_who upgrade tests that use SharedResource.",
     ]
     for marker in markers:
         config.addinivalue_line("markers", marker)
@@ -41,9 +47,9 @@ def pytest_configure(config):
 def shared_checkout(shared_name):
     Satellite(hostname="blank")._swap_nailgun(settings.UPGRADE.FROM_VERSION)
     bx_inst = Broker(
-        workflow=settings.SERVER.deploy_workflows.product,
-        deploy_sat_version=settings.UPGRADE.FROM_VERSION,
-        deploy_network_type=settings.SERVER.network_type,
+        workflow=settings.server.deploy_workflows.product,
+        deploy_sat_version=settings.upgrade.from_version,
+        deploy_network_type=settings.server.network_type,
         host_class=Satellite,
         upgrade_group=f"{shared_name}_shared_checkout",
     )
@@ -57,14 +63,14 @@ def shared_checkout(shared_name):
             filter=f'@inv._broker_args.upgrade_group == "{shared_name}_shared_checkout" |'
             '@inv._broker_args.workflow == "deploy-satellite"'
         )
-    return sat_instance[0]
+    return sat_instance[-1]
 
 
 def shared_cap_checkout(shared_name):
     cap_inst = Broker(
-        workflow=settings.CAPSULE.deploy_workflows.product,
-        deploy_sat_version=settings.UPGRADE.FROM_VERSION,
-        deploy_network_type=settings.CAPSULE.network_type,
+        workflow=settings.capsule.deploy_workflows.product,
+        deploy_sat_version=settings.upgrade.from_version,
+        deploy_network_type=settings.capsule.network_type,
         host_class=Capsule,
         upgrade_group=f'{shared_name}_shared_checkout',
     )
@@ -78,7 +84,7 @@ def shared_cap_checkout(shared_name):
             filter=f'@inv._broker_args.upgrade_group == "{shared_name}_shared_checkout" |'
             '@inv._broker_args.workflow == "deploy-capsule"'
         )
-    return cap_instance[0]
+    return cap_instance[-1]
 
 
 def shared_checkin(sat_instance):
@@ -95,10 +101,10 @@ def shared_checkin(sat_instance):
 def upgrade_action():
     def _upgrade_action(target_sat):
         result = Broker(
-            job_template=settings.UPGRADE.SATELLITE_UPGRADE_JOB_TEMPLATE,
+            job_template=settings.upgrade.satellite_upgrade_job_template,
             target_vm=target_sat.name,
-            sat_version=settings.UPGRADE.TO_VERSION,
-            upgrade_path="ystream",
+            sat_version=settings.upgrade.to_version,
+            upgrade_path=settings.upgrade.upgrade_path,
             tower_inventory=target_sat.tower_inventory,
         ).execute()
 
@@ -278,6 +284,7 @@ def capsule_upgrade_integrated_sat_cap(
         "capsule_setup",
         action=capsule_upgrade_shared_capsule.capsule_setup,
         sat_host=capsule_upgrade_shared_satellite,
+        release=capsule_upgrade_shared_capsule.version,
     ) as cap_setup:
         cap_setup.ready()
     cap_smart_proxy = capsule_upgrade_shared_satellite.api.SmartProxy().search(
@@ -344,6 +351,7 @@ def puppet_upgrade_integrated_sat_cap(
             "capsule_setup",
             action=puppet_upgrade_shared_capsule.capsule_setup,
             sat_host=puppet_upgrade_shared_satellite,
+            release=puppet_upgrade_shared_capsule.version,
         ) as cap_setup,
         SharedResource(
             "puppet_upgrade_enable_puppet_capsule",

--- a/tests/new_upgrades/test_activation_key.py
+++ b/tests/new_upgrades/test_activation_key.py
@@ -73,6 +73,7 @@ def ak_upgrade_setup(content_upgrade_shared_satellite, upgrade_action):
         ak = ak.update(['host_collection'])
         assert len(ak.host_collection) == 1
         sat_upgrade.ready()
+        target_sat._swap_nailgun(settings.upgrade.to_version)
         target_sat._session = None
         yield test_data
 
@@ -95,7 +96,6 @@ def test_ak_upgrade_scenario(ak_upgrade_setup):
     :BlockedBy: SAT-28048, SAT-28990
     """
     target_sat = ak_upgrade_setup.target_sat
-    target_sat._swap_nailgun(settings.UPGRADE.TO_VERSION)
     org = target_sat.api.Organization().search(
         query={'search': f'name={ak_upgrade_setup.org.name}'}
     )[0]

--- a/tests/new_upgrades/test_capsulecontent.py
+++ b/tests/new_upgrades/test_capsulecontent.py
@@ -93,9 +93,10 @@ def capsule_sync_setup(capsule_upgrade_integrated_sat_cap, upgrade_action):
             }
         )
         sat_upgrade.ready()
-        target_sat._swap_nailgun(settings.UPGRADE.TO_VERSION)
-        cap_upgrade.ready()
+        target_sat._swap_nailgun(settings.upgrade.to_version)
         target_sat._session = None
+
+        cap_upgrade.ready()
         capsule._session = None
         yield test_data
 

--- a/tests/new_upgrades/test_client.py
+++ b/tests/new_upgrades/test_client.py
@@ -169,7 +169,7 @@ def test_post_scenario_post_client_package_installation(pre_client_package_insta
     rhel_client.execute('subscription-manager unregister')
     rhel_client.execute('subscription-manager clean')
     target_sat = pre_client_package_installation_setup.satellite
-    target_sat._swap_nailgun(settings.UPGRADE.TO_VERSION)
+    target_sat._swap_nailgun(settings.upgrade.to_version)
     org = target_sat.api.Organization(id=pre_client_package_installation_setup.org.id).read()
     location = target_sat.api.Location(id=pre_client_package_installation_setup.location.id).read()
     lce = target_sat.api.LifecycleEnvironment(

--- a/tests/new_upgrades/test_computeresource_gce.py
+++ b/tests/new_upgrades/test_computeresource_gce.py
@@ -162,9 +162,7 @@ def setup_gce_cr_and_host(
                 'domain': domain,
                 'compute_attrs': compute_attrs,
                 'compute_resource': compute_resource,
-                'gce_finishimg': gce_finishimg,
                 'googleclient': shared_googleclient,
-                'google_host': google_host,
                 'hostgroup': hostgroup,
                 'architecture': default_arch,
                 'os': default_os,
@@ -172,10 +170,12 @@ def setup_gce_cr_and_host(
                 'provision_host_ip': host.ip,
             }
         )
+        target_sat._swap_nailgun(settings.upgrade.to_version)
         target_sat._session = None
         yield test_data
 
 
+@pytest.mark.puppet_upgrades
 def test_post_create_gce_cr_and_host(
     setup_gce_cr_and_host,
 ):
@@ -200,13 +200,21 @@ def test_post_create_gce_cr_and_host(
     pre_upgrade_host = target_sat.api.Host().search(
         query={'search': f'name={setup_gce_cr_and_host.provision_host_name}'}
     )[0]
-    org = target_sat.api.Organization(id=pre_upgrade_host.organization.id).read()
-    loc = target_sat.api.Location(id=pre_upgrade_host.location.id).read()
+
+    # Re-read all entities using IDs to get fresh objects after nailgun re-install
+    architecture = target_sat.api.Architecture(id=setup_gce_cr_and_host.architecture.id).read()
+    compute_resource = target_sat.api.GCEComputeResource(
+        id=setup_gce_cr_and_host.compute_resource.id
+    ).read()
     domain = target_sat.api.Domain(id=pre_upgrade_host.domain.id).read()
+    hostgroup = target_sat.api.HostGroup(id=pre_upgrade_host.hostgroup.id).read()
     image = target_sat.api.Image(
         id=pre_upgrade_host.image.id, compute_resource=pre_upgrade_host.compute_resource.id
     ).read()
-    gce_hostgroup = target_sat.api.HostGroup(id=pre_upgrade_host.hostgroup.id).read()
+    loc = target_sat.api.Location(id=pre_upgrade_host.location.id).read()
+    org = target_sat.api.Organization(id=pre_upgrade_host.organization.id).read()
+    os = target_sat.api.OperatingSystem(id=setup_gce_cr_and_host.os.id).read()
+
     assert pre_upgrade_host.ip == setup_gce_cr_and_host.provision_host_ip
     assert pre_upgrade_host.build_status_label == 'Installed'
     with target_sat.api_factory.satellite_setting('destroy_vm_on_host_delete=True'):
@@ -217,16 +225,17 @@ def test_post_create_gce_cr_and_host(
     # Create new host
     hostname = gen_alpha(length=8)
     host = target_sat.api.Host(
-        architecture=setup_gce_cr_and_host.architecture,
+        architecture=architecture,
         compute_attributes=setup_gce_cr_and_host.compute_attrs,
+        compute_resource=compute_resource,
         domain=domain,
-        hostgroup=gce_hostgroup,
-        organization=org,
-        operatingsystem=setup_gce_cr_and_host.os,
+        hostgroup=hostgroup,
+        image=image,
         location=loc,
+        organization=org,
+        operatingsystem=os,
         name=hostname,
         provision_method='image',
-        image=image,
         root_pass=gen_string('alphanumeric'),
     ).create()
     assert host.name == f'{hostname}.{domain.name}'.lower()
@@ -237,7 +246,6 @@ def test_post_create_gce_cr_and_host(
         assert host.name not in [vm.name for vm in googleclient.list_vms()]
 
     # Modify compute resource
-    compute_resource = setup_gce_cr_and_host.compute_resource
     newgce_name = gen_string('alpha')
     newgce_zone = random.choice(VALID_GCE_ZONES)
     compute_resource.name = newgce_name

--- a/tests/new_upgrades/test_errata.py
+++ b/tests/new_upgrades/test_errata.py
@@ -200,13 +200,14 @@ def generate_errata_for_client_setup(
         errata_ids = [errata.errata_id for errata in erratum_list]
         assert sorted(errata_ids) == sorted(settings.repos.yum_9.errata)
         sat_upgrade.ready()
+        target_sat._swap_nailgun(settings.upgrade.to_version)
         target_sat._session = None
         yield test_data
 
 
 @pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
 @pytest.mark.no_containers
-@pytest.mark.errata_upgrade
+@pytest.mark.errata_upgrades
 def test_post_scenario_errata_count_installation(generate_errata_for_client_setup):
     """Post-upgrade scenario that applies errata on the RHEL client that was set up
     in the pre-upgrade test and verifies that the errata was applied correctly.

--- a/tests/new_upgrades/test_hostgroup.py
+++ b/tests/new_upgrades/test_hostgroup.py
@@ -95,6 +95,7 @@ def hostgroup_upgrade_setup(hostgroup_upgrade_shared_satellite, upgrade_action):
         yield test_data
 
 
+@pytest.mark.hostgroup_upgrades
 def test_post_crud_hostgroup(hostgroup_upgrade_setup, request):
     """After upgrade, Update, delete and clone should work on existing hostgroup(created before
     upgrade)

--- a/tests/new_upgrades/test_provisioningtemplate.py
+++ b/tests/new_upgrades/test_provisioningtemplate.py
@@ -115,10 +115,12 @@ def provisioning_templates_setup(
                 'target_sat': target_sat,
             }
         )
+        target_sat._swap_nailgun(settings.upgrade.to_version)
         target_sat._session = None
         yield test_data
 
 
+@pytest.mark.content_upgrades
 @pytest.mark.parametrize('provisioning_templates_setup', ['bios', 'uefi'], indirect=True)
 def test_post_scenario_provisioning_templates(
     provisioning_templates_setup,

--- a/tests/new_upgrades/test_puppet.py
+++ b/tests/new_upgrades/test_puppet.py
@@ -34,14 +34,15 @@ def puppet_upgrade_setup(puppet_upgrade_integrated_sat_cap, upgrade_action):
             }
         )
         sat_upgrade.ready()
-        satellite._swap_nailgun(settings.UPGRADE.TO_VERSION)
-        cap_upgrade.ready()
+        satellite._swap_nailgun(settings.upgrade.to_version)
         satellite._session = None
+
+        cap_upgrade.ready()
         capsule._session = None
         yield test_data
 
 
-@pytest.mark.puppet_upgrades
+@pytest.mark.capsule_puppet_upgrades
 def test_post_puppet_active(puppet_upgrade_setup):
     """Test that puppet remains active after the upgrade on both,
     Satellite and Capsule.
@@ -66,13 +67,13 @@ def test_post_puppet_active(puppet_upgrade_setup):
         assert 'puppet' in result
         assert 'puppetca' in result
 
-        assert server.execute('rpm -q puppetserver').status == 0
+        assert server.execute('rpm -q openvox-server').status == 0
 
         result = server.execute('systemctl status puppetserver')
         assert 'active (running)' in result.stdout
 
 
-@pytest.mark.puppet_upgrades
+@pytest.mark.capsule_puppet_upgrades
 def test_post_puppet_reporting(puppet_upgrade_setup):
     """Test that puppet is reporting to Satellite after the upgrade.
 

--- a/tests/new_upgrades/test_repository.py
+++ b/tests/new_upgrades/test_repository.py
@@ -48,6 +48,7 @@ def custom_repo_check_setup(sat_upgrade_chost, content_upgrade_shared_satellite,
 
     """
     target_sat = content_upgrade_shared_satellite
+    sat_upgrade_chost._skip_context_checkin = True
     with SharedResource(target_sat.hostname, upgrade_action, target_sat=target_sat) as sat_upgrade:
         test_data = Box(
             {

--- a/tests/new_upgrades/test_role.py
+++ b/tests/new_upgrades/test_role.py
@@ -187,7 +187,6 @@ class TestBuiltInRolesLocked:
     :CaseAutomation: NotAutomated
     """
 
-    @pytest.mark.post_upgrade
     def test_post_builtin_roles_are_cloned(self):
         """Builtin roles in satellite gets locked post upgrade
 
@@ -224,7 +223,6 @@ class TestNewOrganizationAdminRole:
     :CaseAutomation: NotAutomated
     """
 
-    @pytest.mark.post_upgrade
     def test_post_builtin_roles_are_cloned(self):
         """New Organization Admin role creates post upgrade
 

--- a/tests/new_upgrades/test_satellitesync.py
+++ b/tests/new_upgrades/test_satellitesync.py
@@ -57,6 +57,7 @@ def version_cv_export_import_setup(content_upgrade_shared_satellite, upgrade_act
             }
         )
         sat_upgrade.ready()
+        target_sat._swap_nailgun(settings.upgrade.to_version)
         target_sat._session = None
         yield test_data
 

--- a/tests/new_upgrades/test_virtwho.py
+++ b/tests/new_upgrades/test_virtwho.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix-subscriptions
+:Team: Proton
 
 :CaseImportance: High
 


### PR DESCRIPTION
### Problem Statement

- tests/new_upgrades/test_virtwho.py still linked to old team name `Phoenix-subscriptions` instead of `Proton`
- Several upgrade tests not marked with corresponding `*_upgrades` marker
- Several `*_upgrades` markers not registered
- Multiple upgrade test failures

### Solution

- Register and apply missing upgrade markers
- Fix team assignment
- Fix test failures:
  - Use `_swap_nailgun` and re-instantiate nailgun entities as needed to fix post-upgrade api errors
  - Fix capsule deployment / setup to use pre-upgrade version (`settings.upgrade.from_version`)
  - Fix the `upgrade_action` fixture to use `settings.upgrade.upgrade_path` instead of hard-coding `"ystream"`, so that both `"ystream"` and `"zstream"` upgrade paths can be supported.
  - Fix puppet test to verify `openvox-server` rpm is installed instead of the deprecated `puppetserver` rpm.
  - Contenthost upgrade test fixes

### Related Issues

SAT-40414

### PRT tests


## Summary by Sourcery

Align upgrade tests and infrastructure with new settings schema while improving capsule upgrade handling and shared resource robustness.

New Features:
- Register additional *_upgrades pytest markers and tag missing upgrade tests accordingly.

Bug Fixes:
- Fix upgrade tests to use the new settings.upgrade and settings.server/capsule schema and correct Satellite/capsule selection after shared checkouts.
- Ensure post-upgrade tests correctly swap nailgun sessions and reset API sessions to target upgraded Satellites and capsules.
- Update puppet upgrade validation to check for the supported openvox-server package instead of the deprecated puppetserver.
- Fix organization and location handling in host registration to support dicts and objects with id attributes uniformly.
- Resolve capsule upgrade behavior by allowing capsule_setup and repository configuration to accept an explicit release for pre-/post-upgrade scenarios.
- Improve SharedResource locking behavior and logging defaults to prevent timeouts and missing worker identifiers.
- Avoid context check-in issues in repository upgrade tests by allowing explicit control via _skip_context_checkin and correct shared resource usage.

Enhancements:
- Refine Broker usage in content host fixtures to merge host parameters with overrides predictably.
- Clarify and extend capsule setup and repository configuration APIs with explicit arguments and documentation.
- Adjust shared resource selection to use the most recent instance where appropriate in upgrade flows.

Documentation:
- Update Virt-who upgrade test metadata to reference the Proton team.

## Summary by Sourcery

Align upgrade test suite and capsule setup logic with the new upgrade settings schema while improving shared resource robustness and post-upgrade API handling.

New Features:
- Register additional *_upgrades pytest markers and tag relevant upgrade tests to enable targeted upgrade test selection.

Bug Fixes:
- Update upgrade flows and tests to use settings.upgrade and settings.server/capsule schema, including dynamic upgrade_path and correct pre-/post-upgrade Satellite and Capsule versions.
- Fix post-upgrade tests by swapping nailgun sessions and re-instantiating API entities to avoid stale objects after upgrades.
- Relax organization and location handling in host registration to support both dicts and objects exposing id attributes.
- Correct puppet upgrade validation to check for the supported openvox-server package and retag capsule puppet upgrade tests.
- Stabilize shared resource usage in repository and upgrade tests by allowing context check-in control and using the latest shared instances.

Enhancements:
- Extend capsule repository and setup helpers with explicit release control and documentation to better support upgrade scenarios.
- Increase shared resource file lock robustness and clarify logging when unregistering workers.