### PR TITLE
Fix query db in containerized envs

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2343,7 +2343,7 @@ class Capsule(ContentHost, CapsuleMixins):
                 raise CLIReturnCodeError(result.status, result.stderr, f'"{cmd}" failed')
             return result
 
-        if self.install_method == InstallMethod.FOREMANCTL:
+        if settings.server.install_method == InstallMethod.FOREMANCTL:
             base_cmd = f'podman exec postgresql psql -U {db_user} -d {db}'
         else:
             base_cmd = f'sudo -u postgres psql -d {db}'

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1805,7 +1805,6 @@ class Capsule(ContentHost, CapsuleMixins):
         :return: InstallMethod enum value
         :rtype: InstallMethod
         """
-        from robottelo.enums import InstallMethod
 
         # Runtime override
         if hasattr(self, '_install_method_override'):
@@ -1855,7 +1854,6 @@ class Capsule(ContentHost, CapsuleMixins):
         :rtype: list
         """
         from robottelo.constants import InstallationServices
-        from robottelo.enums import InstallMethod
 
         if self.install_method == InstallMethod.FOREMANCTL:
             return InstallationServices.FOREMANCTL_SERVICES

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2339,13 +2339,18 @@ class Capsule(ContentHost, CapsuleMixins):
             CLIReturnCodeError: If the database query fails
         """
 
+        from robottelo.enums import InstallMethod
+
         def _execute_db_query(cmd):
             result = self.execute(cmd)
             if result.status != 0:
                 raise CLIReturnCodeError(result.status, result.stderr, f'"{cmd}" failed')
             return result
 
-        base_cmd = f'sudo -u postgres psql -d {db}'
+        if self.install_method == InstallMethod.FOREMANCTL:
+            base_cmd = f'podman exec postgresql psql -U foreman -d {db}'
+        else:
+            base_cmd = f'sudo -u postgres psql -d {db}'
 
         if output_format == 'json':
             cmd = f'{base_cmd} -A -t -c "SELECT json_agg(row_to_json(t)) FROM ({query}) t"'

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -54,7 +54,7 @@ from robottelo.constants import (
     RHSSO_USER_UPDATE,
     SATELLITE_VERSION,
 )
-from robottelo.enums import NetworkType
+from robottelo.enums import InstallMethod, NetworkType
 from robottelo.exceptions import (
     CapsuleHostError,
     CLIFactoryError,
@@ -2271,7 +2271,6 @@ class Capsule(ContentHost, CapsuleMixins):
         :param foremanctl_parameters: Parameters list for foremanctl deploy
         :return: Installation result
         """
-        from robottelo.enums import InstallMethod
         from robottelo.utils.installer import InstallerCommand
 
         # Determine method
@@ -2338,8 +2337,6 @@ class Capsule(ContentHost, CapsuleMixins):
         Raises:
             CLIReturnCodeError: If the database query fails
         """
-
-        from robottelo.enums import InstallMethod
 
         def _execute_db_query(cmd):
             result = self.execute(cmd)

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2321,13 +2321,14 @@ class Capsule(ContentHost, CapsuleMixins):
 
         return result
 
-    def query_db(self, query, db='foreman', output_format='json'):
+    def query_db(self, query, db='foreman', output_format='json', db_user='foreman'):
         """Execute a PostgreSQL query and return the result.
 
         Args:
             query: SQL query to execute
             db: Database name (default: 'foreman')
             output_format: Output format - 'json' for JSON array, raw output otherwise
+            db_user: Database user (default: 'foreman')
 
         Returns:
             list of dicts if output_format='json', str otherwise
@@ -2343,7 +2344,7 @@ class Capsule(ContentHost, CapsuleMixins):
             return result
 
         if self.install_method == InstallMethod.FOREMANCTL:
