### PR TITLE
[6.17] Add back parametrization for advisor in 6.17

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -218,6 +218,14 @@ class ContentInfo:
         # removes metadata filename
         return os.path.dirname(re.sub(rf'.*{PULP_EXPORT_DIR}', PULP_IMPORT_DIR, export_message))
 
+    def get_reported_value(self, report_key):
+        """
+        Runs satellite-maintain report generate and extracts the value for a given key
+        """
+        result = self.execute(f'satellite-maintain report generate | grep -i "{report_key}"')
+        assert result.status == 0, 'report failed or key not found'
+        return "".join(result.stdout.split(":", 1)[1].split())
+
 
 class SystemInfo:
     """Things that needs access to satellite shell for gaining satellite system configuration"""

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -53,7 +53,8 @@ def sync_recommendations(session):
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('N-1')
 @pytest.mark.parametrize(
-    "module_target_sat_insights", [True, False], ids=["hosted", "local"], indirect=True)
+    "module_target_sat_insights", [True, False], ids=["hosted", "local"], indirect=True
+)
 def test_rhcloud_insights_e2e(
     request,
     rhel_insights_vm,

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -52,12 +52,16 @@ def sync_recommendations(session):
 @pytest.mark.pit_client
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('N-1')
+@pytest.mark.parametrize(
+    "module_target_sat_insights", [True, False], ids=["hosted", "local"], indirect=True)
 def test_rhcloud_insights_e2e(
+    request,
     rhel_insights_vm,
     rhcloud_manifest_org,
     module_target_sat_insights,
 ):
-    """Synchronize hits data from hosted, verify results are displayed in Satellite, and run remediation.
+    """Synchronize hits data from hosted or local Insights Advisor, verify results are displayed
+    in Satellite, and run remediation.
 
     :id: d952e83c-3faf-4299-a048-2eb6ccb8c9c2
 
@@ -66,7 +70,7 @@ def test_rhcloud_insights_e2e(
         2. In Satellite UI, go to Insights > Recommendations.
         3. Run remediation for "OpenSSH config permissions" recommendation against host.
         4. Verify that the remediation job completed successfully.
-        5. Re-sync recommendations.
+        5. Refresh Insights recommendations (re-sync if using hosted Insights).
         6. Search for previously remediated issue.
 
     :expectedresults:
@@ -88,6 +92,7 @@ def test_rhcloud_insights_e2e(
     :CaseAutomation: Automated
     """
     org_name = rhcloud_manifest_org.name
+    local_advisor_enabled = module_target_sat_insights.iop_enabled
 
     # Query for searching the available recommendation
     REC_QUERY = f'hostname = "{rhel_insights_vm.hostname}" and title = "{OPENSSH_RECOMMENDATION}"'
@@ -101,8 +106,9 @@ def test_rhcloud_insights_e2e(
     with module_target_sat_insights.ui_session() as session:
         session.organization.select(org_name=org_name)
 
-        # Sync the recommendations
-        sync_recommendations(session)
+        # Sync the recommendations (hosted Insights only).
+        if not local_advisor_enabled:
+            sync_recommendations(session)
 
         # Verify that we can see the rule hit via insights-client
         result = rhel_insights_vm.execute('insights-client --diagnosis')
@@ -131,11 +137,29 @@ def test_rhcloud_insights_e2e(
             host_name=rhel_insights_vm.hostname,
         )
 
-        # Re-sync the recommendations
-        sync_recommendations(session)
+        # Re-sync the recommendations (hosted Insights only).
+        if not local_advisor_enabled:
+            sync_recommendations(session)
 
         # Verify that the recommendation is not listed anymore.
         assert not session.cloudinsights.search(REC_QUERY)
+
+        # Verify the on_prem report entries
+        if 'local' in request.node.name:
+            assert (
+                module_target_sat_insights.get_reported_value(
+                    'advisor_on_prem_remediations_enabled'
+                )
+                == 'true'
+            )
+            assert (
+                int(
+                    module_target_sat_insights.get_reported_value(
+                        'advisor_on_prem_remediations_count'
+                    )
+                )
+                == 1
+            )
 
 
 @pytest.mark.e2e

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -93,7 +93,7 @@ def test_rhcloud_insights_e2e(
     :CaseAutomation: Automated
     """
     org_name = rhcloud_manifest_org.name
-    local_advisor_enabled = module_target_sat_insights.iop_enabled
+    local_advisor_enabled = module_target_sat_insights.local_advisor_enabled
 
     # Query for searching the available recommendation
     REC_QUERY = f'hostname = "{rhel_insights_vm.hostname}" and title = "{OPENSSH_RECOMMENDATION}"'


### PR DESCRIPTION
Local insights advisor functionality was removed but never rewritten in 6.17. Adding back parametrization for advisor testing. 

Removed here https://github.com/SatelliteQE/robottelo/pull/19286 