### PR TITLE
[Rocket] Skip non-supported component tests for containerized test executions

### DIFF
--- a/tests/foreman/api/test_computeprofile.py
+++ b/tests/foreman/api/test_computeprofile.py
@@ -21,6 +21,8 @@ from robottelo.utils.datafactory import (
     valid_data_list,
 )
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 def test_positive_create_with_name(name, target_sat):

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -25,6 +25,8 @@ from robottelo.constants import (
     AZURERM_PREMIUM_OS_Disk,
 )
 
+pytestmark = pytest.mark.foreman_installer
+
 
 class TestAzureRMComputeResourceTestCase:
     """Tests for ``api/v2/compute_resources``"""

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -24,6 +24,8 @@ from robottelo.config import settings
 from robottelo.constants import GCE_RHEL_CLOUD_PROJECTS, VALID_GCE_ZONES
 from robottelo.utils.issue_handlers import is_open
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.skip_if_not_set('gce')
 class TestGCEComputeResourceTestCases:

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -30,7 +30,7 @@ from robottelo.utils.datafactory import (
     valid_data_list,
 )
 
-pytestmark = [pytest.mark.skip_if_not_set('libvirt')]
+pytestmark = [pytest.mark.skip_if_not_set('libvirt'), pytest.mark.foreman_installer]
 
 
 @pytest.mark.e2e

--- a/tests/foreman/api/test_computeresource_ocpv.py
+++ b/tests/foreman/api/test_computeresource_ocpv.py
@@ -24,7 +24,7 @@ from robottelo.utils.datafactory import (
     valid_data_list,
 )
 
-pytestmark = [pytest.mark.skip_if_not_set('ocpv')]
+pytestmark = [pytest.mark.skip_if_not_set('ocpv'), pytest.mark.foreman_installer]
 
 
 @pytest.mark.e2e

--- a/tests/foreman/api/test_computeresource_vmware.py
+++ b/tests/foreman/api/test_computeresource_vmware.py
@@ -19,6 +19,8 @@ from wrapanapi.systems.virtualcenter import VMWareVirtualMachine
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.e2e
 @pytest.mark.on_premises_provisioning

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -20,6 +20,8 @@ from wait_for import TimedOutError, wait_for
 from robottelo.logging import logger
 from robottelo.utils.datafactory import valid_data_list
 
+pytestmark = pytest.mark.foreman_installer
+
 
 class HostNotDiscoveredException(Exception):
     """Raised when host is not discovered"""

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -18,6 +18,8 @@ from requests.exceptions import HTTPError
 
 from robottelo.utils.datafactory import valid_data_list
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.fixture(scope='module')
 def module_hostgroup(module_org, module_target_sat):

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -24,6 +24,8 @@ from robottelo.enums import NetworkType
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.e2e
 @pytest.mark.upgrade

--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -25,6 +25,8 @@ from requests.exceptions import HTTPError
 from robottelo.config import settings, user_nailgun_config
 from robottelo.utils.datafactory import invalid_names_list, valid_data_list
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.fixture(scope='module')
 def module_user(module_target_sat, module_org, module_location):

--- a/tests/foreman/api/test_template_combination.py
+++ b/tests/foreman/api/test_template_combination.py
@@ -13,6 +13,8 @@
 import pytest
 from requests.exceptions import HTTPError
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.upgrade
 def test_positive_end_to_end_template_combination(request, module_target_sat, module_hostgroup):

