### PR TITLE
[6.18.z] Bump broker from 0.8.7 to 0.8.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Version updates managed by dependabot
 
 apypie==0.8.0
-broker[satlab,docker,ssh2_python]==0.8.7
+broker[satlab,docker,ssh2_python]==0.8.8
 cryptography==49.0.0
 deepdiff==9.0.0
 dynaconf[vault]==3.2.13


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21817

Bumps [broker](https://github.com/SatelliteQE/broker) from 0.8.7 to 0.8.8.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/SatelliteQE/broker/releases">broker's releases</a>.</em></p>
<blockquote>
<h2>The release that locked, not popped</h2>
<h2>What's Changed</h2>
<ul>
<li>Add workflow_poll_interval setting to override default AWX value by <a href="https://github.com/tpapaioa"><code>@​tpapaioa</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/505">SatelliteQE/broker#505</a></li>
<li>[pre-commit.ci] pre-commit autoupdate by <a href="https://github.com/pre-commit-ci"><code>@​pre-commit-ci</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/503">SatelliteQE/broker#503</a></li>
<li>Fix file write race conditions and add humanized timestamp display by <a href="https://github.com/JacobCallahan"><code>@​JacobCallahan</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/510">SatelliteQE/broker#510</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/SatelliteQE/broker/compare/0.8.7...0.8.8">https://github.com/SatelliteQE/broker/compare/0.8.7...0.8.8</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/SatelliteQE/broker/commit/0394217a7fd32e8b1e77531e7a15d09afbf291bb"><code>0394217</code></a> Bump version to 0.8.8</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/7edb3aac4e2ad6c88efff29bbcb0e3223ee5ad9c"><code>7edb3aa</code></a> Fix file write race conditions and add humanized timestamp display</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/4ee2278744abd90dc7b80cb29175fc7c3186751a"><code>4ee2278</code></a> [pre-commit.ci] pre-commit autoupdate</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/b781714284882657846eb6cb42c4d7ab503f3cb0"><code>b781714</code></a> Add workflow_poll_interval setting to override default AWX value</li>
<li>See full diff in <a href="https://github.com/SatelliteQE/broker/compare/0.8.7...0.8.8">compare view</a></li>
</ul>
</details>
<br />
