### PR TITLE
Fix video cleanup to handle tests with multiple UI sessions

### DIFF
--- a/pytest_plugins/video_cleanup.py
+++ b/pytest_plugins/video_cleanup.py
@@ -70,8 +70,9 @@ def pytest_runtest_makereport(item):
                 report.user_properties = [
                     (key, value) for key, value in report.user_properties if key != 'video_url'
                 ]
-                session_id_tuple = next(
-                    (t for t in report.user_properties if t[0] == 'session_id'), None
-                )
-                session_id = session_id_tuple[1] if session_id_tuple else None
-                _clean_video(session_id, item.nodeid)
+                # Extract all session IDs from user_properties (handles multi-session tests)
+                session_ids = [
+                    value for key, value in report.user_properties if key == 'session_id'
+                ]
+                for session_id in session_ids:
+                    _clean_video(session_id, item.nodeid)


### PR DESCRIPTION
### Problem Statement

If a passing test uses multiple sequential UI session context managers, then the video cleanup plugin only cleans up the most recent one, leaving the earlier ones behind.

### Solution

Update the plugin to clean up the directories for all sessions that the test ran.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

### PRT results

The PRT job's robottelo.log shows that all three UI sessions' directories were cleaned up:

```
2026-07-01 21:20:44 - robottelo - INFO - cleaning up video files for session: 4a26953e476b9f92724003ba86538da1 and test: tests/foreman/ui/test_user.py::test_positive_end_to_end
[...]
2026-07-01 21:20:44 - broker.hosts - DEBUG - [HOSTNAME SNIP] executing command: rm -rf /var/www/html/videos/4a26953e476b9f92724003ba86538da1
[...]
2026-07-01 21:20:44 - robottelo - INFO - video cleanup for session 4a26953e476b9f92724003ba86538da1 is complete
2026-07-01 21:20:44 - robottelo - INFO - cleaning up video files for session: 232f6e754f534a447ca89c7821a4d70c and test: tests/foreman/ui/test_user.py::test_positive_end_to_end
[...]
2026-07-01 21:20:44 - broker.hosts - DEBUG - [HOSTNAME SNIP] executing command: rm -rf /var/www/html/videos/232f6e754f534a447ca89c7821a4d70c
[...]
2026-07-01 21:20:44 - robottelo - INFO - video cleanup for session 232f6e754f534a447ca89c7821a4d70c is complete
2026-07-01 21:20:44 - robottelo - INFO - cleaning up video files for session: 31599141c328e7bb3bccb5c62e2ec12c and test: tests/foreman/ui/test_user.py::test_positive_end_to_end
[...]
2026-07-01 21:20:44 - broker.hosts - DEBUG - [HOSTNAME SNIP] executing command: rm -rf /var/www/html/videos/31599141c328e7bb3bccb5c62e2ec12c
[...]
2026-07-01 21:20:45 - robottelo - INFO - video cleanup for session 31599141c328e7bb3bccb5c62e2ec12c is complete
2026-07-01 21:20:45 - robottelo - INFO - Finished teardown for test: tests/foreman/ui/test_user.py::test_positive_end_to_end, result: passed
```
## Summary by Sourcery

Bug Fixes:
- Fix video cleanup plugin to delete videos for tests that use multiple sequential UI sessions.

## Summary by Sourcery

Bug Fixes:
- Fix video cleanup to delete videos for all session IDs recorded for a test, including those from multiple sequential UI sessions.