### PR TITLE
Add bar chart assertions to Ansible and OSCAP tests

### DIFF
--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -530,6 +530,10 @@ def test_positive_oscap_remediation(
         )
         title = 'xccdf_org.ssgproject.content_rule_package_aide_installed'
         session.organization.select(module_org.name)
+        report_chart = session.oscapreport.details(
+            f'id={arf_id}', widget_names=['report_status_chart']
+        )['report_status_chart']
+        assert any(v > 0 for v in report_chart.values())
         results = session.oscapreport.details(f'id={arf_id}', widget_names=['table'], limit=10)[
             'table'
         ]

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -618,6 +618,9 @@ class TestAnsibleREX:
             session.organization.select(module_org.name)
             session.location.select(constants.DEFAULT_LOC)
             assert session.host.search(target_host.name)[0]['Name'] == rhel_contenthost.hostname
+            chart_data = session.dashboard.read('RunDistributionChart')
+            assert 'Ansible' in chart_data, f'RunDistributionChart returned: {chart_data}'
+            assert any(v > 0 for v in chart_data['Ansible'].values())
             session.configreport.search(rhel_contenthost.hostname)
             session.configreport.delete(rhel_contenthost.hostname)
             assert len(session.configreport.read()['table']) == 0


### PR DESCRIPTION
Verify the PF5 Run Distribution Chart on the dashboard after an
Ansible role run, and the Report Status bar chart on OSCAP ARF
report details. Extends existing tests rather than adding new ones.
Requires https://github.com/SatelliteQE/airgun/pull/2453

## Summary by Sourcery

Extend existing OSCAP and Ansible UI tests to validate that related dashboard/report bar charts display non-empty data after successful runs.

Tests:
- Add an OSCAP remediation test assertion that the report status bar chart contains at least one non-zero value.
- Add an Ansible config report test assertion that the dashboard run distribution chart includes Ansible data with at least one non-zero value.