### PR TITLE
Update the disk size so that it does not include the "GB" suffix.

### DIFF
--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -359,7 +359,7 @@ def test_positive_vmware_custom_profile_end_to_end(
     memory_hot_add = True
     cpu_hot_add = True
     cdrom_drive = True
-    disk_size = '10 GB'
+    disk_size = '10'
     network = 'VLAN 400'  # hardcoding network here as this test won't be doing actual provisioning
     storage_data = {
         'storage': {


### PR DESCRIPTION
As per the new VMware UI, the displayed value no longer includes the `GB` suffix. I've removed the suffix from the test validation to avoid test failures.

## Summary by Sourcery

Tests:
- Adjust VMware custom profile end-to-end test expectations to use raw disk size values without unit suffix.

Dependent PR: https://github.com/SatelliteQE/airgun/pull/2468