--- a/tests/foreman/cli/test_bootdisk.py
+++ b/tests/foreman/cli/test_bootdisk.py
@@ -18,6 +18,8 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import HTTPS_MEDIUM_URL, SUBNET_IPAM_TYPES
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.upgrade
 @pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -25,6 +25,8 @@ from robottelo.constants import (
     AZURERM_PREMIUM_OS_Disk,
 )
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.fixture(scope='class')
 def azurerm_hostgroup(

--- a/tests/foreman/cli/test_computeresource_ec2.py
+++ b/tests/foreman/cli/test_computeresource_ec2.py
@@ -15,6 +15,8 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import EC2_REGION_CA_CENTRAL_1, FOREMAN_PROVIDERS
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.fixture(scope='module')
 def aws(module_target_sat):

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -41,6 +41,8 @@ from robottelo.exceptions import CLIReturnCodeError
 from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import parametrized
 
+pytestmark = pytest.mark.foreman_installer
+
 
 def valid_name_desc_data():
     """Random data for valid name and description"""

--- a/tests/foreman/cli/test_computeresource_ocpv.py
+++ b/tests/foreman/cli/test_computeresource_ocpv.py
@@ -23,7 +23,7 @@ from robottelo.exceptions import CLIReturnCodeError
 from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import parametrized
 
-pytestmark = [pytest.mark.skip_if_not_set('ocpv')]
+pytestmark = [pytest.mark.skip_if_not_set('ocpv'), pytest.mark.foreman_installer]
 
 
 def valid_name_desc_data():

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -18,6 +18,8 @@ import pytest
 from robottelo.config import settings
 from robottelo.exceptions import CLIReturnCodeError
 
+pytestmark = pytest.mark.foreman_installer
+
 OSP_SETTINGS = Box(
     username=settings.osp.username,
     password=settings.osp.password,

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -19,6 +19,8 @@ from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.hosts import ContentHost
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.e2e
 @pytest.mark.upgrade

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -15,7 +15,7 @@ from wait_for import wait_for
 
 from robottelo.utils.issue_handlers import is_open
 
-pytestmark = [pytest.mark.run_in_one_thread]
+pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.foreman_installer]
 
 
 @pytest.mark.e2e

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -29,6 +29,8 @@ from robottelo.utils.datafactory import (
     valid_data_list,
 )
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @filtered_datapoint
 def invalid_hostnames_list():

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-pytestmark = [pytest.mark.stubbed]
+pytestmark = [pytest.mark.stubbed, pytest.mark.foreman_installer]
 
 
 # Notes for installer testing:

--- a/tests/foreman/cli/test_provisioning.py
+++ b/tests/foreman/cli/test_provisioning.py
@@ -14,6 +14,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.stubbed
 @pytest.mark.on_premises_provisioning

--- a/tests/foreman/cli/test_provisioningtemplate.py
+++ b/tests/foreman/cli/test_provisioningtemplate.py
@@ -21,6 +21,8 @@ import pytest
 from robottelo import constants
 from robottelo.exceptions import CLIReturnCodeError
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.fixture(scope='module')
 def module_os_with_minor(module_target_sat):

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -19,7 +19,7 @@ from robottelo.config import settings
 from robottelo.hosts import Satellite, get_sat_rhel_version
 
 SSH_PASS = settings.server.ssh_password
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.foreman_installer]
 
 
 @pytest.mark.pit_server

--- a/tests/foreman/destructive/test_discoveredhost.py
+++ b/tests/foreman/destructive/test_discoveredhost.py
@@ -19,7 +19,7 @@ from wait_for import TimedOutError, wait_for
 from robottelo.config import admin_nailgun_config
 from robottelo.logging import logger
 
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.foreman_installer]
 
 
 def _read_log(ch, pattern):

--- a/tests/foreman/destructive/test_fm_health.py
+++ b/tests/foreman/destructive/test_fm_health.py
@@ -16,6 +16,8 @@ import pytest
 
 from robottelo.config import settings
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.satellite_iop_only
 def test_podman_login_check(request, sat_maintain):

--- a/tests/foreman/destructive/test_fm_upgrade.py
+++ b/tests/foreman/destructive/test_fm_upgrade.py
@@ -17,7 +17,7 @@ import pytest
 from robottelo.config import settings
 from robottelo.enums import NetworkType
 
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.foreman_installer]
 
 
 @pytest.mark.skipif(

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -19,7 +19,7 @@ from robottelo.config import settings
 from robottelo.enums import NetworkType
 from robottelo.utils.installer import InstallerCommand
 
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.foreman_installer]
 
 infoblox_package = 'rubygem-infoblox'
 infoblox_dhcp_package = 'rubygem-smart_proxy_dhcp_infoblox'

--- a/tests/foreman/destructive/test_installer.py
+++ b/tests/foreman/destructive/test_installer.py
@@ -232,6 +232,7 @@ def test_negative_handle_invalid_certificate(cert_setup_destructive_teardown):
     assert result.status == 0, f'Hammer Ping failed:\n{result.stderr}'
 
 
