### PR TITLE
remove unsupported vmware7 test for fips

### DIFF
--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -23,7 +23,7 @@ from robottelo.hosts import ContentHost
 @pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
-def test_positive_vmware_cr_end_to_end(target_sat, module_org, module_location, vmware):
+def test_positive_vmware_cr_end_to_end(request, target_sat, module_org, module_location, vmware):
     """Create, Read, Update and Delete VMware compute resources
 
     :id: 96faae3f-bc64-4147-a9fc-09c858e0a68f
@@ -36,6 +36,8 @@ def test_positive_vmware_cr_end_to_end(target_sat, module_org, module_location, 
 
     :CaseImportance: Critical
     """
+    if 'vmware7' in request.node.callspec.id and target_sat.is_fips_enabled():
+        pytest.skip('VMware 7 is not supported in FIPS mode')
     cr_name = gen_string('alpha')
     # Create
     vmware_cr = target_sat.cli.ComputeResource.create(

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -104,13 +104,17 @@ def get_vmware_storagepod_summary_string(vmware, vmwareclient):
 
 @pytest.mark.e2e
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
-def test_positive_cr_end_to_end(session, module_org, module_location, vmware, module_target_sat):
+def test_positive_cr_end_to_end(
+    request, session, module_org, module_location, vmware, module_target_sat
+):
     """Perform end-to-end testing for compute resource VMware component.
 
     :id: 47fc9e77-5b22-46b4-a76c-3217434fde2f
 
     :expectedresults: All expected CRUD actions finished successfully.
     """
+    if 'vmware7' in request.node.callspec.id and module_target_sat.is_fips_enabled():
+        pytest.skip('VMware 7 is not supported in FIPS mode')
     cr_name = gen_string('alpha')
     new_cr_name = gen_string('alpha')
     description = gen_string('alpha')
@@ -210,13 +214,15 @@ def test_positive_retrieve_virtual_machine_list(session, vmware):
 
 @pytest.mark.e2e
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
-def test_positive_image_end_to_end(session, target_sat, vmware):
+def test_positive_image_end_to_end(request, session, target_sat, vmware):
     """Perform end to end testing for compute resource VMware component image.
 
     :id: 6b7949ef-c684-40aa-b181-11f8d4cd39c6
 
     :expectedresults: All expected CRUD actions finished successfully.
     """
+    if 'vmware7' in request.node.callspec.id and target_sat.is_fips_enabled():
+        pytest.skip('VMware 7 is not supported in FIPS mode')
     cr_name = gen_string('alpha')
     image_name = gen_string('alpha')
     new_image_name = gen_string('alpha')
@@ -334,6 +340,8 @@ def test_positive_vmware_custom_profile_end_to_end(
 
     :verifies: SAT-31447
     """
+    if 'vmware7' in request.node.callspec.id and target_sat.is_fips_enabled():
+        pytest.skip('VMware 7 is not supported in FIPS mode')
     cr_name = gen_string('alpha')
     guest_os_names = [
         'Red Hat Enterprise Linux 7 (64-bit)',


### PR DESCRIPTION
### Problem Statement
Root cause: VMware 7 uses TLS cipher suites incompatible with FIPS mode.
This happens when Satellite (in FIPS mode) tries to establish an SSL connection to the VMware 7 server. VMware 7 uses older TLS ciphers (e.g., RC4, 3DES, or older RSA key exchange without forward secrecy) that are disabled in FIPS 140-2. VMware 8 passes the same test — confirming this is a VMware 7 TLS compatibility issue, not a code bug.

### Solution
Skipping the VMware 7 FIPS-enabled test since it is not compatible. This will prevent unnecessary failures from appearing in the job results.

## Summary by Sourcery

Tests:
- Add conditional skipping of VMware 7 UI and CLI end-to-end compute resource tests when the target Satellite is FIPS-enabled.