### PR TITLE
Fix Hammer CLI end to end test case

### DIFF
--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -205,13 +205,13 @@ def test_positive_cli_end_to_end(function_sca_manifest, target_sat, rhel_content
     assert len(cv_version['lifecycle-environments']) == 2
     assert cv_version['lifecycle-environments'][-1]['id'] == lifecycle_environment['id']
 
+    cv_env_id = target_sat.api_factory.get_cvenv_id(content_view['id'], lifecycle_environment['id'])
     # step 2.12: Create a new activation key
     activation_key = _create(
         user,
         target_sat.cli.ActivationKey,
         {
-            'content-view-id': content_view['id'],
-            'lifecycle-environment-id': lifecycle_environment['id'],
+            'content-view-environment-ids': cv_env_id,
             'name': gen_alphanumeric(),
             'organization-id': org['id'],
         },
@@ -299,8 +299,7 @@ def test_positive_cli_end_to_end(function_sca_manifest, target_sat, rhel_content
         {
             'id': host_group['id'],
             'organization-ids': org['id'],
-            'content-view-id': content_view['id'],
-            'lifecycle-environment-id': lifecycle_environment['id'],
+            'content-view-environment-id': cv_env_id,
         }
     )
 


### PR DESCRIPTION
### Problem Statement

PR: https://github.com/Katello/katello/commit/a46d7afdf677bcc71bd128d4566b5e50371c322e

removed `--content-view-id` and `lifecycle-environment-id` which caused failure in robotello tests.

### Solution

Replacing them with `content-view-environment-ids` and `content-view-environment-ids`
which are provided.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Fix CLI end-to-end tests by replacing deprecated content view and lifecycle environment ID parameters with content view environment ID usage.