### PR TITLE
Fix CV tests with relation to cvenv_id

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -485,8 +485,9 @@ class TestContentView:
 
         ac_key = module_target_sat.cli_factory.make_activation_key(
             {
-                'content-view-id': source_cv['id'],
-                'lifecycle-environment-id': env[0]['id'],
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    source_cv['id'], env[0]['id']
+                ),
                 'name': gen_alphanumeric(),
                 'organization-id': module_org.id,
             }
@@ -553,8 +554,9 @@ class TestContentView:
 
         module_target_sat.cli_factory.make_fake_host(
             {
-                'content-view-id': source_cv['id'],
-                'lifecycle-environment-id': env[0]['id'],
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    source_cv['id'], env[0]['id']
+                ),
                 'name': gen_alphanumeric(),
                 'organization-id': module_org.id,
             }
@@ -1759,8 +1761,9 @@ class TestContentView:
         assert content_view['content-host-count'] == '0'
         module_target_sat.cli_factory.make_fake_host(
             {
-                'content-view-id': content_view['id'],
-                'lifecycle-environment-id': env['id'],
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    content_view['id'], env['id']
+                ),
                 'name': gen_alphanumeric(),
                 'organization-id': module_sca_manifest_org.id,
             }
@@ -1831,8 +1834,9 @@ class TestContentView:
 
         module_target_sat.cli_factory.make_fake_host(
             {
-                'content-view-id': content_view['id'],
-                'lifecycle-environment-id': env['id'],
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    content_view['id'], env['id']
+                ),
                 'name': gen_alphanumeric(),
                 'organization-id': module_sca_manifest_org.id,
             }
@@ -1869,8 +1873,9 @@ class TestContentView:
 
         module_target_sat.cli_factory.make_fake_host(
             {
-                'content-view-id': content_view['id'],
-                'lifecycle-environment-id': env['id'],
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    content_view['id'], env['id']
+                ),
                 'name': gen_alphanumeric(),
                 'organization-id': module_org.id,
             }
@@ -3340,8 +3345,9 @@ class TestRollingContentView:
         ak = target_sat.cli.ActivationKey.create(
             {
                 'organization-id': module_org.id,
-                'content-view': rolling_cv['name'],
-                'lifecycle-environment-id': library_id,
+                'content-view-environment-ids': target_sat.api_factory.get_cvenv_id(
+                    rolling_cv['id'], library_id
+                ),
                 'name': gen_alphanumeric(),
             }
         )
@@ -3368,8 +3374,9 @@ class TestRollingContentView:
             {
                 'id': module_ak.id,
                 'organization-id': module_org.id,
-                'content-view': rolling_cv['name'],
-                'lifecycle-environment-id': library_id,
+                'content-view-environment-ids': target_sat.api_factory.get_cvenv_id(
+                    rolling_cv['id'], library_id
+                ),
             }
         )
         # updated module_ak was associated to rolling cv


### PR DESCRIPTION
### Problem Statement
Snap 190 (Katello PR https://github.com/Katello/katello/pull/11753) removed deprecated `--content-view`, `--lifecycle-environment`, and their `id` parameters from hammer activation-key create/update. PRs https://github.com/SatelliteQE/robottelo/pull/21644, https://github.com/SatelliteQE/robottelo/pull/21785, https://github.com/SatelliteQE/robottelo/pull/21804, and https://github.com/SatelliteQE/robottelo/pull/21915 addressed most of the codebase but missed some more locations.

### Solution
This PR fixes 6 tests missed tests in tests/foreman/cli/test_contentview.py


### Related Issues
https://redhat.atlassian.net/browse/SAT-47280


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py -k 'remove_lce_by_id_and_reassign or subscribe_chost_by_id_using or rolling_with_activation_keys'
```

## Summary by Sourcery

Update CLI content view tests to use content view environment IDs instead of deprecated content view and lifecycle environment parameters.

Bug Fixes:
- Fix failing content view CLI tests by aligning activation key and host creation parameters with the new content-view-environment-ids API.

Tests:
- Adjust multiple content view CLI tests to construct activation keys and fake hosts using content view environment IDs obtained from the API factory.