### PR TITLE
Another Batch Of Lce CV Removal Fixes

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1332,9 +1332,10 @@ def test_positive_validate_inherited_cv_lce_ansiblerole(session, target_sat, mod
     target_sat.cli.Ansible.roles_sync(
         {'role-names': SELECTED_ROLE, 'proxy-id': target_sat.nailgun_smart_proxy.id}
     )
+    cv_env_id = target_sat.api_factory.get_cvenv_id(cv, lce)
     hostgroup = target_sat.cli_factory.hostgroup(
         {
-            'content-view-environment': f'{lce.label}/{cv.label}',
+            'content-view-environment-id': cv_env_id,
             'organization-ids': module_host_template.organization.id,
         }
     )

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -30,7 +30,6 @@ from robottelo.config import settings
 from robottelo.constants import (
     ANY_CONTEXT,
     DEFAULT_ARCHITECTURE,
-    DEFAULT_CV,
     DEFAULT_LOC,
     DEFAULT_ORG,
     FAKE_1_CUSTOM_PACKAGE,
@@ -1009,16 +1008,9 @@ def test_positive_check_permissions_affect_create_procedure(
     host_fields = [
         {'name': 'host.hostgroup', 'unexpected_value': hg.name, 'expected_value': filter_hg.name},
         {
-            'name': 'host.lce',
-            'unexpected_value': lc_env.name,
-            'expected_value': filter_lc_env.name,
-        },
-        {
-            'name': 'host.content_view',
-            'unexpected_value': cv.name,
-            'expected_value': filter_cv.name,
-            # content view selection needs the right lce to be selected
-            'other_fields_values': {'host.lce': filter_lc_env.name},
+            'name': 'host.content_view_environment',
+            'unexpected_value': f'{lc_env.name}/{cv.name}',
+            'expected_value': f'{filter_lc_env.name}/{filter_cv.name}',
         },
     ]
     with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
@@ -1852,8 +1844,7 @@ def test_positive_create_with_puppet_class(
         'host.name': host_template.name,
         'host.organization': host_template.organization.name,
         'host.location': host_template.location.name,
-        'host.lce': LIBRARY_LCE,
-        'host.content_view': DEFAULT_CV,
+        'host.content_view_environment': LIBRARY_LCE,
         'operating_system.architecture': host_template.architecture.name,
         'operating_system.operating_system': os_name,
         'operating_system.media_type': 'All Media',
@@ -4428,9 +4419,9 @@ def test_positive_only_single_library_option_in_create_form(target_sat):
         session.organization.select(org_name=DEFAULT_ORG)
         session.location.select(loc_name=ANY_CONTEXT['location'])
         create_form = session.host.get_create_form()
-        create_form.host.lce.open_filter.click()
+        create_form.host.content_view_environment.open_filter.click()
         # Check that 'Library' appears just once
-        assert create_form.host.lce.filter_content.read().count('Library') == 1
+        assert create_form.host.content_view_environment.filter_content.read().count('Library') == 1
 
 
 def test_positive_search_by_report_origin_shows_all_hosts(target_sat):

--- a/tests/foreman/ui/test_puppetenvironment.py
+++ b/tests/foreman/ui/test_puppetenvironment.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from robottelo.constants import DEFAULT_CV, LIBRARY_LCE
+from robottelo.constants import LIBRARY_LCE
 from robottelo.utils.datafactory import gen_string
 
 
@@ -91,8 +91,7 @@ def test_positive_availability_for_host_and_hostgroup_in_multiple_orgs(
                     'host.name': host.name,
                     'host.organization': org.name,
                     'host.location': module_puppet_loc.name,
-                    'host.lce': LIBRARY_LCE,
-                    'host.content_view': DEFAULT_CV,
+                    'host.content_view_environment': LIBRARY_LCE,
                     'host.puppet_environment': env_name,
                     'operating_system.architecture': host.architecture.name,
                     'operating_system.operating_system': os_name,


### PR DESCRIPTION
### Problem Statement
This PR is another batch if fixes that mitigates the removal of CV and LCe


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update UI host tests to use the combined content view environment field instead of separate lifecycle environment and content view fields.

Tests:
- Adjust host creation and permission tests to reference the content view environment selector rather than individual lifecycle environment and content view selectors.
- Update library option filtering assertions and puppet environment availability tests to rely on the unified content view environment field.

## Summary by Sourcery

Align host and hostgroup tests with the combined content view environment field and identifiers instead of separate lifecycle environment and content view selections.

Tests:
- Update host UI permission, inheritance, and creation tests to use the unified content_view_environment field rather than separate host.lce and host.content_view fields.
- Adjust hostgroup creation tests to use content view environment IDs when associating content views and lifecycle environments.