### PR TITLE
Add error handling for container image properties

### DIFF
--- a/pytest_fixtures/core/reporting.py
+++ b/pytest_fixtures/core/reporting.py
@@ -6,6 +6,7 @@ from xdist import get_xdist_worker_id
 
 from robottelo.config import setting_is_set, settings
 from robottelo.hosts import get_sat_rhel_version
+from robottelo.logging import logger
 from robottelo.utils.ohsnap import container_image_properties
 
 FMT_XUNIT_TIME = '%Y-%m-%dT%H:%M:%S'
@@ -51,13 +52,16 @@ def pytest_sessionstart(session):
             xml.add_global_property("SatelliteVersion", sat_version)
             xml.add_global_property("SnapVersion", snap_version)
             xml.add_global_property("BaseOS", rhel_version)
-            if settings.server.deploy_arguments.deploy_container:
-                for name, value in container_image_properties(
-                    settings.ohsnap,
-                    sat_version,
-                    snap_version,
-                ):
-                    xml.add_global_property(name, value)
+            try:
+                if settings.server.deploy_arguments.get('deploy_container'):
+                    for name, value in container_image_properties(
+                        settings.ohsnap,
+                        sat_version,
+                        snap_version,
+                    ):
+                        xml.add_global_property(name, value)
+            except Exception:
+                logger.warning('Failed to fetch container image properties for JUnit XML')
 
 
 @pytest.fixture(autouse=False, scope='session')


### PR DESCRIPTION
Refactor container image properties retrieval with error handling.

### Problem Statement
We're seeing a new issue in CI affecting many CI pipelines. Here is the failure analysis from claude opus.
  1. The line doesn't use .get() like the safer code in marker_deselection.py does. It accesses settings.server.deploy_arguments.deploy_container directly.
  2. The validator defaults (default={} and default=False) only apply when Dynaconf validation runs successfully. If the CI environment has ignore_validation_errors set (line 41 of
  config/__init__.py), validation failures are just logged as warnings — meaning those defaults may never get applied. In that case, deploy_arguments.deploy_container could raise a
  BoxKeyError.
  3. pytest_sessionstart runs before collection, so a crash there would prevent all subsequent output — but the "Processing test items" log line is from metadata_markers.py during collection.
  However, pytest_sessionstart only runs its dangerous code block when get_xdist_worker_id(session) == 'master' AND junitxml is enabled. In CI, both conditions are true. On runs where
  junitxml isn't configured, this code is skipped and everything works fine.
  4. If the BoxKeyError crashes pytest_sessionstart, pytest may abort the session before collection hooks ever run, producing no traceback if the session error handling doesn't catch it
  cleanly. The "Processing test items" line you see could be from the xdist master's log output being interleaved with a worker that got further before the master died.
  5. The alternative suspect — container_image_properties() at lines 55-60 — could cause a hang rather than a crash if the Ohsnap API is unreachable and ohsnap.request_retry.timeout is large.
  This would explain "no error, no traceback" — the process is still alive but blocked on an HTTP request.

### Solution
add the .get to account for missing config values and wrap the whole thing in a try/except to catch other errors, including ohsnap issues.

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
```

## Summary by Sourcery

Add robust handling around container image properties when populating JUnit XML global properties during pytest session startup.

Bug Fixes:
- Prevent crashes when deploy_container configuration is missing or misconfigured by safely accessing the setting and guarding its use.
- Avoid test runs failing due to unexpected errors while fetching container image properties by wrapping the call in a catch-all handler that logs a warning instead.