### PR TITLE
Fix HostGroup UI Tests - Cv_env Issues

### DIFF
--- a/pytest_fixtures/component/host.py
+++ b/pytest_fixtures/component/host.py
@@ -2,7 +2,7 @@
 from fauxfactory import gen_string
 import pytest
 
-from robottelo.constants import DEFAULT_CV, LIBRARY_LCE, PRDS, REPOS, REPOSET
+from robottelo.constants import LIBRARY_LCE, PRDS, REPOS, REPOSET
 
 
 @pytest.fixture
@@ -64,8 +64,7 @@ def host_ui_options(module_host_template):
         'host.name': name,
         'host.organization': module_host_template.organization.name,
         'host.location': module_host_template.location.name,
-        'host.lce': LIBRARY_LCE,
-        'host.content_view': DEFAULT_CV,
+        'host.content_view_environment': LIBRARY_LCE,
         'operating_system.architecture': module_host_template.architecture.name,
         'operating_system.operating_system': os_name,
         'operating_system.media_type': 'All Media',

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -277,7 +277,7 @@ def test_positive_nested_host_groups(
             f'{parent_hg_name}/{child_hg_name}',
             {
                 'host_group.content_view_environment': (
-                    f'{module_lce.name} / {module_published_cv.name}'
+                    f'{module_lce.name}/{module_published_cv.name}'
                 ),
                 'activation_keys.activation_keys': module_ak_cv_lce.name,
             },
@@ -328,7 +328,7 @@ def test_positive_clone_host_groups(
                 'host_group.name': parent_hg_name,
                 'host_group.description': description,
                 'host_group.content_view_environment': (
-                    f'{module_lce.name} / {module_published_cv.name}'
+                    f'{module_lce.name}/{module_published_cv.name}'
                 ),
                 'operating_system.architecture': architecture.name,
                 'operating_system.operating_system': os_name,


### PR DESCRIPTION
### Problem Statement
Snap 190 replaced the separate Lifecycle Environment and Content View dropdowns with a single Content View Environment dropdown in the host and hostgroup create/edit UI forms. 
3 hostgroup UI tests are failing on stream component results.

### Solution
**airgun** (dependency: https://github.com/SatelliteQE/airgun/pull/2461):
Replaced lce and content_view FilteredDropdown widgets with a single content_view_environment widget in the host create view (host_content_view_environment_id).

**robottelo**:
- Updated `host_ui_options` fixture to use host.content_view_environment instead of separate host.lce and host.content_view fields.
- Fixed CV Env value format in test_positive_nested_host_groups and test_positive_clone_host_groups — removed spaces around / to match actual dropdown option text (LCE_name/CV_name).


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostgroup.py -k 'test_positive_create_new_host or test_positive_nested_host_groups or test_positive_clone_host_groups'
airgun: 2461
```

## Summary by Sourcery

Update host UI test data and expectations to align with the unified Content View Environment dropdown.

Enhancements:
- Adjust host UI options fixture to use the combined host.content_view_environment field instead of separate lifecycle environment and content view fields.

Tests:
- Update hostgroup UI tests to match the new Content View Environment display format without spaces around the lifecycle environment/content view separator.