### PR TITLE
[6.18.z] Fix video cleanup to handle tests with multiple UI sessions

### DIFF
--- a/pytest_plugins/video_cleanup.py
+++ b/pytest_plugins/video_cleanup.py
@@ -70,8 +70,9 @@ def pytest_runtest_makereport(item):
                 report.user_properties = [
                     (key, value) for key, value in report.user_properties if key != 'video_url'
                 ]
-                session_id_tuple = next(
-                    (t for t in report.user_properties if t[0] == 'session_id'), None
-                )
-                session_id = session_id_tuple[1] if session_id_tuple else None
-                _clean_video(session_id, item.nodeid)
+                # Extract all session IDs from user_properties (handles multi-session tests)
+                session_ids = [
+                    value for key, value in report.user_properties if key == 'session_id'
+                ]
+                for session_id in session_ids:
+                    _clean_video(session_id, item.nodeid)


### PR DESCRIPTION
### Problem Statement

If a passing test uses multiple sequential UI session context managers, then the video cleanup plugin only cleans up the most recent one, leaving the earlier ones behind.

### Solution

Update the plugin to clean up the directories for all sessions that the test ran.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

### PRT results

Multiple UI session directories are cleaned up:
```
2026-07-02 13:46:52 - robottelo - INFO - cleaning up video files for session: 6865c357ca53af936bb27b45e738d3d7 and test: tests/foreman/ui/test_user.py::test_positive_end_to_end
[...]
2026-07-02 13:46:52 - broker.hosts - DEBUG - [HOSTNAME SNIP] executing command: rm -rf /var/www/html/videos/6865c357ca53af936bb27b45e738d3d7
[...]
2026-07-02 13:46:52 - robottelo - INFO - video cleanup for session 6865c357ca53af936bb27b45e738d3d7 is complete
2026-07-02 13:46:52 - robottelo - INFO - cleaning up video files for session: bc3e5c598fcee0a0d682e4a04a0b14e0 and test: tests/foreman/ui/test_user.py::test_positive_end_to_end
[...]
2026-07-02 13:46:52 - broker.hosts - DEBUG - [HOSTNAME SNIP] executing command: rm -rf /var/www/html/videos/bc3e5c598fcee0a0d682e4a04a0b14e0
[...]
2026-07-02 13:46:53 - robottelo - INFO - video cleanup for session bc3e5c598fcee0a0d682e4a04a0b14e0 is complete
2026-07-02 13:46:53 - robottelo - INFO - cleaning up video files for session: 28ca11339ac2f72b7266e119827f3229 and test: tests/foreman/ui/test_user.py::test_positive_end_to_end
[...]
2026-07-02 13:46:53 - broker.hosts - DEBUG - [HOSTNAME SNIP] executing command: rm -rf /var/www/html/videos/28ca11339ac2f72b7266e119827f3229
[...]
2026-07-02 13:46:53 - robottelo - INFO - video cleanup for session 28ca11339ac2f72b7266e119827f3229 is complete
2026-07-02 13:46:53 - robottelo - INFO - Finished teardown for test: tests/foreman/ui/test_user.py::test_positive_end_to_end, result: passed
```