### PR TITLE
Convert docker private registry test to positive scenario

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1727,31 +1727,28 @@ class TestDockerRepository:
         ),
         indirect=True,
     )
-    def test_negative_synchronize_private_registry_no_passwd(
+    def test_positive_create_docker_repo_with_private_registry_no_passwd(
         self, repo_options, module_product, target_sat
     ):
-        """Create and try to sync a Docker-type repository from a private
-        registry providing empty password and the sync must fail with
-        reasonable error message.
+        """Create a Docker-type repository from a private registry
+        with username but without password.
 
-        :id: 86bde2f1-4761-4045-aa54-c7be7715cd3a
+        :id: 9e4e2139-a990-4e76-a1db-a7be3fd3654b
 
         :parametrized: yes
 
-        :expectedresults: A repository is created with a private Docker \
-            repository and sync fails with reasonable error message.
+        :expectedresults: A Docker repository is created successfully
+            with a private registry using username but no password.
 
         :customerscenario: true
 
-        :BZ: 1475121, 1580510
-
         """
-        with pytest.raises(
-            HTTPError,
-            match='422 Client Error: Unprocessable Content for url: '
-            f'{target_sat.url}/katello/api/v2/repositories',
-        ):
-            target_sat.api.Repository(**repo_options).create()
+        repo = target_sat.api.Repository(**repo_options).create()
+        assert repo.id
+        assert repo.content_type == 'docker'
+        assert repo.docker_upstream_name == settings.docker.private_registry_name
+        assert repo.upstream_username == settings.docker.private_registry_username
+        assert repo.url == settings.docker.private_registry_url
 
     @pytest.mark.upgrade
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem Statement
The existing test `test_negative_synchronize_private_registry_no_passwd` was designed as a negative test expecting failure when creating a Docker repository from a private registry without a password. However, it is actually possible to create a Docker-type repository from a private registry with username but without password, making the negative scenario outdated.

### Solution
  - Converted `test_negative_synchronize_private_registry_no_passwd` to  `test_positive_create_docker_repo_with_private_registry_no_passwd`
  - Updated test to verify successful repository creation instead of expecting failure
  - Removed obsolete `:BZ:` metadata references (1475121, 1580510)
  - Added assertions to validate the created repository attributes (content_type, docker_upstream_name, upstream_username, url)
  - Removed synchronization aspect as it's not required for this positive scenario as discussed with team.

### Related Issues
N/A

```
### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k 'test_positive_create_docker_repo_with_private_registry_no_passwd'
```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Convert the private Docker registry repository test from a negative sync scenario to a positive creation scenario.

Enhancements:
- Update the repository API docstring metadata to reflect the positive creation scenario without password and remove obsolete bug references.

Tests:
- Repurpose the private Docker registry no-password test to assert successful Docker repository creation and validate key repository attributes instead of expecting a sync failure.