### PR TITLE
Update CLI tests for deprecated CV/LCE param removal in snap 190 - PART 1

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -667,12 +667,13 @@ class CLIFactory:
             raise CLIFactoryError(
                 f'Failed to promote version to next environment\n{err.msg}'
             ) from err
+        # Look up CV Env ID for activation key association
+        cv_env_id = self._satellite.api_factory.get_cvenv_id(cv_id, env_id)
         # Create activation key if needed and associate content view with it
         if options.get('activationkey-id') is None:
             activationkey_id = self.make_activation_key(
                 {
-                    'content-view-id': cv_id,
-                    'lifecycle-environment-id': env_id,
+                    'content-view-environment-ids': cv_env_id,
                     'organization-id': org_id,
                 }
             )['id']
@@ -685,8 +686,7 @@ class CLIFactory:
                     {
                         'id': activationkey_id,
                         'organization-id': org_id,
-                        'content-view-id': cv_id,
-                        'lifecycle-environment-id': env_id,
+                        'content-view-environment-ids': cv_env_id,
                     }
                 )
             except CLIReturnCodeError as err:
@@ -793,7 +793,8 @@ class CLIFactory:
             ) from err
         # Get the version id
         try:
-            cvv = self._satellite.cli.ContentView.info({'id': cv_id})['versions'][-1]
+            cv_info = self._satellite.cli.ContentView.info({'id': cv_id})
+            cvv = cv_info['versions'][-1]
         except CLIReturnCodeError as err:
             raise CLIFactoryError(f'Failed to fetch content view info\n{err.msg}') from err
         # Promote version1 to next env
@@ -810,12 +811,13 @@ class CLIFactory:
             raise CLIFactoryError(
                 f'Failed to promote version to next environment\n{err.msg}'
             ) from err
+        # Look up CV Env ID for activation key association
+        cv_env_id = self._satellite.api_factory.get_cvenv_id(cv_id, env_id)
         # Create activation key if needed and associate content view with it
         if options.get('activationkey-id') is None:
             activationkey_id = self.make_activation_key(
                 {
-                    'content-view-id': cv_id,
-                    'lifecycle-environment-id': env_id,
+                    'content-view-environment-ids': cv_env_id,
                     'organization-id': org_id,
                 }
             )['id']
@@ -828,8 +830,7 @@ class CLIFactory:
                     {
                         'id': activationkey_id,
                         'organization-id': org_id,
-                        'content-view-id': cv_id,
-                        'lifecycle-environment-id': env_id,
+                        'content-view-environment-ids': cv_env_id,
                     }
                 )
             except CLIReturnCodeError as err:
@@ -1062,11 +1063,11 @@ class CLIFactory:
                 }
             )
             content_view = self._satellite.cli.ContentView.info({'id': content_view['id']})
