### PR TITLE
Fix for virt-who host status success count

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -699,7 +699,7 @@ def hypervisor_guest_mapping_newcontent_ui(
     # Check guest overview
     guest_new_overview = org_session.host_new.get_details(guest_name, 'overview')
 
-    assert guest_new_overview['overview']['host_status']['status_success'] == '2'
+    assert guest_new_overview['overview']['host_status']['status_success'] == '3'
     # Check guest details
     virtualguest_new_detais = org_session.host_new.get_details(guest_name, 'details')
     assert (


### PR DESCRIPTION
### Problem Statement
Virt-who assertion was failing for `test_positive_deploy_configure_by_id_script` with below error as host status success count appearing as 3 instead of 2 on host details overview page.

```
tests/foreman/virtwho/ui/test_esx_sca.py:71: in test_positive_deploy_configure_by_id_script
    hypervisor_guest_mapping_newcontent_ui(
robottelo/utils/virtwho.py:702: in hypervisor_guest_mapping_newcontent_ui
    assert guest_new_overview['overview']['host_status']['status_success'] == '2'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AssertionError
```

### Solution
Change virt-who host status success count to 3 instead of 2.

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/virtwho/ui/test_esx_sca.py -k  test_positive_deploy_configure_by_id_script

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Correct host status success count assertion in virt-who hypervisor guest mapping UI test from 2 to 3.