### PR TITLE
[6.16.z] Create separate upgrade satellite fixtures and shared resources for puppet with capsule

### DIFF
--- a/tests/new_upgrades/conftest.py
+++ b/tests/new_upgrades/conftest.py
@@ -327,12 +327,34 @@ def puppet_upgrade_shared_satellite():
 
 
 @pytest.fixture
-def puppet_upgrade_shared_capsule():
-    """Mark tests using this fixture with pytest.mark.puppet_upgrades"""
-    cap_instance = shared_cap_checkout("puppet_upgrade")
+def capsule_puppet_upgrade_shared_satellite():
+    """Mark tests using this fixture with pytest.mark.capsule_puppet_upgrades"""
+    sat_instance = shared_checkout("capsule_puppet_upgrade")
     with (
         SharedResource(
-            "puppet_upgrade_capsule",
+            "capsule_puppet_enable_puppet_satellite",
+            action=sat_instance.enable_puppet_satellite,
+            action_is_recoverable=True,
+        ) as enable_puppet,
+        SharedResource(
+            "capsule_puppet_upgrade_satellite",
+            shared_checkin,
+            sat_instance=sat_instance,
+            action_is_recoverable=True,
+        ) as test_duration,
+    ):
+        enable_puppet.ready()
+        yield sat_instance
+        test_duration.ready()
+
+
+@pytest.fixture
+def capsule_puppet_upgrade_shared_capsule():
+    """Mark tests using this fixture with pytest.mark.capsule_puppet_upgrades"""
+    cap_instance = shared_cap_checkout("capsule_puppet_upgrade")
+    with (
+        SharedResource(
+            "capsule_puppet_upgrade_capsule",
             shared_checkin,
             sat_instance=cap_instance,
             action_is_recoverable=True,
@@ -343,8 +365,8 @@ def puppet_upgrade_shared_capsule():
 
 
 @pytest.fixture
-def puppet_upgrade_integrated_sat_cap(
-    puppet_upgrade_shared_satellite, puppet_upgrade_shared_capsule
+def capsule_puppet_upgrade_integrated_sat_cap(
+    capsule_puppet_upgrade_shared_satellite, capsule_puppet_upgrade_shared_capsule
 ):
     """Return a Satellite and Capsule that have been set up"""
     setup_data = Box(
@@ -353,24 +375,26 @@ def puppet_upgrade_integrated_sat_cap(
             "capsule": None,
         }
     )
+    satellite = capsule_puppet_upgrade_shared_satellite
+    capsule = capsule_puppet_upgrade_shared_capsule
     with (
         SharedResource(
-            "capsule_setup",
-            action=puppet_upgrade_shared_capsule.capsule_setup,
-            sat_host=puppet_upgrade_shared_satellite,
-            release=puppet_upgrade_shared_capsule.version,
+            "capsule_puppet_setup_capsule",
+            action=capsule.capsule_setup,
+            sat_host=satellite,
+            release=capsule.version,
         ) as cap_setup,
         SharedResource(
-            "puppet_upgrade_enable_puppet_capsule",
-            action=puppet_upgrade_shared_capsule.enable_puppet_capsule,
+            "capsule_puppet_enable_puppet_capsule",
+            action=capsule.enable_puppet_capsule,
             action_is_recoverable=True,
-            satellite=puppet_upgrade_shared_satellite,
+            satellite=satellite,
         ) as enable_puppet,
     ):
         cap_setup.ready()
         enable_puppet.ready()
-    setup_data.satellite = puppet_upgrade_shared_satellite
-    setup_data.capsule = puppet_upgrade_shared_capsule
+    setup_data.satellite = satellite
+    setup_data.capsule = capsule
     return setup_data
 
 

--- a/tests/new_upgrades/test_puppet.py
+++ b/tests/new_upgrades/test_puppet.py
@@ -20,9 +20,9 @@ from robottelo.utils.shared_resource import SharedResource
 
 
 @pytest.fixture
-def puppet_upgrade_setup(puppet_upgrade_integrated_sat_cap, upgrade_action):
-    satellite = puppet_upgrade_integrated_sat_cap.satellite
-    capsule = puppet_upgrade_integrated_sat_cap.capsule
+def capsule_puppet_upgrade_setup(capsule_puppet_upgrade_integrated_sat_cap, upgrade_action):
+    satellite = capsule_puppet_upgrade_integrated_sat_cap.satellite
+    capsule = capsule_puppet_upgrade_integrated_sat_cap.capsule
     with (
         SharedResource(satellite.hostname, upgrade_action, target_sat=satellite) as sat_upgrade,
         SharedResource(capsule.hostname, upgrade_action, target_sat=capsule) as cap_upgrade,
@@ -43,7 +43,7 @@ def puppet_upgrade_setup(puppet_upgrade_integrated_sat_cap, upgrade_action):
 
 
 @pytest.mark.capsule_puppet_upgrades
-def test_post_puppet_active(puppet_upgrade_setup):
+def test_post_puppet_active(capsule_puppet_upgrade_setup):
     """Test that puppet remains active after the upgrade on both,
     Satellite and Capsule.
 
@@ -60,8 +60,8 @@ def test_post_puppet_active(puppet_upgrade_setup):
     :parametrized: yes
 
     """
-    satellite = puppet_upgrade_setup.satellite
-    capsule = puppet_upgrade_setup.capsule
+    satellite = capsule_puppet_upgrade_setup.satellite
+    capsule = capsule_puppet_upgrade_setup.capsule
     for server in satellite, capsule:
         result = server.get_features()
         assert 'puppet' in result
@@ -74,7 +74,7 @@ def test_post_puppet_active(puppet_upgrade_setup):
 
 
 @pytest.mark.capsule_puppet_upgrades
-def test_post_puppet_reporting(puppet_upgrade_setup):
+def test_post_puppet_reporting(capsule_puppet_upgrade_setup):
     """Test that puppet is reporting to Satellite after the upgrade.
 
     :id:   postupgrade-cdc4f6cc-23d8-4b4a-bd94-5c86b3072828
@@ -88,8 +88,8 @@ def test_post_puppet_reporting(puppet_upgrade_setup):
         2. At least one Config report exists (was created) for the Capsule.
 
     """
-    satellite = puppet_upgrade_setup.satellite
-    capsule = puppet_upgrade_setup.capsule
+    satellite = capsule_puppet_upgrade_setup.satellite
+    capsule = capsule_puppet_upgrade_setup.capsule
     assert capsule.execute('puppet agent -t').status == 0
 
     result = satellite.cli.ConfigReport.list({'search': f'host={capsule.hostname},origin=Puppet'})

--- a/tests/new_upgrades/test_puppet.py
+++ b/tests/new_upgrades/test_puppet.py
@@ -67,7 +67,7 @@ def test_post_puppet_active(capsule_puppet_upgrade_setup):
         assert 'puppet' in result
         assert 'puppetca' in result
 
-        assert server.execute('rpm -q openvox-server').status == 0
+        assert server.execute('rpm -q puppetserver').status == 0
 
         result = server.execute('systemctl status puppetserver')
         assert 'active (running)' in result.stdout


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21748

### Problem Statement

- Tests that don't need a capsule (marked with `puppet_upgrades`) share the same satellite fixture with those that do (marked with `capsule_puppet_upgrades`), causing test failures when they run in parallel and the non-capsule tests begin upgrading the shared Satellite before the pre-upgrade Capsule is fully set up.

```
$ pytest tests/new_upgrades/test_classparameter.py::test_post_puppet_class_parameter_data_and_type[1] tests/new_upgrades/test_puppet.py::test_post_puppet_active -n2 --dist load
[...]
ERROR tests/new_upgrades/test_puppet.py::test_post_puppet_active - robottelo.utils.shared_resource.SharedResourceError: Main worker failed during action
ERROR tests/new_upgrades/test_classparameter.py::test_post_puppet_class_parameter_data_and_type[1] - FileNotFoundError: [Errno 2] No such file or directory: '/tmp/puppet_upgrade_sat_checkout.shared'
=== 12 warnings, 2 errors in 509.59s (0:08:29) ===
```

### Solution

- Create separate `capsule_puppet_upgrade_*` fixtures with separate shared resource names, for use by `capsule_puppet_upgrades` tests, so that they use separate Satellites and don't interfere with each other

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Separate capsule puppet upgrade fixtures and shared resources from general puppet upgrade fixtures to avoid interference between tests that require a Capsule and those that do not.

New Features:
- Introduce dedicated Satellite and Capsule fixtures for capsule-specific puppet upgrade tests.

Enhancements:
- Rename and rewire puppet upgrade fixtures and tests to use capsule-specific shared resources and identifiers for clearer isolation.