### PR TITLE
Add per-auth-source cacert support to LDAP tests

### DIFF
--- a/robottelo/utils/ldap.py
+++ b/robottelo/utils/ldap.py
@@ -1,0 +1,36 @@
+"""Utilities for LDAP-related test helpers."""
+
+from robottelo.config import settings
+
+
+def get_ldap_cacert_pem(sat, server_type, hostname):
+    """Fetch the LDAP CA certificate as PEM without installing it in the OS trust store.
+
+    :param sat: Satellite host object
+    :param str server_type: 'IPA' or 'AD'
+    :param str hostname: LDAP server hostname
+    :returns: PEM-encoded CA certificate string
+    """
+    if server_type == 'IPA':
+        result = sat.execute(f'curl -sf http://{hostname}/ipa/config/ca.crt')
+        assert result.status == 0, f'Failed to fetch IPA CA cert: {result.stderr}'
+        return result.stdout
+    if server_type == 'AD':
+        sat.execute('yum -y --disableplugin=foreman-protector install cifs-utils')
+        sat.execute(
+            rf'mount -t cifs -o username=administrator,pass={settings.ldap.password} '
+            rf'//{hostname}/c\$ /mnt'
+        )
+        try:
+            cert_path = '/mnt/Users/Administrator/Desktop/satqe-QE-SAT6-AD-CA.cer'
+            result = sat.execute(f'cat {cert_path}')
+            assert result.status == 0, 'Failed to read AD CA cert'
+            pem_content = result.stdout
+            if not pem_content.strip().startswith('-----BEGIN'):
+                result = sat.execute(f'openssl x509 -inform DER -in {cert_path}')
+                assert result.status == 0, 'Failed to convert AD CA cert to PEM'
+                pem_content = result.stdout
+        finally:
+            sat.execute('umount /mnt')
+        return pem_content
+    raise ValueError(f'Unsupported server_type for CA cert: {server_type}')

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -18,6 +18,7 @@ import pytest
 from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.utils.datafactory import generate_strings_list, parametrized
+from robottelo.utils.ldap import get_ldap_cacert_pem
 
 
 @pytest.fixture
@@ -202,6 +203,51 @@ class TestIPAAuthSource:
         module_target_sat.cli.LDAPAuthSource.delete({'name': new_name})
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.LDAPAuthSource.info({'name': new_name})
+
+    @pytest.mark.usefixtures("ldap_tear_down")
+    def test_positive_create_with_cacert_ipa(self, default_ipa_host, module_target_sat):
+        """Create LDAP auth source with cacert via hammer CLI and verify it persists.
+
+        :id: 5c35665c-05af-426f-8c7c-761c6c6a81c3
+
+        :steps:
+            1. Fetch the IPA CA certificate PEM and write it to a file on the satellite.
+            2. Create an LDAP auth source with LDAPS and --cacert-file via CLI.
+            3. Read back with ``hammer auth-source ldap info``.
+
+        :expectedresults: The cacert is stored and shown in the CLI info output.
+        """
+        cacert_pem = get_ldap_cacert_pem(module_target_sat, 'IPA', default_ipa_host.hostname)
+        cacert_file = '/tmp/ipa-ca.crt'
+        result = module_target_sat.execute(f"cat > {cacert_file} << 'EOF'\n{cacert_pem}\nEOF")
+        assert result.status == 0, f'Failed to write CA cert to {cacert_file}'
+        try:
+            server_name = gen_string('alpha')
+            auth = module_target_sat.cli_factory.ldap_auth_source(
+                {
+                    'name': server_name,
+                    'onthefly-register': 'true',
+                    'host': default_ipa_host.hostname,
+                    'server-type': LDAP_SERVER_TYPE['CLI']['ipa'],
+                    'attr-login': LDAP_ATTR['login'],
+                    'attr-firstname': LDAP_ATTR['firstname'],
+                    'attr-lastname': LDAP_ATTR['surname'],
+                    'attr-mail': LDAP_ATTR['mail'],
+                    'account': default_ipa_host.ldap_user_cn,
+                    'account-password': default_ipa_host.ldap_user_passwd,
+                    'base-dn': default_ipa_host.base_dn,
+                    'groups-base': default_ipa_host.group_base_dn,
+                    'tls': '1',
+                    'port': '636',
+                    'cacert-file': cacert_file,
+                }
+            )
+            assert auth['server']['name'] == server_name
+            auth_info = module_target_sat.cli.LDAPAuthSource.info({'id': auth['server']['id']})
+            cacert_found = "\n".join(auth_info['server']['ca-certificate'])
+            assert cacert_found.strip() == cacert_pem.strip()
+        finally:
+            module_target_sat.execute(f'rm -f {cacert_file}')
 
     @pytest.mark.parametrize('server_type', ['ipa', 'nonposix_schema'])
     @pytest.mark.usefixtures("ldap_tear_down")

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -18,7 +18,6 @@ import pytest
 from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.utils.datafactory import generate_strings_list, parametrized
