### PR TITLE
Fix deprecated CV/LCE params in AK create/update calls

### DIFF
--- a/pytest_fixtures/component/activationkey.py
+++ b/pytest_fixtures/component/activationkey.py
@@ -74,10 +74,13 @@ def module_ak_with_synced_repo(module_sca_manifest_org, module_target_sat):
         {'product-id': new_product['id'], 'content-type': 'yum'}
     )
     Repository.synchronize({'id': new_repo['id']})
+    cvenv_id = module_target_sat.api_factory.get_cvenv_id(
+        module_sca_manifest_org.default_content_view,
+        module_sca_manifest_org.library,
+    )
     return module_target_sat.cli_factory.make_activation_key(
         {
-            'lifecycle-environment': 'Library',
-            'content-view': 'Default Organization View',
+            'content-view-environment-ids': cvenv_id,
             'organization-id': module_sca_manifest_org.id,
         }
     )

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -451,12 +451,12 @@ class TestDockerClient:
         module_capsule_configured.wait_for_sync(start_time=timestamp)
 
         # 4. Create activation key for the LCE/CV.
+        cvenv_id = sat.api_factory.get_cvenv_id(cv['id'], module_lce)
         ak = sat.cli.ActivationKey.create(
             {
                 'name': gen_string('alpha'),
                 'organization-id': module_org.id,
-                'lifecycle-environment-id': module_lce.id,
-                'content-view-id': cv['id'],
+                'content-view-environment-ids': cvenv_id,
             }
         )
         return Box(repo=repo, cv=cv, ak=ak)

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2597,11 +2597,11 @@ def test_positive_install_uploaded_rpm_on_host(
     target_sat.cli.ContentView.version_promote(
         {'id': content_view['versions'][0]['id'], 'to-lifecycle-environment-id': function_lce.id}
     )
+    cvenv_id = target_sat.api_factory.get_cvenv_id(content_view['id'], function_lce)
     activation_key = target_sat.cli_factory.make_activation_key(
         {
             'organization-id': function_org.id,
-            'lifecycle-environment-id': function_lce.id,
-            'content-view-id': content_view['id'],
+            'content-view-environment-ids': cvenv_id,
         }
     )
     target_sat.cli.ActivationKey.content_override(

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -27,7 +27,6 @@ from robottelo.constants import (
     DEFAULT_CV,
     EXPORT_LIBRARY_NAME,
     FLATPAK_RHEL_RELEASE_VER,
-    LIBRARY_LCE,
     PULP_EXPORT_DIR,
     PULP_IMPORT_DIR,
     REPO_TYPE,
@@ -1621,12 +1620,14 @@ class TestExportImport:
                 )
 
         # Register a content host using AK.
+        cvenv_id = module_import_sat.api_factory.get_cvenv_id(
+            importing_cv['id'], function_import_org_at_isat.library
+        )
         ak = module_import_sat.cli.ActivationKey.create(
             {
                 'name': gen_string('alpha'),
                 'organization-id': function_import_org_at_isat.id,
-                'lifecycle-environment': 'Library',
-                'content-view': importing_cv['name'],
+                'content-view-environment-ids': cvenv_id,
             }
         )
         module_import_sat.cli.ActivationKey.content_override(
@@ -3096,10 +3097,10 @@ class TestExportImport:
 
         # Create an AK with the imported CV, register the content host and check
         # the package count available to install. Filtered package should be missing.
+        cvenv_id = target_sat.api_factory.get_cvenv_id(imp_cv['id'], function_import_org.library)
         ak = target_sat.cli_factory.make_activation_key(
             {
-                'content-view': exp_cv['name'],
-                'lifecycle-environment': LIBRARY_LCE,
+                'content-view-environment-ids': cvenv_id,
                 'organization-id': function_import_org.id,
             }
         )

--- a/tests/foreman/destructive/test_remoteexecution.py
+++ b/tests/foreman/destructive/test_remoteexecution.py
@@ -169,10 +169,11 @@ def test_positive_use_alternate_directory(
     :parametrized: yes
     """
     client = rhel_contenthost
+    org = default_org.read()
+    cvenv_id = target_sat.api_factory.get_cvenv_id(org.default_content_view, org.library)
     ak = target_sat.cli_factory.make_activation_key(
         {
-            'lifecycle-environment': 'Library',
-            'content-view': 'Default Organization View',
+            'content-view-environment-ids': cvenv_id,
             'organization-id': default_org.id,
         }
     )


### PR DESCRIPTION
### Problem Statement
Snap 190 (Katello PR [#11753](https://github.com/Katello/katello/pull/11753)) removed deprecated `--content-view`, `--lifecycle-environment`, and their `id` parameters from hammer activation-key create/update. PRs #21644, #21785, and #21804 addressed most of the codebase but missed some more locations.


### Solution
Replace deprecated parameters using `api_factory.get_cvenv_id()` in the remaining locations:

- pytest_fixtures/component/activationkey.py - module_ak_with_synced_repo fixture: Library + Default Organization View → org.default_content_view / org.library
- tests/foreman/cli/test_repository.py - test_positive_install_uploaded_rpm_on_host: content-view-id + lifecycle-environment-id → get_cvenv_id(content_view['id'], function_lce)
- tests/foreman/cli/test_container_management.py - stage_setup fixture: content-view-id + lifecycle-environment-id → get_cvenv_id(cv['id'], module_lce)
- tests/foreman/cli/test_satellitesync.py - two tests: test_postive_export_import_cv_with_mixed_content_repos and test_positive_export_import_consume_incremental_yum_repo
- tests/foreman/destructive/test_remoteexecution.py - test_positive_use_alternate_directory: Library + Default Organization View → default_org.default_content_view / default_org.library


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_repository.py::TestRepository::test_positive_accessible_content_status tests/foreman/cli/test_repository.py::test_positive_install_uploaded_rpm_on_host tests/foreman/cli/test_container_management.py::TestDockerClient::test_podman_cert_auth tests/foreman/cli/test_satellitesync.py::TestExportImport::test_postive_export_import_cv_with_mixed_content_repos tests/foreman/cli/test_satellitesync.py::TestExportImport::test_positive_export_import_consume_incremental_yum_repo tests/foreman/destructive/test_remoteexecution.py::test_positive_use_alternate_directory
```

## Summary by Sourcery

Update activation key creation in tests and fixtures to use combined content view and lifecycle environment IDs instead of deprecated parameters.

Bug Fixes:
- Replace deprecated activation key content view and lifecycle environment parameters with content-view-environment-ids in remaining test and fixture locations to keep activation key operations compatible with current APIs.

Enhancements:
- Standardize activation key setup in tests by using api_factory.get_cvenv_id for deriving content-view-environment-ids across repository, container management, satellite sync, and remote execution scenarios.