+@pytest.mark.foreman_installer
 def test_negative_installer_invalid_dns_forwarder(target_sat):
     """Satellite installer should not do any impact if any invalid values are set for DNS forwarder
 

--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -16,7 +16,7 @@ import re
 
 import pytest
 
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.foreman_installer]
 
 
 def test_positive_update_katello_certs(cert_setup_destructive_teardown):

--- a/tests/foreman/destructive/test_packages.py
+++ b/tests/foreman/destructive/test_packages.py
@@ -18,7 +18,7 @@ import pytest
 
 from robottelo.hosts import Satellite
 
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.foreman_installer]
 
 
 @pytest.mark.include_capsule

--- a/tests/foreman/destructive/test_rename.py
+++ b/tests/foreman/destructive/test_rename.py
@@ -21,13 +21,15 @@ from robottelo.cli import hammer
 from robottelo.config import settings
 from robottelo.constants import SATELLITE_ANSWER_FILE
 
+pytestmark = [pytest.mark.destructive, pytest.mark.foreman_installer]
+
+
 BCK_MSG = "**** Hostname change complete! ****"
 BAD_HN_MSG = (
     "{0} is not a valid fully qualified domain name. Please use a valid FQDN and try again."
 )
 NO_CREDS_MSG = "Username and/or Password options are missing!"
 BAD_CREDS_MSG = "Unable to authenticate user admin"
-pytestmark = pytest.mark.destructive
 
 
 @pytest.mark.e2e

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -14,6 +14,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.stubbed
 @pytest.mark.upgrade

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -627,6 +627,7 @@ def test_positive_check_installer_hammer_ping(target_sat):
             assert 'ok' in line
 
 
+@pytest.mark.foreman_installer
 def test_installer_cap_pub_directory_accessibility(capsule_configured):
     """Verify the public directory accessibility from capsule url after disabling it from the
     custom-hiera
@@ -682,6 +683,7 @@ def test_installer_cap_pub_directory_accessibility(capsule_configured):
     assert 'Success!' in command_output.stdout
 
 
+@pytest.mark.foreman_installer
 def test_installer_capsule_with_enabled_ansible(module_capsule_configured_ansible):
     """Enables Ansible feature on external Capsule and checks the callback is set correctly
 
@@ -793,7 +795,7 @@ def test_weak_dependency(sat_non_default_install, package):
 @pytest.mark.parametrize(
     'satellite_with_install_method',
     [
-        pytest.param('installer', id='installer-method'),
+        pytest.param('installer', marks=pytest.mark.foreman_installer, id='installer-method'),
         pytest.param('foremanctl', marks=pytest.mark.foremanctl, id='foremanctl-method'),
     ],
     indirect=True,

--- a/tests/foreman/maintain/test_advanced.py
+++ b/tests/foreman/maintain/test_advanced.py
@@ -19,6 +19,9 @@ from robottelo.config import robottelo_tmp_dir, settings
 from robottelo.constants import MAINTAIN_HAMMER_YML
 from robottelo.hosts import get_sat_rhel_version, get_sat_version
 
+pytestmark = pytest.mark.foreman_installer
+
+
 sat_x_y_release = f'{get_sat_version().major}.{get_sat_version().minor}'
 
 

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -29,7 +29,7 @@ from robottelo.constants import (
 from robottelo.content_info import get_repo_files_by_url
 from robottelo.hosts import Satellite
 
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.foreman_installer]
 
 
 BACKUP_DIR = '/tmp/'

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -20,6 +20,8 @@ from robottelo.config import settings
 from robottelo.enums import NetworkType
 from robottelo.utils.installer import InstallerCommand
 
+pytestmark = pytest.mark.foreman_installer
+
 upstream_url = {
     'foreman_repo': 'https://yum.theforeman.org/releases/nightly/el9/x86_64/',
     'puppet_repo': 'https://yum.puppetlabs.com/puppet/el/9/x86_64/',

--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -17,6 +17,8 @@ import yaml
 
 from robottelo.config import robottelo_tmp_dir
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.include_satellite_iop
 @pytest.mark.e2e

--- a/tests/foreman/maintain/test_offload_DB.py
+++ b/tests/foreman/maintain/test_offload_DB.py
@@ -16,6 +16,8 @@ import pytest
 
 from robottelo.config import settings
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.stubbed
 @pytest.mark.skipif((not settings.remotedb.server), reason='Intended only for RemoteDB setup')

--- a/tests/foreman/maintain/test_packages.py
+++ b/tests/foreman/maintain/test_packages.py
@@ -17,7 +17,7 @@ import pytest
 from robottelo.config import settings
 from robottelo.utils.installer import InstallerCommand
 
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.foreman_installer]
 
 
 @pytest.mark.include_capsule

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -24,6 +24,9 @@ from robottelo.constants import (
 )
 from robottelo.hosts import Satellite
 
+pytestmark = pytest.mark.foreman_installer
+
+
 IOP_SERVICES = [
     'iop-core-engine.service',
     'iop-core-gateway.service',

--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -17,6 +17,8 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import SATELLITE_INSTALLER_CONFIG
 
+pytestmark = pytest.mark.foreman_installer
+
 
 def last_y_stream_version(release):
     """Returns the version of the last Y stream

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -32,6 +32,8 @@ from robottelo.hosts import (
 )
 from robottelo.utils.installer import InstallerCommand
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.fixture
 def sync_roles(target_sat):

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -19,6 +19,8 @@ import pytest
 from robottelo.config import settings
 from robottelo.utils.installer import InstallerCommand
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.e2e
 def test_positive_install_sat_with_katello_certs(certs_data, sat_ready_rhel):

