### PR TITLE
[6.17.z] Add to_snap_version for upgrade-scenario tests

### DIFF
--- a/conf/upgrade.yaml.template
+++ b/conf/upgrade.yaml.template
@@ -1,13 +1,15 @@
 UPGRADE:
-  # Base version of the Satellite, Capsule.
+  # Base version of the Satellite or Capsule.
   FROM_VERSION: '6.16'
-  # Target version of the Satellite, Capsule.
+  # Target version of the Satellite or Capsule.
   TO_VERSION: '6.17'
-  # Satellite, Capsule hosts RHEL operating system version.
+  # Target snap version of the Satellite or Capsule (optional).
+  TO_SNAP_VERSION: ''
+  # Satellite or Capsule host's RHEL operating system version.
   OS: rhel9
-  # The job template Broker should use to upgrade a Satellite
+  # The job template Broker should use to upgrade a Satellite or Capsule.
   SATELLITE_UPGRADE_JOB_TEMPLATE: satellite-upgrade
-  # The upgrade path to use when upgrading Satellite (< ystream | zstream >)
+  # The upgrade path to use when upgrading Satellite or Capsule (< ystream | zstream >).
   UPGRADE_PATH: ystream
   # Capsule's activation key will only be available when we spawn the VM using upgrade template.
   CAPSULE_AK:

--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -104,6 +104,7 @@ def upgrade_action():
             job_template=settings.upgrade.satellite_upgrade_job_template,
             target_vm=target_sat.name,
             sat_version=settings.upgrade.to_version,
+            snap_version=settings.upgrade.to_snap_version,
             upgrade_path=settings.upgrade.upgrade_path,
             tower_inventory=target_sat.tower_inventory,
         ).execute()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21705

### Problem Statement

- The `satellite-upgrade` job used in the new_upgrades tests accepts a `snap_version` parameter but the upgrade fixture doesn't pass a value to it
- robottelo always upgrades to the latest snap of the target Satellite version, and doesn't support upgrading to a chosen earlier snap version

### Solution

- Pass in the new (optional) `settings.upgrade.to_snap_version` setting as a parameter

### Related Issues

SAT-40414

### Tests

Verified in internal jenkins run

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

New Features:
- Support configuring a target snapshot version for Satellite upgrade scenario tests via the upgrade settings.

## Summary by Sourcery

New Features:
- Support configuring a target snap version for Satellite upgrade scenario tests via the upgrade settings.