### PR TITLE
drop virtwho cli params

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -50,7 +50,6 @@ DOWNSTREAM_MODULES = {
     'foreman::cli::kubevirt',
     'foreman::cli::puppet',
     'foreman::cli::remote_execution',
-    'foreman::cli::virt_who_configure',
     'foreman::cli::webhooks',
     'foreman::compute::ec2',
     'foreman::compute::libvirt',


### PR DESCRIPTION
### Problem Statement

virtwho cli is recently droped from installer https://github.com/theforeman/foreman-installer/commit/12f5b840ae73f890de4521ce776162204b7abbbd
### Solution

Remove it from expected answers file
### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Remove virt-who CLI entry from the list of expected installer answers in installer tests.