### PR TITLE
Add container metadata in test result junit xml

### DIFF
--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -35,8 +35,10 @@ SERVER:
     UNCONFIGURED: deploy-unconfigured-satellite # workflow to deploy unconfigured sat
     IOP: deploy-satellite-iop # workflow to deploy Satellite with IoP enabled
   # Dictionary of arguments which should be passed along to the deploy workflow
-  # DEPLOY_ARGUMENTS:
+  DEPLOY_ARGUMENTS:
   #  deploy_network_type: '@format { this.server.network_type }'
+  # Set to true when Satellite is deployed from container images instead of RPMs
+    DEPLOY_CONTAINER: False
   # HTTP scheme when building the server URL
   # Suggested values for "scheme" are "http" and "https".
   SCHEME: https

--- a/pytest_fixtures/core/reporting.py
+++ b/pytest_fixtures/core/reporting.py
@@ -5,6 +5,8 @@ import pytest
 from xdist import get_xdist_worker_id
 
 from robottelo.config import setting_is_set, settings
+from robottelo.hosts import get_sat_rhel_version
+from robottelo.utils.ohsnap import container_image_properties
 
 FMT_XUNIT_TIME = '%Y-%m-%dT%H:%M:%S'
 
@@ -42,6 +44,20 @@ def pytest_sessionstart(session):
             xml.add_global_property(
                 'start_time', datetime.datetime.now(datetime.UTC).strftime(FMT_XUNIT_TIME)
             )
