### PR TITLE
Minor fix in test_recommended_repos

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -79,10 +79,11 @@ def module_sca_manifest_org(module_org, module_sca_manifest, module_target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_sca_multiarch_manifest_org(module_org, module_sca_multiarch_manifest, module_target_sat):
+def module_sca_multiarch_manifest_org(module_sca_multiarch_manifest, module_target_sat):
     """Creates an organization and uploads an SCA mode multiarch manifest generated with manifester"""
-    module_target_sat.upload_manifest(module_org.id, module_sca_multiarch_manifest.content)
-    return module_org
+    org = module_target_sat.api.Organization().create()
+    module_target_sat.upload_manifest(org.id, module_sca_multiarch_manifest.content)
+    return org
 
 
 @pytest.fixture(scope='class')

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -877,7 +877,7 @@ def test_recommended_repos(session, filter_type, expected_repos, module_sca_mult
         v = get_sat_version()
 
         displayed_repos = [repo['label'] for repo in rrepos_on]
-        assert len(displayed_repos) > len(expected_repos)
+        assert len(displayed_repos) >= len(expected_repos)
         for repo in expected_repos:
             assert repo in displayed_repos
         if filter_type == 'RPM':


### PR DESCRIPTION
### Problem Statement
The `test_recommended_repos[Kickstart]` fails with `'Owner has already imported from another subscription management application. The following conflicts were found: [ DISTRIBUTOR_CONFLICT ]'` in CI. The reason is that `module_org` is already updated with manifest in one of the previous tests which uses `module_sca_manifest_org` which takes the `module_org` for manifest upload. So uploading yet another manifest fails.

Another issue was the `>` operator, which doesn't cover the case when `RECOMMENDED_REPOS` exactly match the displayed repos.

Last but not least, https://github.com/Katello/katello/pull/11748 migrated the RH repos page to PF5, so we need an AirGun update too.


### Solution
This PR covers first two problems (new org for the multiarch manifest and adding the equality operator)
https://github.com/SatelliteQE/airgun/pull/2459 covers the third one


### Related Issues
https://redhat.atlassian.net/browse/SAT-32073


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_repository.py -k 'test_positive_able_to_disable_and_enable_rhel_repos or test_positive_delete_rhel_repo or test_positive_no_errors_on_repo_scan or test_positive_reposet_disable or test_recommended_repos[Kickstart]'
airgun: 2459
Katello:
    katello: 11748
```

## Summary by Sourcery

Use a fresh organization for multiarch SCA manifest tests and relax recommended repos assertion to allow exact matches.

Bug Fixes:
- Prevent reuse of an organization with an existing manifest by creating a new org for multiarch SCA manifest uploads in tests.
- Allow the recommended repositories test to pass when the number of displayed repos exactly matches the expected repos.