### PR TITLE
[6.18.z] Assert any docker manifest content type can be flatpak, not all

### DIFF
--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -281,7 +281,7 @@ def test_sync_consume_flatpak_repo_via_library(
         )[0]
         sat.cli.Repository.synchronize({'id': local_repo['id']})
         assert 'latest' in sat.api.Repository(id=local_repo['id']).read().include_tags
-        assert all(
+        assert any(
             'flatpak' in m['content_type']
             for m in sat.api.Repository(id=local_repo['id']).docker_manifests()['results']
         )
@@ -299,8 +299,7 @@ def test_sync_consume_flatpak_repo_via_library(
         {
             'name': gen_string('alpha'),
             'organization-id': function_org.id,
-            'lifecycle-environment': 'Library',
-            'content-view': 'Default Organization View',
+            'content-view-environments': 'Library',
         }
     )
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21809

### Problem Statement
https://github.com/SatelliteQE/robottelo/pull/17537 introduced assertion that all docker manifest types within a flatpak repo should be `flatpak`. Recently another content types have been added for Cosign (`cosign_sbom`, `cosign_attestation`, and `cosign_signature`), so the assertion fails. Newly at least one manifest needs to be of `flatpak` type.


### Solution
Check that at least one manifest is `flatpak` type.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_flatpak.py -k test_sync_consume_flatpak_repo_via_library
```

## Summary by Sourcery

Tests:
- Adjust flatpak sync test to assert that at least one docker manifest is of flatpak type and to use the updated content view/environment parameter format when creating the host.