### PR TITLE
Update iop for foremanctl

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -21,7 +21,7 @@ from robottelo.constants import (
     PUPPET_COMMON_INSTALLER_OPTS,
     PUPPET_SATELLITE_INSTALLER,
 )
-from robottelo.enums import NetworkType
+from robottelo.enums import InstallMethod, NetworkType
 from robottelo.exceptions import CLIReturnCodeError, NoManifestProvidedError, SatelliteHostError
 from robottelo.host_helpers.api_factory import APIFactory
 from robottelo.host_helpers.cli_factory import CLIFactory
@@ -458,7 +458,11 @@ class IoPSetup:
         }
 
     def configure_iop(self):
-        """Configure on prem Advisor engine on Satellite"""
+        """Configure on prem Advisor engine on Satellite.
+
+        Branches on install_method: foremanctl uses ``foremanctl deploy --add-feature iop``,
+        installer uses ``satellite-installer --enable-iop --iop-ensure present``.
+        """
         logger.info('Configuring Satellite with local Red Hat Lightspeed')
 
         self.register_to_cdn()
@@ -473,30 +477,33 @@ class IoPSetup:
             iop_settings.stage_username, iop_settings.stage_token, iop_settings.stage_registry
         )
 
-        # Set IPv6 podman proxy on Satellite, to pull from container registry
         self.enable_ipv6_podman_proxy()
 
-        # Set up container image path overrides
-        if image_paths := self.get_iop_image_paths():
-            custom_hiera = f'{robottelo_tmp_dir}/custom-hiera.yaml'
+        if self.install_method == InstallMethod.FOREMANCTL:
+            result = self.execute('foremanctl deploy --add-feature iop', timeout='30m')
+        else:
+            # Set up container image path overrides for satellite-installer
+            if image_paths := self.get_iop_image_paths():
+                custom_hiera = f'{robottelo_tmp_dir}/custom-hiera.yaml'
 
-            with open(custom_hiera, 'w') as f:
-                yaml.dump(
-                    image_paths,
-                    f,
-                    sort_keys=False,
-                    default_flow_style=False,
-                )
-            self.put(custom_hiera, '/etc/foreman-installer/custom-hiera.yaml')
+                with open(custom_hiera, 'w') as f:
+                    yaml.dump(
+                        image_paths,
+                        f,
+                        sort_keys=False,
+                        default_flow_style=False,
+                    )
+                self.put(custom_hiera, '/etc/foreman-installer/custom-hiera.yaml')
 
-        command = InstallerCommand(
-            'enable-iop',
-            iop_ensure='present',
-            scenario='satellite',
-            foreman_initial_admin_password=settings.server.admin_password,
-        ).get_command()
+            command = InstallerCommand(
+                'enable-iop',
+                iop_ensure='present',
+                scenario='satellite',
+                foreman_initial_admin_password=settings.server.admin_password,
+            ).get_command()
 
-        result = self.execute(command, timeout='30m')
+            result = self.execute(command, timeout='30m')
+
         if result.status != 0:
             raise SatelliteHostError(f'Failed to configure IoP: {result.stdout}')
         if not self.iop_enabled:
@@ -507,11 +514,12 @@ class IoPSetup:
             logger.info('IoP is already disabled. Skipping uninstallation.')
             return
 
-        command = InstallerCommand(
-            iop_ensure='absent',
-        ).get_command()
+        if self.install_method == InstallMethod.FOREMANCTL:
+            result = self.execute('foremanctl deploy --remove-feature iop', timeout='30m')
+        else:
+            command = InstallerCommand(iop_ensure='absent').get_command()
+            result = self.execute(command, timeout='30m')
 
-        result = self.execute(command, timeout='30m')
         if result.status != 0:
             raise SatelliteHostError(f'Failed to disable IoP: {result.stdout}')
         if self.iop_enabled:

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -480,6 +480,12 @@ class IoPSetup:
         self.enable_ipv6_podman_proxy()
 
         if self.install_method == InstallMethod.FOREMANCTL:
