### PR TITLE
Update HostCollection negative test's assert

### DIFF
--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -682,9 +682,8 @@ def test_negative_hosts_limit(module_target_sat, module_org_with_parameter, smar
         session.hostcollection.associate_host(hc_name, hosts[0].name)
         with pytest.raises(AssertionError) as context:
             session.hostcollection.associate_host(hc_name, hosts[1].name)
-        assert (
-            f"cannot have more than 1 host(s) associated with host collection '{hc_name}'"
-            in str(context.value)
+        assert f'cannot have more than 1 host(s) associated with host collection {hc_name}' in str(
+            context.value
         )
 
 


### PR DESCRIPTION
Alert message changed --> update it in the test.

<img width="212" height="44" alt="image" src="https://github.com/user-attachments/assets/85269f8b-0cf5-48ef-a0b9-98cb8ade955f" />

## Summary by Sourcery

Tests:
- Update HostCollection negative test to assert the new alert message format.