### PR TITLE
[6.19.z] Add CLAUDE.md symlink pointing to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 **Project**: SatelliteQE Robottelo
 **Repository**: https://github.com/SatelliteQE/robottelo
 
+> **Note for contributors**: `CLAUDE.md` in this repository is a symlink pointing to this file (`AGENTS.md`). It exists so that Claude Code picks up the same instructions. Do not edit `CLAUDE.md` directly — edit `AGENTS.md` instead.
+
 ---
 
 ## Project Overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21853

### Problem Statement
Claude Code looks for a CLAUDE.md file in the working directory to automatically load project context on startup. Without it, Claude Code falls back to parent directories or starts without any project-specific guidance, missing repository-specific conventions and workflows documented in AGENTS.md.


### Solution
A CLAUDE.md symlink pointing to AGENTS.md is added to the repository root. Claude Code follows the symlink and loads the existing AGENTS.md content automatically, keeping a single source of truth while making the context available to Claude Code without any duplication.


### How to test
```
$ cd <your_robottelo_dir>
$ claude
```
Ask Claude `What is your current context file?` It should mention `CLAUDE.md`, which is pointing to `AGENTS.md`, and know all the context.

## Summary by Sourcery

New Features:
- Expose AGENTS.md content to Claude Code by adding a CLAUDE.md reference file in the repository root.