--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -15,6 +15,8 @@
 from fauxfactory import gen_string
 import pytest
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.e2e
 @pytest.mark.upgrade

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -24,7 +24,7 @@ from robottelo.constants import (
     COMPUTE_PROFILE_SMALL,
 )
 
-pytestmark = [pytest.mark.skip_if_not_set('azurerm')]
+pytestmark = [pytest.mark.skip_if_not_set('azurerm'), pytest.mark.foreman_installer]
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -23,7 +23,7 @@ from robottelo.constants import (
     FOREMAN_PROVIDERS,
 )
 
-pytestmark = [pytest.mark.skip_if_not_set('ec2')]
+pytestmark = [pytest.mark.skip_if_not_set('ec2'), pytest.mark.foreman_installer]
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -28,6 +28,8 @@ from robottelo.constants import (
     GCE_NETWORK_DEFAULT,
 )
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.mark.e2e
 @pytest.mark.upgrade

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -26,7 +26,7 @@ from robottelo.constants import (
 from robottelo.hosts import ContentHost
 from robottelo.utils.issue_handlers import is_open
 
-pytestmark = [pytest.mark.skip_if_not_set('libvirt')]
+pytestmark = [pytest.mark.skip_if_not_set('libvirt'), pytest.mark.foreman_installer]
 
 
 @pytest.mark.e2e

--- a/tests/foreman/ui/test_computeresource_ocpv.py
+++ b/tests/foreman/ui/test_computeresource_ocpv.py
@@ -17,7 +17,7 @@ from wait_for import wait_for
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 
-pytestmark = [pytest.mark.skip_if_not_set('ocpv')]
+pytestmark = [pytest.mark.skip_if_not_set('ocpv'), pytest.mark.foreman_installer]
 
 
 @pytest.mark.e2e

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -31,7 +31,7 @@ from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import gen_string
 from robottelo.utils.issue_handlers import is_open
 
-pytestmark = [pytest.mark.skip_if_not_set('vmware')]
+pytestmark = [pytest.mark.skip_if_not_set('vmware'), pytest.mark.foreman_installer]
 
 
 def _round_to_2_significant_digits(x):

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -19,7 +19,7 @@ from robottelo.hosts import ContentHost
 from robottelo.utils import ssh
 from robottelo.utils.issue_handlers import is_open
 
-pytestmark = [pytest.mark.run_in_one_thread]
+pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.foreman_installer]
 
 
 @pytest.fixture

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -18,6 +18,8 @@ import pytest
 from robottelo.config import settings
 from robottelo.enums import NetworkType
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.fixture
 def module_discovery_env(module_org, module_location, module_target_sat):

