### PR TITLE
Change displayMessage to message to accomodate katello changes

### DIFF
--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -133,7 +133,7 @@ class APIFactory:
             if (
                 not strict
                 and e.response.status_code == 409
-                and 'repository is already enabled' in e.response.json()['displayMessage']
+                and 'repository is already enabled' in e.response.json()['message']
             ):
                 pass
             else:


### PR DESCRIPTION
### Problem Statement
From following PR: https://github.com/Katello/katello/commit/b1d64438ac9fc30cf163b4ae2305e36283761481
katello changed key response from `displayMessage` to `message`.
This has caused significant failures in Robotello test suit by `KeyError`

### Solution

Accommodating respective change in Robotello to ensure tests do not fail because of `KeyError`

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Prevent KeyError when handling 409 responses by reading the `message` field instead of `displayMessage` in Katello API error responses.