### PR TITLE
strip query params in custom link in test_documentation_links

### DIFF
--- a/tests/foreman/ui/test_documentation_links.py
+++ b/tests/foreman/ui/test_documentation_links.py
@@ -12,6 +12,8 @@
 
 """
 
+from urllib.parse import urlsplit
+
 import pytest
 import requests
 
@@ -143,10 +145,11 @@ def test_positive_documentation_links(module_target_sat, session, custom_docs_ur
             broken_links.append(link)
             logger.info(f"Following link on {page} page seems broken: \n {link}")
         # If Custom URL is configured, check if it is applied, allow pre-defined exceptions
+        link_base = urlsplit(link)._replace(query='', fragment='').geturl()
         if (
             custom_docs_url_setting
             and custom_docs_url_setting not in link
-            and not (page in exceptions and link in exceptions[page])
+            and not (page in exceptions and link_base in exceptions[page])
         ):
             broken_links.append(link)
             logger.info(


### PR DESCRIPTION
### Problem Statement
 The exception link: `'cloudinventory': ['https://www.redhat.com/en/topics/management/data-application-security'],`
 is linking to [www.redhat.com](http://www.redhat.com/) , which seem to add tracking info to the url _sometimes_.
This means when it happens the test fails, even though it does go to the correct link

### Solution
strip url query params in custom links in test_documentation_links

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest tests/foreman/ui/test_documentation_links.py -k "cloudinventory"

## Summary by Sourcery

Bug Fixes:
- Prevent flaky documentation link tests by stripping query parameters before checking links against the exception list.