### PR TITLE
[6.19.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: check-yaml
     - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.16
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --target-version=py310]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21184

<!--pre-commit.ci start-->
updates:
- [github.com/astral-sh/ruff-pre-commit: v0.15.8 → v0.15.16](https://github.com/astral-sh/ruff-pre-commit/compare/v0.15.8...v0.15.16)
<!--pre-commit.ci end-->

## Summary by Sourcery

Build:
- Bump the astral-sh/ruff-pre-commit hook revision from v0.15.8 to v0.15.9 in the pre-commit configuration.