### PR TITLE
Fix rex_pub_key retrieval for containerized Satellite

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1775,7 +1775,21 @@ class Capsule(ContentHost, CapsuleMixins):
 
     @property
     def rex_pub_key(self):
-        return self.execute(f'cat {self.rex_key_path}').stdout.strip()
+        if settings.server.install_method == InstallMethod.FOREMANCTL:
+            if 'remote-execution' in self.list_foremanctl_features(enabled=True):
+                result = self.execute(
+                    f"podman exec foreman-proxy bash -c 'cat {self.rex_key_path}'"
+                )
+            else:
+                raise SatelliteHostError('remote-execution feature is not enabled')
+        else:
+            result = self.execute(f'cat {self.rex_key_path}')
+        key = result.stdout.strip()
+        if not key:
+            raise ValueError(
+                f'Rex public key is empty. Command returned status {result.status}: {result.stderr}'
+            )
+        return key
 
     def is_foremanctl_available(self):
         """Check if foremanctl is installed on the system.


### PR DESCRIPTION
### Problem Statement
Update REX public key retrieval to handle foremanctl foreman-proxy container

### Solution
Use `podman exec foreman-proxy cat /var/lib/foreman-proxy/ssh/id_rsa_foreman_proxy.pub` to retrieve public key contents.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Handle REX public key retrieval correctly for containerized Satellite installations and validate that the retrieved key is not empty.

Bug Fixes:
- Fix REX public key retrieval when Satellite is installed via foremanctl using the foreman-proxy container.

Enhancements:
- Add validation to raise an error if the REX public key retrieval returns an empty key.