### PR TITLE
[6.18.z] Remove skip for openvox-agent on RHEL7

### DIFF
--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -96,7 +96,10 @@ def test_positive_puppet_bootstrap(
 
 
 @pytest.mark.on_premises_provisioning
-@pytest.mark.rhel_ver_match('[7-9]|10')
+@pytest.mark.rhel_ver_match(
+    f'[{"" if is_open("SAT-41340") else "7"}89]'  # Skip EL7 for provisioning test as UEFI is not supported yet
+    f'{"" if is_open("SAT-30237") else "|10"}'  # Skip EL10 for provisioning test as openvox-agent is not delivered yet
+)
 def test_host_provisioning_with_external_puppetserver(
     request,
     external_puppet_server,
@@ -132,12 +135,6 @@ def test_host_provisioning_with_external_puppetserver(
 
     :customerscenario: true
     """
-    if module_provisioning_rhel_content.os.major == '10' and is_open('SAT-30237'):
-        pytest.skip('Skipping as openvox-agent for EL10 is still not delivered')
-
-    if module_provisioning_rhel_content.os.major == '7' and is_open('SAT-44580'):
-        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
-
     puppet_env = 'production'
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -87,9 +87,6 @@ def test_positive_install_configure_host(
     if agent == 'openvox' and content_hosts[0].os_version.major == 10 and is_open('SAT-30237'):
         pytest.skip('Skipping as openvox-agent for EL10 is still not delivered')
 
-    if agent == 'openvox' and content_hosts[0].os_version.major == 7 and is_open('SAT-44580'):
-        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
-
     if agent == 'puppet' and content_hosts[0].os_version.major == 10:
         pytest.skip('Skipping as there is no puppet-agent for EL10')
 
@@ -150,9 +147,6 @@ def test_positive_run_puppet_agent_generate_report_when_no_message(
     """
     if agent == 'openvox' and rhel_contenthost.os_version.major == 10 and is_open('SAT-30237'):
         pytest.skip('Skipping as openvox-agent for EL10 is still not delivered')
-
-    if agent == 'openvox' and rhel_contenthost.os_version.major == 7 and is_open('SAT-44580'):
-        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
 
     if agent == 'puppet' and rhel_contenthost.os_version.major == 10:
         pytest.skip('Skipping as there is no puppet-agent for EL10')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21547

### Problem Statement
openvox-agent for RHEL7 has been finally delivered.

### Solution
Remove a skip for openvox-agent on RHEL7.

### Related Issues
[SAT-44510](https://redhat.atlassian.net/browse/SAT-44510)
[SAT-45007](https://redhat.atlassian.net/browse/SAT-45007)
[SAT-44871](https://redhat.atlassian.net/browse/SAT-44871)