### PR TITLE
Update FIPs deploy workflow in content_host config template

### DIFF
--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -17,7 +17,8 @@ content_host:
     vm:
       workflow: deploy-rhel
       deploy_rhel_version: '7'
-      deploy_fips: true
+    post_configs:
+      - fips
   rhel8:
     vm:
       workflow: deploy-rhel

--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -15,10 +15,9 @@ content_host:
       container_host: localhost/ubi7:latest
   rhel7_fips:
     vm:
-      workflow: deploy-base-rhel-fips
+      workflow: deploy-rhel
       deploy_rhel_version: '7'
-    post_configs:
-      - fips
+      deploy_fips: true
   rhel8:
     vm:
       workflow: deploy-rhel
@@ -27,10 +26,9 @@ content_host:
       container_host: localhost/ubi8:latest
   rhel8_fips:
     vm:
-      workflow: deploy-base-rhel-fips
+      workflow: deploy-rhel
       deploy_rhel_version: '8'
-    post_configs:
-      - fips
+      deploy_fips: true
   rhel9:
     vm:
       workflow: deploy-rhel
@@ -39,10 +37,9 @@ content_host:
       container_host: localhost/ubi9:latest
   rhel9_fips:
     vm:
-      workflow: deploy-base-rhel-fips
+      workflow: deploy-rhel
       deploy_rhel_version: '9'
-    post_configs:
-      - fips
+      deploy_fips: true
   rhel10:
     vm:
       workflow: deploy-rhel
@@ -51,8 +48,9 @@ content_host:
       container_host: localhost/ubi10:latest
   rhel10_fips:
     vm:
-      workflow: deploy-base-rhel-fips
+      workflow: deploy-rhel
       deploy_rhel_version: '10'
+      deploy_fips: true
   centos7:
     vm:
       deploy_rhel_version: '7'


### PR DESCRIPTION
### Problem Statement

content_host config needs a update for new workflow to checkout FIPs enabled hosts

### Solution
- Replace old `deploy-base-rhel-fips` workflow with `deploy-rhel` workflow with `deploy_fips: true`
- keeping `post_configs:` and `host_post_configs` for RHEL7 FIPS, as it has limitation from image-builder and Lab end.

### Related Issues
satellite-jenkins MR#1549

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Update the content_host CI config template to use the new FIPS-enabled deploy workflow.

CI:
- Switch content_host deployments from the legacy deploy-base-rhel-fips workflow to the deploy-rhel workflow configured with deploy_fips: true.
- Retain unused post_configs and host_post_configs sections in the CI config template for potential future use.