### PR TITLE
Fix foremanctl install for IPv6 deployments

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2138,6 +2138,8 @@ class Capsule(ContentHost, CapsuleMixins):
         # Add IPv6 proxy for IPv6 communication
         self.enable_ipv6_dnf_and_rhsm_proxy()
         self.enable_ipv6_system_proxy()
+        # Add IPv6 proxy for podman to pull from container registry
+        self.enable_ipv6_podman_proxy()
         # Enable RHEL and Satellite repos
         self.register_to_cdn()
         self.setup_rhel_repos()

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2150,6 +2150,7 @@ class Capsule(ContentHost, CapsuleMixins):
                 job_template='upstream-pr-install',
                 target_vm=self.name,
                 pull_requests=pull_requests,
+                deploy_network_type=settings.server.network_type,
             ).execute()
 
         # Install podman (required for foremanctl container operations)

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -919,8 +919,6 @@ class ContentHost(Host, ContentHostMixins):
         if not self.network_type.has_ipv4:
             container_cfg = '/etc/containers/containers.conf'
             proxy_url = settings.http_proxy.http_proxy_ipv6_url
-            # Ensure /etc/containers exists if podman is not installed
-            assert self.execute('rpm -q podman || mkdir -p /etc/containers').status == 0
             if self.execute(f'grep -q "https_proxy" {container_cfg}').status != 0:
                 assert (
                     self.execute(
@@ -2140,8 +2138,8 @@ class Capsule(ContentHost, CapsuleMixins):
         # Add IPv6 proxy for IPv6 communication
         self.enable_ipv6_dnf_and_rhsm_proxy()
         self.enable_ipv6_system_proxy()
-        # Add IPv6 proxy for podman to pull from container registry
-        self.enable_ipv6_podman_proxy()
+        # Add IPv6 proxy for podman to pull from registry & install podman if not pre-installed
+        self.ensure_podman_installed(enable_ipv6_proxy=True)
         # Enable RHEL and Satellite repos
         self.register_to_cdn()
         self.setup_rhel_repos()

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -924,7 +924,7 @@ class ContentHost(Host, ContentHostMixins):
             if self.execute(f'grep -q "https_proxy" {container_cfg}').status != 0:
                 assert (
                     self.execute(
-                        f'echo -e "[engine]\\nenv = [\'https_proxy={proxy_url}\']" >> {container_cfg}'
+                        f'echo -e "[engine]\\nenv = [\'https_proxy={proxy_url}\', \'no_proxy=localhost\']" >> {container_cfg}'
                     ).status
                     == 0
                 )

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -919,6 +919,8 @@ class ContentHost(Host, ContentHostMixins):
         if not self.network_type.has_ipv4:
             container_cfg = '/etc/containers/containers.conf'
             proxy_url = settings.http_proxy.http_proxy_ipv6_url
+            # Ensure /etc/containers exists if podman is not installed
+            assert self.execute('rpm -q podman || mkdir -p /etc/containers').status == 0
             if self.execute(f'grep -q "https_proxy" {container_cfg}').status != 0:
                 assert (
                     self.execute(

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -920,12 +920,12 @@ class ContentHost(Host, ContentHostMixins):
             container_cfg = '/etc/containers/containers.conf'
             proxy_url = settings.http_proxy.http_proxy_ipv6_url
             if self.execute(f'grep -q "https_proxy" {container_cfg}').status != 0:
-                assert (
-                    self.execute(
-                        f'echo -e "[engine]\\nenv = [\'https_proxy={proxy_url}\', \'no_proxy=localhost\']" >> {container_cfg}'
-                    ).status
-                    == 0
+                proxy_env = (
+                    '[engine]\\nenv = ['
+                    f'\\"https_proxy={proxy_url}\\"]\\n'
+                    '[containers]\\nhttp_proxy=false'
                 )
+                assert self.execute(f'echo -e "{proxy_env}" >> {container_cfg}').status == 0
 
     def disable_rhsm_proxy(self):
         """Disables HTTP proxy for subscription manager"""

--- a/tests/foreman/installer/test_install_foremanctl.py
+++ b/tests/foreman/installer/test_install_foremanctl.py
@@ -274,9 +274,8 @@ def test_foremanctl_deploy_certificate_cname(module_sat_ready_rhel):
     assert result.status == 0, (
         f'foremanctl deploy with --certificate-cname failed:\n{result.stderr}'
     )
-
     result = satellite.execute(
-        'curl --fail --silent --show-error --head '
+        'curl --noproxy "*" --fail --silent --show-error --head '
         f'--cacert {FOREMANCTL_CERTS_DIR}/ca.crt '
         f'--resolve "{cname}:443:127.0.0.1" '
         f'https://{cname}/users/login'


### PR DESCRIPTION
### Problem Statement
- Currently, the `upstream-pr-install` JT execution fails for IPv6 because we enable the COPR repository on the host using `HTTPS_PROXY` whenever `deploy_network_type` is set. That configuration is currently missing, causing the test setup to fail on IPv6 deployments.
- Podman pull fails on IPv6 only setup as it can't interact with quay or stage registries causing foremanctl pull-images and foremanctl deploy to fail

### Solution
- Add `deploy_network_type` to the `upstream-pr-install` JT execution so the COPR repository is enabled via `HTTPS_PROXY` and the IPv6 test setup completes successfully.
- Add IPv6 proxy for podman to be able to pull from quay or stage container registries

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Enhancements:
- Propagate settings.server.network_type as deploy_network_type to the upstream-pr-install job template to correctly configure COPR access over HTTPS proxy for IPv6 environments.