### PR TITLE
[6.18.z] Fix test_positive_ansible_config_report_changes_notice_and_failed_tasks_errors on IPv6

### DIFF
--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -497,6 +497,7 @@ class TestAnsibleCfgMgmt:
             2. Verify that any task failures are listed as errors in the config report
         """
         SELECTED_ROLE = 'theforeman.foreman_scap_client'
+        rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
         nc = module_target_sat.nailgun_smart_proxy
         nc.location = [module_location]
         nc.organization = [module_org]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21841

## Summary

- Fixes `test_positive_ansible_config_report_changes_notice_and_failed_tasks_errors` on IPv6 by adding `enable_ipv6_dnf_and_rhsm_proxy()` before the test body — RHEL OS repos are unreachable on IPv6-only hosts without it

## Jira

https://redhat.atlassian.net/browse/SAT-46642

## Test plan

- [x] Verify `test_positive_ansible_config_report_changes_notice_and_failed_tasks_errors` passes on IPv6

🤖 Generated with [Claude Code](https://claude.com/claude-code)