-from robottelo.utils.ldap import get_ldap_cacert_pem
 
 
 @pytest.fixture
@@ -203,51 +202,6 @@ class TestIPAAuthSource:
         module_target_sat.cli.LDAPAuthSource.delete({'name': new_name})
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.LDAPAuthSource.info({'name': new_name})
-
-    @pytest.mark.usefixtures("ldap_tear_down")
-    def test_positive_create_with_cacert_ipa(self, default_ipa_host, module_target_sat):
-        """Create LDAP auth source with cacert via hammer CLI and verify it persists.
-
-        :id: 5c35665c-05af-426f-8c7c-761c6c6a81c3
-
-        :steps:
-            1. Fetch the IPA CA certificate PEM and write it to a file on the satellite.
-            2. Create an LDAP auth source with LDAPS and --cacert-file via CLI.
-            3. Read back with ``hammer auth-source ldap info``.
-
-        :expectedresults: The cacert is stored and shown in the CLI info output.
-        """
-        cacert_pem = get_ldap_cacert_pem(module_target_sat, 'IPA', default_ipa_host.hostname)
-        cacert_file = '/tmp/ipa-ca.crt'
-        result = module_target_sat.execute(f"cat > {cacert_file} << 'EOF'\n{cacert_pem}\nEOF")
-        assert result.status == 0, f'Failed to write CA cert to {cacert_file}'
-        try:
-            server_name = gen_string('alpha')
-            auth = module_target_sat.cli_factory.ldap_auth_source(
-                {
-                    'name': server_name,
-                    'onthefly-register': 'true',
-                    'host': default_ipa_host.hostname,
-                    'server-type': LDAP_SERVER_TYPE['CLI']['ipa'],
-                    'attr-login': LDAP_ATTR['login'],
-                    'attr-firstname': LDAP_ATTR['firstname'],
-                    'attr-lastname': LDAP_ATTR['surname'],
-                    'attr-mail': LDAP_ATTR['mail'],
-                    'account': default_ipa_host.ldap_user_cn,
-                    'account-password': default_ipa_host.ldap_user_passwd,
-                    'base-dn': default_ipa_host.base_dn,
-                    'groups-base': default_ipa_host.group_base_dn,
-                    'tls': '1',
-                    'port': '636',
-                    'cacert-file': cacert_file,
-                }
-            )
-            assert auth['server']['name'] == server_name
-            auth_info = module_target_sat.cli.LDAPAuthSource.info({'id': auth['server']['id']})
-            cacert_found = "\n".join(auth_info['server']['ca-certificate'])
-            assert cacert_found.strip() == cacert_pem.strip()
-        finally:
-            module_target_sat.execute(f'rm -f {cacert_file}')
 
     @pytest.mark.parametrize('server_type', ['ipa', 'nonposix_schema'])
     @pytest.mark.usefixtures("ldap_tear_down")

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -12,7 +12,6 @@
 
 """
 
-import os
 from time import sleep
 
 from navmazing import NavigationTriesExceeded
@@ -21,7 +20,6 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import (
-    CERT_PATH,
     HAMMER_CONFIG,
     HAMMER_SESSIONS,
     LDAP_ATTR,
@@ -30,6 +28,7 @@ from robottelo.constants import (
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.logging import logger
 from robottelo.utils.datafactory import gen_string
+from robottelo.utils.ldap import get_ldap_cacert_pem
 
 pytestmark = [pytest.mark.destructive, pytest.mark.run_in_one_thread]
 
@@ -50,36 +49,6 @@ USING_CREDS = (
     'Using configured credentials for user'  # status when user not logged in and creds in conf
 )
 UNABLE_AUTH = 'Unable to authenticate user'  # attempting to do something without being logged in
-
-
-def set_certificate_in_satellite(server_type, sat, hostname=None):
-    """update the cert settings in satellite based on type of ldap server"""
-    if server_type == 'IPA':
-        certfile = 'ipa.crt'
-        idm_cert_path_url = os.path.join(settings.ipa.hostname, 'ipa/config/ca.crt')
-        sat.download_file(file_url=idm_cert_path_url, local_path=CERT_PATH, file_name=certfile)
-    elif server_type == 'AD':
-        certfile = 'satqe-QE-SAT6-AD-CA.cer'
-        assert hostname is not None
-        sat.execute('yum -y --disableplugin=foreman-protector install cifs-utils')
-        command = r'mount -t cifs -o username=administrator,pass={0} //{1}/c\$ /mnt'
-        sat.execute(command.format(settings.ldap.password, hostname))
-        result = sat.execute(
-            f'cp /mnt/Users/Administrator/Desktop/satqe-QE-SAT6-AD-CA.cer {CERT_PATH}'
-        )
-        if result.status != 0:
-            raise AssertionError('Failed to copy the AD server certificate at right path')
-    result = sat.execute(f'update-ca-trust extract && restorecon -R {CERT_PATH}')
-    if result.status != 0:
-        raise AssertionError('Failed to update and trust the certificate')
-    sat.execute(f'install /{CERT_PATH}/{certfile} /etc/pki/tls/certs/')
-    sat.execute(
-        f'ln -s {certfile} /etc/pki/tls/certs/$(openssl x509 '
-        f'-noout -hash -in /etc/pki/tls/certs/{certfile}).0'
-    )
-    result = sat.execute('systemctl restart httpd')
-    if result.status != 0:
-        raise AssertionError(f'Failed to restart the httpd after applying {server_type} cert')
 
 
 @pytest.fixture
@@ -145,35 +114,34 @@ def generate_otp(secret):
 def test_positive_create_with_https(
     session, module_subscribe_satellite, test_name, auth_data, ldap_tear_down, module_target_sat
 ):
-    """Create LDAP auth_source for IDM with HTTPS.
+    """Create LDAP auth_source for IDM/AD with LDAPS.
 
     :id: 7ff3daa4-2317-11ea-aeb8-d46d6dd3b5b2
 
     :customerscenario: true
 
     :steps:
-        1. Create a new LDAP Auth source with HTTPS, provide organization and
+        1. Create a new LDAP Auth source with LDAPS, provide organization and
            location information.
         2. Fill in all the fields appropriately.
         3. Login with existing LDAP user present.
 
     :BZ: 1785621
 
-    :expectedresults: LDAP auth source for HTTPS should be successful and LDAP login
+    :expectedresults: LDAP auth source for LDAPS should be successful and LDAP login
         should work as expected.
 
     :parametrized: yes
     """
     if auth_data['auth_type'] == 'ipa':
