### PR TITLE
debug_FIPS_only_failure_for_test_positive_cockpit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ broker[satlab,docker,ssh2_python]==0.8.8
 cryptography==49.0.0
 deepdiff==9.1.0
 dynaconf[vault]==3.2.13
+epdb==0.15.1
 fastmcp-slim[client]==3.4.4
 fauxfactory==4.2.2
 jira==3.10.5

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -16,6 +16,7 @@ from airgun.exceptions import NoSuchElementException
 import pytest
 
 from robottelo.constants import ANY_CONTEXT
+from robottelo.logging import logger
 
 
 class TestHostCockpit:
@@ -86,35 +87,40 @@ class TestHostCockpit:
             session.browser.switch_to_window(session.browser.window_handles[0])
             session.browser.close_window(session.browser.window_handles[-1])
 
-            # Debug: capture cockpit connectivity state before webconsole attempt
-            debug_cmds = {
-                'fips_check': 'fips-mode-setup --check 2>&1',
-                'crypto_policy': 'update-crypto-policies --show 2>&1',
-                'firewall_rules': 'firewall-cmd --list-all 2>&1',
-                'cockpit_socket': 'systemctl status cockpit.socket 2>&1',
-                'cockpit_service': 'systemctl status cockpit.service 2>&1',
-                'cockpit_listen': 'ss -tlnp | grep 9090 2>&1',
-                'cockpit_packages': 'rpm -qa | grep cockpit 2>&1',
-            }
-            for label, cmd in debug_cmds.items():
-                result = cockpit_host.execute(cmd)
-                print(f'[cockpit-debug][{label}] rc={result.status}\n{result.stdout}')
+            try:
+                hostname_inside_cockpit = session.host.get_webconsole_content(
+                    entity_name=cockpit_host.hostname,
+                    rhel_version=cockpit_host.os_version.major,
+                )
+            except NoSuchElementException:
+                # Capture debug info after the failure to see what went wrong
+                post_fail_cmds = {
+                    'foreman_cockpit_journal': (
+                        'journalctl -u foreman-cockpit --no-pager -n 50 2>&1'
+                    ),
+                    'foreman_proxy_journal': ('journalctl -u foreman-proxy --no-pager -n 30 2>&1'),
+                    'httpd_error_log': 'tail -30 /var/log/httpd/error_log 2>&1',
+                    'cockpit_proxy_log': ('tail -30 /var/log/httpd/foreman-ssl_error_ssl.log 2>&1'),
+                    'sat_curl_cockpit': (
+                        f'curl -sk -o /dev/null -w "%{{http_code}}"'
+                        f' https://{cockpit_host.hostname}:9090 2>&1'
+                    ),
+                }
+                for label, cmd in post_fail_cmds.items():
+                    result = class_cockpit_sat.execute(cmd)
+                    logger.info(f'[cockpit-debug][sat-{label}] rc={result.status}\n{result.stdout}')
 
-            sat_debug_cmds = {
-                'cockpit_ws_status': 'systemctl status cockpit-ws 2>&1',
-                'cockpit_ws_journal': (
-                    'journalctl -u cockpit-ws --no-pager --since "5 minutes ago" 2>&1'
-                ),
-                'foreman_cockpit_status': 'systemctl status foreman-cockpit 2>&1',
-            }
-            for label, cmd in sat_debug_cmds.items():
-                result = class_cockpit_sat.execute(cmd)
-                print(f'[cockpit-debug][sat-{label}] rc={result.status}\n{result.stdout}')
+                host_cmds = {
+                    'cockpit_service_status': 'systemctl status cockpit.service 2>&1',
+                    'cockpit_journal': 'journalctl -u cockpit --no-pager -n 30 2>&1',
+                }
+                for label, cmd in host_cmds.items():
+                    result = cockpit_host.execute(cmd)
+                    logger.info(
+                        f'[cockpit-debug][host-{label}] rc={result.status}\n{result.stdout}'
+                    )
+                raise
 
-            hostname_inside_cockpit = session.host.get_webconsole_content(
-                entity_name=cockpit_host.hostname,
-                rhel_version=cockpit_host.os_version.major,
-            )
             assert cockpit_host.hostname in hostname_inside_cockpit, (
                 f'cockpit page shows hostname {hostname_inside_cockpit} '
                 f'instead of {cockpit_host.hostname}'

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -94,23 +94,16 @@ class TestHostCockpit:
                 )
             except NoSuchElementException:
                 # /login returns 500 — capture foreman-cockpit-session error