-            base_cmd = f'podman exec postgresql psql -U foreman -d {db}'
+            base_cmd = f'podman exec postgresql psql -U {db_user} -d {db}'
         else:
             base_cmd = f'sudo -u postgres psql -d {db}'
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -2723,11 +2723,12 @@ def test_repository_rpms_id_type(target_sat):
 
     :CaseImportance: Medium
     """
-    db_out = target_sat.execute(
-        'sudo -u postgres psql -d foreman -c "select * from pg_sequences where sequencename=\'katello_repository_rpms_id_seq\';"'
+    db_out = target_sat.query_db(
+        "select * from pg_sequences where sequencename='katello_repository_rpms_id_seq'",
+        output_format='raw',
     )
-    assert 'bigint' in db_out.stdout
-    assert 'integer' not in db_out.stdout
+    assert 'bigint' in db_out
+    assert 'integer' not in db_out
 
 
 def test_negative_readonly_user_actions(

--- a/tests/foreman/api/test_notifications.py
+++ b/tests/foreman/api/test_notifications.py
@@ -233,15 +233,15 @@ def long_running_task(target_sat):
         },
     )
     sql_date_2_days_ago = "now() - INTERVAL '2 days'"
-    result = target_sat.execute(
-        "su - postgres -c \"psql foreman postgres <<EOF\n"
+    query = (
         "UPDATE foreman_tasks_tasks "
         f"SET start_at = {sql_date_2_days_ago}, "
-        f" started_at = {sql_date_2_days_ago}, "
-        f" state_updated_at = {sql_date_2_days_ago} "
-        f"WHERE id=\'{job['task']['id']}\';\nEOF\n\" "
-    )  # fmt: skip  # skip formatting to avoid breaking the SQL query
-    assert 'UPDATE 1' in result.stdout, f'Failed to age task {job["task"]["id"]}: {result.stderr}'
+        f"started_at = {sql_date_2_days_ago}, "
+        f"state_updated_at = {sql_date_2_days_ago} "
+        f"WHERE id='{job['task']['id']}'"
+    )
+    result = target_sat.query_db(query, output_format='raw')
+    assert 'UPDATE 1' in result, f'Failed to age task {job["task"]["id"]}'
 
     yield job
 

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1377,13 +1377,14 @@ class TestRepositorySync:
             releasever=None,
         )
         target_sat.api.Repository(id=repo_id).sync()
-        prod_log_out = target_sat.execute(
-            'sudo -u postgres psql -d foreman -c "select class,execution_plan_uuid,input '
-            'from dynflow_actions where input LIKE \'%"contents_changed":null%\''
-            ' AND class = \'Actions::Katello::Repository::Sync\';"'
+        assert(
+            target_sat.query_db(
+                "select class,execution_plan_uuid,input "
+                "from dynflow_actions where input LIKE '%\"contents_changed\":null%'"
+                " AND class = 'Actions::Katello::Repository::Sync'"
+            )
+            == []
         )
-        assert prod_log_out.status == 0
-        assert "(0 rows)" in prod_log_out.stdout
 
     def test_positive_validate_async_operation_response(self, module_sca_manifest_org, target_sat):
         """Verify that RefreshDistribution action properly tracks Pulp tasks via AsyncOperationResponse.

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1377,7 +1377,7 @@ class TestRepositorySync:
             releasever=None,
         )
         target_sat.api.Repository(id=repo_id).sync()
