### PR TITLE
Block test_positive_validate_inherited_cv_lce_ansiblerole

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1312,6 +1312,8 @@ def test_positive_validate_inherited_cv_lce_ansiblerole(session, target_sat, mod
     :customerscenario: true
 
     :BZ: 1391656, 2094912
+
+    :BlockedBy: SAT-46639
     """
     SELECTED_ROLE = 'RedHatInsights.insights-client'
     cv_name = gen_string('alpha')


### PR DESCRIPTION
Block test_positive_validate_inherited_cv_lce_ansiblerole as it was previously asserting the lce cv assignment by reading the host edit UI from where it's now gone after conversion to cveenvs.
It's tracked by SAT-46639

## Summary by Sourcery

Documentation:
- Document SAT-46639 as the blocking issue for the inherited CV/LCE Ansible role host UI test.