### PR TITLE
Fix CI only failure of test_positive_erratum_installable

### DIFF
--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -217,7 +217,9 @@ def test_positive_rct_shows_sca_enabled(module_sca_manifest, module_target_sat):
 
 
 @pytest.mark.rhel_ver_match('9')
-def test_negative_unregister_and_pull_content(vm):
+def test_negative_unregister_and_pull_content(
+    vm, module_sca_manifest_org, rh_repo_setup_ak, module_target_sat, request
+):
     """Attempt to retrieve content after host has been unregistered from Satellite
 
     :id: de0d0d91-b1e1-4f0e-8a41-c27df4d6b6fd
@@ -230,6 +232,9 @@ def test_negative_unregister_and_pull_content(vm):
     """
     result = vm.run('subscription-manager unregister')
     assert result.status == 0
+    request.addfinalizer(
+        lambda: vm.register(module_sca_manifest_org, None, rh_repo_setup_ak.name, module_target_sat)
+    )
     # Try installing any package from available repos on vm
     result = vm.run('yum install -y katello-agent')
     assert result.status != 0


### PR DESCRIPTION
### Problem Statement
`test_positive_erratum_installable[rhel9-ipv4]` has been failing consistently in CI.
The root cause is test ordering in CI.
With xdist, `test_negative_unregister_and_pull_content` runs before the other RHEL9 tests because "negative" sorts alphabetically before "positive".
This test unregisters the shared module-scoped `vm` content host, which breaks errata applicability for subsequent tests that depend on the same host.
Locally (or in CI), when the test is run in isolation, it passes without issues.

### Solution
Add a finalizer to `test_negative_unregister_and_pull_content` that re-registers the content host (reverting unregister steps from the test) so the state of the `vm` fixture stays the same for other tests.



### PRT test Cases example
<img width="313" height="217" alt="image" src="https://github.com/user-attachments/assets/c7adda2b-4fdd-494a-ba3a-6960c55f3754" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentaccess.py
```

## Summary by Sourcery

Bug Fixes:
- Fix CI flakiness where unregistering a shared VM in a negative content access test broke subsequent RHEL9 erratum tests.