### PR TITLE
[6.18.z] Fix flaky protected-package stderr assertion for dnf on Satellite 

### DIFF
--- a/tests/foreman/destructive/test_packages.py
+++ b/tests/foreman/destructive/test_packages.py
@@ -76,13 +76,13 @@ def test_negative_remove_satellite_packages(sat_maintain):
     # Packages include satellite direct dependencies like foreman,
     # but also dependency of dependencies like wget for foreman
     if isinstance(sat_maintain, Satellite):
-        package_list = ['foreman', 'foreman-proxy', 'katello', 'wget', 'satellite']
+        protected_package = 'satellite'
+        package_list = ['foreman', 'foreman-proxy', 'katello', 'wget', protected_package]
     else:
-        package_list = ['foreman-proxy', 'satellite-capsule']
+        protected_package = 'satellite-capsule'
+        package_list = ['foreman-proxy', protected_package]
     for package in package_list:
         result = sat_maintain.execute(f'yum remove {package}')
         assert result.status != 0
-        assert (
-            'Problem: The operation would result in removing the following protected packages: satellite'
-            in str(result.stderr)
-        )
+        # dnf may report "removing" (direct remove) or "broken dependencies" (dependency remove)
+        assert f'protected packages: {protected_package}' in str(result.stderr)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21806

# Problem Statement

`test_negative_remove_satellite_packages` fails on Stream satellite when `yum remove foreman` is blocked because the test expects the following exact DNF error message:

```text
Problem: The operation would result in removing the following protected packages: satellite
```

On some hosts (for example, Jenkins `satellitemaintain` tier systems), DNF instead reports:

```text
Problem: The operation would result in broken dependencies for the following protected packages: satellite
```

In both cases, the removal operation is correctly blocked and the `satellite` package remains protected. The failure occurs only because the test asserts an exact error string, while DNF may use different wording depending on dependency resolution behavior.

# Solution

Relax the assertion to validate the stable portion of the DNF error message:

```text
protected packages: <name>
```

Use:

- `satellite` for Satellite systems
- `satellite-capsule` for Capsule systems

Retain the existing assertion:

```python
assert result.status != 0
```

to ensure that the package removal operation is blocked.

This makes the test resilient to variations in DNF error wording while continuing to verify the intended behavior.

# Related Issues

- Jenkins failure: `test_negative_remove_satellite_packages[satellite]`
- AssertionError caused by differing protected-package stderr output on Satellite systems

## Summary by Sourcery

Tests:
- Loosen stderr assertion in test_negative_remove_satellite_packages to match the protected package name rather than an exact DNF error string for Satellite and Capsule systems.