### PR TITLE
Fix test_positive_capsule_sync_openstack_container_repos

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -665,7 +665,7 @@ class TestCapsuleContentManagement:
     def test_positive_update_with_immediate_sync(
         self,
         target_sat,
-        module_capsule_configured,
+        capsule_configured,
         function_org,
         function_product,
         function_lce,
@@ -692,12 +692,12 @@ class TestCapsuleContentManagement:
             url=repo_url,
         ).create()
         # Update capsule's download policy to on_demand to match repository's policy
-        module_capsule_configured.update_download_policy('on_demand')
+        capsule_configured.update_download_policy('on_demand')
         # Associate the lifecycle environment with the capsule
-        module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
+        capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
             data={'environment_id': function_lce.id}
         )
-        result = module_capsule_configured.nailgun_capsule.content_lifecycle_environments()
+        result = capsule_configured.nailgun_capsule.content_lifecycle_environments()
 
         assert len(result['results'])
         assert function_lce.id in [capsule_lce['id'] for capsule_lce in result['results']]
@@ -718,7 +718,7 @@ class TestCapsuleContentManagement:
         timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
-        module_capsule_configured.wait_for_sync(start_time=timestamp)
+        capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 2
 
@@ -729,7 +729,7 @@ class TestCapsuleContentManagement:
         assert repo.download_policy == 'immediate'
 
         # Update capsule's download policy as well
-        module_capsule_configured.update_download_policy('immediate')
+        capsule_configured.update_download_policy('immediate')
 
         # Sync repository once again
         repo.sync()
@@ -746,12 +746,12 @@ class TestCapsuleContentManagement:
         timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
-        module_capsule_configured.wait_for_sync(start_time=timestamp)
+        capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 2
 
         # Verify the count of RPMs published on Capsule
-        caps_repo_url = module_capsule_configured.get_published_repo_url(
+        caps_repo_url = capsule_configured.get_published_repo_url(
             org=function_org.label,
             lce=function_lce.label,
             cv=cv.label,


### PR DESCRIPTION
### Problem Statement
The `test_positive_capsule_sync_openstack_container_repos` - a customer-facing test case that syncs openstack repos to a Capsule, started to fail with `[Errno 28] No space left on device`, effectively taking down other tests operating over the module-scoped capsule.

It looks like the openstack repos grew "too big not to fail" on a 100G Capsule with `immediate` download policy.

Looking at https://bugzilla.redhat.com/show_bug.cgi?id=2154734, the BZ doesn't seem to require the `immediate` download policy. That settings seems to leak from `test_positive_update_with_immediate_sync`.


### Solution
We can choose one of these:
1. Brute force - use even bigger Capsule (500G) so the repo gets in.
2. Get rid of the test case if the resource cost is considered too high.
3. Isolate `test_positive_update_with_immediate_sync` to function-scoped capsule.

I've started with 1. but I believe 3. should be better (or more appropriate) option.


### Related Issues
no issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py tests/foreman/api/test_capsulecontent.py -k 'test_positive_update_with_immediate_sync or test_positive_capsule_sync_openstack_container_repos'
```

## Summary by Sourcery

Bug Fixes:
- Use the large Capsule fixture in the openstack container repo sync test to avoid '[Errno 28] No space left on device' failures when syncing large repositories.

## Summary by Sourcery

Use a function-scoped capsule fixture in the immediate sync test to prevent leaking configuration into other capsule content tests.

Bug Fixes:
- Stop openstack container repository sync tests from failing due to shared capsule disk exhaustion by isolating the immediate sync test to a function-scoped capsule.

Enhancements:
- Refine capsule content tests to use a more appropriate capsule fixture for immediate download policy scenarios.