+                settings = '/etc/foreman/cockpit/foreman-cockpit-session.yml'
                 post_fail_cmds = {
-                    'webcon_access_log': (
-                        'grep webcon /var/log/httpd/foreman-ssl_access_ssl.log | tail -15 2>&1'
-                    ),
-                    'session_script_source': ('head -50 /usr/sbin/foreman-cockpit-session 2>&1'),
                     'session_manual_test': (
-                        f'timeout 10 /usr/bin/ruby /usr/sbin/foreman-cockpit-session'
+                        f'FOREMAN_COCKPIT_SETTINGS={settings}'
+                        f' timeout 10 /usr/bin/ruby'
+                        f' /usr/sbin/foreman-cockpit-session'
                         f' {cockpit_host.hostname} 2>&1 || true'
                     ),
-                    'cockpit_ws_stderr': (
-                        'journalctl _SYSTEMD_UNIT=foreman-cockpit.service'
-                        ' --no-pager -o cat 2>&1 | tail -30'
-                    ),
-                    'all_cockpit_logs': (
-                        'journalctl -t cockpit-ws -t foreman-cockpit'
-                        ' -t foreman-cockpit-session'
-                        ' --no-pager -o cat 2>&1 | tail -30'
+                    'webcon_access_log': (
+                        'grep webcon /var/log/httpd/foreman-ssl_access_ssl.log | tail -15 2>&1'
                     ),
                     'ssl_error_log': ('tail -10 /var/log/httpd/foreman-ssl_error_ssl.log 2>&1'),
                 }

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -93,34 +93,37 @@ class TestHostCockpit:
                     rhel_version=cockpit_host.os_version.major,
                 )
             except NoSuchElementException:
-                # /login returns 500 — capture foreman-cockpit-session error
                 host = cockpit_host.hostname
-                # Restart foreman-cockpit with debug logging, then
-                # replay the /login request to capture the error
-                class_cockpit_sat.execute('systemctl stop foreman-cockpit')
+                sat = class_cockpit_sat.hostname
+                # Enable COCKPIT_DEBUG via systemd drop-in and replay
                 class_cockpit_sat.execute(
-                    'COCKPIT_DEBUG=all /usr/libexec/cockpit-ws'
-                    ' --no-tls --address 127.0.0.1 --port 19090'
-                    ' &>/tmp/cockpit-ws-debug.log &'
-                    ' echo $!>/tmp/cockpit-ws-debug.pid;'
-                    ' sleep 2'
+                    'mkdir -p /etc/systemd/system/foreman-cockpit.service.d;'
+                    ' printf "[Service]\\nEnvironment=COCKPIT_DEBUG=all\\n"'
+                    ' > /etc/systemd/system/foreman-cockpit.service.d/debug.conf;'
+                    ' systemctl daemon-reload;'
+                    ' systemctl restart foreman-cockpit'
                 )
                 class_cockpit_sat.execute(
                     f'curl -sk -o /dev/null'
-                    f' https://{class_cockpit_sat.hostname}'
-                    f'/webcon/cockpit+%3D{host}/login 2>&1 || true'
+                    f' https://{sat}/webcon/cockpit+%3D{host}/login'
+                    f' 2>&1 || true'
                 )
                 import time
 
                 time.sleep(3)
