### PR TITLE
Add install-method-aware test collection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -527,6 +527,12 @@ Content hosts are deployed in containers by default. If the host needs to run as
 @pytest.mark.no_containers    # Cannot run in containers
 ```
 
+Tests that require a specific Satellite install method should use `foreman_installer` or `foremanctl` markers. Collection automatically deselects incompatible tests based on `server.install_method` in `conf/server.yaml` (or `ROBOTTELO_SERVER__INSTALL_METHOD`). When `install_method` is `auto`, `server.deploy_arguments.deploy_container` is used as a fallback.
+```python
+@pytest.mark.foreman_installer    # Requires satellite-installer
+@pytest.mark.foremanctl        # Requires foremanctl
+```
+
 ### RHEL Version Markers
 
 **`@pytest.mark.rhel_ver_match()`**: Match RHEL versions based on versions defined in conf/supportability.yaml using regex, or by the N-x convention.

--- a/pytest_plugins/marker_deselection.py
+++ b/pytest_plugins/marker_deselection.py
@@ -1,5 +1,7 @@
 import pytest
 
+from robottelo.config import settings
+from robottelo.enums import InstallMethod
 from robottelo.logging import collection_logger as logger
 
 
@@ -20,6 +22,41 @@ def pytest_addoption(parser):
         parser.addoption(opt, action='store_true', default=False, help=help_text)
 
 
+def _install_method_for_collection():
+    """Resolve install method from server settings for test collection.
+
+    Uses ``server.install_method`` from conf/server.yaml (or
+    ``ROBOTTELO_SERVER__INSTALL_METHOD``). When set to ``auto``, falls back to
+    ``server.deploy_arguments.deploy_container``.
+    """
+    install_method = settings.server.get('install_method', InstallMethod.AUTO)
+    if install_method != InstallMethod.AUTO:
+        return InstallMethod(install_method)
+    if settings.server.deploy_arguments.get('deploy_container'):
+        return InstallMethod.FOREMANCTL
+    return None
+
+
+INCOMPATIBLE_MARKERS = {
+    InstallMethod.FOREMANCTL: 'foreman_installer',
+    InstallMethod.INSTALLER: 'foremanctl',
+}
+DEPLOYMENT_MARKERS = INCOMPATIBLE_MARKERS.values()
+
+
+def _markexpr_selects_marker(markexpr, marker_name):
+    if marker_name not in markexpr:
+        return False
+    return f'not{marker_name}' not in markexpr.replace(' ', '')
+
+
+def _bypass_install_method_filter(config):
+    markexpr = config.option.markexpr
+    if not markexpr:
+        return False
+    return any(_markexpr_selects_marker(markexpr, marker) for marker in DEPLOYMENT_MARKERS)
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(items, config):
     """
@@ -27,25 +64,37 @@ def pytest_collection_modifyitems(items, config):
     """
     include_onprem_provision = config.getoption('include_onprem_provisioning', False)
     include_ipv6_provisioning = config.getoption('include_ipv6_provisioning', False)
+    install_method = _install_method_for_collection()
+    bypass = _bypass_install_method_filter(config)
+    incompatible_marker = None if bypass else INCOMPATIBLE_MARKERS.get(install_method)
+    if install_method and bypass and INCOMPATIBLE_MARKERS.get(install_method):
+        logger.info(
+            'Skipping install method deselection due to manual marker selection '
+            f'(install method: {install_method.value}, markexpr: {config.option.markexpr})'
+        )
 
     selected = []
     deselected = []
-    # Cloud Provisioning Test can be run on new pipeline
     for item in items:
-        item_marks = [m.name for m in item.iter_markers()]
-        # Include / Exclude On Premises Provisioning Tests
+        item_marks = [mark.name for mark in item.iter_markers()]
+
+        if incompatible_marker and incompatible_marker in item_marks:
+            logger.info(
+                f'Deselected test {item.nodeid} due to install method '
+                f'{install_method.value} (marker: {incompatible_marker})'
+            )
+            deselected.append(item)
+            continue
         if 'on_premises_provisioning' in item_marks:
             selected.append(item) if include_onprem_provision else deselected.append(item)
             continue
-        # Include / Exclude IPv6 Provisioning Tests
         if 'ipv6_provisioning' in item_marks:
             selected.append(item) if include_ipv6_provisioning else deselected.append(item)
             continue
-        # This Plugin does not applies to this test
         selected.append(item)
     logger.debug(
         f'Selected {len(selected)} and deselected {len(deselected)} '
         'tests based on auto un-collectable markers and pytest options.'
     )
-    items[:] = selected or items
+    items[:] = selected
     config.hook.pytest_deselected(items=deselected)

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -17,6 +17,7 @@ def pytest_configure(config):
         "rhel_ver_list: Filter rhel_contenthost versions by list",
         "rhel_ver_match: Filter rhel_contenthost versions by regexp, or format 'N-#'",
         "no_containers: Disable container hosts from being used in favor of VMs",
+        "foreman_installer: Tests that require satellite-installer; deselected when server.install_method is foremanctl",
         "include_capsule: For satellite-maintain tests to run on Satellite and Capsule both",
         "include_satellite_iop: For satellite-maintain tests to run on both default Satellite and IoP Satellite",
         "satellite_iop_only: For satellite-maintain tests to run only on IoP Satellite",
@@ -25,7 +26,7 @@ def pytest_configure(config):
         "ldap: Tests related to ldap authentication",
         "no_compose : Skip the marked sanity test for nightly compose",
         "network: Restrict test to specific network environments",
-        "foremanctl: Tests that require foremanctl",
+        "foremanctl: Tests that require foremanctl; deselected when server.install_method is installer",
     ]
     markers.extend(module_markers())
     for marker in markers:


### PR DESCRIPTION
### Problem Statement
Container (foremanctl) and RPM (satellite-installer) deployments need different tests, but pytest had no way to filter by install method.

### Solution
Collection reads `server.install_method` from `conf/server.yaml` (or `ROBOTTELO_SERVER__INSTALL_METHOD`) and deselects incompatible tests:

foremanctl → skips installer_only
installer → skips foremanctl
auto → uses deploy_container as a fallback; no filtering if unset
New marker: `@pytest.mark.foreman_installer`. `@pytest.mark.foremanctl` already exists for foremanctl-only tests.

Manual bypass: `-m foreman_installer` or `-m foremanctl` skips auto-deselection for local runs.

#### What to be aware of
Only mark tests with a hard install-method dependency; most tests need no marker.
Tag incompatible tests incrementally as they're found.

### Related Issues
- SAT-46465

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Introduce install-method-aware pytest test collection that deselects incompatible tests based on server configuration.

New Features:
- Add automatic test deselection driven by server.install_method and deploy_container settings for foremanctl vs installer deployments.
- Document and register installer_only and foremanctl markers for install-method-specific tests.

Enhancements:
- Allow manual bypass of install-method-based filtering via explicit -m marker selection in pytest options.
- Simplify collection behavior by always replacing the items list with the selected set and emitting detailed logging for deselections.