### PR TITLE
[6.18.z] Fix host_conf to resolve post_configs from content_host settings

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -18,12 +18,15 @@ from robottelo.hosts import ContentHost, Satellite
 
 def host_conf(request):
     """A function that returns arguments for Broker host deployment"""
-    conf = params = {}
+    params = {}
     if hasattr(request, 'param'):
         params = request.param
     distro = params.get('distro', 'rhel')
     network = params.get('network', settings.content_host.network_type)
     _rhelver = f"{distro}{params.get('rhel_version', settings.content_host.default_rhel_version)}"
+
+    version_conf = settings.content_host.get(_rhelver).to_dict()
+    post_configs = version_conf.get('post_configs', [])
 
     # check to see if no-containers is passed as an argument to pytest
     deploy_kwargs = {}
@@ -34,18 +37,20 @@ def host_conf(request):
             request.node.get_closest_marker('no_containers'),
         ]
     ):
-        deploy_kwargs = settings.content_host.get(_rhelver).to_dict().get('container', {})
+        deploy_kwargs = version_conf.get('container', {})
         if deploy_kwargs and network:
             deploy_kwargs.update({'Container': str(network)})
     # if we're not using containers or a container isn't available, use a VM
     if not deploy_kwargs:
-        deploy_kwargs = settings.content_host.get(_rhelver).to_dict().get('vm', {})
+        deploy_kwargs = version_conf.get('vm', {})
         if network:
             deploy_kwargs.update({'deploy_network_type': network})
     if network:
         # pass the network type to the deploy kwargs, so the host class can use it
         deploy_kwargs.update({'net_type': network})
-    conf.update(deploy_kwargs)
+    conf = {**deploy_kwargs}
+    if post_configs:
+        conf['post_configs'] = post_configs
     return conf
 
 
@@ -77,6 +82,8 @@ def host_post_config(hosts, config_name):
             if isinstance(val, str) and "{" in val:
                 broker_args[key] = val.format(host=host)
         Broker(**broker_args).execute()
+        host._post_deploy_config = getattr(host, '_post_deploy_config', set()) | {config_name}
+        host.connect()
 
 
 @contextmanager
@@ -256,7 +263,7 @@ def katello_host_tools_tracer_host(rex_contenthost, target_sat):
 def rhel_contenthost_with_repos(request, target_sat):
     """Install katello-host-tools-tracer, create custom
     repositories on the host"""
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with contenthost_factory(request=request) as host:
         # add IPv6 proxy for IPv6 communication
         if not host.network_type.has_ipv4:
             host.enable_ipv6_dnf_and_rhsm_proxy()
@@ -300,7 +307,7 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
 def module_flatpak_contenthost(request):
     assert request.param['rhel_version'] > 8, 'Unsupported RHEL version'
     request.param['no_containers'] = True
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with contenthost_factory(request=request) as host:
         host.register_to_cdn()
         res = host.execute('dnf -y install podman flatpak dbus-x11')
         assert res.status == 0, f'Initial installation failed: {res.stderr}'


### PR DESCRIPTION
Failed Autocherrypick of #22065
Fixes #22072

### Problem Statement
 Currently, `host_conf()` reads post_configs from `request.param`, which fixture_markers never populates. This means post_configs defined in conf/content_host.yaml (e.g., post_configs: [fips] for rhel7_fips) are silently ignored, the enable-fips workflow never runs for FIPS content hosts that rely on it. 

Additionally, host_conf() has a dict aliasing bug (conf = params = {}) that mutates request.param as a side effect, and two fixtures (rhel_contenthost_with_repos, module_flatpak_contenthost) bypass contenthost_factory, so they would never handle post-configs even if host_conf returned them correctly.

### Solution
- Fix host_conf() to read post_configs from the version's settings dict (settings.content_host.<version>.post_configs) instead of request.param
- Fix the dict aliasing bug by constructing conf as a new dict
- Migrate rhel_contenthost_with_repos and module_flatpak_contenthost to use contenthost_factory so all content host fixtures consistently handle post-configs
- Track applied post-configs on the host object via host._post_deploy_config (a set) in host_post_config(), so with host object we can check what was applied

### Related Issues
Follow-up of https://github.com/SatelliteQE/robottelo/pull/16981

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->