### PR TITLE
Update jira issue in test_positive_verify_updated_fdi_image

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -477,7 +477,7 @@ def test_positive_verify_updated_fdi_image(target_sat):
 
     :expectedresults: Installed foreman-discovery-image is built on latest up-to-date RHEL
 
-    Verifies: SAT-24197, SAT-27541, SAT-34778, SAT-40503
+    Verifies: SAT-24197, SAT-27541, SAT-34778, SAT-40503, SAT-47174
 
     :customerscenario: true
 
@@ -486,6 +486,6 @@ def test_positive_verify_updated_fdi_image(target_sat):
     discovery_ks_path = '/usr/share/foreman-discovery-image/foreman-discovery-image.ks'
     target_sat.register_to_cdn()
     target_sat.execute('yum -y --disableplugin=foreman-protector install foreman-discovery-image')
-    version = str(target_sat.os_version)
+    version = '9.7' if is_open('SAT-47174') else str(target_sat.os_version)
     result = target_sat.execute(f'grep "url=" {discovery_ks_path}')
     assert version in result.stdout


### PR DESCRIPTION
### Problem Statement
Currently FDI is based on RHEL 9.7, but SAT is on 9.8, so test_positive_verify_updated_fdi_image started to fail

### Solution
Update jira issue in test_positive_verify_updated_fdi_image to pass until SAT-47174 is fixed


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Adjust discovered host CLI test to account for known SAT-47174 issue while still validating foreman-discovery-image is built on the expected RHEL version.

Bug Fixes:
- Prevent test_positive_verify_updated_fdi_image from failing due to the temporary RHEL 9.7 vs 9.8 mismatch tracked in SAT-47174.

Tests:
- Update test_positive_verify_updated_fdi_image metadata and expected OS version handling to reference SAT-47174 and remain stable until the issue is resolved.