### PR TITLE
Isolate test_positive_capsule_sync_openstack_container_repos

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -1568,7 +1568,7 @@ class TestCapsuleContentManagement:
     def test_positive_capsule_sync_openstack_container_repos(
         self,
         module_target_sat,
-        module_capsule_configured,
+        capsule_configured,
         function_org,
         function_product,
         function_lce,
@@ -1603,6 +1603,7 @@ class TestCapsuleContentManagement:
             repo = module_target_sat.api.Repository(
                 content_type='docker',
                 docker_upstream_name=ups_name,
+                download_policy='on_demand',
                 product=function_product,
                 url=settings.container.rh.registry_hub,
                 upstream_username=settings.subscription.rhn_username,
@@ -1612,10 +1613,10 @@ class TestCapsuleContentManagement:
             repos.append(repo)
 
         # Associate LCE with the capsule
-        module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
+        capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
             data={'environment_id': function_lce.id}
         )
-        result = module_capsule_configured.nailgun_capsule.content_lifecycle_environments()
+        result = capsule_configured.nailgun_capsule.content_lifecycle_environments()
         assert len(result['results'])
         assert function_lce.id in [capsule_lce['id'] for capsule_lce in result['results']]
 
@@ -1630,7 +1631,7 @@ class TestCapsuleContentManagement:
         timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
-        module_capsule_configured.wait_for_sync(start_time=timestamp)
+        capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 2
 


### PR DESCRIPTION
### Problem Statement
In https://github.com/SatelliteQE/robottelo/pull/22055 I tried to fix `test_positive_capsule_sync_openstack_container_repos` (failing with `[Errno 28] No space left on device`) by preventing leakage of `immediate` download policy from another test. Unfortunatelly, it did not help. It seems the content from the module-scoped capsule accumulated regardless, so it doesn't fit in with the openstack repos.


### Solution
Isolate the `test_positive_capsule_sync_openstack_container_repos` with test-scoped capsule.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k test_positive_capsule_sync_openstack_container_repos
```

## Summary by Sourcery

Tests:
- Update test_positive_capsule_sync_openstack_container_repos to use a test-scoped capsule fixture instead of the module-scoped capsule.