### PR TITLE
Fix concurrent report download overwrite issue

### DIFF
--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -15,6 +15,7 @@
 import json
 import os
 from pathlib import Path, PurePath
+import tempfile
 
 from lxml import etree
 import pytest
@@ -31,6 +32,22 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.utils.datafactory import gen_string
+
+
+@pytest.fixture(autouse=True)
+def _isolate_report_downloads():
+    """Use a unique temp directory per test for report downloads.
+
+    Concurrent xdist workers generating the same report template save to the
+    same airgun tmp_dir with the same filename, causing cross-worker overwrites.
+    """
+    import airgun
+
+    original = airgun.settings.airgun.tmp_dir
+    with tempfile.TemporaryDirectory(dir=original) as tmpdir:
+        airgun.settings.airgun.tmp_dir = tmpdir
+        yield
+        airgun.settings.airgun.tmp_dir = original
 
 
 @pytest.fixture


### PR DESCRIPTION
### Problem Statement
I have been seeing cloud billing tests fail occasionally between runs.
Concurrent xdist workers generating the same report template (e.g. "Host - Installed Products") save the downloaded JSON file to the shared airgun.tmp_dir with the same filename.
The last writer wins, causing tests to read another worker's report data and fail with wrong column assertions.

### Solution
Add a per-test _isolate_report_downloads fixture that redirects airgun.settings.airgun.tmp_dir to a unique temporary subdirectory for each test.
This prevents cross-worker file overwrites while keeping the fix scoped to test_reporttemplates.py.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_reporttemplates.py -k 'cloud_billing' -n 8
env:
  ROBOTTELO_server__version__release: 'stream'
  ROBOTTELO_server__version__snap: '199.0'
  ROBOTTELO_server__deploy_arguments__deploy_sat_version: 'stream'
  ROBOTTELO_server__deploy_arguments__deploy_snap_version: '199.0'
```
^^^Current snap 200 is DOA.

## Summary by Sourcery

Isolate report template downloads per test to prevent concurrent workers from overwriting each other’s report files.

Bug Fixes:
- Prevent concurrent xdist workers from overwriting shared report download files that led to flaky cloud billing tests.

Tests:
- Add an autouse fixture in report template UI tests to redirect report downloads to a unique temporary directory per test.