--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -17,6 +17,8 @@ import pytest
 from robottelo.constants import DataFile
 from robottelo.utils.datafactory import gen_string
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.fixture(scope='module')
 def template_data():

--- a/tests/new_upgrades/test_computeresource_gce.py
+++ b/tests/new_upgrades/test_computeresource_gce.py
@@ -27,6 +27,8 @@ from robottelo.constants import (
 )
 from robottelo.utils.shared_resource import SharedResource
 
+pytestmark = pytest.mark.foreman_installer
+
 """The host can be provisioned on GCE CR created in previous version
 
     :steps:

--- a/tests/new_upgrades/test_discovery.py
+++ b/tests/new_upgrades/test_discovery.py
@@ -20,6 +20,8 @@ import pytest
 
 from robottelo.utils.shared_resource import SharedResource
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.fixture
 def fdi_upgrade_setup(fdi_upgrade_shared_satellite, upgrade_action):

--- a/tests/new_upgrades/test_performance_tuning.py
+++ b/tests/new_upgrades/test_performance_tuning.py
@@ -20,6 +20,8 @@ from robottelo.logging import logger
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.shared_resource import SharedResource
 
+pytestmark = pytest.mark.foreman_installer
+
 
 @pytest.fixture
 def perf_tuning_upgrade_setup(perf_tuning_upgrade_shared_satellite, upgrade_action):

--- a/tests/new_upgrades/test_provisioningtemplate.py
+++ b/tests/new_upgrades/test_provisioningtemplate.py
@@ -24,6 +24,8 @@ from robottelo.constants import (
 )
 from robottelo.utils.shared_resource import SharedResource
 
+pytestmark = pytest.mark.foreman_installer
+
 provisioning_template_kinds = ['provision', 'PXEGrub2', 'PXELinux', 'iPXE']
 
 PXE_LOADER_MAP = {

--- a/tests/upgrades/test_computeresource_gce.py
+++ b/tests/upgrades/test_computeresource_gce.py
@@ -15,6 +15,8 @@
 from fauxfactory import gen_string
 import pytest
 
+pytestmark = pytest.mark.foreman_installer
+
 
 class TestScenarioPositiveGCEHostComputeResource:
     """The host can be provisioned on GCE CR created in previous version

--- a/tests/upgrades/test_discovery.py
+++ b/tests/upgrades/test_discovery.py
@@ -17,6 +17,8 @@ import re
 from packaging.version import Version
 import pytest
 
+pytestmark = pytest.mark.foreman_installer
+
 
 class TestDiscoveryImage:
     """Pre-upgrade and post-upgrade scenarios to test Foreman Discovery Image version.

--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -19,6 +19,8 @@ import pytest
 from robottelo.logging import logger
 from robottelo.utils.installer import InstallerCommand
 
+pytestmark = pytest.mark.foreman_installer
+
 
 class TestScenarioPerformanceTuning:
     """The test class contains pre-upgrade and post-upgrade scenarios to test

--- a/tests/upgrades/test_provisioningtemplate.py
+++ b/tests/upgrades/test_provisioningtemplate.py
@@ -17,6 +17,9 @@ import pytest
 
 from robottelo.config import settings
 
+pytestmark = pytest.mark.foreman_installer
+
+
 provisioning_template_kinds = ['provision', 'PXEGrub2', 'PXELinux', 'iPXE']
 
 


### PR DESCRIPTION
### Problem Statement
There are certain components which are unsupported in current release and running those tests would cause failures in containerized test executions

### Solution
Skipping such non-supported component tests from containerized test executions by marking them with `pytest.mark.foreman_installer`

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Mark unsupported or installer-related Foreman and upgrade tests so they can be excluded from containerized runs.

Tests:
- Tag a wide set of Foreman API/UI/CLI, destructive, installer, maintain, sys, and upgrade test modules with the foreman_installer pytest marker to allow skipping them in containerized environments.
- Extend existing pytestmark lists in several tests (e.g., libvirt/ocpv/vmware/azurerm/ec2 compute resources, discovery, destructive flows) to include the foreman_installer marker while preserving their other conditions (destructive, skip_if_not_set, run_in_one_thread, stubbed).