### PR TITLE
Use safer HTTP 409 message check in enable_rhrepo

### DIFF
--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -133,7 +133,7 @@ class APIFactory:
             if (
                 not strict
                 and e.response.status_code == 409
-                and 'repository is already enabled' in e.response.json()['displayMessage']
+                and 'repository is already enabled' in e.response.json().get('message', '')
             ):
                 pass
             else:


### PR DESCRIPTION
### Problem Statement
Some tests CI fail when the `enable_rhrepo_and_fetchid` tries to enable a repo which is already enabled. The helper already handles that situation (see the `strict` param), but the key for error message has changed in https://github.com/Katello/katello/pull/11773, so now it fails with `KeyError`.
```
robottelo/host_helpers/api_factory.py:131: in enable_rhrepo_and_fetchid
    r_set.enable(data=payload)
../../lib64/python3.12/site-packages/nailgun/entities.py:7749: in enable
    return _handle_response(response, self._server_config, synchronous, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../lib64/python3.12/site-packages/nailgun/entities.py:118: in _handle_response
    response.raise_for_status()
../../lib64/python3.12/site-packages/requests/models.py:1028: in raise_for_status
    raise HTTPError(http_error_msg, response=self)
E   requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://satellite.redhat.com/katello/api/v2/repository_sets/7421/enable

During handling of the above exception, another exception occurred:
tests/foreman/api/test_repositories.py:312: in test_positive_sync_mulitple_large_repos
    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
robottelo/host_helpers/api_factory.py:136: in enable_rhrepo_and_fetchid
    and 'repository is already enabled' in e.response.json()['displayMessage']
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   KeyError: 'displayMessage'
```


### Solution
Update the key to `message` and use `get` so a potential future change will propagate the original HTTP error.


### Testing
From within any test which calls `target_sat.api_factory.enable_rhrepo_and_fetchid`, run this call twice. With this PR no `KeyError` is raised and the test continues.

## Summary by Sourcery

Bug Fixes:
- Avoid KeyError when handling HTTP 409 conflicts by reading the repository already enabled message from the JSON 'message' field using a safe lookup.