### PR TITLE
Fixed Bootdisk Plugin test

### DIFF
--- a/tests/foreman/cli/test_bootdisk.py
+++ b/tests/foreman/cli/test_bootdisk.py
@@ -64,6 +64,9 @@ def test_positive_bootdisk_download_https(
             'os-family': 'Redhat',
         }
     )
+    cv_env_id = module_target_sat.api_factory.get_cvenv_id(
+        module_default_org_view.id, module_lce_library.id
+    )
     host = module_target_sat.cli_factory.make_host(
         {
             'organization-id': module_sca_manifest_org.id,
@@ -78,8 +81,7 @@ def test_positive_bootdisk_download_https(
             'root-password': settings.provisioning.host_root_password,
             'partition-table-id': default_partitiontable.id,
             'content-source-id': capsule.id,
-            'content-view-id': module_default_org_view.id,
-            'lifecycle-environment-id': module_lce_library.id,
+            'content-view-environment-ids': cv_env_id,
         }
     )
 


### PR DESCRIPTION
### Problem Statement

PR: https://github.com/Katello/katello/commit/a46d7afdf677bcc71bd128d4566b5e50371c322e

removed `--content-view-id` and `lifecycle-environment-id` which caused failure in robotello tests.

### Solution

Replacing them with  `content-view-environment-ids` 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update bootdisk CLI test to align with new content view and lifecycle environment parameters.

Bug Fixes:
- Fix bootdisk HTTPS download test failure caused by deprecated content view and lifecycle environment flags.

Tests:
- Adjust bootdisk CLI host creation in the test suite to use combined content-view-environment-ids instead of separate content view and lifecycle environment IDs.