+            for service, image in settings.rh_cloud.iop.image_paths.items():
+                quadlet_name = f'iop-{service.replace("_", "-")}'
+                self.execute(
+                    f"sed -i 's|^Image=.*|Image={image}|' "
+                    f"/etc/containers/systemd/{quadlet_name}.image"
+                )
             result = self.execute('foremanctl deploy --add-feature iop', timeout='30m')
         else:
             # Set up container image path overrides for satellite-installer

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -460,7 +460,7 @@ class IoPSetup:
     def configure_iop(self):
         """Configure on prem Advisor engine on Satellite.
 
-        Branches on install_method: foremanctl uses ``foremanctl deploy --add-feature iop``,
+        Based on install_method: foremanctl uses ``foremanctl deploy --add-feature iop``,
         installer uses ``satellite-installer --enable-iop --iop-ensure present``.
         """
         logger.info('Configuring Satellite with local Red Hat Lightspeed')

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -3264,7 +3264,6 @@ class Satellite(Capsule, SatelliteMixins):
     @property
     def iop_enabled(self):
         """Return boolean indicating whether IoP (local Red Hat Lightspeed) is enabled."""
-        from robottelo.enums import InstallMethod
 
         if self.install_method == InstallMethod.FOREMANCTL:
             return 'iop' in self.list_foremanctl_features(enabled=True)

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -3264,7 +3264,12 @@ class Satellite(Capsule, SatelliteMixins):
     @property
     def iop_enabled(self):
         """Return boolean indicating whether IoP (local Red Hat Lightspeed) is enabled."""
