### PR TITLE
[6.16.z] OpenVox cherrypicks

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -42,6 +42,9 @@ REPOS:
     RHEL7: replace-with-rhel7-http-link
     RHEL8: replace-with-rhel8-http-link
     RHEL9: replace-with-rhel9-http-link
+  OPENVOX_AGENT_REPO:
+    RHEL8: some-url
+    RHEL9: some-url
   # Downstream Satellite-maintain repo
   SATMAINTENANCE_REPO: replace-with-sat-maintain-repo
   MOCK_SERVICE_REPO_BASE: replace-with-repo-providing-robttelo-mock-service

--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -43,6 +43,7 @@ REPOS:
     RHEL8: replace-with-rhel8-http-link
     RHEL9: replace-with-rhel9-http-link
   OPENVOX_AGENT_REPO:
+    RHEL7: some-url
     RHEL8: some-url
     RHEL9: some-url
   # Downstream Satellite-maintain repo

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -13,6 +13,7 @@ from robottelo import constants
 from robottelo.config import settings
 from robottelo.enums import NetworkType
 from robottelo.hosts import ContentHost
+from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -45,21 +46,32 @@ def module_provisioning_rhel_content(
     rh_repos = []
     tasks = []
     rh_repo_id = ""
-    content_view = sat.api.ContentView(organization=module_sca_manifest_org).create()
 
-    # Custom Content for Client repo
+    # Custom Content for Client repos
     custom_product = sat.api.Product(
         organization=module_sca_manifest_org, name=f'rhel{rhel_ver}_{gen_string("alpha")}'
     ).create()
-    client_repo = sat.api.Repository(
-        organization=module_sca_manifest_org,
-        product=custom_product,
-        content_type='yum',
-        url=settings.repos.SATCLIENT_REPO[f'rhel{rhel_ver}'],
-    ).create()
-    task = client_repo.sync(synchronous=False)
-    tasks.append(task)
-    content_view.repository = [client_repo]
+    client_repos_urls = [settings.repos.SATCLIENT_REPO[f'rhel{rhel_ver}']]
+    if (
+        rhel_ver in (8, 9)  # only RHEL 8 and 9 openvox-agent repositories are available
+        or (
+            rhel_ver == 7 and not is_open('SAT-44580')
+        )  # openvox-agent for EL7 is still not delivered
+    ):
+        client_repos_urls.append(settings.repos.OPENVOX_AGENT_REPO[f'rhel{rhel_ver}'])
+    client_repos = [
+        sat.api.Repository(
+            organization=module_sca_manifest_org,
+            product=custom_product,
+            content_type='yum',
+            url=url,
+        ).create()
+        for url in client_repos_urls
+    ]
+    tasks.extend([repo.sync(synchronous=False) for repo in client_repos])
+
+    content_view = sat.api.ContentView(organization=module_sca_manifest_org).create()
+    content_view.repository = client_repos
 
     for name in repo_names:
         rh_kickstart_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
@@ -89,7 +101,9 @@ def module_provisioning_rhel_content(
                 tasks.append(task)
                 rh_repos.append(rh_repo)
                 content_view.repository.append(rh_repo)
-                content_view.update(['repository'])
+    content_view.update(['repository'])
+
+    # wait for all repo sync tasks to finish
     for task in tasks:
         sat.wait_for_tasks(
             search_query=(f'id = {task["id"]}'),
@@ -97,6 +111,7 @@ def module_provisioning_rhel_content(
         )
         task_status = sat.api.ForemanTask(id=task['id']).poll()
         assert task_status['result'] == 'success'
+
     rhel_xy = Version(
         constants.REPOS['kickstart'][f'rhel{rhel_ver}']['version']
         if rhel_ver <= 7
@@ -109,6 +124,7 @@ def module_provisioning_rhel_content(
     os = o_systems[0].read()
     # return only the first kickstart repo - RHEL X KS or RHEL X BaseOS KS
     ksrepo = rh_repos[0]
+
     publish = content_view.publish()
     task_status = sat.wait_for_tasks(
         search_query=(f'Actions::Katello::ContentView::Publish and id = {publish["id"]}'),
@@ -116,21 +132,21 @@ def module_provisioning_rhel_content(
         max_tries=10,
     )
     assert task_status[0].result == 'success'
-    content_view = sat.api.ContentView(
-        organization=module_sca_manifest_org, name=content_view.name
-    ).search()[0]
+    # create new activation key for provisioning
     ak = sat.api.ActivationKey(
         organization=module_sca_manifest_org,
         content_view=content_view,
         environment=module_lce_library,
     ).create()
+    # enable all custom repos in the activation key
+    product_content = ak.product_content(data={'content_access_mode_all': '1'})['results']
+    content_overrides = [
+        {'content_label': content['label'], 'value': '1'}
+        for content in product_content
+        if content['vendor'] == 'Custom'
+    ]
+    ak.content_override(data={'content_overrides': content_overrides})
 
-    # Ensure client repo is enabled in the activation key
-    content = ak.product_content(data={'content_access_mode_all': '1'})['results']
-    client_repo_label = [repo['label'] for repo in content if repo['name'] == client_repo.name][0]
-    ak.content_override(
-        data={'content_overrides': [{'content_label': client_repo_label, 'value': '1'}]}
-    )
     return Box(os=os, ak=ak, ksrepo=ksrepo, cv=content_view)
 
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -268,21 +268,18 @@ def oracle_host(request, version):
         yield host
 
 
-@pytest.fixture(scope='module', params=[{'rhel_version': 8, 'no_containers': True}])
-def external_puppet_server(request):
-    deploy_args = host_conf(request)
-    deploy_args['target_cores'] = 2
-    deploy_args['target_memory'] = '4GiB'
-    with Broker(**deploy_args, host_class=ContentHost) as host:
+@pytest.fixture(scope='module')
+def external_puppet_server():
+    with Broker(
+        host_class=ContentHost,
+        workflow=settings.server.deploy_workflows.os,
+        deploy_rhel_version=settings.server.version.rhel_version,
+        deploy_network_type=settings.server.network_type,
+    ) as host:
         host.register_to_cdn()
-        # Install puppet packages
-        assert (
-            host.execute(
-                'dnf install -y https://yum.puppet.com/puppet-release-el-8.noarch.rpm'
-            ).status
-            == 0
-        )
-        assert host.execute('dnf install -y puppetserver').status == 0
+        # Enable satellite repositories to install Puppet server
+        host.create_custom_repos(satellite=settings.repos.satellite_repo)
+        assert host.execute('dnf -y install openvox-server').status == 0
         # Source puppet profiles
         host.execute('. /etc/profile.d/puppet-agent.sh')
         # Setup Puppet Server CA

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -978,9 +978,7 @@ class ContentHost(Host, ContentHostMixins):
                 f'Failed to put hostname in ssh known_hosts files:\n{result.stderr}'
             )
 
-    def configure_puppet(
-        self, proxy_hostname=None, run_puppet_agent=True, install_puppet_agent7=False
-    ):
+    def configure_puppet(self, proxy_hostname=None, run_agent=True, use_openvox=True):
         """Configures puppet on the virtual machine/Host.
         :param proxy_hostname: external capsule hostname
         :return: None.
@@ -989,21 +987,21 @@ class ContentHost(Host, ContentHostMixins):
         if proxy_hostname is None:
             proxy_hostname = settings.server.hostname
 
-        if install_puppet_agent7:
+        self.create_custom_repos(
+            sat_client=settings.repos.satclient_repo[f'RHEL{self.os_version.major}']
+        )
+        if use_openvox:
             self.create_custom_repos(
-                sat_client=settings.repos['SATCLIENT_REPO'][f'RHEL{self.os_version.major}']
-            )
-        else:
-            self.create_custom_repos(
-                sat_client=settings.repos['SATCLIENT2_REPO'][f'RHEL{self.os_version.major}']
+                openvox_agent=settings.repos.openvox_agent_repo[f'RHEL{self.os_version.major}']
             )
 
-        result = self.execute('yum install puppet-agent -y')
-        if result.status != 0:
-            raise ContentHostError('Failed to install the puppet-agent rpm')
+        rpm_name = 'openvox-agent' if use_openvox else 'puppet-agent'
+        if self.execute(f'yum -y install {rpm_name}').status != 0:
+            raise ContentHostError('Failed to install the puppet agent rpm')
 
-        rpm_version = self.execute('rpm -q --qf "%{VERSION}" puppet-agent').stdout
-        assert '7' in rpm_version if install_puppet_agent7 else '7' not in rpm_version
+        assert self.execute(f'rpm -q {rpm_name}').status == 0, (
+            'Puppet agent package is not installed'
+        )
 
         cert_name = self.hostname
         puppet_conf = (
@@ -1030,11 +1028,9 @@ class ContentHost(Host, ContentHostMixins):
         proxy_host = Host(hostname=proxy_hostname)
         proxy_host.execute(f'puppetserver ca sign --certname {cert_name}')
 
-        if run_puppet_agent:
-            # This particular puppet run would create the host entity under
-            # 'All Hosts' and let's redirect stderr to /dev/null as errors at
-            #  this stage can be ignored.
-            result = self.execute('/opt/puppetlabs/bin/puppet agent -t 2> /dev/null')
+        if run_agent:
+            # This particular puppet run would create the host entity under 'All Hosts'
+            result = self.execute('/opt/puppetlabs/bin/puppet agent -t')
             if result.status:
                 raise ContentHostError('Failed to configure puppet on the content host')
 

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -96,7 +96,9 @@ def test_positive_puppet_bootstrap(
 
 
 @pytest.mark.on_premises_provisioning
-@pytest.mark.rhel_ver_match(r'^\d+$')
+@pytest.mark.rhel_ver_match(
+    f'[{"" if is_open("SAT-41340") else "7"}89]'  # Skip EL7 for provisioning test as UEFI is not supported yet
+)
 def test_host_provisioning_with_external_puppetserver(
     request,
     external_puppet_server,
@@ -132,9 +134,6 @@ def test_host_provisioning_with_external_puppetserver(
 
     :customerscenario: true
     """
-    if module_provisioning_rhel_content.os.major == '7' and is_open('SAT-44580'):
-        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
-
     puppet_env = 'production'
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -18,6 +18,8 @@ import pytest
 import requests
 from wait_for import wait_for
 
+from robottelo.utils.issue_handlers import is_open
+
 
 @pytest.mark.e2e
 def test_positive_puppet_bootstrap(
@@ -130,6 +132,9 @@ def test_host_provisioning_with_external_puppetserver(
 
     :customerscenario: true
     """
+    if module_provisioning_rhel_content.os.major == '7' and is_open('SAT-44580'):
+        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
+
     puppet_env = 'production'
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat
@@ -166,8 +171,8 @@ def test_host_provisioning_with_external_puppetserver(
     # the result of the installation. Wait until Satellite reports that the host is installed.
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
-        timeout=1500,
-        delay=10,
+        timeout='40m',
+        delay=30,
     )
     host = host.read()
     assert host.build_status_label == 'Installed'
@@ -193,8 +198,8 @@ def test_host_provisioning_with_external_puppetserver(
     assert provisioning_host.subscribed, 'Host is not subscribed'
 
     # Validate external Puppet server deployment with Satellite
-    assert provisioning_host.execute('rpm -q puppet-agent').status == 0, (
-        'Puppet agent package is not installed'
+    assert provisioning_host.execute('rpm -q --whatprovides puppet-agent').status == 0, (
+        'Package providing Puppet agent is not installed'
     )
 
     assert (

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -18,6 +18,7 @@ import pytest
 from wait_for import wait_for
 
 from robottelo.exceptions import CLIReturnCodeError
+from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -51,10 +52,10 @@ def test_positive_CRD_satellite(run_puppet_agent, session_puppet_enabled_sat):
 
 @pytest.mark.e2e
 @pytest.mark.client_release
-@pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.parametrize('client_repo_ver', ['1', '2'], ids=['client1', 'client2'])
+@pytest.mark.rhel_ver_match('[7-9]')
+@pytest.mark.parametrize('agent', ['openvox', 'puppet'])
 def test_positive_install_configure_host(
-    session_puppet_enabled_sat, session_puppet_enabled_capsule, content_hosts, client_repo_ver
+    session_puppet_enabled_sat, session_puppet_enabled_capsule, content_hosts, agent
 ):
     """Test that puppet-agent can be installed from the sat-client repo
     and configured to report back to the Satellite.
@@ -83,10 +84,13 @@ def test_positive_install_configure_host(
 
     :Verifies: SAT-25418
     """
+    if agent == 'openvox' and content_hosts[0].os_version.major == 7 and is_open('SAT-44580'):
+        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
+
     puppet_infra_host = [session_puppet_enabled_sat, session_puppet_enabled_capsule]
     for client, puppet_proxy in zip(content_hosts, puppet_infra_host, strict=True):
         client.configure_puppet(
-            proxy_hostname=puppet_proxy.hostname, install_puppet_agent7=(client_repo_ver == '1')
+            proxy_hostname=puppet_proxy.hostname, use_openvox=(agent == 'openvox')
         )
         report = session_puppet_enabled_sat.cli.ConfigReport.list(
             {'search': f'host~{client.hostname}'}
@@ -104,10 +108,10 @@ def test_positive_install_configure_host(
 
 
 @pytest.mark.e2e
-@pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.parametrize('client_repo_ver', ['1', '2'], ids=['client1', 'client2'])
+@pytest.mark.rhel_ver_match('[7-9]')
+@pytest.mark.parametrize('agent', ['openvox', 'puppet'])
 def test_positive_run_puppet_agent_generate_report_when_no_message(
-    session_puppet_enabled_sat, rhel_contenthost, client_repo_ver
+    session_puppet_enabled_sat, rhel_contenthost, agent
 ):
     """Verify that puppet-agent can be installed from the sat-client repo
     and configured to report back to the Satellite, and contains the origin
@@ -136,12 +140,15 @@ def test_positive_run_puppet_agent_generate_report_when_no_message(
     :BZ: 2192939, 2257327, 2257314
     :parametrized: yes
     """
+    if agent == 'openvox' and rhel_contenthost.os_version.major == 7 and is_open('SAT-44580'):
+        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
+
     sat = session_puppet_enabled_sat
     client = rhel_contenthost
     client.configure_puppet(
         proxy_hostname=sat.hostname,
-        run_puppet_agent=False,
-        install_puppet_agent7=(client_repo_ver == '1'),
+        run_agent=False,
+        use_openvox=(agent == 'openvox'),
     )
     # Run either 'puppet agent --detailed-exitcodes' or 'systemctl restart puppet'
     # to generate Puppet config report for host without any messages

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -18,7 +18,6 @@ import pytest
 from wait_for import wait_for
 
 from robottelo.exceptions import CLIReturnCodeError
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -84,9 +83,6 @@ def test_positive_install_configure_host(
 
     :Verifies: SAT-25418
     """
-    if agent == 'openvox' and content_hosts[0].os_version.major == 7 and is_open('SAT-44580'):
-        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
-
     puppet_infra_host = [session_puppet_enabled_sat, session_puppet_enabled_capsule]
     for client, puppet_proxy in zip(content_hosts, puppet_infra_host, strict=True):
         client.configure_puppet(
@@ -140,9 +136,6 @@ def test_positive_run_puppet_agent_generate_report_when_no_message(
     :BZ: 2192939, 2257327, 2257314
     :parametrized: yes
     """
-    if agent == 'openvox' and rhel_contenthost.os_version.major == 7 and is_open('SAT-44580'):
-        pytest.skip('Skipping as openvox-agent for EL7 is still not delivered')
-
     sat = session_puppet_enabled_sat
     client = rhel_contenthost
     client.configure_puppet(

--- a/tests/foreman/destructive/test_puppetplugin.py
+++ b/tests/foreman/destructive/test_puppetplugin.py
@@ -38,9 +38,12 @@ def assert_puppet_status(server, expected):
     assert ('puppet' in result) is expected
     assert ('puppetca' in result) is expected
 
-    result = server.execute('rpm -q puppetserver')
-    assert (result.status == 0) is expected
-    assert ('package puppetserver is not installed' in result.stdout) is not expected
+    result = server.execute('rpm -q --whatprovides puppetserver')
+    assert (result.status == 0) is expected, (
+        'No package provides puppetserver capability'
+        if expected
+        else 'puppetserver capability is provided when it should not be'
+    )
 
     result = server.execute('systemctl status puppetserver')
     assert ('active (running)' in result.stdout) is expected


### PR DESCRIPTION
Cherrypick of PRs: 
- https://github.com/SatelliteQE/robottelo/pull/21394
- https://github.com/SatelliteQE/robottelo/pull/21453
- https://github.com/SatelliteQE/robottelo/pull/21547
- https://github.com/SatelliteQE/robottelo/pull/21651

### Problem Statement
OpenVox cherrypicks for 6.16.z

### Related Issues
Prt blocked on https://redhat.atlassian.net/browse/SAT-47308


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->