### PR TITLE
[6.19.Z] Fix Azure UD provision UI test Selenium session idle timeout

### DIFF
--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -196,11 +196,10 @@ def test_positive_azurerm_host_provision_ud(
     fqdn = f'{hostname}.{sat_azure_domain.name}'.lower()
     cloudimg_image = module_azurerm_cloudimg.name
 
-    with sat_azure.ui_session() as session:
-        session.organization.select(org_name=sat_azure_org.name)
-        session.location.select(loc_name=sat_azure_loc.name)
-        # Provision Host
-        try:
+    try:
+        with sat_azure.ui_session() as session:
+            session.organization.select(org_name=sat_azure_org.name)
+            session.location.select(loc_name=sat_azure_loc.name)
             with sat_azure.skip_yum_update_during_provisioning(
                 template='Kickstart default user data'
             ):
@@ -221,21 +220,21 @@ def test_positive_azurerm_host_provision_ud(
                     == module_azure_hg.name
                 )
 
-                # AzureRm Cloud assertion
-                azurecloud_vm = azurermclient.get_vm(name=hostname.lower())
-                assert azurecloud_vm
-                assert azurecloud_vm.is_running
-                assert azurecloud_vm.name == hostname.lower()
-                assert (
-                    azurecloud_vm.ip
-                    == host_page['overview']['details']['details'][
-                        f'{settings.server.NETWORK_TYPE}_address'
-                    ]
-                )
-                assert azurecloud_vm.type == AZURERM_VM_SIZE_DEFAULT
+        # After ui_session: Azure SDK does not use WebDriver (avoids Grid idle-session teardown).
+        azurecloud_vm = azurermclient.get_vm(name=hostname.lower())
+        assert azurecloud_vm
+        assert azurecloud_vm.is_running
+        assert azurecloud_vm.name == hostname.lower()
+        assert (
+            azurecloud_vm.ip
+            == host_page['overview']['details']['details'][
+                f'{settings.server.NETWORK_TYPE}_address'
+            ]
+        )
+        assert azurecloud_vm.type == AZURERM_VM_SIZE_DEFAULT
 
-        finally:
-            azure_vm = sat_azure.api.Host().search(query={'search': f'name={fqdn}'})
-            if azure_vm:
-                with sat_azure.api_factory.satellite_setting('destroy_vm_on_host_delete=True'):
-                    azure_vm[0].delete(synchronous=False)
+    finally:
+        azure_vm = sat_azure.api.Host().search(query={'search': f'name={fqdn}'})
+        if azure_vm:
+            with sat_azure.api_factory.satellite_setting('destroy_vm_on_host_delete=True'):
+                azure_vm[0].delete(synchronous=False)


### PR DESCRIPTION
# Problem Statement

`test_positive_azurerm_host_provision_ud` fails on Selenium Grid with an `InvalidSessionIdException` during `ui_session` teardown.

The Selenium Grid removes the browser session after approximately 240 seconds of inactivity, while the test continues performing long-running post-provision validation steps inside the active `ui_session`, including:

- `get_host_statuses`
- `get_details`
- Azure SDK validation through `azurermclient`

As a result, the WebDriver session expires before teardown, causing the test to fail with `InvalidSessionIdException`.

# Solution

Restrict the scope of `ui_session` to only the UI actions required for provisioning:

- Select organization and location
- Execute `session.host.create()`

After the browser session is closed, perform all validation outside of `ui_session`:

- Verify host build status and host group using the Nailgun API
- Verify Azure VM state using `azurermclient`

This prevents the WebDriver session from remaining idle while API and Azure validation tasks are running and avoids Selenium Grid session timeouts during teardown.

# Related Issues

-  Cherrypick of PR #21469 for 6.19.z