-        set_certificate_in_satellite(server_type='IPA', sat=module_target_sat)
         username = settings.ipa.user
         account_name = auth_data['ldap_user_cn']
+        server_type = 'IPA'
     else:
-        set_certificate_in_satellite(
-            server_type='AD', sat=module_target_sat, hostname=auth_data['ldap_hostname']
-        )
         username = settings.ldap.username
         account_name = f"cn={auth_data['ldap_user_cn']},{auth_data['base_dn']}"
+        server_type = 'AD'
+    cacert_pem = get_ldap_cacert_pem(module_target_sat, server_type, auth_data['ldap_hostname'])
     org = module_target_sat.api.Organization().create()
     loc = module_target_sat.api.Location().create()
     ldap_auth_name = gen_string('alphanumeric')
@@ -184,6 +152,7 @@ def test_positive_create_with_https(
                 'ldap_server.name': ldap_auth_name,
                 'ldap_server.host': auth_data['ldap_hostname'],
                 'ldap_server.ldaps': True,
+                'ldap_server.cacert': cacert_pem,
                 'ldap_server.server_type': auth_data['server_type'],
                 'account.account_name': account_name,
                 'account.password': auth_data['ldap_user_passwd'],
@@ -205,6 +174,7 @@ def test_positive_create_with_https(
         assert ldap_source['ldap_server']['name'] == ldap_auth_name
         assert ldap_source['ldap_server']['host'] == auth_data['ldap_hostname']
         assert ldap_source['ldap_server']['port'] == '636'
+        assert ldap_source['ldap_server']['cacert'].strip() == cacert_pem.strip()
     with (
         module_target_sat.ui_session(
             test_name, username, auth_data['ldap_user_passwd']

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -141,14 +141,17 @@ def test_positive_create_with_https(
     :customerscenario: true
 
     :steps:
-        1. Create a new LDAP Auth source with LDAPS, provide organization and
+        1. Attempt a test connection with a wrong CA certificate — expect failure.
+        2. Attempt a test connection with the correct CA certificate — expect success.
+        3. Create a new LDAP Auth source with LDAPS, provide organization and
            location information.
-        2. Fill in all the fields appropriately.
-        3. Login with existing LDAP user present.
+        4. Fill in all the fields appropriately.
+        5. Login with existing LDAP user present.
 
     :BZ: 1785621
 
-    :expectedresults: LDAP auth source for LDAPS should be successful and LDAP login
+    :expectedresults: Test connection fails with a wrong CA certificate and succeeds with the
+        correct one. LDAP auth source for LDAPS should be successful and LDAP login
         should work as expected.
 
     :parametrized: yes
@@ -162,11 +165,36 @@ def test_positive_create_with_https(
         account_name = f"cn={auth_data['ldap_user_cn']},{auth_data['base_dn']}"
         server_type = 'AD'
     cacert_pem = get_ldap_cacert_pem(module_target_sat, server_type, auth_data['ldap_hostname'])
+    wrong_cacert_result = module_target_sat.execute(
+        'cat /etc/pki/ca-trust/source/anchors/katello_server-host-cert.crt'
+    )
+    assert wrong_cacert_result.status == 0, (
+        f'Failed to read Satellite host cert: {wrong_cacert_result.stderr}'
+    )
+    wrong_cacert = wrong_cacert_result.stdout
     org = module_target_sat.api.Organization().create()
     loc = module_target_sat.api.Location().create()
     ldap_auth_name = gen_string('alphanumeric')
 
     with session:
+        with pytest.raises(AssertionError) as error:
+            session.ldapauthentication.test_connection(
+                {
+                    'ldap_server.host': auth_data['ldap_hostname'],
+                    'ldap_server.ldaps': True,
+                    'ldap_server.cacert': wrong_cacert,
+                }
+            )
+        assert error.match('certificate verify failed')
+
+        session.ldapauthentication.test_connection(
+            {
+                'ldap_server.host': auth_data['ldap_hostname'],
+                'ldap_server.ldaps': True,
+                'ldap_server.cacert': cacert_pem,
+            }
+        )
+
         session.ldapauthentication.create(
             {
                 'ldap_server.name': ldap_auth_name,

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -92,6 +92,20 @@ def rhsso_groups_teardown(module_target_sat, default_sso_host):
 
 
 @pytest.fixture
+def untrust_rhit_cas(module_target_sat):
+    """Temporarily remove Red Hat IT Root CAs from the system trust store."""
+    anchors = '/etc/pki/ca-trust/source/anchors'
+    backup_dir = '/tmp/ca-backup'
+    module_target_sat.execute(f'mkdir -p {backup_dir}')
+    module_target_sat.execute(f'mv {anchors}/*-IT-Root-CA.pem {backup_dir}/')
+    module_target_sat.execute('update-ca-trust extract')
+    yield
+    module_target_sat.execute(f'mv {backup_dir}/* {anchors}/')
+    module_target_sat.execute(f'rm -rf {backup_dir}')
+    module_target_sat.execute('update-ca-trust extract')
+
+
+@pytest.fixture
 def configure_hammer_session(parametrized_enrolled_sat, enable=True):
     """Take backup of the hammer config file and enable use_sessions"""
     parametrized_enrolled_sat.execute(f'cp {HAMMER_CONFIG} {HAMMER_CONFIG}.backup')
@@ -112,7 +126,13 @@ def generate_otp(secret):
 @pytest.mark.upgrade
 @pytest.mark.parametrize('auth_data', ['AD_2019', 'IPA'], indirect=True)
 def test_positive_create_with_https(
-    session, module_subscribe_satellite, test_name, auth_data, ldap_tear_down, module_target_sat
+    session,
+    module_subscribe_satellite,
+    test_name,
+    auth_data,
+    ldap_tear_down,
+    module_target_sat,
+    untrust_rhit_cas,
 ):
     """Create LDAP auth_source for IDM/AD with LDAPS.
 
@@ -174,7 +194,13 @@ def test_positive_create_with_https(
         assert ldap_source['ldap_server']['name'] == ldap_auth_name
         assert ldap_source['ldap_server']['host'] == auth_data['ldap_hostname']
         assert ldap_source['ldap_server']['port'] == '636'
-        assert ldap_source['ldap_server']['cacert'].strip() == cacert_pem.strip()
+
+        # In AD's case, the CA cert uses CRLF line endings
+        # when this cert is uploaded to Satellite and read back through hammer,
+        # the line endings are replaced with unix LF-only line endings.
+        assert (
+            ldap_source['ldap_server']['cacert'].strip() == cacert_pem.replace("\r\n", "\n").strip()
+        )
     with (
         module_target_sat.ui_session(
             test_name, username, auth_data['ldap_user_passwd']
@@ -1084,3 +1110,45 @@ def test_negative_autonegotiate_with_autonegotiation_disabled(
         # User has not been added
         user = parametrized_enrolled_sat.api.User().search(query={'search': f'login={user}'})
         assert not user
+
+
+@pytest.mark.parametrize('ldap_auth_source', ['IPA'], indirect=True)
+def test_ldaps_cacert_test_connection(
+    session, ldap_auth_source, module_target_sat, untrust_rhit_cas
+):
+    """LDAPS auth source without cacert fails test connection and succeeds with it.
+
+    :id: 63ef2536-cffa-453e-bf8d-4b887623270d
+
+    :steps:
+        1. Open an existing LDAP auth source created without TLS.
+        2. Enable LDAPS without providing a cacert.
+        3. Click test connection.
+        4. Provide a cacert.
+        5. Click test connection.
+
+    :expectedresults: Test connection fails at first due to untrusted CA certificate
+        and passes once the cacert is provided.
+
+    :parametrized: yes
+    """
+    ldap_data, auth_source = ldap_auth_source
+    cacert = get_ldap_cacert_pem(module_target_sat, 'IPA', ldap_data['ldap_hostname'])
+    with session:
+        with pytest.raises(AssertionError) as error:
+            session.ldapauthentication.test_connection(
+                {
+                    'ldap_server.host': ldap_data['ldap_hostname'],
+                    'ldap_server.ldaps': True,
+                }
+            )
+        # No error details in toast https://projects.theforeman.org/issues/39552
+        assert error.match('Danger alert: Error')
+
+        session.ldapauthentication.test_connection(
+            {
+                'ldap_server.host': ldap_data['ldap_hostname'],
+                'ldap_server.ldaps': True,
+                'ldap_server.cacert': cacert,
+            }
+        )

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -196,8 +196,8 @@ def test_positive_create_with_https(
         assert ldap_source['ldap_server']['port'] == '636'
 
         # In AD's case, the CA cert uses CRLF line endings
-        # when this cert is uploaded to Satellite and read back through hammer,
-        # the line endings are replaced with unix LF-only line endings.
+        # when this cert is uploaded to Satellite, the line endings are replaced
+        # with unix LF-only line endings.
         assert (
             ldap_source['ldap_server']['cacert'].strip() == cacert_pem.replace("\r\n", "\n").strip()
         )
@@ -1110,45 +1110,3 @@ def test_negative_autonegotiate_with_autonegotiation_disabled(
         # User has not been added
         user = parametrized_enrolled_sat.api.User().search(query={'search': f'login={user}'})
         assert not user
-
-
-@pytest.mark.parametrize('ldap_auth_source', ['IPA'], indirect=True)
-def test_ldaps_cacert_test_connection(
-    session, ldap_auth_source, module_target_sat, untrust_rhit_cas
-):
-    """LDAPS auth source without cacert fails test connection and succeeds with it.
-
-    :id: 63ef2536-cffa-453e-bf8d-4b887623270d
-
-    :steps:
-        1. Open an existing LDAP auth source created without TLS.
-        2. Enable LDAPS without providing a cacert.
-        3. Click test connection.
-        4. Provide a cacert.
-        5. Click test connection.
-
-    :expectedresults: Test connection fails at first due to untrusted CA certificate
-        and passes once the cacert is provided.
-
-    :parametrized: yes
-    """
-    ldap_data, auth_source = ldap_auth_source
-    cacert = get_ldap_cacert_pem(module_target_sat, 'IPA', ldap_data['ldap_hostname'])
-    with session:
-        with pytest.raises(AssertionError) as error:
-            session.ldapauthentication.test_connection(
-                {
-                    'ldap_server.host': ldap_data['ldap_hostname'],
-                    'ldap_server.ldaps': True,
-                }
-            )
-        # No error details in toast https://projects.theforeman.org/issues/39552
-        assert error.match('Danger alert: Error')
-
-        session.ldapauthentication.test_connection(
-            {
-                'ldap_server.host': ldap_data['ldap_hostname'],
-                'ldap_server.ldaps': True,
-                'ldap_server.cacert': cacert,
-            }
-        )

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -12,45 +12,19 @@
 
 """
 
-import os
-
 from fauxfactory import gen_url
 from navmazing import NavigationTriesExceeded
 import pyotp
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import ANY_CONTEXT, CERT_PATH, LDAP_ATTR, PERMISSIONS
+from robottelo.constants import ANY_CONTEXT, LDAP_ATTR, PERMISSIONS
 from robottelo.utils.datafactory import gen_string
+from robottelo.utils.ldap import get_ldap_cacert_pem
 
 pytestmark = [pytest.mark.run_in_one_thread]
 
 EXTERNAL_GROUP_NAME = 'foobargroup'
-
-
-def set_certificate_in_satellite(server_type, target_sat, hostname=None):
-    """update the cert settings in satellite based on type of ldap server"""
-    if server_type == 'IPA':
-        idm_cert_path_url = os.path.join(settings.ipa.hostname, 'ipa/config/ca.crt')
-        target_sat.download_file(
-            file_url=idm_cert_path_url, local_path=CERT_PATH, file_name='ipa.crt'
-        )
-    elif server_type == 'AD':
-        assert hostname is not None
-        target_sat.execute('yum -y --disableplugin=foreman-protector install cifs-utils')
-        command = r'mount -t cifs -o username=administrator,pass={0} //{1}/c\$ /mnt'
-        target_sat.execute(command.format(settings.ldap.password, hostname))
-        result = target_sat.execute(
-            f'cp /mnt/Users/Administrator/Desktop/satqe-QE-SAT6-AD-CA.cer {CERT_PATH}'
-        )
-        if result.status != 0:
-            raise AssertionError('Failed to copy the AD server certificate at right path')
-    result = target_sat.execute(f'update-ca-trust extract && restorecon -R {CERT_PATH}')
-    if result.status != 0:
-        raise AssertionError('Failed to update and trust the certificate')
-    result = target_sat.execute('systemctl restart httpd')
-    if result.status != 0:
-        raise AssertionError(f'Failed to restart the httpd after applying {server_type} cert')
 
 
 @pytest.fixture
@@ -839,6 +813,46 @@ def test_positive_test_connection_functionality(session, ldap_auth_source):
     ldap_data, auth_source = ldap_auth_source
     with session:
         session.ldapauthentication.test_connection({'ldap_server.host': ldap_data['ldap_hostname']})
+
+
+@pytest.mark.parametrize('ldap_auth_source', ['IPA'], indirect=True)
+def test_ldaps_cacert_test_connection(session, ldap_auth_source, target_sat):
+    """LDAPS auth source without cacert fails test connection and succeeds with it.
+
+    :id: 63ef2536-cffa-453e-bf8d-4b887623270d
+
+    :steps:
+        1. Open an existing LDAP auth source created without TLS.
+        2. Enable LDAPS without providing a cacert.
+        3. Click test connection.
+        4. Provide a cacert.
+        5. Click test connection.
+
+    :expectedresults: Test connection fails at first due to untrusted CA certificate
+        and passes once the cacert is provided.
+
+    :parametrized: yes
+    """
+    ldap_data, auth_source = ldap_auth_source
+    cacert = get_ldap_cacert_pem(target_sat, 'IPA', ldap_data['ldap_hostname'])
+    with session:
+        with pytest.raises(AssertionError) as error:
+            session.ldapauthentication.test_connection(
+                {
+                    'ldap_server.host': ldap_data['ldap_hostname'],
+                    'ldap_server.ldaps': True,
+                }
+            )
+        # No error details in toast https://projects.theforeman.org/issues/39552
+        assert error.match('Danger alert: Error')
+
+        session.ldapauthentication.test_connection(
+            {
+                'ldap_server.host': ldap_data['ldap_hostname'],
+                'ldap_server.ldaps': True,
+                'ldap_server.cacert': cacert,
+            }
+        )
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1080,8 +1080,8 @@ def test_ldaps_cacert_test_connection(session, ldap_auth_source, target_sat):
                     'ldap_server.cacert': wrong_cacert,
                 }
             )
-        # No error details in toast https://projects.theforeman.org/issues/39552
-        assert error.match('Danger alert: Error')
+
+        assert error.match('certificate verify failed')
 
         session.ldapauthentication.test_connection(
             {

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -20,6 +20,7 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT, LDAP_ATTR, PERMISSIONS
 from robottelo.utils.datafactory import gen_string
+from robottelo.utils.ldap import get_ldap_cacert_pem
 
 pytestmark = [pytest.mark.run_in_one_thread]
 
@@ -1041,6 +1042,54 @@ def test_login_failure_if_internal_user_exist(
             assert error.typename == 'NavigationTriesExceeded'
     finally:
         target_sat.api.User(id=user.id).delete()
+
+
+@pytest.mark.parametrize('ldap_auth_source', ['IPA'], indirect=True)
+def test_ldaps_cacert_test_connection(session, ldap_auth_source, target_sat):
+    """LDAPS auth source fails test connection with a wrong cacert and succeeds with the right one.
+
+    :id: eddf4ddf-03d2-4aa1-981f-c30078e3dc54
+
+    :steps:
+        1. Open an existing LDAP auth source created without TLS.
+        2. Enable LDAPS and provide a wrong cacert (the Satellite host certificate).
+        3. Click test connection — expect failure.
+        4. Replace the cacert with the real IPA CA certificate.
+        5. Click test connection — expect success.
+
+    :expectedresults: Test connection fails with a wrong CA certificate and passes once the
+        correct IPA CA certificate is provided.
+
+    :parametrized: yes
+    """
+    ldap_data, auth_source = ldap_auth_source
+    wrong_cacert_result = target_sat.execute(
+        'cat /etc/pki/ca-trust/source/anchors/katello_server-host-cert.crt'
+    )
+    assert wrong_cacert_result.status == 0, (
+        f'Failed to read Satellite host cert: {wrong_cacert_result.stderr}'
+    )
+    wrong_cacert = wrong_cacert_result.stdout
+    cacert = get_ldap_cacert_pem(target_sat, 'IPA', ldap_data['ldap_hostname'])
+    with session:
+        with pytest.raises(AssertionError) as error:
+            session.ldapauthentication.test_connection(
+                {
+                    'ldap_server.host': ldap_data['ldap_hostname'],
+                    'ldap_server.ldaps': True,
+                    'ldap_server.cacert': wrong_cacert,
+                }
+            )
+        # No error details in toast https://projects.theforeman.org/issues/39552
+        assert error.match('Danger alert: Error')
+
+        session.ldapauthentication.test_connection(
+            {
+                'ldap_server.host': ldap_data['ldap_hostname'],
+                'ldap_server.ldaps': True,
+                'ldap_server.cacert': cacert,
+            }
+        )
 
 
 def test_userlist_with_external_admin(

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -20,7 +20,6 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT, LDAP_ATTR, PERMISSIONS
 from robottelo.utils.datafactory import gen_string
-from robottelo.utils.ldap import get_ldap_cacert_pem
 
 pytestmark = [pytest.mark.run_in_one_thread]
 
@@ -813,46 +812,6 @@ def test_positive_test_connection_functionality(session, ldap_auth_source):
     ldap_data, auth_source = ldap_auth_source
     with session:
         session.ldapauthentication.test_connection({'ldap_server.host': ldap_data['ldap_hostname']})
-
-
-@pytest.mark.parametrize('ldap_auth_source', ['IPA'], indirect=True)
-def test_ldaps_cacert_test_connection(session, ldap_auth_source, target_sat):
-    """LDAPS auth source without cacert fails test connection and succeeds with it.
-
-    :id: 63ef2536-cffa-453e-bf8d-4b887623270d
-
-    :steps:
-        1. Open an existing LDAP auth source created without TLS.
-        2. Enable LDAPS without providing a cacert.
-        3. Click test connection.
-        4. Provide a cacert.
-        5. Click test connection.
-
-    :expectedresults: Test connection fails at first due to untrusted CA certificate
-        and passes once the cacert is provided.
-
-    :parametrized: yes
-    """
-    ldap_data, auth_source = ldap_auth_source
-    cacert = get_ldap_cacert_pem(target_sat, 'IPA', ldap_data['ldap_hostname'])
-    with session:
-        with pytest.raises(AssertionError) as error:
-            session.ldapauthentication.test_connection(
-                {
-                    'ldap_server.host': ldap_data['ldap_hostname'],
-                    'ldap_server.ldaps': True,
-                }
-            )
-        # No error details in toast https://projects.theforeman.org/issues/39552
-        assert error.match('Danger alert: Error')
-
-        session.ldapauthentication.test_connection(
-            {
-                'ldap_server.host': ldap_data['ldap_hostname'],
-                'ldap_server.ldaps': True,
-                'ldap_server.cacert': cacert,
-            }
-        )
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -20,7 +20,6 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT, LDAP_ATTR, PERMISSIONS
 from robottelo.utils.datafactory import gen_string
-from robottelo.utils.ldap import get_ldap_cacert_pem
 
 pytestmark = [pytest.mark.run_in_one_thread]
 
@@ -1042,54 +1041,6 @@ def test_login_failure_if_internal_user_exist(
             assert error.typename == 'NavigationTriesExceeded'
     finally:
         target_sat.api.User(id=user.id).delete()
-
-
-@pytest.mark.parametrize('ldap_auth_source', ['IPA'], indirect=True)
-def test_ldaps_cacert_test_connection(session, ldap_auth_source, target_sat):
-    """LDAPS auth source fails test connection with a wrong cacert and succeeds with the right one.
-
-    :id: eddf4ddf-03d2-4aa1-981f-c30078e3dc54
-
-    :steps:
-        1. Open an existing LDAP auth source created without TLS.
-        2. Enable LDAPS and provide a wrong cacert (the Satellite host certificate).
-        3. Click test connection — expect failure.
-        4. Replace the cacert with the real IPA CA certificate.
-        5. Click test connection — expect success.
-
-    :expectedresults: Test connection fails with a wrong CA certificate and passes once the
-        correct IPA CA certificate is provided.
-
-    :parametrized: yes
-    """
-    ldap_data, auth_source = ldap_auth_source
-    wrong_cacert_result = target_sat.execute(
-        'cat /etc/pki/ca-trust/source/anchors/katello_server-host-cert.crt'
-    )
-    assert wrong_cacert_result.status == 0, (
-        f'Failed to read Satellite host cert: {wrong_cacert_result.stderr}'
-    )
-    wrong_cacert = wrong_cacert_result.stdout
-    cacert = get_ldap_cacert_pem(target_sat, 'IPA', ldap_data['ldap_hostname'])
-    with session:
-        with pytest.raises(AssertionError) as error:
-            session.ldapauthentication.test_connection(
-                {
-                    'ldap_server.host': ldap_data['ldap_hostname'],
-                    'ldap_server.ldaps': True,
-                    'ldap_server.cacert': wrong_cacert,
-                }
-            )
-
-        assert error.match('certificate verify failed')
-
-        session.ldapauthentication.test_connection(
-            {
-                'ldap_server.host': ldap_data['ldap_hostname'],
-                'ldap_server.ldaps': True,
-                'ldap_server.cacert': cacert,
-            }
-        )
 
 
 def test_userlist_with_external_admin(


### PR DESCRIPTION
### Problem Statement

https://github.com/theforeman/foreman/pull/11107 adds a cacert attribute to ldap auth servers which obsoletes the old way of handling ca certs (by including in the system trust store).

### Solution

Switch to per-source CA cert handling.

### Related Issues

https://redhat.atlassian.net/browse/SAT-45933
https://redhat.atlassian.net/browse/SAT-46986

Requires:
- https://github.com/SatelliteQE/airgun/pull/2486
- https://github.com/SatelliteQE/nailgun/pull/1430
- https://github.com/theforeman/foreman/pull/11107
- https://github.com/theforeman/hammer-cli-foreman/pull/658

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Adopt per-auth-source CA certificate handling for LDAP/LDAPS integration tests and ensure CA certs are provided and validated explicitly instead of via the system trust store.

New Features:
- Add a shared LDAP utility to retrieve IPA and AD CA certificates as PEM without installing them in the OS trust store.
- Introduce UI and CLI tests that verify LDAPS auth sources require and persist the correct per-source CA certificate, including failure on invalid certs.

Enhancements:
- Refactor LDAP authentication tests to use the new LDAP CA retrieval helper instead of modifying the system trust store.
- Add a fixture to temporarily remove and restore Red Hat IT root CAs to better isolate LDAPS behavior in destructive tests.

Tests:
- Extend LDAP UI, destructive, and CLI test coverage to validate LDAPS connections and hammer-based LDAP auth source creation with explicit cacert configuration.