-                class_cockpit_sat.execute(
-                    'kill $(cat /tmp/cockpit-ws-debug.pid) 2>/dev/null || true'
+                result = class_cockpit_sat.execute(
+                    'journalctl -u foreman-cockpit --no-pager -n 100 2>&1'
                 )
-                result = class_cockpit_sat.execute('cat /tmp/cockpit-ws-debug.log 2>&1')
                 logger.info(
-                    f'[cockpit-debug][sat-cockpit_ws_debug_log] rc={result.status}\n{result.stdout}'
+                    f'[cockpit-debug][sat-cockpit_ws_debug_journal]'
+                    f' rc={result.status}\n{result.stdout}'
                 )
-                class_cockpit_sat.execute('systemctl start foreman-cockpit')
+                # Cleanup
+                class_cockpit_sat.execute(
+                    'rm -rf /etc/systemd/system/foreman-cockpit.service.d;'
+                    ' systemctl daemon-reload;'
+                    ' systemctl restart foreman-cockpit'
+                )
                 raise
 
             assert cockpit_host.hostname in hostname_inside_cockpit, (

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -16,6 +16,7 @@ from airgun.exceptions import NoSuchElementException
 import pytest
 
 from robottelo.constants import ANY_CONTEXT
+from robottelo.logging import logger
 
 
 class TestHostCockpit:
@@ -85,6 +86,32 @@ class TestHostCockpit:
 
             session.browser.switch_to_window(session.browser.window_handles[0])
             session.browser.close_window(session.browser.window_handles[-1])
+
+            # Debug: capture cockpit connectivity state before webconsole attempt
+            debug_cmds = {
+                'fips_check': 'fips-mode-setup --check 2>&1',
+                'crypto_policy': 'update-crypto-policies --show 2>&1',
+                'firewall_rules': 'firewall-cmd --list-all 2>&1',
+                'cockpit_socket': 'systemctl status cockpit.socket 2>&1',
+                'cockpit_service': 'systemctl status cockpit.service 2>&1',
+                'cockpit_listen': 'ss -tlnp | grep 9090 2>&1',
+                'cockpit_packages': 'rpm -qa | grep cockpit 2>&1',
+            }
+            for label, cmd in debug_cmds.items():
+                result = cockpit_host.execute(cmd)
+                logger.info(f'[cockpit-debug][{label}] rc={result.status}\n{result.stdout}')
+
+            sat_debug_cmds = {
+                'cockpit_ws_status': 'systemctl status cockpit-ws 2>&1',
+                'cockpit_ws_journal': (
+                    'journalctl -u cockpit-ws --no-pager --since "5 minutes ago" 2>&1'
+                ),
+                'foreman_cockpit_status': 'systemctl status foreman-cockpit 2>&1',
+            }
+            for label, cmd in sat_debug_cmds.items():
+                result = class_cockpit_sat.execute(cmd)
+                logger.info(f'[cockpit-debug][sat-{label}] rc={result.status}\n{result.stdout}')
+
             hostname_inside_cockpit = session.host.get_webconsole_content(
                 entity_name=cockpit_host.hostname,
                 rhel_version=cockpit_host.os_version.major,

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -95,29 +95,39 @@ class TestHostCockpit:
             except NoSuchElementException:
                 # Capture debug info after the failure to see what went wrong
                 post_fail_cmds = {
-                    'foreman_cockpit_journal': (
-                        'journalctl -u foreman-cockpit --no-pager -n 50 2>&1'
-                    ),
                     'webcon_access_log': (
                         'grep webcon /var/log/httpd/foreman-ssl_access_ssl.log | tail -20 2>&1'
                     ),
-                    'ssl_error_log': 'tail -30 /var/log/httpd/foreman-ssl_error_ssl.log 2>&1',
-                    'httpd_journal': 'journalctl -u httpd --no-pager -n 30 2>&1',
-                    'sat_curl_cockpit': (
-                        f'curl -sk -o /dev/null -w "%{{http_code}}"'
-                        f' https://{cockpit_host.hostname}:9090 2>&1'
+                    'foreman_cockpit_full': (
+                        'journalctl -u foreman-cockpit --no-pager --since "5 minutes ago" 2>&1'
                     ),
-                    'foreman_cockpit_recent': (
-                        'journalctl -u foreman-cockpit --no-pager --since "2 minutes ago" 2>&1'
+                    'foreman_cockpit_all_output': (
+                        'journalctl _SYSTEMD_UNIT=foreman-cockpit.service'
+                        ' --no-pager --since "5 minutes ago" -o verbose 2>&1'
                     ),
+                    'cockpit_session_errors': (
+                        'journalctl -t cockpit-ws --no-pager --since "5 minutes ago" 2>&1'
+                    ),
+                    'foreman_cockpit_session_log': (
+                        'find /var/log -name "*cockpit*" -newer /tmp 2>/dev/null'
+                        ' | xargs tail -30 2>&1'
+                    ),
+                    'syslog_cockpit': (
+                        'grep -i cockpit /var/log/messages 2>/dev/null | tail -20 2>&1'
+                    ),
+                    'ssl_error_log': ('tail -30 /var/log/httpd/foreman-ssl_error_ssl.log 2>&1'),
                 }
                 for label, cmd in post_fail_cmds.items():
                     result = class_cockpit_sat.execute(cmd)
                     logger.info(f'[cockpit-debug][sat-{label}] rc={result.status}\n{result.stdout}')
 
                 host_cmds = {
-                    'cockpit_service_status': 'systemctl status cockpit.service 2>&1',
-                    'cockpit_journal': 'journalctl -u cockpit --no-pager -n 30 2>&1',
+                    'cockpit_journal': (
+                        'journalctl -u cockpit --no-pager --since "5 minutes ago" 2>&1'
+                    ),
+                    'cockpit_ws_journal': (
+                        'journalctl -t cockpit-ws --no-pager --since "5 minutes ago" 2>&1'
+                    ),
                 }
                 for label, cmd in host_cmds.items():
                     result = cockpit_host.execute(cmd)

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -95,41 +95,32 @@ class TestHostCockpit:
             except NoSuchElementException:
                 # /login returns 500 — capture foreman-cockpit-session error
                 host = cockpit_host.hostname
-                sat = class_cockpit_sat.hostname
-                post_fail_cmds = {
-                    'login_response_body': (
-                        f'curl -sk https://{sat}/webcon/cockpit+%3D{host}/login 2>&1 || true'
-                    ),
-                    'find_cockpit_ssh': (
-                        'find / -name "cockpit-ssh" -o -name "cockpit-ssh-agent"'
-                        ' 2>/dev/null | head -5; rpm -ql cockpit-ws 2>/dev/null'
-                        ' | grep ssh; rpm -qa | grep cockpit 2>&1'
-                    ),
-                    'cockpit_ws_config': (
-                        'cat /etc/cockpit/cockpit.conf 2>/dev/null || true;'
-                        ' cat /etc/foreman/cockpit/*.yml 2>&1'
-                    ),
-                    'host_cockpit_tls_log': 'placeholder',
-                    'webcon_login_line': (
-                        'grep "cockpit.*login"'
-                        ' /var/log/httpd/foreman-ssl_access_ssl.log'
-                        ' | tail -5 2>&1'
-                    ),
-                }
-                for label, cmd in post_fail_cmds.items():
-                    result = class_cockpit_sat.execute(cmd)
-                    logger.info(f'[cockpit-debug][sat-{label}] rc={result.status}\n{result.stdout}')
+                # Restart foreman-cockpit with debug logging, then
+                # replay the /login request to capture the error
+                class_cockpit_sat.execute('systemctl stop foreman-cockpit')
+                class_cockpit_sat.execute(
+                    'COCKPIT_DEBUG=all /usr/libexec/cockpit-ws'
+                    ' --no-tls --address 127.0.0.1 --port 19090'
+                    ' &>/tmp/cockpit-ws-debug.log &'
+                    ' echo $!>/tmp/cockpit-ws-debug.pid;'
+                    ' sleep 2'
+                )
+                class_cockpit_sat.execute(
+                    f'curl -sk -o /dev/null'
+                    f' https://{class_cockpit_sat.hostname}'
+                    f'/webcon/cockpit+%3D{host}/login 2>&1 || true'
+                )
+                import time
 
-                host_cmds = {
-                    'cockpit_tls_journal': (
-                        'journalctl -u cockpit -t cockpit-tls -t cockpit-ws --no-pager -n 30 2>&1'
-                    ),
-                }
-                for label, cmd in host_cmds.items():
-                    result = cockpit_host.execute(cmd)
-                    logger.info(
-                        f'[cockpit-debug][host-{label}] rc={result.status}\n{result.stdout}'
-                    )
+                time.sleep(3)
+                class_cockpit_sat.execute(
+                    'kill $(cat /tmp/cockpit-ws-debug.pid) 2>/dev/null || true'
+                )
+                result = class_cockpit_sat.execute('cat /tmp/cockpit-ws-debug.log 2>&1')
+                logger.info(
+                    f'[cockpit-debug][sat-cockpit_ws_debug_log] rc={result.status}\n{result.stdout}'
+                )
+                class_cockpit_sat.execute('systemctl start foreman-cockpit')
                 raise
 
             assert cockpit_host.hostname in hostname_inside_cockpit, (

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -95,22 +95,21 @@ class TestHostCockpit:
             except NoSuchElementException:
                 # /login returns 500 — capture foreman-cockpit-session error
                 host = cockpit_host.hostname
+                sat = class_cockpit_sat.hostname
                 post_fail_cmds = {
-                    'cockpit_ssh_test': (
-                        f'timeout 10 /usr/libexec/cockpit-ssh root@{host} 2>&1 || true'
+                    'login_response_body': (
+                        f'curl -sk https://{sat}/webcon/cockpit+%3D{host}/login 2>&1 || true'
                     ),
-                    'ssh_verbose_test': (
-                        f'timeout 5 ssh -vvv -o StrictHostKeyChecking=no'
-                        f' -o BatchMode=yes root@{host}'
-                        f' "echo ok" 2>&1 || true'
+                    'find_cockpit_ssh': (
+                        'find / -name "cockpit-ssh" -o -name "cockpit-ssh-agent"'
+                        ' 2>/dev/null | head -5; rpm -ql cockpit-ws 2>/dev/null'
+                        ' | grep ssh; rpm -qa | grep cockpit 2>&1'
                     ),
-                    'sat_ssh_ciphers': 'ssh -Q cipher 2>&1 | head -20',
-                    'host_sshd_fips_config': (
-                        f'ssh -o StrictHostKeyChecking=no root@{host}'
-                        f' "sshd -T 2>/dev/null'
-                        f' | grep -iE \\"ciphers|macs|kexalgorithms\\""'
-                        f' 2>&1 || true'
+                    'cockpit_ws_config': (
+                        'cat /etc/cockpit/cockpit.conf 2>/dev/null || true;'
+                        ' cat /etc/foreman/cockpit/*.yml 2>&1'
                     ),
+                    'host_cockpit_tls_log': 'placeholder',
                     'webcon_login_line': (
                         'grep "cockpit.*login"'
                         ' /var/log/httpd/foreman-ssl_access_ssl.log'
@@ -120,6 +119,17 @@ class TestHostCockpit:
                 for label, cmd in post_fail_cmds.items():
                     result = class_cockpit_sat.execute(cmd)
                     logger.info(f'[cockpit-debug][sat-{label}] rc={result.status}\n{result.stdout}')
+
+                host_cmds = {
+                    'cockpit_tls_journal': (
+                        'journalctl -u cockpit -t cockpit-tls -t cockpit-ws --no-pager -n 30 2>&1'
+                    ),
+                }
+                for label, cmd in host_cmds.items():
+                    result = cockpit_host.execute(cmd)
+                    logger.info(
+                        f'[cockpit-debug][host-{label}] rc={result.status}\n{result.stdout}'
+                    )
                 raise
 
             assert cockpit_host.hostname in hostname_inside_cockpit, (

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -94,18 +94,28 @@ class TestHostCockpit:
                 )
             except NoSuchElementException:
                 # /login returns 500 — capture foreman-cockpit-session error
-                settings = '/etc/foreman/cockpit/foreman-cockpit-session.yml'
+                host = cockpit_host.hostname
                 post_fail_cmds = {
-                    'session_manual_test': (
-                        f'FOREMAN_COCKPIT_SETTINGS={settings}'
-                        f' timeout 10 /usr/bin/ruby'
-                        f' /usr/sbin/foreman-cockpit-session'
-                        f' {cockpit_host.hostname} 2>&1 || true'
+                    'cockpit_ssh_test': (
+                        f'timeout 10 /usr/libexec/cockpit-ssh root@{host} 2>&1 || true'
                     ),
-                    'webcon_access_log': (
-                        'grep webcon /var/log/httpd/foreman-ssl_access_ssl.log | tail -15 2>&1'
+                    'ssh_verbose_test': (
+                        f'timeout 5 ssh -vvv -o StrictHostKeyChecking=no'
+                        f' -o BatchMode=yes root@{host}'
+                        f' "echo ok" 2>&1 || true'
                     ),
-                    'ssl_error_log': ('tail -10 /var/log/httpd/foreman-ssl_error_ssl.log 2>&1'),
+                    'sat_ssh_ciphers': 'ssh -Q cipher 2>&1 | head -20',
+                    'host_sshd_fips_config': (
+                        f'ssh -o StrictHostKeyChecking=no root@{host}'
+                        f' "sshd -T 2>/dev/null'
+                        f' | grep -iE \\"ciphers|macs|kexalgorithms\\""'
+                        f' 2>&1 || true'
+                    ),
+                    'webcon_login_line': (
+                        'grep "cockpit.*login"'
+                        ' /var/log/httpd/foreman-ssl_access_ssl.log'
+                        ' | tail -5 2>&1'
+                    ),
                 }
                 for label, cmd in post_fail_cmds.items():
                     result = class_cockpit_sat.execute(cmd)

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -13,10 +13,10 @@
 """
 
 from airgun.exceptions import NoSuchElementException
+import epdb
 import pytest
 
 from robottelo.constants import ANY_CONTEXT
-from robottelo.logging import logger
 
 
 class TestHostCockpit:
@@ -87,67 +87,12 @@ class TestHostCockpit:
             session.browser.switch_to_window(session.browser.window_handles[0])
             session.browser.close_window(session.browser.window_handles[-1])
 
-            try:
-                hostname_inside_cockpit = session.host.get_webconsole_content(
-                    entity_name=cockpit_host.hostname,
-                    rhel_version=cockpit_host.os_version.major,
-                )
-            except NoSuchElementException:
-                # Grab read_auth_reply method and inject debug logging
-                result = class_cockpit_sat.execute(
-                    'grep -n "def read_auth_reply\\|def send_auth"'
-                    ' /usr/sbin/foreman-cockpit-session 2>&1'
-                )
-                logger.info(
-                    f'[cockpit-debug][sat-auth_methods_lines] rc={result.status}\n{result.stdout}'
-                )
-                result = class_cockpit_sat.execute(
-                    'grep -n "def read_auth_reply" /usr/sbin/foreman-cockpit-session'
-                    ' | head -1 | cut -d: -f1'
-                )
-                line_num = result.stdout.strip()
-                if line_num:
-                    start = max(1, int(line_num) - 2)
-                    end = int(line_num) + 20
-                    result = class_cockpit_sat.execute(
-                        f'sed -n "{start},{end}p" /usr/sbin/foreman-cockpit-session 2>&1'
-                    )
-                    logger.info(
-                        f'[cockpit-debug][sat-read_auth_reply_source]'
-                        f' rc={result.status}\n{result.stdout}'
-                    )
-                # Patch the script to log what read_auth_reply returns
-                class_cockpit_sat.execute(
-                    "sed -i"
-                    " 's/token = read_auth_reply/"
-                    "reply = read_auth_reply;"
-                    " LOG.error(\"AUTH_REPLY: [#{reply}]\");"
-                    " token = reply/'"
-                    " /usr/sbin/foreman-cockpit-session"
-                )
-                class_cockpit_sat.execute('systemctl restart foreman-cockpit')
-                class_cockpit_sat.execute(
-                    f'curl -sk -o /dev/null'
-                    f' https://{class_cockpit_sat.hostname}'
-                    f'/webcon/cockpit+%3D{cockpit_host.hostname}/login'
-                    f' 2>&1 || true'
-                )
-                import time
+            epdb.serve(port=8888)
 
-                time.sleep(3)
-                result = class_cockpit_sat.execute(
-                    'journalctl -u foreman-cockpit --no-pager -n 30 2>&1'
-                )
-                logger.info(
-                    f'[cockpit-debug][sat-patched_session_output]'
-                    f' rc={result.status}\n{result.stdout}'
-                )
-                # Restore original script
-                class_cockpit_sat.execute(
-                    'yum reinstall -y rubygem-foreman_remote_execution-cockpit 2>/dev/null || true'
-                )
-                raise
-
+            hostname_inside_cockpit = session.host.get_webconsole_content(
+                entity_name=cockpit_host.hostname,
+                rhel_version=cockpit_host.os_version.major,
+            )
             assert cockpit_host.hostname in hostname_inside_cockpit, (
                 f'cockpit page shows hostname {hostname_inside_cockpit} '
                 f'instead of {cockpit_host.hostname}'

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -93,16 +93,58 @@ class TestHostCockpit:
                     rhel_version=cockpit_host.os_version.major,
                 )
             except NoSuchElementException:
-                # Line 304 crashes: undefined method `[]' for nil
+                # Grab read_auth_reply method and inject debug logging
                 result = class_cockpit_sat.execute(
-                    'sed -n "280,330p" /usr/sbin/foreman-cockpit-session 2>&1'
+                    'grep -n "def read_auth_reply\\|def send_auth"'
+                    ' /usr/sbin/foreman-cockpit-session 2>&1'
                 )
                 logger.info(
-                    f'[cockpit-debug][sat-session_line_304] rc={result.status}\n{result.stdout}'
+                    f'[cockpit-debug][sat-auth_methods_lines] rc={result.status}\n{result.stdout}'
                 )
-                result = class_cockpit_sat.execute('wc -l /usr/sbin/foreman-cockpit-session 2>&1')
+                result = class_cockpit_sat.execute(
+                    'grep -n "def read_auth_reply" /usr/sbin/foreman-cockpit-session'
+                    ' | head -1 | cut -d: -f1'
+                )
+                line_num = result.stdout.strip()
+                if line_num:
+                    start = max(1, int(line_num) - 2)
+                    end = int(line_num) + 20
+                    result = class_cockpit_sat.execute(
+                        f'sed -n "{start},{end}p" /usr/sbin/foreman-cockpit-session 2>&1'
+                    )
+                    logger.info(
+                        f'[cockpit-debug][sat-read_auth_reply_source]'
+                        f' rc={result.status}\n{result.stdout}'
+                    )
+                # Patch the script to log what read_auth_reply returns
+                class_cockpit_sat.execute(
+                    "sed -i"
+                    " 's/token = read_auth_reply/"
+                    "reply = read_auth_reply;"
+                    " LOG.error(\"AUTH_REPLY: [#{reply}]\");"
+                    " token = reply/'"
+                    " /usr/sbin/foreman-cockpit-session"
+                )
+                class_cockpit_sat.execute('systemctl restart foreman-cockpit')
+                class_cockpit_sat.execute(
+                    f'curl -sk -o /dev/null'
+                    f' https://{class_cockpit_sat.hostname}'
+                    f'/webcon/cockpit+%3D{cockpit_host.hostname}/login'
+                    f' 2>&1 || true'
+                )
+                import time
+
+                time.sleep(3)
+                result = class_cockpit_sat.execute(
+                    'journalctl -u foreman-cockpit --no-pager -n 30 2>&1'
+                )
                 logger.info(
-                    f'[cockpit-debug][sat-session_line_count] rc={result.status}\n{result.stdout}'
+                    f'[cockpit-debug][sat-patched_session_output]'
+                    f' rc={result.status}\n{result.stdout}'
+                )
+                # Restore original script
+                class_cockpit_sat.execute(
+                    'yum reinstall -y rubygem-foreman_remote_execution-cockpit 2>/dev/null || true'
                 )
                 raise
 

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -16,7 +16,6 @@ from airgun.exceptions import NoSuchElementException
 import pytest
 
 from robottelo.constants import ANY_CONTEXT
-from robottelo.logging import logger
 
 
 class TestHostCockpit:
@@ -99,7 +98,7 @@ class TestHostCockpit:
             }
             for label, cmd in debug_cmds.items():
                 result = cockpit_host.execute(cmd)
-                logger.info(f'[cockpit-debug][{label}] rc={result.status}\n{result.stdout}')
+                print(f'[cockpit-debug][{label}] rc={result.status}\n{result.stdout}')
 
             sat_debug_cmds = {
                 'cockpit_ws_status': 'systemctl status cockpit-ws 2>&1',
@@ -110,7 +109,7 @@ class TestHostCockpit:
             }
             for label, cmd in sat_debug_cmds.items():
                 result = class_cockpit_sat.execute(cmd)
-                logger.info(f'[cockpit-debug][sat-{label}] rc={result.status}\n{result.stdout}')
+                print(f'[cockpit-debug][sat-{label}] rc={result.status}\n{result.stdout}')
 
             hostname_inside_cockpit = session.host.get_webconsole_content(
                 entity_name=cockpit_host.hostname,

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -93,47 +93,30 @@ class TestHostCockpit:
                     rhel_version=cockpit_host.os_version.major,
                 )
             except NoSuchElementException:
-                # Capture debug info after the failure to see what went wrong
+                # /login returns 500 — capture foreman-cockpit-session error
                 post_fail_cmds = {
                     'webcon_access_log': (
-                        'grep webcon /var/log/httpd/foreman-ssl_access_ssl.log | tail -20 2>&1'
+                        'grep webcon /var/log/httpd/foreman-ssl_access_ssl.log | tail -15 2>&1'
                     ),
-                    'foreman_cockpit_full': (
-                        'journalctl -u foreman-cockpit --no-pager --since "5 minutes ago" 2>&1'
+                    'session_script_source': ('head -50 /usr/sbin/foreman-cockpit-session 2>&1'),
+                    'session_manual_test': (
+                        f'timeout 10 /usr/bin/ruby /usr/sbin/foreman-cockpit-session'
+                        f' {cockpit_host.hostname} 2>&1 || true'
                     ),
-                    'foreman_cockpit_all_output': (
+                    'cockpit_ws_stderr': (
                         'journalctl _SYSTEMD_UNIT=foreman-cockpit.service'
-                        ' --no-pager --since "5 minutes ago" -o verbose 2>&1'
+                        ' --no-pager -o cat 2>&1 | tail -30'
                     ),
-                    'cockpit_session_errors': (
-                        'journalctl -t cockpit-ws --no-pager --since "5 minutes ago" 2>&1'
+                    'all_cockpit_logs': (
+                        'journalctl -t cockpit-ws -t foreman-cockpit'
+                        ' -t foreman-cockpit-session'
+                        ' --no-pager -o cat 2>&1 | tail -30'
                     ),
-                    'foreman_cockpit_session_log': (
-                        'find /var/log -name "*cockpit*" -newer /tmp 2>/dev/null'
-                        ' | xargs tail -30 2>&1'
-                    ),
-                    'syslog_cockpit': (
-                        'grep -i cockpit /var/log/messages 2>/dev/null | tail -20 2>&1'
-                    ),
-                    'ssl_error_log': ('tail -30 /var/log/httpd/foreman-ssl_error_ssl.log 2>&1'),
+                    'ssl_error_log': ('tail -10 /var/log/httpd/foreman-ssl_error_ssl.log 2>&1'),
                 }
                 for label, cmd in post_fail_cmds.items():
                     result = class_cockpit_sat.execute(cmd)
                     logger.info(f'[cockpit-debug][sat-{label}] rc={result.status}\n{result.stdout}')
-
-                host_cmds = {
-                    'cockpit_journal': (
-                        'journalctl -u cockpit --no-pager --since "5 minutes ago" 2>&1'
-                    ),
-                    'cockpit_ws_journal': (
-                        'journalctl -t cockpit-ws --no-pager --since "5 minutes ago" 2>&1'
-                    ),
-                }
-                for label, cmd in host_cmds.items():
-                    result = cockpit_host.execute(cmd)
-                    logger.info(
-                        f'[cockpit-debug][host-{label}] rc={result.status}\n{result.stdout}'
-                    )
                 raise
 
             assert cockpit_host.hostname in hostname_inside_cockpit, (

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -13,10 +13,10 @@
 """
 
 from airgun.exceptions import NoSuchElementException
-import epdb
 import pytest
 
 from robottelo.constants import ANY_CONTEXT
+from robottelo.logging import logger
 
 
 class TestHostCockpit:
@@ -71,6 +71,17 @@ class TestHostCockpit:
 
             service_restart = class_cockpit_sat.cli.Service.restart()
             assert service_restart.status == 0
+
+            # Patch session script to log auth reply
+            class_cockpit_sat.execute(
+                "sed -i 's/token = read_auth_reply/"
+                "reply = read_auth_reply;"
+                " LOG.error(\"AUTH_REPLY_LOCAL: [#{reply}]\");"
+                " token = reply/'"
+                " /usr/sbin/foreman-cockpit-session"
+            )
+            class_cockpit_sat.execute('systemctl restart foreman-cockpit')
+
             # SAT-36783 can be triggered by just having wide characters anywhere
             # in the payload that gets sent between Satellite, Capsule and
             # cockpit. The password doesn't have to be accepted, it doesn't even
@@ -86,13 +97,24 @@ class TestHostCockpit:
 
             session.browser.switch_to_window(session.browser.window_handles[0])
             session.browser.close_window(session.browser.window_handles[-1])
-
-            epdb.serve(port=8888)
-
             hostname_inside_cockpit = session.host.get_webconsole_content(
                 entity_name=cockpit_host.hostname,
                 rhel_version=cockpit_host.os_version.major,
             )
+
+            # Capture what the session script received
+            result = class_cockpit_sat.execute(
+                'journalctl -u foreman-cockpit --no-pager -n 20 2>&1'
+            )
+            logger.info(f'[cockpit-debug][sat-local-journal] rc={result.status}\n{result.stdout}')
+
+            # Restore original script
+            class_cockpit_sat.execute(
+                'yum reinstall -y rubygem-foreman_remote_execution-cockpit'
+                ' 2>/dev/null;'
+                ' systemctl restart foreman-cockpit 2>/dev/null || true'
+            )
+
             assert cockpit_host.hostname in hostname_inside_cockpit, (
                 f'cockpit page shows hostname {hostname_inside_cockpit} '
                 f'instead of {cockpit_host.hostname}'

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -93,36 +93,16 @@ class TestHostCockpit:
                     rhel_version=cockpit_host.os_version.major,
                 )
             except NoSuchElementException:
-                host = cockpit_host.hostname
-                sat = class_cockpit_sat.hostname
-                # Enable COCKPIT_DEBUG via systemd drop-in and replay
-                class_cockpit_sat.execute(
-                    'mkdir -p /etc/systemd/system/foreman-cockpit.service.d;'
-                    ' printf "[Service]\\nEnvironment=COCKPIT_DEBUG=all\\n"'
-                    ' > /etc/systemd/system/foreman-cockpit.service.d/debug.conf;'
-                    ' systemctl daemon-reload;'
-                    ' systemctl restart foreman-cockpit'
-                )
-                class_cockpit_sat.execute(
-                    f'curl -sk -o /dev/null'
-                    f' https://{sat}/webcon/cockpit+%3D{host}/login'
-                    f' 2>&1 || true'
-                )
-                import time
-
-                time.sleep(3)
+                # Line 304 crashes: undefined method `[]' for nil
                 result = class_cockpit_sat.execute(
-                    'journalctl -u foreman-cockpit --no-pager -n 100 2>&1'
+                    'sed -n "280,330p" /usr/sbin/foreman-cockpit-session 2>&1'
                 )
                 logger.info(
-                    f'[cockpit-debug][sat-cockpit_ws_debug_journal]'
-                    f' rc={result.status}\n{result.stdout}'
+                    f'[cockpit-debug][sat-session_line_304] rc={result.status}\n{result.stdout}'
                 )
-                # Cleanup
-                class_cockpit_sat.execute(
-                    'rm -rf /etc/systemd/system/foreman-cockpit.service.d;'
-                    ' systemctl daemon-reload;'
-                    ' systemctl restart foreman-cockpit'
+                result = class_cockpit_sat.execute('wc -l /usr/sbin/foreman-cockpit-session 2>&1')
+                logger.info(
+                    f'[cockpit-debug][sat-session_line_count] rc={result.status}\n{result.stdout}'
                 )
                 raise
 

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -98,12 +98,17 @@ class TestHostCockpit:
                     'foreman_cockpit_journal': (
                         'journalctl -u foreman-cockpit --no-pager -n 50 2>&1'
                     ),
-                    'foreman_proxy_journal': ('journalctl -u foreman-proxy --no-pager -n 30 2>&1'),
-                    'httpd_error_log': 'tail -30 /var/log/httpd/error_log 2>&1',
-                    'cockpit_proxy_log': ('tail -30 /var/log/httpd/foreman-ssl_error_ssl.log 2>&1'),
+                    'webcon_access_log': (
+                        'grep webcon /var/log/httpd/foreman-ssl_access_ssl.log | tail -20 2>&1'
+                    ),
+                    'ssl_error_log': 'tail -30 /var/log/httpd/foreman-ssl_error_ssl.log 2>&1',
+                    'httpd_journal': 'journalctl -u httpd --no-pager -n 30 2>&1',
                     'sat_curl_cockpit': (
                         f'curl -sk -o /dev/null -w "%{{http_code}}"'
                         f' https://{cockpit_host.hostname}:9090 2>&1'
+                    ),
+                    'foreman_cockpit_recent': (
+                        'journalctl -u foreman-cockpit --no-pager --since "2 minutes ago" 2>&1'
                     ),
                 }
                 for label, cmd in post_fail_cmds.items():


### PR DESCRIPTION
### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Capture cockpit host and Satellite cockpit service status, firewall, crypto policy, and recent logs during the positive cockpit test for troubleshooting.