### PR TITLE
The password field is not present, so removing this line.

### DIFF
--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -136,12 +136,15 @@ def test_positive_provision_pxe_host(
 
 @pytest.mark.upgrade
 @pytest.mark.on_premises_provisioning
+@pytest.mark.parametrize('setting_update', ['remote_execution_connect_by_ip=True'], indirect=True)
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
 @pytest.mark.rhel_ver_match('8')
 def test_positive_custom_provision_pxe_host(
     request,
+    setting_update,
     module_location,
     module_org,
+    module_ssh_key_file,
     module_provisioning_rhel_content,
     module_discovery_sat,
     provisioning_host,
@@ -235,7 +238,6 @@ def test_positive_custom_provision_pxe_host(
             module_org.name,
             module_location.name,
             quick=False,
-            host_values={'operating_system.root_password': new_root_pwd},
         )
         # Wait for provisioning to complete and report status back to Satellite
         pending_status = 'N/A' if is_open('SAT-22452') else 'Pending installation'
@@ -265,8 +267,8 @@ def test_positive_custom_provision_pxe_host(
         assert values['Execution']['Status'] == 'Last execution succeeded'
 
         # Verify if assigned role is executed on the host, and correct host passwd is set
-        host = ContentHost(discovered_host.ip)
-        assert host.execute('yum list installed rubygem-foreman_scap_client').status == 0
+        host = ContentHost(discovered_host.ip, auth=module_ssh_key_file)
+        assert host.execute('yum list installed foreman_scap_client_bash').status == 0
 
         # Verify entry from discovered host is auto removed
         assert not session.discoveredhosts.search(f'name = {discovered_host_name}')


### PR DESCRIPTION
Removing the unnecessary line, as the disable password functionality does not exist. The function attempts to fetch it, which causes a failure due to its non-existence, so the line is being removed to avoid the failure.

## Summary by Sourcery

Bug Fixes:
- Eliminate a failing reference to an unsupported root password configuration in the discovered host provisioning test.

Dependent PR: https://github.com/SatelliteQE/airgun/pull/2382