+            cv_env_id = self._satellite.api_factory.get_cvenv_id(content_view['id'], lce_id)
             activation_key = self.make_activation_key(
                 {
                     'organization-id': org_id,
-                    'lifecycle-environment-id': lce_id,
-                    'content-view-id': content_view['id'],
+                    'content-view-environment-ids': cv_env_id,
                 }
             )
         data = dict(

--- a/robottelo/host_helpers/repository_mixins.py
+++ b/robottelo/host_helpers/repository_mixins.py
@@ -698,11 +698,11 @@ class RepositoryCollection:
         lifecycle environment and subscriptions"""
         if subscription_names is None:
             subscription_names = []
+        cv_env_id = self.satellite.api_factory.get_cvenv_id(content_view_id, lce_id)
         activation_key = self.satellite.cli_factory.make_activation_key(
             {
                 'organization-id': org_id,
-                'lifecycle-environment-id': lce_id,
-                'content-view-id': content_view_id,
+                'content-view-environment-ids': cv_env_id,
             }
         )
         if override is not None:

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -86,8 +86,7 @@ def test_positive_create_with_default_lce_by_id(
     new_ak_env = module_target_sat.cli_factory.make_activation_key(
         {
             'organization-id': module_org.id,
-            'lifecycle-environment-id': lce['id'],
-            'content-view': module_promoted_cv.name,
+            'content-view-environments': f'{lce["label"]}/{module_promoted_cv.label}',
         }
     )
     assert new_ak_env.content_view_environments[0].name == lce['name']
@@ -109,8 +108,7 @@ def test_positive_create_with_non_default_lce(
     new_ak_env = module_target_sat.cli_factory.make_activation_key(
         {
             'organization-id': module_org.id,
-            'lifecycle-environment-id': module_lce.id,
-            'content-view': module_promoted_cv.name,
+            'content-view-environments': f'{module_lce.label}/{module_promoted_cv.label}',
         }
     )
     assert new_ak_env.content_view_environments[0].name == module_lce.name
@@ -131,8 +129,7 @@ def test_positive_create_with_default_lce_by_name(
     new_ak_env = module_target_sat.cli_factory.make_activation_key(
         {
             'organization-id': module_org.id,
-            'lifecycle-environment': lce['name'],
-            'content-view': module_promoted_cv.name,
+            'content-view-environments': f'{lce["label"]}/{module_promoted_cv.label}',
         }
     )
     assert new_ak_env.content_view_environments[0].name == lce['name']
@@ -155,8 +152,7 @@ def test_positive_create_with_cv(name, module_org, get_default_env, module_targe
     module_target_sat.cli.ContentView.publish({'id': new_cv['id']})
     new_ak = module_target_sat.cli_factory.make_activation_key(
         {
-            'content-view': new_cv['name'],
-            'lifecycle-environment': get_default_env['name'],
+            'content-view-environments': f'{get_default_env["label"]}/{new_cv["label"]}',
             'organization-id': module_org.id,
         }
     )
@@ -362,8 +358,7 @@ def test_positive_delete_with_cv(
     new_ak = module_target_sat.cli_factory.make_activation_key(
         {
             'organization-id': module_org.id,
-            'lifecycle-environment-id': lce['id'],
-            'content-view': module_promoted_cv.name,
+            'content-view-environments': f'{lce["label"]}/{module_promoted_cv.label}',
         }
     )
     module_target_sat.cli.ActivationKey.delete({'id': new_ak['id']})
@@ -384,8 +379,7 @@ def test_positive_delete_with_lce(
     new_ak = module_target_sat.cli_factory.make_activation_key(
         {
             'organization-id': module_org.id,
-            'lifecycle-environment': get_default_env['name'],
-            'content-view': module_promoted_cv.name,
+            'content-view-environments': f'{get_default_env["label"]}/{module_promoted_cv.label}',
         }
     )
     module_target_sat.cli.ActivationKey.delete({'id': new_ak['id']})
@@ -472,8 +466,7 @@ def test_positive_update_lce(module_org, get_default_env, module_target_sat, mod
     ak_env = module_target_sat.cli_factory.make_activation_key(
         {
             'organization-id': module_org.id,
-            'lifecycle-environment-id': get_default_env['id'],
-            'content-view': module_promoted_cv.name,
+            'content-view-environments': f'{get_default_env["label"]}/{module_promoted_cv.label}',
         }
     )
 
@@ -489,8 +482,7 @@ def test_positive_update_lce(module_org, get_default_env, module_target_sat, mod
     module_target_sat.cli.ActivationKey.update(
         {
             'id': ak_env['id'],
-            'lifecycle-environment-id': env['id'],
-            'content-view': new_cv['name'],
+            'content-view-environments': f'{env["label"]}/{new_cv["label"]}',
             'organization-id': module_org.id,
         }
     )
@@ -512,8 +504,7 @@ def test_positive_update_cv(
     ak_cv = module_target_sat.cli_factory.make_activation_key(
         {
             'organization-id': module_org.id,
-            'lifecycle-environment-id': lce['id'],
-            'content-view': module_promoted_cv.name,
+            'content-view-environments': f'{lce["label"]}/{module_promoted_cv.label}',
         }
     )
 
@@ -525,8 +516,7 @@ def test_positive_update_cv(
 
     module_target_sat.cli.ActivationKey.update(
         {
-            'content-view': new_cv.name,
-            'lifecycle-environment-id': module_lce.id,
+            'content-view-environments': f'{module_lce.label}/{new_cv.label}',
             'name': ak_cv['name'],
             'organization-id': module_org.id,
         }
@@ -645,8 +635,7 @@ def test_positive_usage_limit(module_org, module_location, target_sat, content_h
     )
     new_ak = target_sat.cli_factory.make_activation_key(
         {
-            'lifecycle-environment-id': env['id'],
-            'content-view': new_cv['name'],
+            'content-view-environments': f'{env["label"]}/{new_cv["label"]}',
             'organization-id': module_org.id,
             'max-hosts': max_hosts,
         }
@@ -842,8 +831,7 @@ def test_positive_update_aks_to_chost(
     new_aks = [
         module_target_sat.cli_factory.make_activation_key(
             {
-                'lifecycle-environment-id': env['id'],
-                'content-view': new_cv['name'],
+                'content-view-environments': f'{env["label"]}/{new_cv["label"]}',
                 'organization-id': module_org.id,
             }
         )
@@ -918,8 +906,7 @@ def test_positive_list_by_cv_id(module_org, module_target_sat, get_default_env, 
     activation_key = module_target_sat.cli_factory.make_activation_key(
         {
             'organization-id': module_org.id,
-            'lifecycle-environment-id': lce['id'],
-            'content-view-id': module_promoted_cv.id,
+            'content-view-environments': f'{lce["label"]}/{module_promoted_cv.label}',
         }
     )
     result = module_target_sat.cli.ActivationKey.list(

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -906,8 +906,7 @@ def test_sync_consume_flatpak_repo_via_library(
         {
             'name': gen_string('alpha'),
             'organization-id': function_org.id,
-            'lifecycle-environment': 'Library',
-            'content-view': 'Default Organization View',
+            'content-view-environments': 'Library',
         }
     )
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -330,7 +330,7 @@ def test_positive_host_list_with_cve(
 @pytest.mark.e2e
 @pytest.mark.cli_host_create
 @pytest.mark.upgrade
-def test_positive_create_and_delete(target_sat, module_lce_library, module_published_cv):
+def test_positive_create_and_delete(target_sat):
     """A host can be created and deleted
 
     :id: 59fcbe50-9c6b-4c3c-87b3-272b4b584fb3
@@ -348,13 +348,19 @@ def test_positive_create_and_delete(target_sat, module_lce_library, module_publi
         'type=interface,mac={},identifier=eth0,name={},domain_id={},'
         'ip={},primary=true,provision=true'
     ).format(host.mac, gen_string('alpha'), host.domain.id, gen_ipaddr())
+    library = target_sat.api.LifecycleEnvironment().search(
+        query={'search': f'name=Library and organization_id={host.organization.id}'}
+    )[0]
+    default_cv = target_sat.api.ContentView(organization=host.organization).search(
+        query={'search': 'name="Default Organization View"'}
+    )[0]
+    cvenv_id = target_sat.api_factory.get_cvenv_id(default_cv, library)
     new_host = target_sat.cli_factory.make_host(
         {
             'architecture-id': host.architecture.id,
-            'content-view-id': module_published_cv.id,
+            'content-view-environment-ids': cvenv_id,
             'domain-id': host.domain.id,
             'interface': interface,
-            'lifecycle-environment-id': module_lce_library.id,
             'location-id': host.location.id,
             'mac': host.mac,
             'medium-id': host.medium.id,
@@ -369,13 +375,13 @@ def test_positive_create_and_delete(target_sat, module_lce_library, module_publi
     assert new_host['organization']['name'] == host.organization.name
     assert (
         new_host['content-information']['content-view-environments']['1']['content-view-name']
-        == module_published_cv.name
+        == default_cv.name
     )
     assert (
         new_host['content-information']['content-view-environments']['1'][
             'lifecycle-environment-name'
         ]
-        == module_lce_library.name
+        == library.name
     )
     host_interface = target_sat.cli.HostInterface.info(
         {'host-id': new_host['id'], 'id': new_host['network-interfaces']['1']['id']}
@@ -469,8 +475,7 @@ def test_negative_create_with_content_source(
         module_target_sat.cli_factory.make_fake_host(
             {
                 'content-source-id': gen_integer(10000, 99999),
-                'content-view-id': module_published_cv.id,
-                'lifecycle-environment-id': module_lce_library.id,
+                'content-view-environments': f'{module_lce_library.label}/{module_published_cv.label}',
                 'organization': module_org.name,
             }
         )
@@ -496,8 +501,7 @@ def test_negative_update_content_source(
     host = module_target_sat.cli_factory.make_fake_host(
         {
             'content-source-id': module_default_proxy['id'],
-            'content-view-id': module_published_cv.id,
-            'lifecycle-environment-id': module_lce_library.id,
+            'content-view-environments': f'{module_lce_library.label}/{module_published_cv.label}',
             'organization': module_org.name,
         }
     )
@@ -527,8 +531,7 @@ def test_positive_create_with_lce_and_cv(
     """
     new_host = module_target_sat.cli_factory.make_fake_host(
         {
-            'content-view-id': module_promoted_cv.id,
-            'lifecycle-environment-id': module_lce.id,
+            'content-view-environments': f'{module_lce.label}/{module_promoted_cv.label}',
             'organization-id': module_org.id,
         }
     )
@@ -580,8 +583,7 @@ def test_negative_create_with_name(
             {
                 'name': name,
                 'organization-id': module_org.id,
-                'content-view-id': module_published_cv.id,
-                'lifecycle-environment-id': module_lce_library.id,
+                'content-view-environments': f'{module_lce_library.label}/{module_published_cv.label}',
             }
         )
 
@@ -601,8 +603,7 @@ def test_negative_create_with_unpublished_cv(module_lce, module_org, module_cv, 
     with pytest.raises(CLIFactoryError):
         module_target_sat.cli_factory.make_fake_host(
             {
-                'content-view-id': module_cv.id,
-                'lifecycle-environment-id': module_lce.id,
+                'content-view-environments': f'{module_lce.label}/{module_cv.label}',
                 'organization-id': module_org.id,
             }
         )
@@ -628,7 +629,7 @@ def test_positive_katello_and_openscap_loaded(target_sat):
     :BZ: 1671148
     """
     help_output = target_sat.cli.Host.execute('host update --help')
-    for arg in ['lifecycle-environment[-id]', 'openscap-proxy-id']:
+    for arg in ['content-view-environment-ids', 'openscap-proxy-id']:
         assert any(f'--{arg}' in line for line in help_output.split('\n')), (
             f'--{arg} not supported by update subcommand'
         )
@@ -729,9 +730,9 @@ def test_positive_create_inherit_lce_cv(
 
     :BZ: 1391656
     """
+    cvenv_id = target_sat.api_factory.get_cvenv_id(module_published_cv, module_lce_library)
     hostgroup = target_sat.api.HostGroup(
-        content_view=module_published_cv,
-        lifecycle_environment=module_lce_library,
+        content_view_environment_id=cvenv_id,
         organization=[module_org],
     ).create()
     host = target_sat.cli_factory.make_fake_host(
@@ -770,6 +771,7 @@ def test_positive_create_inherit_nested_hostgroup(target_sat):
     content_view = target_sat.api.ContentView(organization=options.organization).create()
     content_view.publish()
     content_view.read().version[0].promote(data={'environment_ids': lce.id, 'force': False})
+    cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lce)
     host_name = gen_string('alpha').lower()
     nested_hg_name = gen_string('alpha')
     parent_hostgroups = []
@@ -782,9 +784,8 @@ def test_positive_create_inherit_nested_hostgroup(target_sat):
         parent_hostgroups.append(parent_hg)
         nested_hg = target_sat.api.HostGroup(
             architecture=options.architecture,
-            content_view=content_view,
+            content_view_environment_id=cvenv_id,
             domain=options.domain,
-            lifecycle_environment=lce,
             location=[options.location],
             medium=options.medium,
             name=nested_hg_name,
@@ -829,11 +830,11 @@ def test_positive_list_with_nested_hostgroup(target_sat):
     content_view = target_sat.api.ContentView(organization=options.organization).create()
     content_view.publish()
     content_view.read().version[0].promote(data={'environment_ids': lce.id, 'force': False})
+    cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lce)
     parent_hg = target_sat.api.HostGroup(
         name=parent_hg_name,
         organization=[options.organization],
-        content_view=content_view,
-        lifecycle_environment=lce,
+        content_view_environment_id=cvenv_id,
         ptable=options.ptable,
     ).create()
     nested_hg = target_sat.api.HostGroup(
@@ -2188,12 +2189,18 @@ def test_positive_host_with_puppet(
     :CaseImportance: Critical
     """
     update_smart_proxy(session_puppet_enabled_sat, module_puppet_loc, session_puppet_enabled_proxy)
+    default_cv = session_puppet_enabled_sat.api.ContentView(organization=module_puppet_org).search(
+        query={'search': 'name="Default Organization View"'}
+    )[0]
+    cvenv_id = session_puppet_enabled_sat.api_factory.get_cvenv_id(
+        default_cv, module_puppet_lce_library
+    )
     host = session_puppet_enabled_sat.cli_factory.make_fake_host(
         {
             'puppet-environment-id': module_puppet_environment.id,
             'organization-id': module_puppet_org.id,
             'location-id': module_puppet_loc.id,
-            'lifecycle-environment-id': module_puppet_lce_library.id,
+            'content-view-environment-ids': cvenv_id,
             'puppet-ca-proxy-id': session_puppet_enabled_proxy.id,
             'puppet-proxy-id': session_puppet_enabled_proxy.id,
         }
@@ -2269,7 +2276,12 @@ def test_positive_list_scparams(
             'puppet-environment': module_env_search.name,
             'organization-id': module_puppet_org.id,
             'location-id': module_puppet_loc.id,
-            'lifecycle-environment-id': module_puppet_lce_library.id,
+            'content-view-environment-ids': session_puppet_enabled_sat.api_factory.get_cvenv_id(
+                session_puppet_enabled_sat.api.ContentView(organization=module_puppet_org).search(
+                    query={'search': 'name="Default Organization View"'}
+                )[0],
+                module_puppet_lce_library,
+            ),
             'puppet-ca-proxy-id': session_puppet_enabled_proxy.id,
             'puppet-proxy-id': session_puppet_enabled_proxy.id,
         }
@@ -2314,7 +2326,12 @@ def test_positive_create_with_puppet_class_name(
             'puppet-environment': module_env_search.name,
             'organization-id': module_puppet_org.id,
             'location-id': module_puppet_loc.id,
-            'lifecycle-environment-id': module_puppet_lce_library.id,
+            'content-view-environment-ids': session_puppet_enabled_sat.api_factory.get_cvenv_id(
+                session_puppet_enabled_sat.api.ContentView(organization=module_puppet_org).search(
+                    query={'search': 'name="Default Organization View"'}
+                )[0],
+                module_puppet_lce_library,
+            ),
             'puppet-ca-proxy-id': session_puppet_enabled_proxy.id,
             'puppet-proxy-id': session_puppet_enabled_proxy.id,
         }
@@ -2354,7 +2371,12 @@ def test_positive_update_host_owner_and_verify_puppet_class_name(
             'puppet-environment': module_env_search.name,
             'organization-id': module_puppet_org.id,
             'location-id': module_puppet_loc.id,
-            'lifecycle-environment-id': module_puppet_lce_library.id,
+            'content-view-environment-ids': session_puppet_enabled_sat.api_factory.get_cvenv_id(
+                session_puppet_enabled_sat.api.ContentView(organization=module_puppet_org).search(
+                    query={'search': 'name="Default Organization View"'}
+                )[0],
+                module_puppet_lce_library,
+            ),
             'puppet-ca-proxy-id': session_puppet_enabled_proxy.id,
             'puppet-proxy-id': session_puppet_enabled_proxy.id,
         }
@@ -2464,8 +2486,7 @@ def test_positive_create_host_with_lifecycle_environment_name(
     found_host = False
     new_host = module_target_sat.cli_factory.make_fake_host(
         {
-            'content-view-id': module_promoted_cv.id,
-            'lifecycle-environment': module_lce.name,
+            'content-view-environments': f'{module_lce.label}/{module_promoted_cv.label}',
             'organization-id': module_org.id,
         }
     )

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -31,10 +31,10 @@ def _make_fake_host_helper(module_org, sat):
         {'organization-id': module_org.id, 'name': LIBRARY_LCE}
     )
     default_cv = sat.cli.ContentView.info({'organization-id': module_org.id, 'name': DEFAULT_CV})
+    cvenv_id = sat.api_factory.get_cvenv_id(default_cv['id'], library['id'])
     return sat.cli_factory.make_fake_host(
         {
-            'content-view-id': default_cv['id'],
-            'lifecycle-environment-id': library['id'],
+            'content-view-environment-ids': cvenv_id,
             'name': gen_string('alpha', 15),
             'organization-id': module_org.id,
         }

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -130,6 +130,7 @@ def test_positive_create_with_multiple_entities_and_delete(
         session_puppet_enabled_sat.cli.ContentView.version_promote(
             {'id': cv['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
         )
+        cvenv_id = session_puppet_enabled_sat.api_factory.get_cvenv_id(cv['id'], lce['id'])
         # Network
         domain = session_puppet_enabled_sat.cli_factory.make_domain(
             {'location-ids': loc['id'], 'organization-ids': org_2.id}
@@ -160,11 +161,10 @@ def test_positive_create_with_multiple_entities_and_delete(
             'organization-ids': [org.id for org in orgs],
             'locations': loc['name'],
             'puppet-environment': env['name'],
-            'lifecycle-environment-id': lce['id'],
+            'content-view-environment-id': cvenv_id,
             'puppet-proxy': puppet_content_source['name'],
             'puppet-ca-proxy': puppet_content_source['name'],
             'content-source-id': puppet_content_source['id'],
-            'content-view': cv['name'],
             'domain': domain['name'],
             'subnet': subnet['name'],
             'architecture': arch['name'],

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -73,8 +73,7 @@ def local_ak(module_sca_manifest_org, local_environment, local_content_view, mod
     )
     return module_target_sat.cli_factory.make_activation_key(
         {
-            'lifecycle-environment-id': local_environment['id'],
-            'content-view': local_content_view['name'],
+            'content-view-environments': f'{local_environment["label"]}/{local_content_view["label"]}',
             'organization-id': module_sca_manifest_org.id,
         }
     )

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -210,13 +210,16 @@ def prepare_scap_client_and_prerequisites(
     # Create a hostgroup
     hgrp_name = gen_string('alpha')
     policy_name = gen_string('alpha')
+    content_view = target_sat.api.ContentView(
+        organization=module_org, name=cv_name[distro]
+    ).search()[0]
+    cvenv_id = target_sat.api_factory.get_cvenv_id(content_view, lifecycle_env)
     hostgroup = target_sat.cli_factory.hostgroup(
         {
             'content-source-id': default_proxy,
             'name': hgrp_name,
             'organization': module_org.name,
-            'lifecycle-environment': lifecycle_env.name,
-            'content-view': cv_name[distro],
+            'content-view-environment-id': cvenv_id,
             'ansible-role-ids': role_id,
             'openscap-proxy-id': default_proxy,
         }

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1342,8 +1342,7 @@ def test_positive_validate_inherited_cv_lce_ansiblerole(session, target_sat, mod
     )
     hostgroup = target_sat.cli_factory.hostgroup(
         {
-            'content-view-id': cv.id,
-            'lifecycle-environment-id': lce.id,
+            'content-view-environment': f'{lce.label}/{cv.label}',
             'organization-ids': module_host_template.organization.id,
         }
     )


### PR DESCRIPTION
### Problem Statement

Snap 190 (upstream katello PR [#11753](https://github.com/Katello/katello/pull/11753)) removed the deprecated `--content-view-id`, `--lifecycle-environment-id`, `--content-view`, and `--lifecycle-environment` parameters from multiple hammer CLI commands:
- `hammer host create/update`
- `hammer activation-key create/update`
- `hammer hostgroup create`

Robottelo PR [#21644](https://github.com/SatelliteQE/robottelo/pull/21644) updated the API/nailgun side but missed all CLI (hammer) calls that pass these params.

### Solution

Replaced deprecated parameters with their new equivalents across 10 files:
  - --content-view-environments (format: LCE_label/CV_label) for host and activation key commands
  - --content-view-environment-id (singular, by ID via get_cvenv_id()) for hostgroup commands
  - --content-view-environment-ids (by ID via get_cvenv_id()) where label lookup has org-scoping issues
  
  Updated files:
  - `robottelo/host_helpers/cli_factory.py` — _setup_org_for_a_custom_repo, _setup_org_for_a_rh_repo AK creation
  - `robottelo/host_helpers/repository_mixins.py` — _create_activation_key_with_cv_lce AK creation
  - `tests/foreman/cli/test_activationkey.py` — all AK create/update calls
  - `tests/foreman/cli/test_host.py` — host create, hostgroup API, help text assertion
  - `tests/foreman/cli/test_hostcollection.py` — _make_fake_host_helper
  - `tests/foreman/cli/test_hostgroup.py` — hostgroup create
  - `tests/foreman/cli/test_reporttemplates.py` — AK fixture
  - `tests/foreman/cli/test_capsulecontent.py` — AK create for flatpak test
  - `tests/foreman/longrun/test_oscap.py` — hostgroup create
  - `tests/foreman/ui/test_host.py` — hostgroup create for ansible role test

### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_activationkey.py
```
^^^ PASSING # 15766
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py
```
^^^ PASSING   #  15765  & # 15778
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_hostcollection.py tests/foreman/cli/test_hostgroup.py
```
^^^ PASSING # 15774
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_errata.py tests/foreman/cli/test_reporttemplates.py tests/foreman/cli/test_capsulecontent.py
```

```
trigger: test-robottelo
pytest: tests/foreman/api/test_errata.py tests/foreman/api/test_reporttemplates.py
```
^^ 56/59 passed in # 15762 (3 failing seem unrelated to changes made in this PR) 
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py tests/foreman/ui/test_activationkey.py tests/foreman/ui/test_reporttemplates.py tests/foreman/ui/test_imagemode.py tests/foreman/ui/test_package.py
```

```
trigger: test-robottelo
pytest: tests/foreman/longrun/test_oscap.py
```
^^^ PASSING # 15771
Co-Authored-By: Claude <noreply@anthropic.com>

## Summary by Sourcery

Update CLI-based tests and shared factory helpers to align with the removal of deprecated content view and lifecycle environment parameters in snap 190.

Bug Fixes:
- Replace deprecated content view and lifecycle environment CLI parameters in activation key and host-related tests with the new combined content-view-environment(s) options to keep tests compatible with current hammer behavior.

Enhancements:
- Adjust shared CLI factory helpers to construct and use the new content-view-environments label format when creating or updating activation keys and related resources.
- Update host CLI help assertion to validate the new content-view-environment-ids option instead of the removed lifecycle-environment flags.

## Summary by Sourcery

Align CLI-based tests and shared helpers with the new content view environment parameters introduced in snap 190, replacing deprecated content view and lifecycle environment flags.

Bug Fixes:
- Update host and activation key CLI tests to use content-view-environment(s) parameters instead of removed content-view and lifecycle-environment options, keeping them compatible with current hammer behavior.
- Adjust host help assertion to check for content-view-environment-ids in the host update command help output.

Enhancements:
- Update CLI factory and repository helper utilities to construct and pass the combined content-view-environments label to activation key creation and update flows.
- Adapt hostgroup and OSCAP-related tests to use content-view-environment-id for associating content views and lifecycle environments.
- Simplify host creation test setup by deriving default content view and Library lifecycle environment directly via API instead of relying on injected fixtures.