### PR TITLE
Add log level test for foreman and proxy

### DIFF
--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -382,3 +382,81 @@ class TestSOSReportForemanctl:
         if sensitive_check.stdout.strip():
             for line in sensitive_check.stdout.splitlines():
                 assert SCRUB_MARKER in line, f'Sensitive value not scrubbed in log line: {line}'
+
+
+@pytest.mark.foremanctl
+def test_positive_foremanctl_log_level(module_target_sat):
+    """Verify foremanctl deploy log level parameters for Foreman and Proxy services.
+
+    :id: 3170785b-5327-43f6-a2b5-8e3f4049da45
+
+    :steps:
+        1. Deploy with --foreman-log-level=debug --foreman-proxy-log-level=debug --log-level=debug
+        2. Verify all three parameters are persisted in parameters file
+        3. Trigger Foreman activity and verify DEBUG [D] output in foreman journal
+        4. Trigger Proxy activity and verify DEBUG [D] output in foreman-proxy journal
+        5. Reset all log level parameters in a single deploy
+        6. Verify all log level parameters are removed from parameters file
+
+    :expectedresults:
+        1. All log level parameters are persisted correctly
+        2. Both services emit DEBUG-level [D] log entries
+        3. All parameters are removed after reset
+    """
+    sat = module_target_sat
+
+    result = sat.execute(
+        'foremanctl deploy'
+        ' --add-feature hammer'
+        ' --foreman-log-level=debug'
+        ' --foreman-proxy-log-level=debug'
+        ' --log-level=debug',
+        timeout='30m',
+    )
+    assert result.status == 0, (
+        f'foremanctl deploy with log level parameters failed:\n{result.stderr}'
+    )
+
+    # Verify all parameters are persisted
+    params = sat.load_remote_yaml_file(FOREMANCTL_PARAMETERS_FILE)
+    assert params.foreman_log_level == 'debug', (
+        f'foreman_log_level not persisted correctly: {params.get("foreman_log_level")}'
+    )
+    assert params.foreman_proxy_log_level == 'debug', (
+        f'foreman_proxy_log_level not persisted correctly: {params.get("foreman_proxy_log_level")}'
+    )
+    assert params.log_level == 'debug', (
+        f'log_level not persisted correctly: {params.get("log_level")}'
+    )
+
+    # Trigger activity and verify DEBUG [D|...] output in foreman journal
+    sat.execute('hammer host list')
+    result = sat.execute(r'journalctl --no-pager -u foreman.service --since "-2 min" | grep "\[D|"')
+    assert result.status == 0, 'No DEBUG-level [D|...] messages found in foreman.service journal'
+
+    # Trigger activity and verify DEBUG [D] output in foreman-proxy journal
+    sat.execute('hammer proxy refresh-features --id 1')
+    result = sat.execute(
+        r'journalctl --no-pager -u foreman-proxy.service --since "-2 min" | grep "\[D\]"'
+    )
+    assert result.status == 0, 'No DEBUG-level [D] messages found in foreman-proxy.service journal'
+
+    # Reset all log level parameters in a single deploy
+    result = sat.execute(
+        'foremanctl deploy'
+        ' --reset-foreman-log-level'
+        ' --reset-foreman-proxy-log-level'
+        ' --reset-log-level',
+        timeout='30m',
+    )
+    assert result.status == 0, f'Reset log level parameters failed:\n{result.stderr}'
+
+    # Verify all parameters are removed
+    params = sat.load_remote_yaml_file(FOREMANCTL_PARAMETERS_FILE)
+    assert 'foreman_log_level' not in params, (
+        'foreman_log_level still present in parameters after reset'
+    )
+    assert 'foreman_proxy_log_level' not in params, (
+        'foreman_proxy_log_level still present in parameters after reset'
+    )
+    assert 'log_level' not in params, 'log_level still present in parameters after reset'


### PR DESCRIPTION
Adding foremanctl log level management tests for foreman and foreman-proxy

## Summary by Sourcery

Tests:
- Introduce a new foremanctl log level test that validates parameter persistence, debug logging for Foreman and Proxy, and parameter reset behavior.