+            rhel_version = get_sat_rhel_version().base_version
+            sat_version = settings.server.version.get('release')
+            snap_version = settings.server.version.get('snap', '')
+            xml.add_global_property("SatelliteNetworkType", str(settings.server.network_type))
+            xml.add_global_property("SatelliteVersion", sat_version)
+            xml.add_global_property("SnapVersion", snap_version)
+            xml.add_global_property("BaseOS", rhel_version)
+            if settings.server.deploy_arguments.deploy_container:
+                for name, value in container_image_properties(
+                    settings.ohsnap,
+                    sat_version,
+                    snap_version,
+                ):
+                    xml.add_global_property(name, value)
 
 
 @pytest.fixture(autouse=False, scope='session')

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -35,6 +35,7 @@ VALIDATORS = dict(
         Validator('server.deploy_workflows.product', must_exist=True),
         Validator('server.deploy_workflows.os', must_exist=True),
         Validator('server.deploy_arguments', must_exist=True, is_type_of=dict, default={}),
+        Validator('server.deploy_arguments.deploy_container', default=False, is_type_of=bool),
         Validator('server.scheme', default='https'),
         Validator('server.port', default=443),
         Validator('server.ssh_username', default='root'),

--- a/robottelo/utils/ohsnap.py
+++ b/robottelo/utils/ohsnap.py
@@ -103,6 +103,85 @@ def dogfood_repository(
     return Box(**repository)
 
 
+def parse_container_image_ref(image_ref):
+    """Parse a container image reference into registry, image name, and tag/digest."""
+    registry, _, remainder = image_ref.partition('/')
+    if not remainder:
+        return '', image_ref, ''
+    name_with_tag = remainder.split('/')[-1]
+    if '@' in name_with_tag:
+        name, tag = name_with_tag.split('@', 1)
+    elif ':' in name_with_tag:
+        name, tag = name_with_tag.rsplit(':', 1)
+    else:
+        name, tag = name_with_tag, ''
+    return registry, name, tag
+
+
+def ohsnap_container_images(ohsnap, release, snap_version, is_all=True):
+    """Return container image metadata from Ohsnap for a release and snap version."""
+    url = f'{ohsnap.host}/api/releases/{release}/snaps/{snap_version}/container_images'
+    if is_all:
+        url += '?all=true'
+    try:
+        res, _ = wait_for(
+            lambda: requests.get(url, hooks={'response': ohsnap_response_hook}),
+            handle_exception=True,
+            raise_original=True,
+            timeout=ohsnap.request_retry.timeout,
+            delay=ohsnap.request_retry.delay,
+        )
+        if res.status_code != 200:
+            logger.warning(
+                'Ohsnap container images request failed: url=%s status=%s',
+                url,
+                res.status_code,
+            )
+            return []
+        container_images = res.json().get('container_images', [])
+        logger.info(
+            'Fetched %s container images from Ohsnap for release=%s snap=%s',
+            len(container_images),
+            release,
+            snap_version,
+        )
+        for image_data in container_images:
+            image_ref = image_data.get('image', '')
+            registry, name, tag = parse_container_image_ref(image_ref)
+            logger.info(
+                'Ohsnap container image metadata: name=%s image=%s registry=%s tag=%s vcs_ref=%s '
+                'source_url=%s build_date=%s',
+                name,
+                image_ref,
+                registry,
+                tag,
+                image_data.get('vcs_ref', ''),
+                image_data.get('source_url', ''),
+                image_data.get('build_date', ''),
+            )
+        return container_images
+    except Exception as err:
+        logger.warning(
+            'Failed to fetch Ohsnap container images for release=%s snap=%s: %s',
+            release,
+            snap_version,
+            err,
+        )
+        return []
+
+
+def container_image_properties(ohsnap, release, snap_version):
+    """Build property name/value pairs for Ohsnap container image metadata."""
+    properties = []
+    for image_data in ohsnap_container_images(ohsnap, release, snap_version):
+        image_ref = image_data['image']
+        _, name, _ = parse_container_image_ref(image_ref)
+        prefix = f'Container_{name}'
+        properties.append((f'{prefix}_Image', image_ref))
+        properties.append((f'{prefix}_VCS', image_data.get('vcs_ref', '')))
+    return properties
+
+
 def ohsnap_snap_rpms(ohsnap, sat_version, snap_version, os_major, is_all=True):
     sat_xy = '.'.join(sat_version.split('.')[:2])
     url = f'{ohsnap.host}/api/releases/{sat_version}/snaps/{snap_version}/rpms'

--- a/tests/robottelo/test_ohsnap.py
+++ b/tests/robottelo/test_ohsnap.py
@@ -1,0 +1,132 @@
+"""Tests for module ``robottelo.utils.ohsnap``."""
+
+from unittest import mock
+
+import pytest
+
+from robottelo.utils.ohsnap import (
+    container_image_properties,
+    ohsnap_container_images,
+    parse_container_image_ref,
+)
+
+FAKE_IMAGE_DIGEST = 'sha256:0000000000000000000000000000000000000000000000000000000000000001'
+FAKE_VCS_REF = 'aleprocne'
+SAMPLE_CONTAINER_IMAGES_RESPONSE = {
+    'container_images': [
+        {
+            'image': f'registry.example.com/satellite/foreman-rhel9@{FAKE_IMAGE_DIGEST}',
+            'build_date': '2026-01-01T00:00:00Z',
+            'vcs_ref': FAKE_VCS_REF,
+            'source_url': f'https://git.example.com/org/repo/-/commit/{FAKE_VCS_REF}',
+        },
+        {
+            'image': 'registry.example.com/satellite/pulp-rhel9:1.0.0',
+            'build_date': '2026-01-01T00:00:00Z',
+            'vcs_ref': 'cafebabe',
+            'source_url': 'https://git.example.com/org/repo/-/commit/cafebabe',
+        },
+    ]
+}
+
+
+@pytest.fixture
+def ohsnap():
+    return mock.Mock(
+        host='https://ohsnap.example.com',
+        request_retry=mock.Mock(timeout=1, delay=1),
+    )
+
+
+@pytest.mark.parametrize(
+    ('image_ref', 'registry', 'name', 'tag'),
+    [
+        (
+            'registry.example.com/satellite/foreman-rhel9@sha256:aleprocne',
+            'registry.example.com',
+            'foreman-rhel9',
+            'sha256:aleprocne',
+        ),
+        (
+            'registry.example.com/satellite/pulp-rhel9:1.0.0',
+            'registry.example.com',
+            'pulp-rhel9',
+            '1.0.0',
+        ),
+        (
+            'registry.example.com/satellite/candlepin-rhel9',
+            'registry.example.com',
+            'candlepin-rhel9',
+            '',
+        ),
+        (
+            'foreman-rhel9:latest',
+            '',
+            'foreman-rhel9:latest',
+            '',
+        ),
+    ],
+    ids=['digest', 'version-tag', 'no-tag', 'image-only'],
+)
+def test_parse_container_image_ref(image_ref, registry, name, tag):
+    assert parse_container_image_ref(image_ref) == (registry, name, tag)
+
+
+@mock.patch('robottelo.utils.ohsnap.wait_for')
+def test_ohsnap_container_images(mock_wait_for, ohsnap):
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = SAMPLE_CONTAINER_IMAGES_RESPONSE
+    mock_wait_for.return_value = (mock_response, None)
+
+    images = ohsnap_container_images(ohsnap, 'stream', '1.0')
+
+    assert len(images) == 2
+    mock_wait_for.assert_called_once()
+
+
+@mock.patch('robottelo.utils.ohsnap.wait_for')
+def test_ohsnap_container_images_non_200_returns_empty_list(mock_wait_for, ohsnap):
+    mock_response = mock.Mock()
+    mock_response.status_code = 404
+    mock_wait_for.return_value = (mock_response, None)
+
+    assert ohsnap_container_images(ohsnap, 'stream', '1.0') == []
+
+
+@mock.patch('robottelo.utils.ohsnap.wait_for')
+def test_ohsnap_container_images_returns_empty_on_fetch_error(mock_wait_for, ohsnap):
+    mock_wait_for.side_effect = RuntimeError('connection failed')
+
+    assert ohsnap_container_images(ohsnap, 'stream', '1.0') == []
+
+
+@mock.patch('robottelo.utils.ohsnap.ohsnap_container_images')
+def test_container_image_properties(mock_container_images, ohsnap):
+    mock_container_images.return_value = SAMPLE_CONTAINER_IMAGES_RESPONSE['container_images']
+
+    properties = dict(container_image_properties(ohsnap, 'stream', '1.0'))
+
+    mock_container_images.assert_called_once_with(ohsnap, 'stream', '1.0')
+    assert set(properties) == {
+        'Container_foreman-rhel9_Image',
+        'Container_foreman-rhel9_VCS',
+        'Container_pulp-rhel9_Image',
+        'Container_pulp-rhel9_VCS',
+    }
+    assert properties['Container_foreman-rhel9_Image'] == (
+        f'registry.example.com/satellite/foreman-rhel9@{FAKE_IMAGE_DIGEST}'
+    )
+    assert properties['Container_foreman-rhel9_VCS'] == FAKE_VCS_REF
+    assert (
+        properties['Container_pulp-rhel9_Image']
+        == 'registry.example.com/satellite/pulp-rhel9:1.0.0'
+    )
+    assert properties['Container_pulp-rhel9_VCS'] == 'cafebabe'
+
+
+@mock.patch('robottelo.utils.ohsnap.ohsnap_container_images')
+def test_container_image_properties_returns_empty_when_ohsnap_empty(mock_container_images, ohsnap):
+    mock_container_images.return_value = []
+
+    assert container_image_properties(ohsnap, 'stream', '1.0') == []


### PR DESCRIPTION
### Problem Statement
We'll be running Robottelo tests on deployments managed via foremanctl.

### Solution
Add metadata for the containers being used for the given release x snap version.

### Related Issues
SAT-46465

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Expose container image metadata from Ohsnap and include it in junit XML test reports when running against container-based deployments.

New Features:
- Add helper functions to fetch and parse container image metadata from Ohsnap for a given release and snap version.
- Populate junit XML global properties with container image and VCS information when tests run on container deployments.

Enhancements:
- Extend configuration validation with a boolean flag to indicate container-based deployment for conditional reporting logic.

Tests:
- Add unit tests for parsing container image references, fetching container images from Ohsnap, and building container image properties.