### PR TITLE
Add virt-who Deploy Config Ansible REX job tests for all hypervisors

### DIFF
--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -4,9 +4,9 @@ from robottelo.config import settings
 from robottelo.constants import REPOS
 from robottelo.utils.datafactory import gen_string
 from robottelo.utils.virtwho import (
-    deploy_configure_by_command,
+    deploy_configure_by_job_api,
+    deploy_configure_by_job_ui,
     deploy_configure_by_script,
-    get_configure_command,
     get_guest_info,
 )
 
@@ -226,39 +226,26 @@ def virtwho_config_ui(
 
 @pytest.fixture
 def deploy_type_api(
-    request,
     org_module,
     form_data_api,
     register_sat_and_enable_aps_repo,
     virtwho_config_api,
     target_sat,
 ):
-    deploy_type = request.param.lower()
     assert virtwho_config_api.status == 'unknown'
-    if "id" in deploy_type:
-        command = get_configure_command(virtwho_config_api.id, org_module.name)
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command,
-            form_data_api['hypervisor_type'],
-            debug=True,
-            org=org_module.label,
-            target_sat=target_sat,
-        )
-    elif "script" in deploy_type:
-        script = virtwho_config_api.deploy_script()
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script['virt_who_config_script'],
-            form_data_api['hypervisor_type'],
-            debug=True,
-            org=org_module.label,
-            target_sat=target_sat,
-        )
+    script = virtwho_config_api.deploy_script()
+    hypervisor_name, guest_name = deploy_configure_by_script(
+        script['virt_who_config_script'],
+        form_data_api['hypervisor_type'],
+        debug=True,
+        org=org_module.label,
+        target_sat=target_sat,
+    )
     return hypervisor_name, guest_name
 
 
 @pytest.fixture
 def deploy_type_ui(
-    request,
     org_module,
     form_data_ui,
     org_session,
@@ -266,26 +253,58 @@ def deploy_type_ui(
     virtwho_config_ui,
     target_sat,
 ):
-    deploy_type = request.param.lower()
     values = org_session.virtwho_configure.read(form_data_ui['name'])
-    if "id" in deploy_type:
-        command = values['deploy']['command']
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command,
-            form_data_ui['hypervisor_type'],
-            debug=True,
-            org=org_module.label,
-            target_sat=target_sat,
-        )
-    elif "script" in deploy_type:
-        script = values['deploy']['script']
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script,
-            form_data_ui['hypervisor_type'],
-            debug=True,
-            org=org_module.label,
-            target_sat=target_sat,
-        )
+    script = values['deploy']['script']
+    hypervisor_name, guest_name = deploy_configure_by_script(
+        script,
+        form_data_ui['hypervisor_type'],
+        debug=True,
+        org=org_module.label,
+        target_sat=target_sat,
+    )
+    return hypervisor_name, guest_name
+
+
+@pytest.fixture
+def deploy_via_job_ui(
+    org_module,
+    form_data_ui,
+    org_session,
+    register_sat_and_enable_aps_repo,
+    setup_libvirt_ssh_auth,
+    target_sat,
+    rhel_contenthost,
+    module_location,
+    module_capsule_configured,
+):
+    hypervisor_name, guest_name = deploy_configure_by_job_ui(
+        org_session,
+        form_data_ui,
+        form_data_ui['hypervisor_type'],
+        debug=True,
+        org=org_module.label,
+        target_sat=target_sat,
+        content_host=rhel_contenthost,
+        location=module_location,
+        capsule=module_capsule_configured,
+    )
+    return hypervisor_name, guest_name
+
+@pytest.fixture
+def deploy_via_job_api(
+    org_module,
+    form_data_api,
+    register_sat_and_enable_aps_repo,
+    setup_libvirt_ssh_auth,
+    target_sat,
+):
+    hypervisor_name, guest_name = deploy_configure_by_job_api(
+        form_data_api,
+        form_data_api['hypervisor_type'],
+        debug=True,
+        org=org_module.label,
+        target_sat=target_sat,
+    )
     return hypervisor_name, guest_name
 
 

