### PR TITLE
[6.18.z] Fix proxy xdist race - 422 "Name has already been taken" error

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2228,7 +2228,22 @@ class Satellite(Capsule, SatelliteMixins):
             http_proxy_name = 'IPv6 HTTP Proxy for Content sync'
             http_proxy_url = settings.http_proxy.http_proxy_ipv6_url
         if not self.cli.HttpProxy.exists(search=('name', http_proxy_name)):
-            http_proxy = self.api.HTTPProxy(name=http_proxy_name, url=http_proxy_url).create()
+            try:
+                http_proxy = self.api.HTTPProxy(name=http_proxy_name, url=http_proxy_url).create()
+            except requests.exceptions.HTTPError as err:
+                response = getattr(err, 'response', None)
+                if (
+                    response is None
+                    or response.status_code != 422
+                    or 'already been taken' not in (response.text or '')
+                ):
+                    raise
+                # Race between xdist workers: another worker created the proxy
+                # after our CLI check but before our API create call.
+                logger.info(f'HTTP Proxy "{http_proxy_name}" already exists, using existing proxy.')
+                http_proxy = self.api.HTTPProxy().search(
+                    query={'search': f'name="{http_proxy_name}"'}
+                )[0]
         else:
             logger.info('The HTTP Proxy is already enabled. Skipping the HTTP Proxy setup.')
             http_proxy = self.api.HTTPProxy().search(query={'search': f'name="{http_proxy_name}"'})[


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21780

### Problem Statement
The `enable_satellite_http_proxy` method in `hosts.py` has a race condition when multiple xdist workers share the same satellite.
Both workers check for the proxy via CLI simultaneously, both find it missing, one creates it successfully, and the other crashes with a 422 "Name has already been taken" error.


### Solution
Wrap the HTTPProxy.create() call in a try/except that catches the 422 "already been taken" error and proceeds with configuring the proxy settings.
Since the settings are configured by name/URL strings (not by the proxy object), the proxy's existence is sufficient — we don't need to retrieve it.
The return value becomes None in the race-loss case, which is safe because disable_satellite_http_proxy already guards with if http_proxy:.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Prevent HTTP proxy creation from failing with a 422 error when concurrent xdist workers attempt to create the same proxy.

## Summary by Sourcery

Bug Fixes:
- Prevent HTTP proxy setup from failing with a 422 error when multiple xdist workers concurrently create the same proxy.