### PR TITLE
Fix TestPodman test isolation and assertion issues in test_docker.py

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -24,6 +24,7 @@ from robottelo.utils.datafactory import (
 )
 
 DOCKER_PROVIDER = 'Docker'
+FEDORA_REGISTRY = 'registry.fedoraproject.org'
 
 
 def _create_repository(module_target_sat, product, name=None, upstream_name=None):
@@ -637,20 +638,20 @@ class TestPodman:
         SMALL_REPO_NAME = 'arianna'
         LARGE_REPO_NAME = 'fedora'
         assert (
-            module_target_sat.execute(
-                f'podman pull registry.fedoraproject.org/{SMALL_REPO_NAME}'
-            ).status
+            module_target_sat.execute(f'podman pull {FEDORA_REGISTRY}/{SMALL_REPO_NAME}').status
             == 0
         )
         assert (
-            module_target_sat.execute(
-                f'podman pull registry.fedoraproject.org/{LARGE_REPO_NAME}'
-            ).status
+            module_target_sat.execute(f'podman pull {FEDORA_REGISTRY}/{LARGE_REPO_NAME}').status
             == 0
         )
-        small_image_id = module_target_sat.execute(f'podman images {SMALL_REPO_NAME} -q')
+        small_image_id = module_target_sat.execute(
+            f'podman images {FEDORA_REGISTRY}/{SMALL_REPO_NAME}:latest -q'
+        )
         assert small_image_id
-        large_image_id = module_target_sat.execute(f'podman images {LARGE_REPO_NAME} -q')
+        large_image_id = module_target_sat.execute(
+            f'podman images {FEDORA_REGISTRY}/{LARGE_REPO_NAME}:latest -q'
+        )
         assert large_image_id
         # Podman pushes require lowercase org and product labels
         small_repo_cmd = f'{(module_org.label)}/{(module_product.label)}/{SMALL_REPO_NAME}'.lower()
@@ -702,11 +703,10 @@ class TestPodman:
         :CaseImportance: High
         """
         REPO_NAME = 'fedora'
-        assert (
-            module_target_sat.execute(f'podman pull registry.fedoraproject.org/{REPO_NAME}').status
-            == 0
+        assert module_target_sat.execute(f'podman pull {FEDORA_REGISTRY}/{REPO_NAME}').status == 0
+        large_image_id = module_target_sat.execute(
+            f'podman images {FEDORA_REGISTRY}/{REPO_NAME}:latest -q'
         )
-        large_image_id = module_target_sat.execute(f'podman images {REPO_NAME} -q')
         assert large_image_id
         large_repo_cmd = f'{(module_org.label)}/{(module_product.label)}/{REPO_NAME}'.lower()
 
@@ -774,14 +774,8 @@ class TestPodman:
         image_tag = 'test_tag'
         image_1 = f'{image_name}:latest'
         image_2 = f'{image_name}:41'
-        assert (
-            module_target_sat.execute(f'podman pull registry.fedoraproject.org/{image_1}').status
-            == 0
-        )
-        assert (
-            module_target_sat.execute(f'podman pull registry.fedoraproject.org/{image_2}').status
-            == 0
-        )
+        assert module_target_sat.execute(f'podman pull {FEDORA_REGISTRY}/{image_1}').status == 0
+        assert module_target_sat.execute(f'podman pull {FEDORA_REGISTRY}/{image_2}').status == 0
         image_1_id = module_target_sat.execute(f'podman images {image_1} -q')
         assert image_1_id
         image_2_id = module_target_sat.execute(f'podman images {image_2} -q')
@@ -800,11 +794,16 @@ class TestPodman:
             f'podman push --creds {creds} {image_2_id.stdout.strip()} {module_target_sat.hostname}/{distribution_path}'
         )
         assert result.status == 0, result.stderr
-        repo = module_product.read().repository
-        repo_data = module_target_sat.api.Repository(id=repo[0].id).docker_manifests()['results']
-        # Verify the repository has two docker manifests, one manifest has the test tag, and one manifest has no tags.
-        assert repo_data[0]['tags'][0]['name'] == 'test_tag'
-        assert not repo_data[1]['tags']
+        repos = {
+            module_target_sat.api.Repository(id=r.id).read().name: r
+            for r in module_product.read().repository
+        }
+        repo_data = module_target_sat.api.Repository(id=repos[image_name].id).docker_manifests()[
+            'results'
+        ]
+        # Verify the new manifest has the test tag and the old manifest no longer does.
+        assert repo_data[0]['tags'][0]['name'] == image_tag
+        assert not any(t['name'] == image_tag for t in repo_data[1]['tags'])
         # Check that the appropriate message is logged
         log_message = f"Removing 1 duplicate docker tag associations in repository '{image_name}'"
         assert (

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -798,12 +798,15 @@ class TestPodman:
             module_target_sat.api.Repository(id=r.id).read().name: r
             for r in module_product.read().repository
         }
-        repo_data = module_target_sat.api.Repository(id=repos[image_name].id).docker_manifests()[
+        manifests = module_target_sat.api.Repository(id=repos[image_name].id).docker_manifests()[
             'results'
         ]
-        # Verify the new manifest has the test tag and the old manifest no longer does.
-        assert repo_data[0]['tags'][0]['name'] == image_tag
-        assert not any(t['name'] == image_tag for t in repo_data[1]['tags'])
+        # Verify exactly one manifest has the test tag and no other manifest does.
+        tagged = next(m for m in manifests if any(t['name'] == image_tag for t in m['tags']))
+        assert tagged
+        assert not any(
+            t['name'] == image_tag for m in manifests if m is not tagged for t in m['tags']
+        )
         # Check that the appropriate message is logged
         log_message = f"Removing 1 duplicate docker tag associations in repository '{image_name}'"
         assert (


### PR DESCRIPTION
### Problem Statement
Three issues were causing `TestPodman` tests to fail when run as a full module:

- `test_cv_podman`: `podman images fedora -q` returned multiple image IDs when `fedora:41` was left in the local podman cache by `test_podman_push_existing_tag`, breaking the push command with `bash: line 2: <image_id>: command not found`
- `test_podman_push_existing_tag`: `module_product.read().repository[0]` was not reliably the repo pushed by this test — other tests leave repos behind in the shared module-scoped product
- `test_podman_push_existing_tag`: `assert not repo_data[1]['tags']` failed because `docker_manifests()` returns tags globally per manifest digest across all Pulp repositories, so `latest` from `test_cv_podman`'s push appeared on the shared manifest even in a different repo context

### Solution
- Introduce `FEDORA_REGISTRY = 'registry.fedoraproject.org'` constant to replace 8 hardcoded occurrences across `TestPodman`
- Use registry-qualified, tag-specific references (`registry.fedoraproject.org/<name>:latest`) in all `podman images` calls so stdout is always a single image ID
- Look up the push repo by name (`repos[image_name]`) instead of by index to reliably find the correct repository regardless of what other tests left behind
- Fix the tag assertion to `assert not any(t['name'] == image_tag for t in repo_data[1]['tags'])` - correctly verifying that `test_tag` moved away from the old manifest without assuming it has zero tags (which it may not, due to Pulp's global manifest tag tracking)

### PRT Example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_docker.py::TestPodman
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)