### PR TITLE
Fix nested hostgroup creation in test_global_registration_form_populate

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -320,7 +320,11 @@ def test_global_registration_form_populate(
         content_view=function_sca_manifest_org.default_content_view.id,
         group_parameters_attributes=[group_params],
     ).create()
-    target_sat.api.HostGroup(name=hg_nested_name, parent=parent_hg).create()
+    target_sat.api.HostGroup(
+        name=hg_nested_name,
+        parent=parent_hg,
+        organization=[function_sca_manifest_org],
+    ).create()
     new_org = target_sat.api.Organization().create()
     cvenv_id = target_sat.api_factory.get_cvenv_id(
         new_org.default_content_view,


### PR DESCRIPTION
### Problem Statement
The test `test_global_registration_form_populate` was failing with a `RowNotFound` error when attempting to navigate to and update a nested hostgroup via the UI. The navigation failed because the nested hostgroup was not visible in the UI table.

### Root Cause
When creating a nested hostgroup via API without specifying the `organization` parameter, the hostgroup is created in Satellite but is not associated with any organization context. This causes it to be invisible in the UI when a specific organization is selected, leading to navigation failures when the test attempts to find and update the hostgroup.

### Solution
Added `organization=[function_sca_manifest_org]` parameter to the nested hostgroup creation to ensure it is properly associated with the organization and visible in the UI.

### Changes
```python
# Before (broken):
target_sat.api.HostGroup(name=hg_nested_name, parent=parent_hg).create()

# After (fixed):
target_sat.api.HostGroup(
    name=hg_nested_name,
    parent=parent_hg,
    organization=[function_sca_manifest_org],
).create()
```

### Testing
- Ran `pytest -sv tests/foreman/ui/test_registration.py -k test_global_registration_form_populate`
- Test now **PASSES** successfully


## Summary by Sourcery

Ensure nested hostgroup creation in the global registration form UI test associates the hostgroup with the organization context so it is visible in the UI.

Bug Fixes:
- Fix failure in test_global_registration_form_populate by creating the nested hostgroup within the correct organization context.

Tests:
- Adjust test_global_registration_form_populate hostgroup setup to include the organization so the nested hostgroup appears in the UI and the test passes reliably.