### PR TITLE
[6.19.z] Make updates to calling wait_for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -752,7 +752,7 @@ pytest_plugins = [
 
 **Solution**:
 - Add timeout to long-running operations
-- Use `wait_for()` with proper timeout
+- Use `wait_for()` with proper timeout in seconds passed as int
 - Check for blocking I/O operations
 
 ```python

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -171,7 +171,7 @@ def test_host_provisioning_with_external_puppetserver(
     # the result of the installation. Wait until Satellite reports that the host is installed.
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
-        timeout='40m',
+        timeout=2400,
         delay=30,
     )
     host = host.read()

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -88,7 +88,7 @@ class TestDockerClient:
             # publishing takes few seconds sometimes
             result, _ = wait_for(
                 lambda: module_container_contenthost.execute(f'docker pull {repo["published-at"]}'),
-                num_sec=60,
+                timeout=60,
                 delay=2,
                 fail_condition=lambda out: out.status != 0,
                 logger=logger,
@@ -306,7 +306,7 @@ class TestDockerClient:
         # publishing takes few seconds sometimes
         result, _ = wait_for(
             lambda: module_container_contenthost.execute(docker_pull_command),
-            num_sec=60,
+            timeout=60,
             delay=2,
             fail_condition=lambda out: out.status != 0,
             logger=logger,

--- a/tests/robottelo/test_dependencies.py
+++ b/tests/robottelo/test_dependencies.py
@@ -131,7 +131,7 @@ def test_testimony():
 def test_wait_for():
     from wait_for import wait_for
 
-    assert wait_for(lambda: True, num_sec=1, delay=1)
+    assert wait_for(lambda: True, timeout=1, delay=1)
 
 
 def test_wrapanapi():


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21708

### Problem Statement
@mshriver is changing the way [wait_for](https://github.com/RedHatQE/wait_for/) handles `timeout` parameter and removes `num_sec` parameter completely.

### Solution
Update the wait_for calls in robottelo.

### More info
For more info, check the related thread in `forum-satellite-eng` on Slack from 1st of June.

## Summary by Sourcery

Tests:
- Adjust test wait_for calls to use the timeout argument instead of the removed num_sec parameter and normalize timeout values.