### PR TITLE
[6.16.z] Add Dragonfly team and update component test owners (#21709)

### DIFF
--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: AuditLog
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Search
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/api/test_eol_banner.py
+++ b/tests/foreman/api/test_eol_banner.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Dashboard
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 """

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -4,7 +4,7 @@
 
 :CaseComponent: HTTPProxy
 
-:team: Endeavour
+:team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/api/test_notifications.py
+++ b/tests/foreman/api/test_notifications.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Notifications
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Reporting
 
-:team: Endeavour
+:team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/api/test_settings.py
+++ b/tests/foreman/api/test_settings.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Settings
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -4,7 +4,7 @@
 
 :CaseComponent: HTTPProxy
 
-:team: Endeavour
+:team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Logging
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: Medium
 

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -5,7 +5,7 @@
 
 :CaseComponent: Reporting
 
-:team: Endeavour
+:team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/cli/test_settings.py
+++ b/tests/foreman/cli/test_settings.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Settings
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: AuditLog
 
-:Team: Endeavour
+:Team: Dragonfly
 
 """
 

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Search
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_branding.py
+++ b/tests/foreman/ui/test_branding.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Branding
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Dashboard
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_documentation_links.py
+++ b/tests/foreman/ui/test_documentation_links.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Branding
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_eol_banner.py
+++ b/tests/foreman/ui/test_eol_banner.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Dashboard
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -4,7 +4,7 @@
 
 :CaseComponent: HTTPProxy
 
-:team: Endeavour
+:team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Reporting
 
-:team: Endeavour
+:team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_search.py
+++ b/tests/foreman/ui/test_search.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Search
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: Medium
 """

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Settings
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/new_upgrades/test_bookmarks.py
+++ b/tests/new_upgrades/test_bookmarks.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Search
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 

--- a/tests/upgrades/test_bookmarks.py
+++ b/tests/upgrades/test_bookmarks.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Search
 
-:Team: Endeavour
+:Team: Dragonfly
 
 :CaseImportance: High
 


### PR DESCRIPTION
Cherry-pick https://github.com/SatelliteQE/robottelo/pull/21709
Fixes https://github.com/SatelliteQE/robottelo/issues/21720
### Problem Statement
- There was a split of Endeavour and a new team, Dragonfly. The new team has new members and responsibilities

### Solution
- Update the Robottelo test owners accordingly.

### Related Issues
- SAT-45860