### PR TITLE
Do not proxy all traffic on IPv6 - use per-repo proxy for IPv4-only URLs

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -207,3 +207,7 @@ REPOS:
 
   RPM_MISSING_FILELISTS:
     URL: ''
+
+  IPV4_URL_REGEXPS:
+  - '^(http|https)://ipv4_only_host'
+  - '^(http|https)://ipv6_unroutable_host'

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -537,11 +537,15 @@ class ContentHost(Host, ContentHostMixins):
         cp.read_file(io.StringIO(config))
         return cp
 
-    def create_custom_repos(self, **kwargs):
+    def create_custom_repos(self, proxy=None, enabled=1, gpgcheck=0, **kwargs):
         """Create custom repofiles.
         Each ``kwargs`` item will result in one repository file created. Where
         the key is the repository filename and repository name, and the value
         is the repository URL.
+
+        :param proxy: Optional proxy URL to set per-repo (default: None).
+        :param enabled: Value for the ``enabled`` field (default 1).
+        :param gpgcheck: Value for the ``gpgcheck`` field (default 0).
 
         For example::
 
@@ -558,7 +562,19 @@ class ContentHost(Host, ContentHostMixins):
 
         """
         for name, url in kwargs.items():
-            content = f'[{name}]\nname={name}\nbaseurl={url}\nenabled=1\ngpgcheck=0'
+            # auto-detect ipv6to4 proxy for ipv6 host and ipv4 urls
+            repo_proxy = proxy
+            if repo_proxy is None and not self.network_type.has_ipv4:
+                for pattern in settings.repos.ipv4_url_regexps:
+                    if re.search(pattern, url):
+                        repo_proxy = settings.http_proxy.http_proxy_ipv6_url
+                        break
+
+            content = (
+                f'[{name}]\nname={name}\nbaseurl={url}\nenabled={enabled}\ngpgcheck={gpgcheck}'
+            )
+            if repo_proxy:
+                content += f'\nproxy={repo_proxy}'
             self.execute(f'echo "{content}" > /etc/yum.repos.d/{name}.repo')
 
     def get_base_url_for_older_rhel_minor(self):

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -497,7 +497,6 @@ class TestAnsibleCfgMgmt:
             2. Verify that any task failures are listed as errors in the config report
         """
         SELECTED_ROLE = 'theforeman.foreman_scap_client'
-        rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
         nc = module_target_sat.nailgun_smart_proxy
         nc.location = [module_location]
         nc.organization = [module_org]
@@ -583,7 +582,6 @@ class TestAnsibleREX:
             2. Job report should be created.
         """
         SELECTED_ROLE = 'RedHatInsights.insights-client'
-        rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
         if rhel_contenthost.os_version.major <= 7:
             rhel_contenthost.create_custom_repos(rhel7=settings.repos.rhel7_os)
             assert rhel_contenthost.execute('yum install -y insights-client').status == 0
@@ -784,7 +782,6 @@ class TestAnsibleREX:
         :Verifies: SAT-30807
         """
         # Adding IPv6 proxy for IPv6 communication
-        rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
         rhel_contenthost.enable_ipv6_system_proxy()
         client = rhel_contenthost
         # Enable Ansible repository and Install ansible or ansible-core package


### PR DESCRIPTION
## Problem Statement

`enable_ipv6_dnf_and_rhsm_proxy()` sets a global DNF and RHSM proxy for the entire content host session. This is overly broad:

- **Satellite client repos** (e.g. `satclient_repo`) are hosted on dualstack hosts — they are reachable directly over IPv6 and do not need a proxy
- **RHEL OS repos** are hosted on IPv4-only hosts — these genuinely require an IPv6-to-IPv4 proxy
- **RHSM** communication goes to Satellite itself, which is an IPv6-reachable host in our test environment — proxying it is unnecessary and potentially harmful

Routing all traffic through a proxy when only a subset of URLs actually need it adds unnecessary overhead and masks real IPv6 connectivity issues.

## Summary

- Extends `create_custom_repos` in `hosts.py` with `proxy`, `enabled`, and `gpgcheck` keyword arguments for per-repo configuration
- Adds auto-detection of IPv6-to-IPv4 proxy based on URL patterns from `settings.repos.ipv4_url_regexps` — no manual proxy passing needed in tests
- Removes all `enable_ipv6_dnf_and_rhsm_proxy()` calls from `tests/foreman/ui/test_ansible.py` — per-repo auto-detection handles the IPv4 repo case transparently

Depends on #21841

## Jira

https://redhat.atlassian.net/browse/SAT-46866

## Test plan

- [ ] Verify all three affected tests in `test_ansible.py` pass on IPv6

🤖 Generated with [Claude Code](https://claude.com/claude-code)