-        assert(
+        assert (
             target_sat.query_db(
                 "select class,execution_plan_uuid,input "
                 "from dynflow_actions where input LIKE '%\"contents_changed\":null%'"

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -619,16 +619,8 @@ class TestOpenScap:
             pytest.fail("failed to list policies")
         assert name in [policy['name'] for policy in result]
         # check for orphaned entries
-        db_out = module_target_sat.execute(
-            'sudo -u postgres psql -d foreman -c "select * from foreman_openscap_assets"'
-        )
-        assert db_out.status == 0
-        assert "(0 rows)" in db_out.stdout
-        db_out = module_target_sat.execute(
-            'sudo -u postgres psql -d foreman -c "select * from foreman_openscap_asset_policies"'
-        )
-        assert db_out.status == 0
-        assert "(0 rows)" in db_out.stdout
+        assert module_target_sat.query_db('select * from foreman_openscap_assets') == []
+        assert module_target_sat.query_db('select * from foreman_openscap_asset_policies') == []
 
     def test_positive_associate_scap_policy_with_hostgroup_via_ansible(
         self, scap_content, module_target_sat

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -679,17 +679,14 @@ def test_positive_health_check_corrupted_roles(sat_maintain, request):
         options={'role': role_name, 'permissions': ['view_hosts', 'console_hosts']}
     )
     sat_maintain.query_db(
-        f"UPDATE permissions SET resource_type = '{resource_type}' "
-        f"WHERE name = 'console_hosts'",
+        f"UPDATE permissions SET resource_type = '{resource_type}' WHERE name = 'console_hosts'",
         output_format='raw',
     )
     result = sat_maintain.cli.Filter.list(options={'search': role_name}, output_format='yaml')
     # Shows the filter id which comprises of role id hence asserting 2 here
     assert result.count('Id') == 2
     # Run corrupted-roles check.
-    result = sat_maintain.cli.Health.check(
-        options={'label': 'corrupted-roles', 'assumeyes': True}
-    )
+    result = sat_maintain.cli.Health.check(options={'label': 'corrupted-roles', 'assumeyes': True})
     assert result.status == 0
     assert 'FAIL' in result.stdout
     # Verify corrupted roles are fixed and new filter is created for updated resource_type.

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -642,7 +642,6 @@ def test_positive_remove_job_file(sat_maintain):
     assert sat_maintain.execute("ls -l /var/lib/pulp/job1.0.0").status != 0
 
 
-@pytest.mark.foreman_installer
 def test_positive_health_check_corrupted_roles(sat_maintain, request):
     """Verify corrupted-roles check.
 
@@ -735,7 +734,6 @@ def test_positive_health_check_non_rh_packages(sat_maintain, request):
     assert 'WARNING' in result.stdout
 
 
-@pytest.mark.foreman_installer
 def test_positive_health_check_duplicate_permissions(sat_maintain):
     """Verify duplicate-permissions check
 

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -642,6 +642,7 @@ def test_positive_remove_job_file(sat_maintain):
     assert sat_maintain.execute("ls -l /var/lib/pulp/job1.0.0").status != 0
 
 
+@pytest.mark.foreman_installer
 def test_positive_health_check_corrupted_roles(sat_maintain, request):
     """Verify corrupted-roles check.
 
@@ -667,10 +668,9 @@ def test_positive_health_check_corrupted_roles(sat_maintain, request):
 
     @request.addfinalizer
     def _finalize():
-        resource_type = r"'\''Host'\''"
-        sat_maintain.execute(
-            f'''sudo su - postgres -c "psql -d foreman -c 'UPDATE permissions SET
-                        resource_type = {resource_type} WHERE name = {permission_name};'"'''
+        sat_maintain.query_db(
+            "UPDATE permissions SET resource_type = 'Host' WHERE name = 'console_hosts'",
+            output_format='raw',
         )
         sat_maintain.cli.Role.delete(options={'name': role_name})
 
@@ -678,18 +678,18 @@ def test_positive_health_check_corrupted_roles(sat_maintain, request):
     sat_maintain.cli.Filter.create(
         options={'role': role_name, 'permissions': ['view_hosts', 'console_hosts']}
     )
-    permission_name = r"'\''console_hosts'\''"
-    resource_type = rf"'\''{resource_type}'\''"
-    setup = sat_maintain.execute(
-        f'''sudo su - postgres -c "psql -d foreman -c 'UPDATE permissions SET
-            resource_type = {resource_type} WHERE name = {permission_name};'"'''
+    sat_maintain.query_db(
+        f"UPDATE permissions SET resource_type = '{resource_type}' "
+        f"WHERE name = 'console_hosts'",
+        output_format='raw',
     )
-    assert setup.status == 0
     result = sat_maintain.cli.Filter.list(options={'search': role_name}, output_format='yaml')
     # Shows the filter id which comprises of role id hence asserting 2 here
     assert result.count('Id') == 2
     # Run corrupted-roles check.
-    result = sat_maintain.cli.Health.check(options={'label': 'corrupted-roles', 'assumeyes': True})
+    result = sat_maintain.cli.Health.check(
+        options={'label': 'corrupted-roles', 'assumeyes': True}
+    )
     assert result.status == 0
     assert 'FAIL' in result.stdout
     # Verify corrupted roles are fixed and new filter is created for updated resource_type.
@@ -738,6 +738,7 @@ def test_positive_health_check_non_rh_packages(sat_maintain, request):
     assert 'WARNING' in result.stdout
 
 
+@pytest.mark.foreman_installer
 def test_positive_health_check_duplicate_permissions(sat_maintain):
     """Verify duplicate-permissions check
 
@@ -758,13 +759,11 @@ def test_positive_health_check_duplicate_permissions(sat_maintain):
     :BZ: 1849110, 1884024
     """
     # Verify if check failed because of duplicate permissions
-    name = r"'\''view_ansible_variables'\''"
-    resource_type = r"'\''AnsibleVariable'\''"
-    result = sat_maintain.execute(
-        f'''sudo su - postgres -c "psql -d foreman -c 'INSERT INTO permissions(name, resource_type)
-            VALUES({name}, {resource_type});'"'''
+    sat_maintain.query_db(
+        "INSERT INTO permissions(name, resource_type) "
+        "VALUES('view_ansible_variables', 'AnsibleVariable')",
+        output_format='raw',
     )
-    assert result.status == 0
     result = sat_maintain.cli.Health.check({'label': 'duplicate-permissions', 'assumeyes': True})
     assert result.status == 0
     assert 'FAIL' in result.stdout

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -4531,19 +4531,19 @@ def test_positive_search_by_report_origin_shows_all_hosts(target_sat):
     timestamp = '2025-05-16 16:16:16'
     report_count = 25
 
-    target_sat.execute(
-        'su - postgres -c "psql -d foreman -c \\"'
+    target_sat.query_db(
         f"INSERT INTO reports (host_id, origin, reported_at) "
-        f"SELECT {host1.id}, 'Puppet', '{timestamp}'::timestamp + (i || ' seconds')::interval "
-        f"FROM generate_series(1, {report_count}) AS i"
-        '\\""'
+        f"SELECT {host1.id}, 'Puppet', '{timestamp}'::timestamp "
+        f"+ (i || ' seconds')::interval "
+        f"FROM generate_series(1, {report_count}) AS i",
+        output_format='raw',
     )
-    target_sat.execute(
-        'su - postgres -c "psql -d foreman -c \\"'
+    target_sat.query_db(
         f"INSERT INTO reports (host_id, origin, reported_at) "
-        f"SELECT {host2.id}, 'Puppet', '{timestamp}'::timestamp + (i || ' seconds')::interval "
-        f"FROM generate_series(1, 2) AS i"
-        '\\""'
+        f"SELECT {host2.id}, 'Puppet', '{timestamp}'::timestamp "
+        f"+ (i || ' seconds')::interval "
+        f"FROM generate_series(1, 2) AS i",
+        output_format='raw',
     )
 
     with target_sat.ui_session() as session:


### PR DESCRIPTION
### Problem Statement
fix the `query_db` function to support, containerized Satellite env where psql runs in separate container.

[SAT-47278](https://redhat.atlassian.net/browse/SAT-47278)


### Solution
Update `_execute_db_query` function to check install method. This will change the base cmd that is ran when running sql queries.

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_contentview.py::test_repository_rpms_id_type tests/foreman/api/test_notifications.py::test_positive_notification_for_long_running_tasks tests/foreman/api/test_repository.py::TestRepositorySync::test_positive_sync_repo_null_contents_changed tests/foreman/cli/test_oscap.py::TestOpenScap::test_positive_associate_scap_policy_with_hostgroups tests/foreman/maintain/test_health.py::test_positive_health_check_corrupted_roles tests/foreman/maintain/test_health.py::test_positive_health_check_duplicate_permissions tests/foreman/ui/test_host.py::test_positive_search_by_report_origin_shows_all_hosts
```

## Summary by Sourcery

Update database query helper to support different Satellite installation methods and refactor tests to use it consistently instead of ad‑hoc psql shell commands.

Bug Fixes:
- Fix database querying in containerized Satellite environments by selecting the appropriate psql invocation based on install method.

Enhancements:
- Extend query_db to choose the correct base psql command for foremanctl-based and traditional installations.
- Adjust tests to rely on query_db return values rather than shell command status/stdout parsing where appropriate.

Tests:
- Refactor multiple API, CLI, UI, and maintain health-check tests to use the shared query_db helper for database setup and verification.
- Mark selected health-check tests with the foreman_installer marker to scope them to relevant environments.