### PR TITLE
Skip katello-ca-consumer RPM upgrade test for foremanctl installs

### DIFF
--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -109,6 +109,7 @@ def test_host_registration_end_to_end(
     assert rhel_contenthost.subscription_config['server']['port'] == CLIENT_PORT
 
 
+@pytest.mark.foreman_installer
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_upgrade_katello_ca_consumer_rpm(module_org, module_location, target_sat, rhel_contenthost):
     """After updating the consumer cert the rhsm.conf file still points to Satellite host name


### PR DESCRIPTION
### Problem Statement

The `test_upgrade_katello_ca_consumer_rpm` test downloads and rebuilds the katello-ca-consumer RPM to verify that updating the consumer certificate maintains proper configuration. However, the katello-ca-consumer RPM is no longer hosted on foremanctl installations, causing this test to fail.

### Solution

Added `@pytest.mark.foreman_installer` marker to restrict the test to satellite-installer deployments only. This ensures the test only runs in environments where the katello-ca-consumer RPM is available.

### Related Issues

N/A

## Summary by Sourcery

Tests:
- Restrict the katello-ca-consumer RPM upgrade test to run only on foreman-installer (satellite-installer) deployments.