--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -270,12 +270,10 @@ def deploy_via_job_ui(
     org_module,
     form_data_ui,
     org_session,
-    register_sat_and_enable_aps_repo,
     setup_libvirt_ssh_auth,
     target_sat,
     rhel_contenthost,
-    module_location,
-    module_capsule_configured,
+    default_location,
 ):
     hypervisor_name, guest_name = deploy_configure_by_job_ui(
         org_session,
@@ -285,8 +283,7 @@ def deploy_via_job_ui(
         org=org_module.label,
         target_sat=target_sat,
         content_host=rhel_contenthost,
-        location=module_location,
-        capsule=module_capsule_configured,
+        location=default_location,
     )
     return hypervisor_name, guest_name
 
@@ -295,9 +292,10 @@ def deploy_via_job_ui(
 def deploy_via_job_api(
     org_module,
     form_data_api,
-    register_sat_and_enable_aps_repo,
     setup_libvirt_ssh_auth,
     target_sat,
+    rhel_contenthost,
+    default_location,
 ):
     hypervisor_name, guest_name = deploy_configure_by_job_api(
         form_data_api,
@@ -305,6 +303,8 @@ def deploy_via_job_api(
         debug=True,
         org=org_module.label,
         target_sat=target_sat,
+        content_host=rhel_contenthost,
+        location=default_location,
     )
     return hypervisor_name, guest_name
 

--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -290,6 +290,7 @@ def deploy_via_job_ui(
     )
     return hypervisor_name, guest_name
 
+
 @pytest.fixture
 def deploy_via_job_api(
     org_module,

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -232,8 +232,10 @@ def _get_hypervisor_mapping(hypervisor_type):
     timeout = 60 if hypervisor_type == 'ahv' else 20
 
     wait_for(
-        lambda: 'Sending updated Host-to-guest mapping to' in get_rhsm_log()
-                or 'Host-to-guest mapping being sent to' in get_rhsm_log(),
+        lambda: (
+            'Sending updated Host-to-guest mapping to' in get_rhsm_log()
+            or 'Host-to-guest mapping being sent to' in get_rhsm_log()
+        ),
         timeout=timeout,
         delay=2,
     )
@@ -337,16 +339,17 @@ def deploy_validation_on_host(hypervisor_type, host):
     svc_result = host.execute('systemctl status virt-who')
     if 'Active: active (running)' not in svc_result.stdout:
         raise VirtWhoError(
-            f'Failed to start virt-who service on {host.hostname}. '
-            f'Output: {svc_result.stdout}'
+            f'Failed to start virt-who service on {host.hostname}. Output: {svc_result.stdout}'
         )
     guest_name, guest_uuid = get_guest_info(hypervisor_type)
     timeout = 60 if hypervisor_type == 'ahv' else 20
     wait_for(
-        lambda: 'Sending updated Host-to-guest mapping to'
-        in host.execute('cat /var/log/rhsm/rhsm.log').stdout
-        or 'Host-to-guest mapping being sent to'
-        in host.execute('cat /var/log/rhsm/rhsm.log').stdout,
+        lambda: (
+            'Sending updated Host-to-guest mapping to'
+            in host.execute('cat /var/log/rhsm/rhsm.log').stdout
+            or 'Host-to-guest mapping being sent to'
+            in host.execute('cat /var/log/rhsm/rhsm.log').stdout
+        ),
         timeout=timeout,
         delay=2,
     )
@@ -438,9 +441,7 @@ def deploy_configure_by_job_api(
     target_sat.add_rex_key(target_sat)
 
     template_id = (
-        target_sat.api.JobTemplate()
-        .search(query={'search': 'name="Deploy virt-who Config"'})[0]
-        .id
+        target_sat.api.JobTemplate().search(query={'search': 'name="Deploy virt-who Config"'})[0].id
     )
     username, password = Base._get_username_password()
 
@@ -466,9 +467,7 @@ def deploy_configure_by_job_api(
             'search_query': f'name = {target_sat.hostname}',
         },
     )
-    target_sat.wait_for_tasks(
-        f'resource_type = JobInvocation and resource_id = {job["id"]}'
-    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
     result = target_sat.api.JobInvocation(id=job['id']).read()
     if result.succeeded != 1:
         raise VirtWhoError(
@@ -549,12 +548,8 @@ def deploy_configure_by_job_ui(
         'target_hosts_and_inputs.virt_who_hypervisor_id': form_data.get(
             'hypervisor_id', 'hostname'
         ),
-        'target_hosts_and_inputs.virt_who_debug': str(
-            form_data.get('debug', debug)
-        ).lower(),
-        'target_hosts_and_inputs.virt_who_filtering_mode': form_data.get(
-            'filtering_mode', 'none'
-        ),
+        'target_hosts_and_inputs.virt_who_debug': str(form_data.get('debug', debug)).lower(),
+        'target_hosts_and_inputs.virt_who_filtering_mode': form_data.get('filtering_mode', 'none'),
         'target_hosts_and_inputs.virt_who_hypervisor_server': form_data.get(
             'hypervisor_content.server', ''
         ),

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -14,7 +14,6 @@ from robottelo import ssh
 from robottelo.cli.base import Base
 from robottelo.cli.host import Host
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG
 from robottelo.hosts import ContentHost
 
 ETC_VIRTWHO_CONFIG = "/etc/virt-who.conf"
@@ -179,15 +178,6 @@ def get_configure_id(name, target_sat=None):
     raise VirtWhoError(f"No configure id found for {name}")
 
 
-def get_configure_command(config_id, org=DEFAULT_ORG):
-    """Return the deploy command line based on configure id.
-    :param str config_id: the unique id of the configure file you have created.
-    :param str org: the satellite organization name.
-    """
-    username, password = Base._get_username_password()
-    return f"hammer -u {username} -p {password} virt-who-config deploy --id {config_id} --organization '{org}' "
-
-
 def get_configure_file(config_id):
     """Return the configuration file full name in /etc/virt-who.d
     :param str config_id: the unique id of the configuration file you have created.
@@ -240,8 +230,10 @@ def _get_hypervisor_mapping(hypervisor_type):
     """
     # Increase timeout for hypervisors like Nutanix Prism Central which can be slower
     timeout = 60 if hypervisor_type == 'ahv' else 20
+
     wait_for(
-        lambda: 'Host-to-guest mapping being sent to' in get_rhsm_log(),
+        lambda: 'Sending updated Host-to-guest mapping to' in get_rhsm_log()
+                or 'Host-to-guest mapping being sent to' in get_rhsm_log(),
         timeout=timeout,
         delay=2,
     )
@@ -334,6 +326,61 @@ def deploy_validation(hypervisor_type):
     return hypervisor_name, guest_name
 
 
+def deploy_validation_on_host(hypervisor_type, host):
+    """Validate virt-who deployment on a remote content host.
+
+    :param str hypervisor_type: esx, libvirt, rhevm, xen, kubevirt, ahv
+    :param host: ContentHost object where virt-who is deployed.
+    :raises: VirtWhoError: If virt-who service is not running or mapping not found.
+    :return: tuple of (hypervisor_name, guest_name)
+    """
+    svc_result = host.execute('systemctl status virt-who')
+    if 'Active: active (running)' not in svc_result.stdout:
+        raise VirtWhoError(
+            f'Failed to start virt-who service on {host.hostname}. '
+            f'Output: {svc_result.stdout}'
+        )
+    guest_name, guest_uuid = get_guest_info(hypervisor_type)
+    timeout = 60 if hypervisor_type == 'ahv' else 20
+    wait_for(
+        lambda: 'Sending updated Host-to-guest mapping to'
+        in host.execute('cat /var/log/rhsm/rhsm.log').stdout
+        or 'Host-to-guest mapping being sent to'
+        in host.execute('cat /var/log/rhsm/rhsm.log').stdout,
+        timeout=timeout,
+        delay=2,
+    )
+    logs = host.execute('cat /var/log/rhsm/rhsm.log').stdout.strip()
+    mapping = []
+    entry = None
+    for line in logs.split('\n'):
+        if not line:
+            continue
+        if line[0].isdigit():
+            if entry:
+                mapping.append(_parse_entry(entry))
+            entry = '{'
+            continue
+        if entry:
+            entry += line
+    else:
+        mapping.append(_parse_entry(entry))
+    mapping = [m for m in mapping if m is not None]
+    hypervisor_name = None
+    for item in mapping[-1]['hypervisors']:
+        for guest in item['guestIds']:
+            if guest_uuid in guest['guestId']:
+                hypervisor_name = item['hypervisorId']['hypervisorId']
+                break
+    if not hypervisor_name:
+        raise VirtWhoError(f'Failed to get hypervisor_name for guest {guest_name}')
+    for h in Host.list({'search': hypervisor_name}):
+        Host.delete({'id': h['id']})
+    host.execute('rm -f /var/log/rhsm/rhsm.log')
+    host.execute('systemctl restart virt-who; sleep 10')
+    return hypervisor_name, guest_name
+
+
 def get_activation_key(org, target_sat):
     """Create a virt-who activation key for the given organization.
     :param str org: The label of the organization for which the activation key is created.
@@ -360,40 +407,183 @@ def get_activation_key(org, target_sat):
     return ak.name
 
 
-def deploy_configure_by_command(
-    command,
+def deploy_configure_by_job_api(
+    form_data,
     hypervisor_type,
     debug=False,
     org='Default_Organization',
     activation_key=None,
     target_sat=None,
 ):
-    """Deploy and run virt-who service by the hammer command.
+    """Deploy and run virt-who service via the 'Deploy virt-who Config' Ansible REX job (API).
 
-    :param str command: get the command by UI/CLI/API, it should be like:
-        `hammer virt-who-config deploy --id 1 --organization-id 1`
-    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt, ahv
+    :param dict form_data: Hypervisor config data with connection details.
+    :param str hypervisor_type: esx, libvirt, rhevm, xen, kubevirt, ahv
     :param bool debug: if VIRTWHO_DEBUG=1, this option should be True.
     :param str org: Organization Label
     :param str activation_key: Activation key for system registration (optional)
-    :param target_sat: Satellite object for registration (optional)
+    :param target_sat: Satellite object for registration and job execution.
     """
     virtwho_cleanup()
     guest_name, guest_uuid = get_guest_info(hypervisor_type)
     if Host.list({'search': guest_name}):
         Host.delete({'name': guest_name})
 
-    # If target_sat is provided but activation_key is not, create one for global registration
     if target_sat and not activation_key:
         activation_key = get_activation_key(org, target_sat)
     register_system(
         get_system(hypervisor_type), activation_key=activation_key, org=org, target_sat=target_sat
     )
-    ret, stdout = runcmd(command)
-    if ret != 0 or 'Finished successfully' not in stdout:
-        raise VirtWhoError(f"Failed to deploy configure by {command}")
+
+    target_sat.add_rex_key(target_sat)
+
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Deploy virt-who Config"'})[0]
+        .id
+    )
+    username, password = Base._get_username_password()
+
+    inputs = {
+        'virt_who_hypervisor_type': hypervisor_type,
+        'virt_who_organization_label': org,
+        'virt_who_service_user': username,
+        'virt_who_service_user_password': password,
+        'virt_who_hypervisor_id': form_data.get('hypervisor_id', 'hostname'),
+        'virt_who_debug': 'true' if form_data.get('debug', debug) else 'false',
+        'virt_who_filtering_mode': form_data.get('filtering_mode', 'none'),
+        'virt_who_hypervisor_server': form_data.get('hypervisor_server', ''),
+        'virt_who_hypervisor_username': form_data.get('hypervisor_username', ''),
+        'virt_who_hypervisor_password': form_data.get('hypervisor_password', ''),
+    }
+
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': inputs,
+            'targeting_type': 'static_query',
+            'search_query': f'name = {target_sat.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(
+        f'resource_type = JobInvocation and resource_id = {job["id"]}'
+    )
+    result = target_sat.api.JobInvocation(id=job['id']).read()
+    if result.succeeded != 1:
+        raise VirtWhoError(
+            f'Failed to deploy virt-who config via Ansible job. '
+            f'Succeeded: {result.succeeded}, Failed: {result.failed}'
+        )
     if debug:
         return deploy_validation(hypervisor_type)
+    return None
+
+
+def deploy_configure_by_job_ui(
+    session,
+    form_data,
+    hypervisor_type,
+    debug=False,
+    org='Default_Organization',
+    activation_key=None,
+    target_sat=None,
+    content_host=None,
+    location=None,
+    capsule=None,
+):
+    """Deploy and run virt-who service via the 'Deploy virt-who Config' job template (UI).
+
+    :param session: Airgun browser session.
+    :param dict form_data: Hypervisor config data with connection details.
+    :param str hypervisor_type: esx, libvirt, rhevm, xen, kubevirt, ahv
+    :param bool debug: if VIRTWHO_DEBUG=1, this option should be True.
+    :param str org: Organization Label
+    :param str activation_key: Activation key for system registration (optional)
+    :param target_sat: Satellite object for registration and job execution.
+    :param content_host: ContentHost object to use as REX job target.
+    :param location: Location object for content host registration.
+    :param capsule: Capsule object to use as smart proxy for registration.
+    """
+    guest_name, guest_uuid = get_guest_info(hypervisor_type)
+    if Host.list({'search': guest_name}):
+        Host.delete({'name': guest_name})
+
+    if target_sat and not activation_key:
+        activation_key = get_activation_key(org, target_sat)
+    register_system(
+        get_system(hypervisor_type), activation_key=activation_key, org=org, target_sat=target_sat
+    )
+
+    org_obj = target_sat.api.Organization().search(query={'search': f'label={org}'})[0]
+    nc = capsule.nailgun_smart_proxy
+    target_sat.api.SmartProxy(id=nc.id, organization=[org_obj]).update(['organization'])
+    target_sat.api.SmartProxy(id=nc.id, location=[location]).update(['location'])
+
+    library_lce = target_sat.api.LifecycleEnvironment().search(
+        query={'search': f'name=Library and organization_id={org_obj.id}'}
+    )[0]
+    capsule.nailgun_capsule.content_add_lifecycle_environment(
+        data={'environment_id': library_lce.id}
+    )
+
+    result = content_host.api_register(
+        target_sat,
+        smart_proxy=nc,
+        organization=org_obj,
+        activation_keys=[activation_key],
+        location=location,
+        force=True,
+    )
+    assert result.status == 0, f'Failed to register content host: {result.stderr}'
+
+    username, password = Base._get_username_password()
+
+    job_values = {
+        'category_and_template.job_category': 'Virt-who',
+        'category_and_template.job_template_text_input': 'Deploy virt-who Config',
+        'target_hosts_and_inputs.virt_who_hypervisor_type': hypervisor_type,
+        'target_hosts_and_inputs.virt_who_organization_label': org,
+        'target_hosts_and_inputs.virt_who_service_user': username,
+        'target_hosts_and_inputs.virt_who_service_user_password': password,
+        'target_hosts_and_inputs.virt_who_hypervisor_id': form_data.get(
+            'hypervisor_id', 'hostname'
+        ),
+        'target_hosts_and_inputs.virt_who_debug': str(
+            form_data.get('debug', debug)
+        ).lower(),
+        'target_hosts_and_inputs.virt_who_filtering_mode': form_data.get(
+            'filtering_mode', 'none'
+        ),
+        'target_hosts_and_inputs.virt_who_hypervisor_server': form_data.get(
+            'hypervisor_content.server', ''
+        ),
+        'target_hosts_and_inputs.virt_who_hypervisor_username': form_data.get(
+            'hypervisor_content.username', ''
+        ),
+        'target_hosts_and_inputs.virt_who_hypervisor_password': form_data.get(
+            'hypervisor_content.password', ''
+        ),
+    }
+    session.host_new.schedule_job(content_host.hostname, job_values)
+    job_description = 'Deploy virt-who configuration virt-who-config'
+    session.jobinvocation.wait_job_invocation_state(
+        entity_name=job_description,
+        host_name=content_host.hostname,
+    )
+    status = session.jobinvocation.read(
+        entity_name=job_description,
+        host_name=content_host.hostname,
+    )
+    if status['hosts'][0]['Status'] != 'Succeeded':
+        raise VirtWhoError(
+            f'Failed to deploy virt-who config via UI job invocation. '
+            f'Status: {status["hosts"][0]["Status"]}'
+        )
+    content_host.execute('rm -f /var/log/rhsm/rhsm.log')
+    content_host.execute('systemctl restart virt-who; sleep 10')
+    if debug:
+        return deploy_validation_on_host(hypervisor_type, content_host)
     return None
 
 
@@ -630,21 +820,6 @@ def create_http_proxy(org, location, name=None, url=None, http_type='https'):
         location=[location.id],
     ).create()
     return http_proxy.url, http_proxy.name, http_proxy.id
-
-
-def get_configure_command_option(deploy_type, args, org=DEFAULT_ORG):
-    """Return the deploy command line based on option.
-    :param str option: the unique id of the configure file you have created.
-    :param str org: the satellite organization name.
-    """
-    username, password = Base._get_username_password()
-    if deploy_type == 'location-id':
-        return f"hammer -u {username} -p {password} virt-who-config deploy --id {args['id']} --location-id '{args['location-id']}' "
-    if deploy_type == 'organization-title':
-        return f"hammer -u {username} -p {password} virt-who-config deploy --id {args['id']} --organization-title '{args['organization-title']}' "
-    if deploy_type == 'name':
-        return f"hammer -u {username} -p {password} virt-who-config deploy --name {args['name']} --organization '{org}' "
-    return None
 
 
 def vw_fake_conf_create(

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -14,6 +14,7 @@ from robottelo import ssh
 from robottelo.cli.base import Base
 from robottelo.cli.host import Host
 from robottelo.config import settings
+from robottelo.constants import REPOS
 from robottelo.hosts import ContentHost
 
 ETC_VIRTWHO_CONFIG = "/etc/virt-who.conf"
@@ -410,24 +411,16 @@ def get_activation_key(org, target_sat):
     return ak.name
 
 
-def deploy_configure_by_job_api(
-    form_data,
-    hypervisor_type,
-    debug=False,
-    org='Default_Organization',
-    activation_key=None,
-    target_sat=None,
-):
-    """Deploy and run virt-who service via the 'Deploy virt-who Config' Ansible REX job (API).
+def _setup_virtwho_guest(hypervisor_type, org, activation_key, target_sat):
+    """Common setup for virt-who deploy functions: create activation key,
+    register the hypervisor guest system, and return the activation key name.
 
-    :param dict form_data: Hypervisor config data with connection details.
     :param str hypervisor_type: esx, libvirt, rhevm, xen, kubevirt, ahv
-    :param bool debug: if VIRTWHO_DEBUG=1, this option should be True.
     :param str org: Organization Label
-    :param str activation_key: Activation key for system registration (optional)
-    :param target_sat: Satellite object for registration and job execution.
+    :param str activation_key: Activation key name, or None to auto-create.
+    :param target_sat: Satellite object.
+    :return str: The activation key name used for registration.
     """
-    virtwho_cleanup()
     guest_name, guest_uuid = get_guest_info(hypervisor_type)
     if Host.list({'search': guest_name}):
         Host.delete({'name': guest_name})
@@ -437,8 +430,63 @@ def deploy_configure_by_job_api(
     register_system(
         get_system(hypervisor_type), activation_key=activation_key, org=org, target_sat=target_sat
     )
+    return activation_key
 
-    target_sat.add_rex_key(target_sat)
+
+def _register_content_host_with_virtwho(content_host, target_sat, org, activation_key, location):
+    """Register a content host to Satellite with virt-who pre-installed.
+
+    Registers to CDN first to install virt-who from AppStream, then
+    registers to Satellite so the host is available for REX job targeting.
+
+    :param content_host: ContentHost object.
+    :param target_sat: Satellite object.
+    :param str org: Organization label.
+    :param str activation_key: Activation key name.
+    :param location: Location object for content host registration.
+    """
+    org_obj = target_sat.api.Organization().search(query={'search': f'label={org}'})[0]
+
+    content_host.register_to_cdn()
+    aps_repo = REPOS[f'rhel{content_host.os_version.major}_aps']['id']
+    content_host.enable_repo(aps_repo, force=True)
+    result = content_host.execute('dnf install -y virt-who')
+    assert result.status == 0, f'Failed to install virt-who from CDN: {result.stderr}'
+
+    result = content_host.api_register(
+        target_sat,
+        organization=org_obj,
+        activation_keys=[activation_key],
+        location=location,
+        force=True,
+    )
+    assert result.status == 0, f'Failed to register content host: {result.stderr}'
+
+
+def deploy_configure_by_job_api(
+    form_data,
+    hypervisor_type,
+    debug=False,
+    org='Default_Organization',
+    activation_key=None,
+    target_sat=None,
+    content_host=None,
+    location=None,
+):
+    """Deploy and run virt-who service via the 'Deploy virt-who Config' Ansible REX job (API).
+
+    :param dict form_data: Hypervisor config data with connection details.
+    :param str hypervisor_type: esx, libvirt, rhevm, xen, kubevirt, ahv
+    :param bool debug: if VIRTWHO_DEBUG=1, this option should be True.
+    :param str org: Organization Label
+    :param str activation_key: Activation key for system registration (optional)
+    :param target_sat: Satellite object for registration and job execution.
+    :param content_host: ContentHost object to use as REX job target.
+    :param location: Location object for content host registration.
+    """
+    virtwho_cleanup()
+    activation_key = _setup_virtwho_guest(hypervisor_type, org, activation_key, target_sat)
+    _register_content_host_with_virtwho(content_host, target_sat, org, activation_key, location)
 
     template_id = (
         target_sat.api.JobTemplate().search(query={'search': 'name="Deploy virt-who Config"'})[0].id
@@ -464,7 +512,7 @@ def deploy_configure_by_job_api(
             'job_template_id': template_id,
             'inputs': inputs,
             'targeting_type': 'static_query',
-            'search_query': f'name = {target_sat.hostname}',
+            'search_query': f'name = {content_host.hostname}',
         },
     )
     target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
@@ -474,8 +522,10 @@ def deploy_configure_by_job_api(
             f'Failed to deploy virt-who config via Ansible job. '
             f'Succeeded: {result.succeeded}, Failed: {result.failed}'
         )
+    content_host.execute('rm -f /var/log/rhsm/rhsm.log')
+    content_host.execute('systemctl restart virt-who; sleep 10')
     if debug:
-        return deploy_validation(hypervisor_type)
+        return deploy_validation_on_host(hypervisor_type, content_host)
     return None
 
 
@@ -489,7 +539,6 @@ def deploy_configure_by_job_ui(
     target_sat=None,
     content_host=None,
     location=None,
-    capsule=None,
 ):
     """Deploy and run virt-who service via the 'Deploy virt-who Config' job template (UI).
 
@@ -502,39 +551,9 @@ def deploy_configure_by_job_ui(
     :param target_sat: Satellite object for registration and job execution.
     :param content_host: ContentHost object to use as REX job target.
     :param location: Location object for content host registration.
-    :param capsule: Capsule object to use as smart proxy for registration.
     """
-    guest_name, guest_uuid = get_guest_info(hypervisor_type)
-    if Host.list({'search': guest_name}):
-        Host.delete({'name': guest_name})
-
-    if target_sat and not activation_key:
-        activation_key = get_activation_key(org, target_sat)
-    register_system(
-        get_system(hypervisor_type), activation_key=activation_key, org=org, target_sat=target_sat
-    )
-
-    org_obj = target_sat.api.Organization().search(query={'search': f'label={org}'})[0]
-    nc = capsule.nailgun_smart_proxy
-    target_sat.api.SmartProxy(id=nc.id, organization=[org_obj]).update(['organization'])
-    target_sat.api.SmartProxy(id=nc.id, location=[location]).update(['location'])
-
-    library_lce = target_sat.api.LifecycleEnvironment().search(
-        query={'search': f'name=Library and organization_id={org_obj.id}'}
-    )[0]
-    capsule.nailgun_capsule.content_add_lifecycle_environment(
-        data={'environment_id': library_lce.id}
-    )
-
-    result = content_host.api_register(
-        target_sat,
-        smart_proxy=nc,
-        organization=org_obj,
-        activation_keys=[activation_key],
-        location=location,
-        force=True,
-    )
-    assert result.status == 0, f'Failed to register content host: {result.stderr}'
+    activation_key = _setup_virtwho_guest(hypervisor_type, org, activation_key, target_sat)
+    _register_content_host_with_virtwho(content_host, target_sat, org, activation_key, location)
 
     username, password = Base._get_username_password()
 
@@ -560,6 +579,8 @@ def deploy_configure_by_job_ui(
             'hypervisor_content.password', ''
         ),
     }
+
+    session.location.select(location.name)
     session.host_new.schedule_job(content_host.hostname, job_values)
     job_description = 'Deploy virt-who configuration virt-who-config'
     session.jobinvocation.wait_job_invocation_state(
@@ -601,16 +622,7 @@ def deploy_configure_by_script(
     script_filename = "/tmp/deploy_script.sh"
     script_content = script_content.replace('&amp;', '&').replace('&gt;', '>').replace('&lt;', '<')
     virtwho_cleanup()
-    guest_name, guest_uuid = get_guest_info(hypervisor_type)
-    if Host.list({'search': guest_name}):
-        Host.delete({'name': guest_name})
-    # If target_sat is provided but activation_key is not, create one for global registration
-    if target_sat and not activation_key:
-        activation_key = get_activation_key(org, target_sat)
-
-    register_system(
-        get_system(hypervisor_type), activation_key=activation_key, org=org, target_sat=target_sat
-    )
+    _setup_virtwho_guest(hypervisor_type, org, activation_key, target_sat)
     with open(script_filename, 'w') as fp:
         fp.write(script_content)
     ssh.get_client().put(script_filename, script_filename)

--- a/tests/foreman/virtwho/api/test_esx_sca.py
+++ b/tests/foreman/virtwho/api/test_esx_sca.py
@@ -24,8 +24,32 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforEsx:
+    def test_positive_deploy_configure_by_job(
+        self,
+        module_sca_manifest_org,
+        deploy_via_job_api,
+    ):
+        """Verify virt-who configuration deployed via Ansible REX job using API.
+
+        :id: a6db0e04-1ccb-4941-8ced-660211b14a59
+
+        :steps:
+            1. Run the 'Deploy virt-who Config' Ansible REX job targeting the Satellite via API
+            2. Verify virt-who service is running and reporting
+
+        :expectedresults:
+            1. Ansible REX job completes successfully
+            2. virt-who service reports hypervisor-guest mapping
+
+        :Verifies: SAT-46996
+
+        :CaseImportance: High
+        """
+        hypervisor_name, guest_name = deploy_via_job_api
+        assert hypervisor_name
+        assert guest_name
+
     @pytest.mark.upgrade
-    @pytest.mark.parametrize('deploy_type_api', ['script'], indirect=True)
     def test_positive_deploy_configure_by_script(
         self,
         module_sca_manifest_org,

--- a/tests/foreman/virtwho/api/test_esx_sca.py
+++ b/tests/foreman/virtwho/api/test_esx_sca.py
@@ -24,6 +24,8 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforEsx:
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
     def test_positive_deploy_configure_by_job(
         self,
         module_sca_manifest_org,

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -13,7 +13,6 @@
 :BlockedBy: SAT-45010
 """
 
-import pytest
 
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
@@ -23,7 +22,31 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforHyperv:
-    @pytest.mark.parametrize('deploy_type_api', ['script'], indirect=True)
+    def test_positive_deploy_configure_by_job(
+        self,
+        module_sca_manifest_org,
+        deploy_via_job_api,
+    ):
+        """Verify virt-who configuration deployed via Ansible REX job using API.
+
+        :id: ddd0c018-9b5c-4075-a784-c822c7c48b4a
+
+        :steps:
+            1. Run the 'Deploy virt-who Config' Ansible REX job targeting the Satellite via API
+            2. Verify virt-who service is running and reporting
+
+        :expectedresults:
+            1. Ansible REX job completes successfully
+            2. virt-who service reports hypervisor-guest mapping
+
+        :Verifies: SAT-46996
+
+        :CaseImportance: High
+        """
+        hypervisor_name, guest_name = deploy_via_job_api
+        assert hypervisor_name
+        assert guest_name
+
     def test_positive_deploy_configure_by_script(
         self,
         module_sca_manifest_org,

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -13,6 +13,9 @@
 :BlockedBy: SAT-45010
 """
 
+import pytest
+
+from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,
@@ -21,6 +24,8 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforHyperv:
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
     def test_positive_deploy_configure_by_job(
         self,
         module_sca_manifest_org,

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -13,7 +13,6 @@
 :BlockedBy: SAT-45010
 """
 
-
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -11,7 +11,6 @@
 :BlockedBy: SAT-36027, SAT-45010
 """
 
-
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -11,7 +11,6 @@
 :BlockedBy: SAT-36027, SAT-45010
 """
 
-import pytest
 
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
@@ -21,7 +20,31 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforKubevirt:
-    @pytest.mark.parametrize('deploy_type_api', ['script'], indirect=True)
+    def test_positive_deploy_configure_by_job(
+        self,
+        module_sca_manifest_org,
+        deploy_via_job_api,
+    ):
+        """Verify virt-who configuration deployed via Ansible REX job using API.
+
+        :id: de336fbb-01c9-4f37-b558-09d4e098e3c3
+
+        :steps:
+            1. Run the 'Deploy virt-who Config' Ansible REX job targeting the Satellite via API
+            2. Verify virt-who service is running and reporting
+
+        :expectedresults:
+            1. Ansible REX job completes successfully
+            2. virt-who service reports hypervisor-guest mapping
+
+        :Verifies: SAT-46996
+
+        :CaseImportance: High
+        """
+        hypervisor_name, guest_name = deploy_via_job_api
+        assert hypervisor_name
+        assert guest_name
+
     def test_positive_deploy_configure_by_script(
         self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
     ):

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -11,6 +11,9 @@
 :BlockedBy: SAT-36027, SAT-45010
 """
 
+import pytest
+
+from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,
@@ -19,6 +22,8 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforKubevirt:
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
     def test_positive_deploy_configure_by_job(
         self,
         module_sca_manifest_org,

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -11,7 +11,6 @@
 :BlockedBy: SAT-45010
 """
 
-
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -11,6 +11,9 @@
 :BlockedBy: SAT-45010
 """
 
+import pytest
+
+from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,
@@ -19,6 +22,8 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforLibvirt:
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
     def test_positive_deploy_configure_by_job(
         self,
         module_sca_manifest_org,

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -11,7 +11,6 @@
 :BlockedBy: SAT-45010
 """
 
-import pytest
 
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
@@ -21,7 +20,31 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforLibvirt:
-    @pytest.mark.parametrize('deploy_type_api', ['script'], indirect=True)
+    def test_positive_deploy_configure_by_job(
+        self,
+        module_sca_manifest_org,
+        deploy_via_job_api,
+    ):
+        """Verify virt-who configuration deployed via Ansible REX job using API.
+
+        :id: e895d3bc-df40-47f5-b793-7223ab7067c9
+
+        :steps:
+            1. Run the 'Deploy virt-who Config' Ansible REX job targeting the Satellite via API
+            2. Verify virt-who service is running and reporting
+
+        :expectedresults:
+            1. Ansible REX job completes successfully
+            2. virt-who service reports hypervisor-guest mapping
+
+        :Verifies: SAT-46996
+
+        :CaseImportance: High
+        """
+        hypervisor_name, guest_name = deploy_via_job_api
+        assert hypervisor_name
+        assert guest_name
+
     def test_positive_deploy_configure_by_script(
         self,
         module_sca_manifest_org,

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -13,6 +13,9 @@
 :BlockedBy: SAT-45010
 """
 
+import pytest
+
+from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,
@@ -21,6 +24,8 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforNutanix:
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
     def test_positive_deploy_configure_by_job(
         self,
         module_sca_manifest_org,

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -13,7 +13,6 @@
 :BlockedBy: SAT-45010
 """
 
-import pytest
 
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
@@ -23,7 +22,31 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtWhoConfigforNutanix:
-    @pytest.mark.parametrize('deploy_type_api', ['script'], indirect=True)
+    def test_positive_deploy_configure_by_job(
+        self,
+        module_sca_manifest_org,
+        deploy_via_job_api,
+    ):
+        """Verify virt-who configuration deployed via Ansible REX job using API.
+
+        :id: e9e30140-d333-41f6-8132-39f1bae74f3d
+
+        :steps:
+            1. Run the 'Deploy virt-who Config' Ansible REX job targeting the Satellite via API
+            2. Verify virt-who service is running and reporting
+
+        :expectedresults:
+            1. Ansible REX job completes successfully
+            2. virt-who service reports hypervisor-guest mapping
+
+        :Verifies: SAT-46996
+
+        :CaseImportance: High
+        """
+        hypervisor_name, guest_name = deploy_via_job_api
+        assert hypervisor_name
+        assert guest_name
+
     def test_positive_deploy_configure_by_script(
         self, default_org, virtwho_config_api, target_sat, deploy_type_api
     ):

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -13,7 +13,6 @@
 :BlockedBy: SAT-45010
 """
 
-
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -38,7 +38,6 @@ from robottelo.utils.virtwho import (
 @pytest.mark.usefixtures('delete_host')
 class TestVirtwhoConfigforEsx:
     @pytest.mark.upgrade
-    @pytest.mark.parametrize('deploy_type_ui', ['script'], indirect=True)
     def test_positive_deploy_configure_by_script(
         self,
         module_sca_manifest_org,
@@ -66,6 +65,39 @@ class TestVirtwhoConfigforEsx:
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
+
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
+    def test_positive_deploy_configure_by_job(
+        self,
+        module_sca_manifest_org,
+        org_session,
+        deploy_via_job_ui,
+        default_location,
+    ):
+        """Verify virt-who configuration deployed via Ansible REX job.
+
+        :id: c05a3927-0ea7-45a7-abd2-47ab375ac0a9
+
+        :steps:
+            1. Run the 'Deploy virt-who Config' Ansible REX job targeting the Satellite
+            2. Verify virt-who service is running and reporting
+            3. Check hypervisor and guest mapping in UI
+
+        :expectedresults:
+            1. Ansible REX job completes successfully
+            2. virt-who service reports hypervisor-guest mapping
+            3. Hypervisor host and virtual guest are visible in UI
+
+        :Verifies: SAT-46996
+
+        :CaseImportance: High
+        """
+        hypervisor_name, guest_name = deploy_via_job_ui
+        org_session.organization.select(org_name=module_sca_manifest_org.name)
         hypervisor_guest_mapping_newcontent_ui(
             org_session, default_location, hypervisor_name, guest_name
         )
@@ -680,7 +712,6 @@ class TestVirtwhoConfigforEsx:
         results = org_session.virtwho_configure.read(name)
         assert 'encrypted_password=$cr_password' in results['deploy']['script']
 
-    @pytest.mark.parametrize('deploy_type_ui', ['script'], indirect=True)
     def test_positive_minimal_report_hypervisor(
         self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, module_target_sat
     ):

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -13,6 +13,7 @@
 
 import pytest
 
+from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,
@@ -23,7 +24,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtwhoConfigforHyperv:
-    @pytest.mark.parametrize('deploy_type_ui', ['script'], indirect=True)
     def test_positive_deploy_configure_by_script(
         self,
         module_sca_manifest_org,
@@ -51,6 +51,39 @@ class TestVirtwhoConfigforHyperv:
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
+
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
+    def test_positive_deploy_configure_by_job(
+        self,
+        module_sca_manifest_org,
+        org_session,
+        deploy_via_job_ui,
+        default_location,
+    ):
+        """Verify virt-who configuration deployed via Ansible REX job.
+
+        :id: 5043cd87-33de-411d-8a73-7731f62d8fa8
+
+        :steps:
+            1. Run the 'Deploy virt-who Config' Ansible REX job targeting the Satellite
+            2. Verify virt-who service is running and reporting
+            3. Check hypervisor and guest mapping in UI
+
+        :expectedresults:
+            1. Ansible REX job completes successfully
+            2. virt-who service reports hypervisor-guest mapping
+            3. Hypervisor host and virtual guest are visible in UI
+
+        :Verifies: SAT-46996
+
+        :CaseImportance: High
+        """
+        hypervisor_name, guest_name = deploy_via_job_ui
+        org_session.organization.select(org_name=module_sca_manifest_org.name)
         hypervisor_guest_mapping_newcontent_ui(
             org_session, default_location, hypervisor_name, guest_name
         )

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -13,6 +13,7 @@
 
 import pytest
 
+from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,
@@ -23,7 +24,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtwhoConfigforKubevirt:
-    @pytest.mark.parametrize('deploy_type_ui', ['script'], indirect=True)
     def test_positive_deploy_configure_by_script(
         self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
     ):
@@ -46,6 +46,39 @@ class TestVirtwhoConfigforKubevirt:
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
+
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
+    def test_positive_deploy_configure_by_job(
+        self,
+        module_sca_manifest_org,
+        org_session,
+        deploy_via_job_ui,
+        default_location,
+    ):
+        """Verify virt-who configuration deployed via Ansible REX job.
+
+        :id: dd31a456-3931-4bf4-a59f-2d84553ac2e4
+
+        :steps:
+            1. Run the 'Deploy virt-who Config' Ansible REX job targeting the Satellite
+            2. Verify virt-who service is running and reporting
+            3. Check hypervisor and guest mapping in UI
+
+        :expectedresults:
+            1. Ansible REX job completes successfully
+            2. virt-who service reports hypervisor-guest mapping
+            3. Hypervisor host and virtual guest are visible in UI
+
+        :Verifies: SAT-46996
+
+        :CaseImportance: High
+        """
+        hypervisor_name, guest_name = deploy_via_job_ui
+        org_session.organization.select(org_name=module_sca_manifest_org.name)
         hypervisor_guest_mapping_newcontent_ui(
             org_session, default_location, hypervisor_name, guest_name
         )

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -13,6 +13,7 @@
 
 import pytest
 
+from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_script,
     get_configure_file,
@@ -23,7 +24,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtwhoConfigforLibvirt:
-    @pytest.mark.parametrize('deploy_type_ui', ['script'], indirect=True)
     def test_positive_deploy_configure_by_script(
         self,
         module_sca_manifest_org,
@@ -51,6 +51,39 @@ class TestVirtwhoConfigforLibvirt:
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
+
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
+    def test_positive_deploy_configure_by_job(
+        self,
+        module_sca_manifest_org,
+        org_session,
+        deploy_via_job_ui,
+        default_location,
+    ):
+        """Verify virt-who configuration deployed via Ansible REX job.
+
+        :id: 2745d285-8103-446f-9c0f-1e5faf33a0dc
+
+        :steps:
+            1. Run the 'Deploy virt-who Config' Ansible REX job targeting the Satellite
+            2. Verify virt-who service is running and reporting
+            3. Check hypervisor and guest mapping in UI
+
+        :expectedresults:
+            1. Ansible REX job completes successfully
+            2. virt-who service reports hypervisor-guest mapping
+            3. Hypervisor host and virtual guest are visible in UI
+
+        :Verifies: SAT-46996
+
+        :CaseImportance: High
+        """
+        hypervisor_name, guest_name = deploy_via_job_ui
+        org_session.organization.select(org_name=module_sca_manifest_org.name)
         hypervisor_guest_mapping_newcontent_ui(
             org_session, default_location, hypervisor_name, guest_name
         )

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -14,6 +14,7 @@
 from fauxfactory import gen_string
 import pytest
 
+from robottelo.config import settings
 from robottelo.utils.virtwho import (
     check_message_in_rhsm_log,
     deploy_configure_by_script,
@@ -26,7 +27,6 @@ from robottelo.utils.virtwho import (
 
 
 class TestVirtwhoConfigforNutanix:
-    @pytest.mark.parametrize('deploy_type_ui', ['script'], indirect=True)
     def test_positive_deploy_configure_by_script(
         self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
     ):
@@ -49,6 +49,39 @@ class TestVirtwhoConfigforNutanix:
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(
+            org_session, default_location, hypervisor_name, guest_name
+        )
+
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
+    def test_positive_deploy_configure_by_job(
+        self,
+        module_sca_manifest_org,
+        org_session,
+        deploy_via_job_ui,
+        default_location,
+    ):
+        """Verify virt-who configuration deployed via Ansible REX job.
+
+        :id: 88e3db70-49ea-4d8c-a9a6-2a33efe60559
+
+        :steps:
+            1. Run the 'Deploy virt-who Config' Ansible REX job targeting the Satellite
+            2. Verify virt-who service is running and reporting
+            3. Check hypervisor and guest mapping in UI
+
+        :expectedresults:
+            1. Ansible REX job completes successfully
+            2. virt-who service reports hypervisor-guest mapping
+            3. Hypervisor host and virtual guest are visible in UI
+
+        :Verifies: SAT-46996
+
+        :CaseImportance: High
+        """
+        hypervisor_name, guest_name = deploy_via_job_ui
+        org_session.organization.select(org_name=module_sca_manifest_org.name)
         hypervisor_guest_mapping_newcontent_ui(
             org_session, default_location, hypervisor_name, guest_name
         )


### PR DESCRIPTION
## Summary
- Added test coverage for the 'Deploy virt-who Config' Ansible REX job template across all hypervisor types (ESX, HyperV, KubeVirt, Libvirt, Nutanix) via both API and UI paths — 10 new test cases total
- Both API and UI deploy paths now target a content host (instead of Satellite/Capsule) by registering it to CDN for virt-who package availability, then to Satellite for REX job targeting
- Removed capsule dependency from deploy_configure_by_job_ui — no longer requires module_capsule_configured or smart proxy setup
- Extracted common setup into reusable helpers (`_setup_virtwho_guest` and `_register_content_host_with_virtwho`) to eliminate duplication across all three deploy functions (API job, UI job, script)
- Removed `register_sat_and_enable_aps_repo` dependency from job-based deploy fixtures since content hosts now get virt-who from CDN directly
- Simplified existing deploy fixtures by removing the unused 'id' deploy type, keeping only 'script'
- Cleaned up unused helper functions and updated log pattern matching for newer Satellite versions

Verifies: SAT-46996

Airgun PR: https://github.com/SatelliteQE/airgun/pull/2488

## Test plan
- [ ] Run API deploy-by-job tests: `pytest tests/foreman/virtwho/api/test_esx_sca.py -k test_positive_deploy_configure_by_job`
- [ ] Run UI deploy-by-job tests: `pytest tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_deploy_configure_by_job`
- [ ] Verify existing deploy-by-script tests still pass: `pytest tests/foreman/virtwho/api/test_esx_sca.py -k test_positive_deploy_configure_by_script`
- [ ] Note: API and UI deploy-by-job tests should NOT be run in parallel against the same Satellite — they share ESX hypervisor/guest state and will conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add new coverage for deploying virt-who configuration via the Ansible REX job against a content host, and refactor shared virt-who deployment logic to support all hypervisor types.

New Features:
- Introduce API and UI helpers to deploy virt-who via the 'Deploy virt-who Config' Ansible REX job targeting a registered content host.
- Add API and UI virt-who job-based tests for ESX, HyperV, KubeVirt, Libvirt, and Nutanix hypervisors validating hypervisor-guest mapping on the content host.

Enhancements:
- Refactor virt-who deployment utilities to share guest setup and registration logic across job-based and script-based flows.
- Update RHSM log parsing and waiting logic to support newer virt-who mapping messages.
- Simplify virt-who deploy fixtures by removing hammer-based deploy variants and relying solely on script and job-based execution paths.

Tests:
- Add pytest fixtures for deploying virt-who configuration via Ansible REX job (API and UI) against a content host.
- Extend UI virt-who SCA test suites to validate REX job deployment for all supported hypervisors and mapping visibility in the UI.
- Extend API virt-who SCA test suites to validate REX job deployment success and hypervisor/guest mapping for all supported hypervisors.

Chores:
- Remove unused hammer deploy helpers and configuration command builders from virt-who utilities.