### PR TITLE
Add test for SAT-43062: orphan cleanup respects automatic_content_count_updates

### DIFF
--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -337,6 +337,44 @@ def test_positive_update_counts(target_sat, module_capsule_configured):
     )
 
 
+def test_positive_orphan_cleanup_skips_content_counts(
+    target_sat,
+    module_capsule_configured,
+):
+    """Verify orphan cleanup does not trigger UpdateContentCounts
+    when automatic_content_count_updates is disabled.
+
+    :id: d167af46-bf99-45bd-a93b-075d9e373ca4
+
+    :Verifies: SAT-43062
+
+    :setup:
+        1. Satellite with registered external Capsule.
+
+    :steps:
+        1. Disable ``automatic_content_count_updates``.
+        2. Run orphan cleanup via ``foreman-rake katello:delete_orphaned_content``.
+        3. Wait for the ``RemoveOrphans`` task to complete.
+        4. Check that no ``UpdateContentCounts`` tasks were triggered after the timestamp.
+
+    :expectedresults:
+        1. Orphan cleanup completes successfully.
+        2. No ``UpdateContentCounts`` task is created for any capsule.
+    """
+    with target_sat.api_factory.satellite_setting('automatic_content_count_updates=false'):
+        timestamp = datetime.now(UTC).replace(microsecond=0)
+        target_sat.run_orphan_cleanup(module_capsule_configured.nailgun_smart_proxy.id)
+        with pytest.raises(AssertionError, match='No task was found'):
+            target_sat.wait_for_tasks(
+                search_query=(
+                    'label = Actions::Katello::CapsuleContent::UpdateContentCounts'
+                    f' and started_at >= "{timestamp}"'
+                ),
+                search_rate=2,
+                max_tries=5,
+            )
+
+
 @pytest.mark.parametrize('setting_update', ['automatic_content_count_updates=True'], indirect=True)
 def test_positive_content_counts_granularity(
     request,


### PR DESCRIPTION


(cherry picked from commit 43425910adaad4138c1df95817671cbd1009cdda)

### Problem Statement

6.19.z is expected to receive a bug fix for `automatic_content_count_updates` and needs testing.

### Solution

Adds 6.19.z testing for SAT-43062.  Tests that the `automatic_content_count_updates` is respected for capsules.

### Related Issues

https://redhat.atlassian.net/browse/SAT-43062

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->