### PR TITLE
Session timed out due to inactivity

### DIFF
--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -208,29 +208,30 @@ def test_positive_image_provision_end_to_end(
     """
     sat = module_provisioning_sat.sat
     hostname = gen_string('alpha').lower()
-    host = sat.cli.Host.create(
-        {
-            'name': hostname,
-            'organization': module_sca_manifest_org.name,
-            'location': module_location.name,
-            'hostgroup': module_vmware_hostgroup.name,
-            'compute-resource-id': module_vmware_cr.id,
-            'image': module_vmware_image.name,
-            'ip': None,
-            'mac': None,
-            #'parameters': 'name=package_upgrade,type=boolean,value=false',
-            'typed-parameters': r'name=package_upgrade\,value=false\,parameter_type=boolean',
-            'compute-attributes': f'cluster={settings.vmware.cluster},'
-            f'path=/Datacenters/{settings.vmware.datacenter}/vm/,'
-            'scsi_controller_type=VirtualLsiLogicController,'
-            'guest_id=rhel8_64Guest,firmware=automatic,virtual_tpm=true'
-            'cpus=1,memory_mb=6000, start=1',
-            'interface': 'compute_type=VirtualVmxnet3,'
-            f'compute_network=VLAN {settings.provisioning.vlan_id}',
-            'volume': f'name=Hard disk,size_gb=10,thin=true,eager_zero=false,storage_pod={settings.vmware.datastore_cluster}',
-            'provision-method': 'image',
-        }
-    )
+    with sat.hammer_api_timeout():
+        host = sat.cli.Host.create(
+            {
+                'name': hostname,
+                'organization': module_sca_manifest_org.name,
+                'location': module_location.name,
+                'hostgroup': module_vmware_hostgroup.name,
+                'compute-resource-id': module_vmware_cr.id,
+                'image': module_vmware_image.name,
+                'ip': None,
+                'mac': None,
+                #'parameters': 'name=package_upgrade,type=boolean,value=false',
+                'typed-parameters': r'name=package_upgrade\,value=false\,parameter_type=boolean',
+                'compute-attributes': f'cluster={settings.vmware.cluster},'
+                f'path=/Datacenters/{settings.vmware.datacenter}/vm/,'
+                'scsi_controller_type=VirtualLsiLogicController,'
+                'guest_id=rhel8_64Guest,firmware=automatic,virtual_tpm=true'
+                'cpus=1,memory_mb=6000, start=1',
+                'interface': 'compute_type=VirtualVmxnet3,'
+                f'compute_network=VLAN {settings.provisioning.vlan_id}',
+                'volume': f'name=Hard disk,size_gb=10,thin=true,eager_zero=false,storage_pod={settings.vmware.datastore_cluster}',
+                'provision-method': 'image',
+            }
+        )
     # teardown
     request.addfinalizer(lambda: sat.provisioning_cleanup(host['name'], interface='CLI'))
 

--- a/tests/foreman/ui/test_computeresource_ocpv.py
+++ b/tests/foreman/ui/test_computeresource_ocpv.py
@@ -87,7 +87,7 @@ def test_positive_userdata_image_provision_end_to_end(
 
         wait_for(
             lambda: (
-                sat.api.Host().search(query={'search': f'name="{host_fqdn}"'})[0].build_status_label
+                session.host_new.get_host_statuses(name)['Build']['Status']
                 != 'Pending installation'
             ),
             timeout=1500,


### PR DESCRIPTION
Root Cause: -

  Selenium session timeout due to long wait_for loop. Here's the sequence:

  1. Opens a UI session (Selenium browser)
  2. Creates a host via the UI (works fine)
  3. Waits up to 1500 seconds (25 minutes) for the host's `build_status_label` to change from `'Pending installation`', polling every 10 seconds via the API (not the browser)
  4. During this 25-minute wait, the Selenium browser sits idle
  5. Selenium Grid's inactivity timeout (default ~300-1800 seconds) kills the session
  6. When the wait_for times out (or completes) and the with ui_session() context manager tries to close the browser, it gets `InvalidSessionIdException` because the session was already removed

  The Problem: -

  The `wait_for` uses the API (sat.api.Host().search(...)) to poll, not the browser. So the Selenium session gets no activity for the entire polling duration and Selenium Grid terminates it for inactivity.

  Solution: -

To avoid this issue, I am adding a search action through the session. This will keep the session active and prevent it from timing out or failing.

## Summary by Sourcery

Bug Fixes:
- Prevent VMware image provisioning tests from failing when long-running CLI operations exceed the default Hammer API timeout.