### PR TITLE
check satellite assertion error

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -545,7 +545,7 @@ class InstallationVerification:
 
         sat_version = 'stream' if self.is_stream else self.version
         if settings.server.version.source != 'nightly':
-            assert settings.server.version.release == sat_version
+            assert settings.server.version.release == sat_version, f'sat_version: {sat_version}'
 
         # Check journald for errors using installation-method-aware service list
         services = self.get_service_names()


### PR DESCRIPTION
### Problem Statement

Check why assertion is failing.

### Solution

The PR is for test purpose. DO NOT MERGE IT.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Enhancements:
- Include the expected Satellite version value in the install assertion failure message to aid debugging.