### PR TITLE
[6.18.z] Use openvox server and agent during provisioning

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -47,8 +47,10 @@ REPOS:
     RHEL9: replace-with-rhel9-http-link
     RHEL10: replace-with-rhel10-http-link
   OPENVOX_AGENT_REPO:
+    RHEL7: some-url
     RHEL8: some-url
     RHEL9: some-url
+    RHEL10: some-url
   # Downstream Satellite-maintain repo
   SATMAINTENANCE_REPO: replace-with-sat-maintain-repo
   MOCK_SERVICE_REPO_BASE: replace-with-repo-providing-robttelo-mock-service

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -46,21 +46,35 @@ def module_provisioning_rhel_content(
     rh_repos = []
     tasks = []
     rh_repo_id = ""
-    content_view = sat.api.ContentView(organization=module_sca_manifest_org).create()
 
-    # Custom Content for Client repo
+    # Custom Content for Client repos
     custom_product = sat.api.Product(
         organization=module_sca_manifest_org, name=f'rhel{rhel_ver}_{gen_string("alpha")}'
     ).create()
-    client_repo = sat.api.Repository(
-        organization=module_sca_manifest_org,
-        product=custom_product,
-        content_type='yum',
-        url=settings.repos.SATCLIENT_REPO[f'rhel{rhel_ver}'],
-    ).create()
-    task = client_repo.sync(synchronous=False)
-    tasks.append(task)
-    content_view.repository = [client_repo]
+    client_repos_urls = [settings.repos.SATCLIENT_REPO[f'rhel{rhel_ver}']]
+    if (
+        rhel_ver in (8, 9)  # only RHEL 8 and 9 openvox-agent repositories are available
+        or (
+            rhel_ver == 10 and not is_open('SAT-30237')
+        )  # openvox-agent for EL10 is still not delivered
+        or (
+            rhel_ver == 7 and not is_open('SAT-44580')
+        )  # openvox-agent for EL7 is still not delivered
+    ):
+        client_repos_urls.append(settings.repos.OPENVOX_AGENT_REPO[f'rhel{rhel_ver}'])
+    client_repos = [
+        sat.api.Repository(
+            organization=module_sca_manifest_org,
+            product=custom_product,
+            content_type='yum',
+            url=url,
+        ).create()
+        for url in client_repos_urls
+    ]
+    tasks.extend([repo.sync(synchronous=False) for repo in client_repos])
+
+    content_view = sat.api.ContentView(organization=module_sca_manifest_org).create()
+    content_view.repository = client_repos
 
     for name in repo_names:
         rh_kickstart_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
@@ -90,7 +104,9 @@ def module_provisioning_rhel_content(
                 tasks.append(task)
                 rh_repos.append(rh_repo)
                 content_view.repository.append(rh_repo)
-                content_view.update(['repository'])
+    content_view.update(['repository'])
+
+    # wait for all repo sync tasks to finish
     for task in tasks:
         sat.wait_for_tasks(
             search_query=(f'id = {task["id"]}'),
@@ -99,6 +115,7 @@ def module_provisioning_rhel_content(
         )
         task_status = sat.api.ForemanTask(id=task['id']).poll()
         assert task_status['result'] == 'success'
+
     rhel_xy = Version(
         constants.REPOS['kickstart'][f'rhel{rhel_ver}']['version']
         if rhel_ver == 7
@@ -111,6 +128,7 @@ def module_provisioning_rhel_content(
     os = o_systems[0].read()
     # return only the first kickstart repo - RHEL X KS or RHEL X BaseOS KS
     ksrepo = rh_repos[0]
+
     publish = content_view.publish()
     task_status = sat.wait_for_tasks(
         search_query=(f'Actions::Katello::ContentView::Publish and id = {publish["id"]}'),
@@ -118,21 +136,21 @@ def module_provisioning_rhel_content(
         max_tries=10,
     )
     assert task_status[0].result == 'success'
-    content_view = sat.api.ContentView(
-        organization=module_sca_manifest_org, name=content_view.name
-    ).search()[0]
+    # create new activation key for provisioning
     ak = sat.api.ActivationKey(
         organization=module_sca_manifest_org,
         content_view=content_view,
         environment=module_lce_library,
     ).create()
+    # enable all custom repos in the activation key
+    product_content = ak.product_content(data={'content_access_mode_all': '1'})['results']
+    content_overrides = [
+        {'content_label': content['label'], 'value': '1'}
+        for content in product_content
+        if content['vendor'] == 'Custom'
+    ]
+    ak.content_override(data={'content_overrides': content_overrides})
 
-    # Ensure client repo is enabled in the activation key
-    content = ak.product_content(data={'content_access_mode_all': '1'})['results']
-    client_repo_label = [repo['label'] for repo in content if repo['name'] == client_repo.name][0]
-    ak.content_override(
-        data={'content_overrides': [{'content_label': client_repo_label, 'value': '1'}]}
-    )
     return Box(os=os, ak=ak, ksrepo=ksrepo, cv=content_view)
 
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -361,18 +361,18 @@ def bootc_host():
         yield host
 
 
-@pytest.fixture(scope='module', params=[{'rhel_version': 8, 'no_containers': True}])
-def external_puppet_server(request):
-    with contenthost_factory(request=request, target_cores=2, target_memory='4GiB') as host:
+@pytest.fixture(scope='module')
+def external_puppet_server():
+    with Broker(
+        host_class=ContentHost,
+        workflow=settings.server.deploy_workflows.os,
+        deploy_rhel_version=settings.server.version.rhel_version,
+        deploy_network_type=settings.server.network_type,
+    ) as host:
         host.register_to_cdn()
-        # Install puppet packages
-        assert (
-            host.execute(
-                'dnf install -y https://yum.puppet.com/puppet-release-el-8.noarch.rpm'
-            ).status
-            == 0
-        )
-        assert host.execute('dnf install -y puppetserver').status == 0
+        # Enable satellite repositories to install Puppet server
+        host.create_custom_repos(satellite=settings.repos.satellite_repo)
+        assert host.execute('dnf -y install openvox-server').status == 0
         # Source puppet profiles
         host.execute('. /etc/profile.d/puppet-agent.sh')
         # Setup Puppet Server CA

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -96,7 +96,7 @@ def test_positive_puppet_bootstrap(
 
 
 @pytest.mark.on_premises_provisioning
-@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
+@pytest.mark.rhel_ver_match('[7-9]|10')
 def test_host_provisioning_with_external_puppetserver(
     request,
     external_puppet_server,
@@ -132,8 +132,11 @@ def test_host_provisioning_with_external_puppetserver(
 
     :customerscenario: true
     """
-    if is_open('SAT-30237') and module_provisioning_rhel_content.os.major == '10':
-        pytest.skip('Skipping as puppet-agent packages are missing from EL10 client repo')
+    if module_provisioning_rhel_content.os.major == '10' and is_open('SAT-30237'):
+        pytest.skip('Skipping as openvox-agent for EL10 is still not delivered')
+
+    if module_provisioning_rhel_content.os.major == '7' and is_open('SAT-44580'):
+        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
 
     puppet_env = 'production'
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
@@ -171,8 +174,8 @@ def test_host_provisioning_with_external_puppetserver(
     # the result of the installation. Wait until Satellite reports that the host is installed.
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
-        timeout=1500,
-        delay=10,
+        timeout='40m',
+        delay=30,
     )
     host = host.read()
     assert host.build_status_label == 'Installed'
@@ -198,8 +201,8 @@ def test_host_provisioning_with_external_puppetserver(
     assert provisioning_host.subscribed, 'Host is not subscribed'
 
     # Validate external Puppet server deployment with Satellite
-    assert provisioning_host.execute('rpm -q puppet-agent').status == 0, (
-        'Puppet agent package is not installed'
+    assert provisioning_host.execute('rpm -q --whatprovides puppet-agent').status == 0, (
+        'Package providing Puppet agent is not installed'
     )
 
     assert (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21453

### Problem Statement
There are new client repositories providing OpenVox Agent 8 as a replacement for Puppet Agent 7

### Solution
Update Puppet provisioning automation where we use external Perforce Puppet 7 server and agent to OpenVox server 8 and agent.
Install OpenVox server from Satellite repository

### Related Issues
[SAT-44510](https://redhat.atlassian.net/browse/SAT-44510)
[SAT-44871](https://redhat.atlassian.net/browse/SAT-44871)