### PR TITLE
Block test_positive_global_registration_end_to_end

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -152,10 +152,14 @@ def test_positive_global_registration_end_to_end(
 
     :BZ: 1993874
 
+    :Verifies: SAT-47528
+
     :expectedresults: Host is successfully registered, remote execution and insights
          client work out of the box
 
     :parametrized: yes
+
+    :BlockedBy: SAT-47528
     """
     # Adding IPv6 proxy for IPv6 communication
     rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()


### PR DESCRIPTION
`test_positive_global_registration_end_to_end` found SAT-47528, the part of the test flow is generating reg. command and filling the registration form, where the rex interface is filled which hits the mentioned bug.

## Summary by Sourcery

Tests:
- Annotate the global registration end-to-end test with Verifies and BlockedBy references to SAT-47528.