### PR TITLE
Fix REX sudoers template assertions for foreman#11019

### DIFF
--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -622,7 +622,7 @@ class TestProvisioningTemplate:
         assert f'chown -R {rex_user}: ~{rex_user}' in rex_snippet
         assert f'chown -R {rex_user}: ~{rex_user}/.ssh' in rex_snippet
         assert (
-            f'echo "{rex_user} ALL = (ALL) NOPASSWD : ALL" > /etc/sudoers.d/{rex_user}\necho "Defaults:{rex_user} !requiretty" >> /etc/sudoers.d/{rex_user}'
+            f'echo "{rex_user} ALL = (ALL) NOPASSWD : ALL" > /etc/sudoers.d/{rex_user}'
             in rex_snippet
         )
         assert ssh_key in rex_snippet


### PR DESCRIPTION
## Problem Statement

`test_positive_template_check_rex_snippet` fails on stream after Foreman removed the `Defaults:!requiretty` entry from the `remote_execution_ssh_keys` provisioning snippet. The test was still asserting the old two-line sudoers configuration, causing the rendered kickstart template to no longer match the expected output.

## Solution

- Expect only the `NOPASSWD` sudoers entry for Red Hat hosts.
- Assert that `Defaults:!requiretty` is **not** present in the rendered snippet.

## Related Issues
- Foreman PR: https://github.com/theforeman/foreman/pull/11019

## PRT Example

```yaml
trigger: test-robottelo
pytest: tests/foreman/api/test_provisioningtemplate.py -k test_positive_template_check_rex_snippet
provisioning: true

## Summary by Sourcery

Adjust REX sudoers snippet expectations in provisioning template tests to match updated Foreman behavior.

Bug Fixes:
- Update sudoers-related assertions to no longer require the removed Defaults:!requiretty entry in the REX snippet.

Tests:
- Modify test_positive_template_check_rex_snippet to only expect the NOPASSWD sudoers line and explicitly assert that Defaults:!requiretty is absent from the rendered snippet.