### PR TITLE
Fix deprecated CV/LCE params in CLI docker AK tests

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -842,8 +842,9 @@ class TestDockerActivationKey:
         """
         activation_key = module_target_sat.cli_factory.make_activation_key(
             {
-                'content-view-id': content_view_promote['content-view-id'],
-                'lifecycle-environment-id': module_lce.id,
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    content_view_promote['content-view-id'], module_lce
+                ),
                 'organization-id': module_org.id,
             }
         )
@@ -867,8 +868,9 @@ class TestDockerActivationKey:
         """
         activation_key = module_target_sat.cli_factory.make_activation_key(
             {
-                'content-view-id': content_view_promote['content-view-id'],
-                'lifecycle-environment-id': module_lce.id,
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    content_view_promote['content-view-id'], module_lce
+                ),
                 'organization-id': module_org.id,
             }
         )
@@ -891,8 +893,9 @@ class TestDockerActivationKey:
             {
                 'id': activation_key['id'],
                 'organization-id': module_org.id,
-                'content-view-id': another_cv['id'],
-                'lifecycle-environment-id': module_lce.id,
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    another_cv['id'], module_lce
+                ),
             }
         )
         activation_key = module_target_sat.cli.ActivationKey.info({'id': activation_key['id']})
@@ -940,8 +943,9 @@ class TestDockerActivationKey:
         )
         activation_key = module_target_sat.cli_factory.make_activation_key(
             {
-                'content-view-id': comp_content_view['id'],
-                'lifecycle-environment-id': module_lce.id,
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    comp_content_view['id'], module_lce
+                ),
                 'organization-id': module_org.id,
             }
         )
@@ -990,8 +994,9 @@ class TestDockerActivationKey:
         )
         activation_key = module_target_sat.cli_factory.make_activation_key(
             {
-                'content-view-id': comp_content_view['id'],
-                'lifecycle-environment-id': module_lce.id,
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    comp_content_view['id'], module_lce
+                ),
                 'organization-id': module_org.id,
             }
         )
@@ -1014,8 +1019,9 @@ class TestDockerActivationKey:
             {
                 'id': activation_key['id'],
                 'organization-id': module_org.id,
-                'content-view-id': another_cv['id'],
-                'lifecycle-environment-id': module_lce.id,
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    another_cv['id'], module_lce
+                ),
             }
         )
         activation_key = module_target_sat.cli.ActivationKey.info({'id': activation_key['id']})


### PR DESCRIPTION
### Problem Statement

Snap 190 removed `--content-view-id` and `--lifecycle-environment-id` from `hammer activation-key create/update`.
4 docker-related activation key tests are failing on stream component results.

### Solution

Replaced deprecated parameters with `--content-view-environment-ids` using `api_factory.get_cvenv_id()` in `tests/foreman/cli/test_docker.py` — 4 `make_activation_key` and 2 `ActivationKey.update` calls.

### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_docker.py -k 'test_positive_add_docker_repo_cv or test_positive_remove_docker_repo_cv or test_positive_add_docker_repo_ccv or test_positive_remove_docker_repo_ccv'
```
Co-Authored-By: Claude <noreply@anthropic.com>

## Summary by Sourcery

Update docker activation key CLI tests to use non-deprecated content view / lifecycle environment parameters.

Bug Fixes:
- Replace deprecated activation key CLI parameters with content-view-environment-ids in docker-related tests to restore compatibility with current hammer behavior.

Tests:
- Adjust docker activation key content view tests to derive content view environment IDs via api_factory.get_cvenv_id().