### PR TITLE
Block negative CLI host create/update tests

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -467,9 +467,13 @@ def test_negative_create_with_content_source(
 
     :BZ: 1260697
 
+    :Verifies: SAT-47465
+
     :expectedresults: Host was not created
 
     :CaseImportance: Medium
+
+    :BlockedBy: SAT-47465
     """
     with pytest.raises(CLIFactoryError):
         module_target_sat.cli_factory.make_fake_host(
@@ -491,12 +495,16 @@ def test_negative_update_content_source(
 
     :BZ: 1260697, 1483252, 1313056
 
+    :Verifies: SAT-47465
+
     :customerscenario: true
 
     :expectedresults: Host was not updated. Content source remains the same
         as it was before update
 
     :CaseImportance: Medium
+
+    :BlockedBy: SAT-47465
     """
     host = module_target_sat.cli_factory.make_fake_host(
         {


### PR DESCRIPTION
Block `test_negative_create_with_content_source ` & `test_negative_update_content_source ` as they found SAT-47465.

## Summary by Sourcery

Tests:
- Annotate negative host create and update content source CLI tests with Verifies and BlockedBy metadata for SAT-47465.