-        return self.api.RHCloud().advisor_engine_config()['use_iop_mode']
+        from robottelo.enums import InstallMethod
+
+        if self.install_method == InstallMethod.FOREMANCTL:
+            return 'iop' in self.list_foremanctl_features(enabled=True)
+        result = self.execute('systemctl is-active iop-core-engine')
+        return result.status == 0
 
 
 class SSOHost(Host):

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -115,11 +115,18 @@ def test_positive_install_iop_custom_certs(
     assert result.status == 0, f'Error logging in to container registry: {result.stdout}'
 
     if satellite.install_method == InstallMethod.FOREMANCTL:
+        for service, image in iop_settings.image_paths.items():
+            quadlet_name = f'iop-{service.replace("_", "-")}'
+            satellite.execute(
+                f"sed -i 's|^Image=.*|Image={image}|' "
+                f"/etc/containers/systemd/{quadlet_name}.image"
+            )
         result = satellite.execute(
             'foremanctl deploy --add-feature iop'
             f' --certificate-source=custom_server'
             f' --certificate-server-certificate /root/{certs_data["cert_file_name"]}'
-            f' --certificate-server-key /root/{certs_data["key_file_name"]}',
+            f' --certificate-server-key /root/{certs_data["key_file_name"]}'
+            f' --certificate-server-ca-certificate /root/{certs_data["ca_bundle_file_name"]}',
             timeout='30m',
         )
     else:
@@ -368,6 +375,7 @@ def process_iop_log_options(installer_output):
     return options_dict
 
 
+@pytest.mark.foreman_installer
 def test_set_iop_log_level_via_installer(module_satellite_iop):
     """Set IoP log level to DEBUG using satellite-installer options.
 
@@ -385,10 +393,6 @@ def test_set_iop_log_level_via_installer(module_satellite_iop):
 
     :Verifies: SAT-41750
     """
-    if module_satellite_iop.install_method == InstallMethod.FOREMANCTL:
-        pytest.skip(
-            'IoP log level configuration via satellite-installer not available on foremanctl'
-        )
 
     NEW_LOG_LEVEL = 'DEBUG'
 

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -16,6 +16,7 @@ import pytest
 import yaml
 
 from robottelo.config import settings
+from robottelo.enums import InstallMethod
 from robottelo.utils.installer import InstallerCommand
 
 IOP_SERVICES = [
@@ -113,24 +114,33 @@ def test_positive_install_iop_custom_certs(
     )
     assert result.status == 0, f'Error logging in to container registry: {result.stdout}'
 
-    # Set up container image path overrides
-    custom_hiera_yaml = yaml.dump(
-        {f'iop::{service}::image': path for service, path in iop_settings.image_paths.items()}
-    )
-    satellite.execute(f'echo "{custom_hiera_yaml}" > /etc/foreman-installer/custom-hiera.yaml')
+    if satellite.install_method == InstallMethod.FOREMANCTL:
+        result = satellite.execute(
+            'foremanctl deploy --add-feature iop'
+            f' --certificate-source=custom_server'
+            f' --certificate-server-certificate /root/{certs_data["cert_file_name"]}'
+            f' --certificate-server-key /root/{certs_data["key_file_name"]}',
+            timeout='30m',
+        )
+    else:
+        # Set up container image path overrides
+        custom_hiera_yaml = yaml.dump(
+            {f'iop::{service}::image': path for service, path in iop_settings.image_paths.items()}
+        )
+        satellite.execute(f'echo "{custom_hiera_yaml}" > /etc/foreman-installer/custom-hiera.yaml')
 
-    command = InstallerCommand(
-        'enable-iop',
-        'certs-update-server',
-        'certs-update-server-ca',
-        scenario='satellite',
-        certs_server_cert=f'/root/{certs_data["cert_file_name"]}',
-        certs_server_key=f'/root/{certs_data["key_file_name"]}',
-        certs_server_ca_cert=f'/root/{certs_data["ca_bundle_file_name"]}',
-        foreman_initial_admin_password=settings.server.admin_password,
-    ).get_command()
+        command = InstallerCommand(
+            'enable-iop',
+            'certs-update-server',
+            'certs-update-server-ca',
+            scenario='satellite',
+            certs_server_cert=f'/root/{certs_data["cert_file_name"]}',
+            certs_server_key=f'/root/{certs_data["key_file_name"]}',
+            certs_server_ca_cert=f'/root/{certs_data["ca_bundle_file_name"]}',
+            foreman_initial_admin_password=settings.server.admin_password,
+        ).get_command()
 
-    result = satellite.execute(command, timeout='30m')
+        result = satellite.execute(command, timeout='30m')
     assert result.status == 0
 
     result = satellite.execute('hammer ping')
@@ -222,8 +232,11 @@ def test_disable_enable_iop(module_satellite_iop, module_sca_manifest, rhel_cont
     assert result.status == 0, 'Initial insights-client upload failed'
 
     # Disable IoP
-    command = InstallerCommand(iop_ensure='absent').get_command()
-    result = satellite.execute(command, timeout='10m')
+    if satellite.install_method == InstallMethod.FOREMANCTL:
+        result = satellite.execute('foremanctl deploy --remove-feature iop', timeout='30m')
+    else:
+        command = InstallerCommand(iop_ensure='absent').get_command()
+        result = satellite.execute(command, timeout='10m')
     assert result.status == 0, 'Failed to disable IoP'
 
     result = satellite.execute('satellite-maintain service restart')
@@ -260,8 +273,11 @@ def test_disable_enable_iop(module_satellite_iop, module_sca_manifest, rhel_cont
     assert result.status == 0, 'Failed to unregister from Red Hat Lightspeed'
 
     # Re-enable IoP
-    command = InstallerCommand(iop_ensure='present').get_command()
-    result = satellite.execute(command, timeout='10m')
+    if satellite.install_method == InstallMethod.FOREMANCTL:
+        result = satellite.execute('foremanctl deploy --add-feature iop', timeout='30m')
+    else:
+        command = InstallerCommand(iop_ensure='present').get_command()
+        result = satellite.execute(command, timeout='10m')
     assert result.status == 0, 'Failed to re-enable IoP'
 
     result = satellite.execute('satellite-maintain service restart')
@@ -369,6 +385,11 @@ def test_set_iop_log_level_via_installer(module_satellite_iop):
 
     :Verifies: SAT-41750
     """
+    if module_satellite_iop.install_method == InstallMethod.FOREMANCTL:
+        pytest.skip(
+            'IoP log level configuration via satellite-installer not available on foremanctl'
+        )
+
     NEW_LOG_LEVEL = 'DEBUG'
 
     # Retrieve the IoP log level settings from satellite-installer help output

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -118,8 +118,7 @@ def test_positive_install_iop_custom_certs(
         for service, image in iop_settings.image_paths.items():
             quadlet_name = f'iop-{service.replace("_", "-")}'
             satellite.execute(
-                f"sed -i 's|^Image=.*|Image={image}|' "
-                f"/etc/containers/systemd/{quadlet_name}.image"
+                f"sed -i 's|^Image=.*|Image={image}|' /etc/containers/systemd/{quadlet_name}.image"
             )
         result = satellite.execute(
             'foremanctl deploy --add-feature iop'


### PR DESCRIPTION
IOP is currently enabled using satellite-installer. We need functionality for both satellite-installer and foremanctl. 

Tests are failing with: 
`"requests.exceptions.HTTPError: 404 Client Error: Not Found for url:Satellite.com/api/v2/rh_cloud/advisor_engine_config`

*Updated methods to look at Installment type and set up iop accordingly.*

## Summary by Sourcery

Enable IoP lifecycle management across foremanctl and satellite-installer deployments while supporting their distinct service and authentication workflows.

New Features:
- Support configuring and removing IoP on both foremanctl- and satellite-installer-managed installations.

Bug Fixes:
- Avoid IoP status checks through an unavailable API endpoint on foremanctl installations.
- Preserve credentials for multiple container registries in the Podman authfile.

Enhancements:
- Use installation-method-specific service restart and IoP status handling.