### PR TITLE
Fix test_positive_tag_whitelist for pulp-container 2.27.9 companion tag behavior

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2463,7 +2463,12 @@ class TestTokenAuthContainerRepository:
 
         :parametrized: yes
 
-        :expectedresults: multiple products and repos are created
+        :expectedresults:
+            1. Repos are created with correct fields.
+            2. After sync, at least one docker manifest is present.
+            3. The whitelisted 'latest' tag is synced.
+            4. No unexpected tags are synced beyond 'latest' and its cosign sig companions
+               (sha256-<hash>.sig), which may be present when 'latest' is a manifest list.
         """
         container_repo = getattr(settings.container_repo.registries, repo_key)
 
@@ -2498,7 +2503,21 @@ class TestTokenAuthContainerRepository:
             repo.sync(timeout=600)
             synced_repo = repo.read()
             assert synced_repo.content_counts['docker_manifest'] >= 1
-            assert synced_repo.content_counts['docker_tag'] == 1
+            synced_tags = [
+                t.name
+                for t in module_target_sat.api.DockerTag().search(
+                    query={'repository_id': repo.id, 'per_page': '999'}
+                )
+            ]
+            assert 'latest' in synced_tags, f"'latest' tag missing from synced tags: {synced_tags}"
+            # Since pulp-container 2.27.9, companion cosign sig tags may be correctly synced
+            # alongside the whitelisted manifest list tags (pulp#2096). Any tag beyond 'latest'
+            # must be a sig companion (sha256-<hash>.sig); other sources may have none.
+            assert all(
+                re.match(r'^sha256-[a-f0-9]+\.sig$', name)
+                for name in synced_tags
+                if name != 'latest'
+            ), f"Unexpected non-sig tags synced alongside 'latest': {synced_tags}"
 
 
 class TestPythonRepository:


### PR DESCRIPTION
### Problem Statement
Since [pulp-container 2.27.9](https://pulpproject.org/pulp_container/changes/#2.27.9), cosign signature companion tags (sha256-<hash>.sig) are correctly synced alongside whitelisted manifest list tags ([pulp#2096](https://github.com/pulp/pulp_container/issues/2096)). Previously these were silently skipped, causing test_positive_tag_whitelist to pass with an exact count of 1 tag. After the fix in pulp-container, the test started failing with `assert 5 == 1` because the latest tag (a manifest list) now correctly pulls in its 4 cosign sig companions.


### Solution
Replace the brittle docker_tag == 1 count assertion with semantically correct checks:
- Query tags scoped to the specific repository (repository_id) to avoid cross-repo contamination
- Assert latest is present among synced tags
- Allow sig companion tags matching sha256-<hash>.sig and nothing else

Sources without sig companions pass because `all()` on an empty iterable is `True`.


### Related Issues
https://github.com/pulp/pulp_container/issues/2096


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k test_positive_tag_whitelist
```

## Summary by Sourcery

Update container repository tag whitelist test to account for cosign signature companion tags synced with manifest list tags.

Bug Fixes:
- Fix test_positive_tag_whitelist to correctly validate synced tags when cosign signature companion tags are present.

Enhancements:
- Tighten expected results documentation for the tag whitelist test to describe required tags and allowed companion signatures.