### PR TITLE
Mark test_positive_export_import_mldsa_content destructive

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -3248,6 +3248,7 @@ class TestExportImport:
         )
 
     @pytest.mark.pqc
+    @pytest.mark.destructive
     @pytest.mark.rhel_ver_match('N-0')
     @pytest.mark.no_containers
     @pytest.mark.parametrize('export_format', ['importable', 'syncable'])
@@ -3263,6 +3264,9 @@ class TestExportImport:
         """Export and import the latest RHEL BaseOS repository with ML-DSA signed
         packages, then consume content from the import Satellite and verify the
         V6 ML-DSA-87+Ed448 signatures are intact end-to-end.
+
+        Marked destructive to get a fresh Satellite for the export side since
+        immediate sync of RHEL BaseOS would exhaust disk on a shared target_sat.
 
         :id: 17640f0e-0d7c-46de-aee4-a05e73a04d3a
 
@@ -3314,6 +3318,9 @@ class TestExportImport:
                 'product': repo_dict['product'],
             }
         )
+        # Set immediate policy explicitly — class_immediate_rh_download_policy applies to
+        # class_target_sat, not to the fresh destructive target_sat this test gets.
+        target_sat.cli.Repository.update({'download-policy': 'immediate', 'id': repo['id']})
         target_sat.cli.Repository.synchronize({'id': repo['id']}, timeout='30m')
 
         cv = target_sat.cli_factory.make_content_view({'organization-id': eorg.id})


### PR DESCRIPTION
### Problem Statement
The `test_positive_export_import_mldsa_content` fails in CI with `[Errno 28] No space left on device` on the export SAT because the RHEL BaseOS content combined with content from the other cases does not fit in.


### Solution
The easiest solution is to mark the test case "destructive" to force separate export SAT for this specific test case.
Another approach would be a module-scoped export SAT with larger flavor, which would require more fixture duplication (not using the `target_sat`). For now I stick to the first option.


### Related Issues
no issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py::TestExport tests/foreman/cli/test_satellitesync.py::TestExportImport
```

## Summary by Sourcery

Mark Satellite export/import CLI tests as destructive and ensure immediate repository download policy on fresh Satellite instances to avoid disk exhaustion on shared targets.

Bug Fixes:
- Prevent ML-DSA content export/import test from failing due to disk space exhaustion on a shared target Satellite.

Tests:
- Mark podman repo and ML-DSA content export/import tests as destructive to run on separate Satellite instances.
- Explicitly set repository download policy to immediate in the ML-DSA export/import test when using a fresh destructive target Satellite.