### PR TITLE
[6.19.z] update Jira issue in clone_report_template test

### DIFF
--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -1039,7 +1039,7 @@ def test_positive_clone_report_template(module_target_sat):
     cloned_template = module_target_sat.cli.ReportTemplate.info({'name': clone_name})
     assert cloned_template['name'] == clone_name
     assert cloned_template['cloned-from-id'] == template['id']
-    if is_open('SAT-42163'):
+    if is_open('SAT-47454'):
         module_target_sat.cli.ReportTemplate.update(
             {'id': cloned_template['id'], 'locked': 'false'}
         )


### PR DESCRIPTION
### Problem Statement

The original issue (SAT-42163) in `tests.foreman.cli.test_reporttemplates::test_positive_clone_report_template` test is considered closed (it's Release Pending),
but the newer RPM package has not yet been delivered. This causes the test to fail.

### Solution

Update Jira issue to an opened one, until the new package is delivered.

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_reporttemplates.py -k 'test_positive_clone_report_template'
```
