### PR TITLE
[6.19.z] Move test_positive_update_capsule_with_hammer to SatelliteMaintain/Rocket

### DIFF
--- a/tests/foreman/api/test_capsule.py
+++ b/tests/foreman/api/test_capsule.py
@@ -16,7 +16,7 @@ from fauxfactory import gen_string, gen_url
 import pytest
 from requests import HTTPError
 
-from robottelo.config import settings, user_nailgun_config
+from robottelo.config import user_nailgun_config
 
 
 @pytest.mark.e2e
@@ -215,65 +215,3 @@ def test_positive_import_puppet_classes(
         assert result['message'] in [update_msg, no_update_msg]
 
     request.addfinalizer(puppet_sat.api.SmartProxy(id=proxy.id).delete)
-
-
-@pytest.mark.upgrade
-def test_positive_update_capsule_with_hammer(module_capsule_configured, target_sat):
-    """Upgrade capsule with hammer installed
-
-    :id: 903a4140-74f3-428a-8768-ecb610fef2fa
-
-    :steps:
-        1. Configure the Satellite utils repo on Capsule
-        2. Install hammer on capsule
-        3. Install and verify installation of hammer on capsule
-        4. Run satellite-maintain upgrade check
-        5. Run satellite-maintain upgrade run
-        6. Verify upgrade finished
-
-    :expectedresults: Hammer is installed on capsule, and Capsule upgrade works successfully.
-
-    :verifies: SAT-31371
-
-    :customerscenario: true
-
-    """
-    hammer_config_dir = '/root/.hammer'
-    default_ca_path = '/etc/pki/katello/certs/katello-default-ca.crt'
-    hammer_config_file = f'{hammer_config_dir}/cli_config.yml'
-
-    module_capsule_configured.create_custom_repos(satutils=settings.repos.satutils_repo)
-    result = module_capsule_configured.execute(
-        'dnf install -y rubygem-hammer_cli_katello rubygem-hammer_cli_foreman'
-    )
-    assert result.status == 0
-    assert module_capsule_configured.execute('rpm -q rubygem-hammer_cli').status == 0
-    hammer_config_content = (
-        f':foreman:\n'
-        f'  :host: "{target_sat.url}"\n'
-        f'  :verify_ssl: true\n'
-        f'  :ssl_ca_file: "{default_ca_path}"\n'
-    )
-    module_capsule_configured.put(hammer_config_content, hammer_config_file, temp_file=True)
-    assert 'FAIL' not in module_capsule_configured.cli.Base.ping()
-    template_name = 'Capsule Update Playbook'
-    template = target_sat.api.JobTemplate().search(query={'search': f'name="{template_name}"'})
-    assert template, f'{template_name} job template not found on Satellite'
-    module_capsule_configured.add_rex_key(satellite=target_sat)
-    job = target_sat.api.JobInvocation().run(
-        synchronous=False,
-        data={
-            'job_template_id': template[0].id,
-            'inputs': {
-                'whitelist_options': 'repositories-validate,repositories-setup,non-rh-packages',
-            },
-            'targeting_type': 'static_query',
-            'search_query': f'name = {module_capsule_configured.hostname}',
-        },
-    )
-    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
-    result = target_sat.api.JobInvocation(id=job['id']).read()
-    assert result.succeeded == 1
-
-    assert module_capsule_configured.execute('rpm -q rubygem-hammer_cli').status == 0
-    assert 'FAIL' not in module_capsule_configured.cli.Base.ping()

--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -163,6 +163,68 @@ def test_positive_self_update_maintain_package(sat_maintain):
     )
 
 
+@pytest.mark.upgrade
+def test_positive_update_capsule_with_hammer(module_capsule_configured, target_sat):
+    """Upgrade capsule with hammer installed
+
+    :id: 903a4140-74f3-428a-8768-ecb610fef2fa
+
+    :steps:
+        1. Configure the Satellite utils repo on Capsule
+        2. Install hammer on capsule
+        3. Install and verify installation of hammer on capsule
+        4. Run satellite-maintain upgrade check
+        5. Run satellite-maintain upgrade run
+        6. Verify upgrade finished
+
+    :expectedresults: Hammer is installed on capsule, and Capsule upgrade works successfully.
+
+    :verifies: SAT-31371
+
+    :customerscenario: true
+
+    """
+    hammer_config_dir = '/root/.hammer'
+    default_ca_path = '/etc/pki/katello/certs/katello-default-ca.crt'
+    hammer_config_file = f'{hammer_config_dir}/cli_config.yml'
+
+    module_capsule_configured.create_custom_repos(satutils=settings.repos.satutils_repo)
+    result = module_capsule_configured.execute(
+        'dnf install -y rubygem-hammer_cli_katello rubygem-hammer_cli_foreman'
+    )
+    assert result.status == 0
+    assert module_capsule_configured.execute('rpm -q rubygem-hammer_cli').status == 0
+    hammer_config_content = (
+        f':foreman:\n'
+        f'  :host: "{target_sat.url}"\n'
+        f'  :verify_ssl: true\n'
+        f'  :ssl_ca_file: "{default_ca_path}"\n'
+    )
+    module_capsule_configured.put(hammer_config_content, hammer_config_file, temp_file=True)
+    assert 'FAIL' not in module_capsule_configured.cli.Base.ping()
+    template_name = 'Capsule Update Playbook'
+    template = target_sat.api.JobTemplate().search(query={'search': f'name="{template_name}"'})
+    assert template, f'{template_name} job template not found on Satellite'
+    module_capsule_configured.add_rex_key(satellite=target_sat)
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template[0].id,
+            'inputs': {
+                'whitelist_options': 'repositories-validate,repositories-setup,non-rh-packages',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {module_capsule_configured.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = target_sat.api.JobInvocation(id=job['id']).read()
+    assert result.succeeded == 1
+
+    assert module_capsule_configured.execute('rpm -q rubygem-hammer_cli').status == 0
+    assert 'FAIL' not in module_capsule_configured.cli.Base.ping()
+
+
 @pytest.mark.stubbed
 @pytest.mark.include_capsule
 def test_positive_self_upgrade_for_ystream(sat_maintain):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21790

## Summary

- Moves `test_positive_update_capsule_with_hammer` from `tests/foreman/api/test_capsule.py` (CaseComponent: ForemanProxy / Team: Endeavour) to `tests/foreman/maintain/test_upgrade.py` (CaseComponent: SatelliteMaintain / Team: Rocket)
- Removes the `settings` import from `test_capsule.py` that was added solely for this test in PR #19933
- No change to test logic

## Why

The test installs hammer on a capsule and then upgrades it via `satellite-maintain` using the REX job template "Capsule Update Playbook". This is a `satellite-maintain` operation, not a ForemanProxy/Capsule API operation. Keeping it in `test_capsule.py` caused it to appear under the wrong component in Jira test result tracking (foremanproxy 6.19.2), obscuring failures from the team responsible for it.

## Jira

https://redhat.atlassian.net/browse/SAT-46508

## Test plan

- [ ] Verify `test_positive_update_capsule_with_hammer` no longer appears in ForemanProxy/Endeavour test results
- [ ] Verify the test appears under SatelliteMaintain/Rocket in test results after next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Relocate a satellite-maintain capsule upgrade test to the appropriate test module without altering its behavior.

Tests:
- Move the capsule upgrade with hammer test from the Foreman API capsule suite into the satellite-maintain upgrade suite to align ownership and reporting.
- Remove the now-unneeded dependency on capsule API test settings that existed only for this test.