### PR TITLE
Fix test_positive_dump_enc_yaml: accept both RSA and Ed25519 SSH keys

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2116,7 +2116,8 @@ def test_positive_dump_enc_yaml(target_sat):
     assert f'fqdn: {target_sat.hostname}' in enc_dump
     ip_prefix = 'ip6' if target_sat.network_type == NetworkType.IPV6 else 'ip'
     assert f'{ip_prefix}: {target_sat.ip_addr}' in enc_dump
-    assert 'ssh-rsa' in enc_dump
+    # Check for SSH key (either RSA or Ed25519)
+    assert 'ssh-rsa' in enc_dump or 'ssh-ed25519' in enc_dump
 
 
 # -------------------------- HOST TRACE SUBCOMMAND SCENARIOS -------------------------


### PR DESCRIPTION
## Problem
The test `test_positive_dump_enc_yaml` was failing with:
```
AssertionError: assert 'ssh-rsa' in enc_dump
```

## Root Cause
Satellite/Foreman has migrated from RSA to Ed25519 SSH keys for remote execution. Ed25519 is more secure and efficient than RSA.

The ENC dump now contains:
```yaml
remote_execution_ssh_keys:
  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...
```

instead of the old RSA format.

## Solution
Updated the assertion to accept both key types for backward compatibility:
```python
# Old:
assert 'ssh-rsa' in enc_dump

# New:
assert 'ssh-rsa' in enc_dump or 'ssh-ed25519' in enc_dump
```

This makes the test compatible with both:
- Older Satellite versions (using RSA keys)
- Newer Satellite versions (using Ed25519 keys)

## Testing
✅ Test passes with Ed25519 keys
✅ Test will pass with RSA keys (backward compatible)

## Related
- Related to Satellite's security improvements moving to Ed25519

## Summary by Sourcery

Relax ENC YAML SSH key assertion to support multiple key types in host tests.

Bug Fixes:
- Fix ENC dump YAML test to accept either RSA or Ed25519 SSH keys in the remote execution configuration.

Tests:
- Update host ENC YAML test to assert presence of either RSA or Ed25519 SSH keys for compatibility with different Satellite versions.