### PR TITLE
test for cloning locked partition table

### DIFF
--- a/pytest_fixtures/component/partition_table.py
+++ b/pytest_fixtures/component/partition_table.py
@@ -1,3 +1,4 @@
+from fauxfactory import gen_alpha
 import pytest
 
 from robottelo.constants import DEFAULT_PTABLE
@@ -9,3 +10,12 @@ def default_partition_table(session_target_sat):
     return session_target_sat.api.PartitionTable().search(
         query={'search': f'name="{DEFAULT_PTABLE}"'}
     )[0]
+
+
+@pytest.fixture(scope='module')
+def locked_partition_table(module_target_sat):
+    """Create a locked partition table. Delete it afterward."""
+    ptable = module_target_sat.api.PartitionTable(name=gen_alpha(), locked=True).create()
+    yield ptable
+    ptable.locked = False
+    ptable.update(['locked']).delete()

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -18,7 +18,7 @@ http://theforeman.org/api/apidoc/v2/ptables.html
 
 import random
 
-from fauxfactory import gen_integer, gen_string
+from fauxfactory import gen_alpha, gen_integer, gen_string
 import pytest
 from requests.exceptions import HTTPError
 
@@ -221,3 +221,19 @@ class TestPartitionTable:
         ptable.layout = new_layout
         with pytest.raises(HTTPError):
             assert ptable.update(['layout']).layout != new_layout
+
+    def test_positive_clone_locked_ptable(self, target_sat, locked_partition_table):
+        """Clone a locked partition table. Verify the cloned ptable is not locked.
+
+        :id: 97d32564-5aa9-11f1-b7e0-000c29a0e355
+
+        :Verifies: SAT-43678
+
+        :expectedresults: User can clone a locked partition table. The cloned ptable is not locked.
+        """
+        name_cloned = gen_alpha()
+        ptable = target_sat.api.PartitionTable(id=locked_partition_table.id).clone(
+            data={'ptable': {'name': name_cloned}}
+        )
+        assert ptable['name'] == name_cloned
+        assert ptable['locked'] is False


### PR DESCRIPTION
## Problem Statement
New test coverage for cloning locked partition tables to ensure the clone operation works correctly and the cloned partition table is not locked.

## Solution
- Added `locked_partition_table` fixture in `pytest_fixtures/component/partition_table.py` that creates a locked partition table and handles cleanup (unlocking and deletion)
- Added `test_positive_clone_locked_ptable` in `tests/foreman/api/test_partitiontable.py` that: 
  - Clones a locked partition table
  - Verifies the clone has the correct name
  - Verifies the cloned partition table is not locked

### Related Issues
Verifies SAT-43678
Requires https://github.com/SatelliteQE/nailgun/pull/1420

## PRT Instructions
```yaml
trigger: test-robottelo
pytest: tests/foreman/api/test_partitiontable.py -k test_positive_clone_locked_ptable
nailgun: 1420
```

## Summary by Sourcery

Add test coverage for cloning locked partition tables and introduce a fixture to provision a locked partition table for reuse in tests.

New Features:
- Introduce a reusable locked_partition_table pytest fixture that provisions and cleans up a locked partition table.

Tests:
- Add an API test that clones a locked partition table and asserts the cloned partition table has the expected name and is not locked.