### PR TITLE
Update domain tests fixtures to comply with new validations

### DIFF
--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -47,13 +47,26 @@ def valid_create_params():
             ),
             'description': gen_string(str_type='utf8', length=255),
         },
+        {
+            'name': f'{gen_string(str_type="alpha").lower()}-{gen_string(str_type="alpha").lower()}.example.com',
+            'description': gen_string(str_type='alpha'),
+        },
     ]
 
 
 @filtered_datapoint
 def invalid_create_params():
-    """Returns a list of invalid domain create parameters"""
-    return [{'name': gen_string(str_type='utf8', length=256)}]
+    """Returns a list of invalid domain create parameters
+
+    Domain names must comply with RFC 1035/2181: spaces, UTF-8 characters,
+    and special symbols are rejected.
+    """
+    return [
+        {'name': gen_string(str_type='utf8', length=256)},
+        {'name': f'white spaces {gen_string(str_type="alpha").lower()}.com'},
+        {'name': gen_string(str_type='utf8')},
+        {'name': f'{gen_string(str_type="alpha").lower()}!@#.com'},
+    ]
 
 
 @filtered_datapoint
@@ -79,6 +92,10 @@ def valid_update_params():
                 f'.{gen_string(str_type="alpha", length=60).lower()}.example.com'
             ),
             'description': gen_string(str_type='utf8', length=255),
+        },
+        {
+            'name': f'{gen_string(str_type="alpha").lower()}-{gen_string(str_type="alpha").lower()}.example.com',
+            'description': gen_string(str_type='alpha'),
         },
     ]
 

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -25,16 +25,26 @@ from robottelo.utils.datafactory import (
 
 @filtered_datapoint
 def valid_create_params():
-    """Returns a list of valid domain create parameters"""
+    """Returns a list of valid domain create parameters
+
+    Domain names must comply with RFC 1035/2181: only letters, numbers,
+    dashes and dots are allowed.
+    """
     return [
         {
-            'name': 'white spaces {}'.format(gen_string(str_type='utf8')),
+            'name': f'{gen_string(str_type="alpha").lower()}.example.com',
             'description': gen_string(str_type='alpha'),
         },
-        {'name': gen_string(str_type='utf8'), 'description': gen_string(str_type='utf8')},
+        {
+            'name': f'{gen_string(str_type="alphanumeric").lower()}.test.org',
+            'description': gen_string(str_type='utf8'),
+        },
         {'name': gen_string(str_type='numeric'), 'description': gen_string(str_type='numeric')},
         {
-            'name': gen_string(str_type='utf8', length=255),
+            'name': (
+                f'{gen_string(str_type="alpha", length=60).lower()}'
+                f'.{gen_string(str_type="alpha", length=60).lower()}.example.com'
+            ),
             'description': gen_string(str_type='utf8', length=255),
         },
     ]
@@ -48,16 +58,26 @@ def invalid_create_params():
 
 @filtered_datapoint
 def valid_update_params():
-    """Returns a list of valid domain update parameters"""
+    """Returns a list of valid domain update parameters
+
+    Domain names must comply with RFC 1035/2181: only letters, numbers,
+    dashes and dots are allowed.
+    """
     return [
         {
-            'name': 'white spaces {}'.format(gen_string(str_type='utf8')),
+            'name': f'{gen_string(str_type="alpha").lower()}.example.com',
             'description': gen_string(str_type='alpha'),
         },
-        {'name': gen_string(str_type='utf8'), 'description': gen_string(str_type='utf8')},
+        {
+            'name': f'{gen_string(str_type="alphanumeric").lower()}.test.org',
+            'description': gen_string(str_type='utf8'),
+        },
         {'name': gen_string(str_type='numeric'), 'description': gen_string(str_type='numeric')},
         {
-            'name': gen_string(str_type='utf8', length=255),
+            'name': (
+                f'{gen_string(str_type="alpha", length=60).lower()}'
+                f'.{gen_string(str_type="alpha", length=60).lower()}.example.com'
+            ),
             'description': gen_string(str_type='utf8', length=255),
         },
     ]


### PR DESCRIPTION
### Problem Statement
Upstream Foreman PR https://github.com/theforeman/foreman/pull/10977 introduced DNS domain name format validation that enforces RFC 1035/2181 compliance.

Domain names can now only contain letters, numbers, dashes, and dots.

The test `test_positive_create_update_delete_domain` was failing since snap 188 as it was generating domain names with UTF-8 characters and spaces via `gen_string('utf8')`, which are now rejected by the server.

### Solution
Updated `valid_create_params()` and `valid_update_params()` to generate RFC-compliant domain names using `gen_string('alpha')` and `gen_string('alphanumeric')`with dots.

Descriptions were left unchanged (including UTF-8) since the validation only applies to the domain name field.
`valid_update_params()` was also updated preemptively — Phase 1 of the upstream change validates only on :create, but Phase 2 will extend validation to updates.


### PRT test Cases example
<img width="359" height="373" alt="image" src="https://github.com/user-attachments/assets/89d21365-6484-4b0d-a9c5-88f290af3d8a" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_domain.py
```

## Summary by Sourcery

Align domain CLI tests with new RFC-compliant DNS name validation.

Documentation:
- Document DNS domain name RFC 1035/2181 compliance requirements in the valid domain parameter helpers' docstrings.

Tests:
- Update domain create and update test fixtures to generate RFC 1035/2181-compliant domain names using only letters, numbers, dashes and dots.