### PR TITLE
MCP testing on IPv6

### DIFF
--- a/pytest_fixtures/component/mcp.py
+++ b/pytest_fixtures/component/mcp.py
@@ -55,8 +55,11 @@ def _setup_mcp_server(target_sat, image_settings):
     )
     assert target_sat.execute('firewall-cmd --reload').status == 0
     target_sat.ensure_podman_installed()
+
     authfile_arg = ''
-    network_arg = '--network ipv6' if not target_sat.network_type.has_ipv4 else ''
+    network_arg = ''
+    pull_proxy_env = ''
+    mcp_host = '0.0.0.0'
     ca_mountpoint = '/app/ca.pem'
 
     if image_settings.get('registry_username') and image_settings.get('registry_password'):
@@ -69,8 +72,11 @@ def _setup_mcp_server(target_sat, image_settings):
 
     if not target_sat.network_type.has_ipv4:
         target_sat.execute('podman network create --ipv6 ipv6')
+        network_arg = '--network ipv6'
+        mcp_host = '::'
+        pull_proxy_env = f'https_proxy={settings.http_proxy.http_proxy_ipv6_url} '
 
-    pull_cmd = f'podman pull {authfile_arg} {image_settings.registry_url}/{image_settings.image_path}:{image_settings.image_tag}'
+    pull_cmd = f'{pull_proxy_env}podman pull {authfile_arg} {image_settings.registry_url}/{image_settings.image_path}:{image_settings.image_tag}'
     assert target_sat.execute(pull_cmd).status == 0
 
     run_cmd = (
@@ -78,7 +84,7 @@ def _setup_mcp_server(target_sat, image_settings):
         f'-d --pull=never -it -p {settings.foreman_mcp.port}:8080 '
         f'-v /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:{ca_mountpoint}:ro,Z '
         f'{image_name}:{image_settings.image_tag} '
-        f'--foreman-url https://{target_sat.hostname} --host 0.0.0.0 '
+        f'--foreman-url https://{target_sat.hostname} --host {mcp_host} '
         f'--allowed-rex-features "katello_errata_install,katello_package_install" '
         f'--allowed-cv-actions "publish,promote,incremental_update"'
     )
@@ -86,7 +92,13 @@ def _setup_mcp_server(target_sat, image_settings):
     assert run_result.status == 0
     container_id = run_result.stdout.strip()[:12]
     wait_for(
-        lambda: target_sat.execute(f'curl localhost:{settings.foreman_mcp.port}/mcp/').status == 0,
+        lambda: (
+            target_sat.execute(
+                f'curl -H "Accept: text/event-stream" '
+                f'http://{target_sat.hostname}:{settings.foreman_mcp.port}/mcp'
+            ).status
+            == 0
+        ),
         timeout=60,
         delay=2,
     )

--- a/tests/foreman/sys/test_mcp.py
+++ b/tests/foreman/sys/test_mcp.py
@@ -21,14 +21,9 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import FAKE_9_YUM_UPDATED_PACKAGES
-from robottelo.enums import NetworkType
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    settings.server.network_type == NetworkType.IPV6,
-    reason='IPV6 scenario is not essential for this case',
-)
 async def test_positive_list_hosts(module_target_sat_foreman_mcp):
     """Test that the MCP response matches with what is available on Satellite
 
@@ -65,10 +60,6 @@ async def test_positive_list_hosts(module_target_sat_foreman_mcp):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    settings.server.network_type == NetworkType.IPV6,
-    reason='IPV6 scenario is not essential for this case',
-)
 async def test_negative_alter_data(module_target_sat_foreman_mcp):
     """Test that MCP server cannot alter Satellite
 
@@ -104,10 +95,6 @@ async def test_negative_alter_data(module_target_sat_foreman_mcp):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    settings.server.network_type == NetworkType.IPV6,
-    reason='IPV6 scenario is not essential for this case',
-)
 @pytest.mark.parametrize(
     ('user_fixture', 'allowed_resource', 'denied_resource', 'auth_type'),
     [


### PR DESCRIPTION
## Summary

- Enables MCP server setup to work on IPv6-only Satellite instances
- On IPv6: creates a dedicated podman IPv6 network, binds the MCP server to `::` instead of `0.0.0.0`, and routes the container image pull through the IPv6 HTTP proxy
- Fixes the readiness check to use `http://<hostname>:<port>/mcp` with the correct `Accept` header instead of `localhost`
- Removes `skipif` markers that were skipping all three MCP tests on IPv6

## Test plan

- [x] Verify MCP tests pass on IPv4
- [x] Verify MCP tests pass on IPv6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable MCP component tests and server setup to support IPv6-only Satellite environments while improving the MCP readiness check.

New Features:
- Add IPv6-specific MCP server configuration including dedicated podman IPv6 network, IPv6 host binding, and IPv6 HTTP proxy usage for image pulls.

Bug Fixes:
- Fix MCP readiness check to use the Satellite hostname, MCP endpoint path, and required Accept header instead of localhost.

Tests:
- Enable MCP tests on IPv6 by removing skip markers that previously excluded all MCP test cases on IPv6 setups.