### PR TITLE
[6.19.z] Convert docker private registry test to positive scenario

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1727,31 +1727,28 @@ class TestDockerRepository:
         ),
         indirect=True,
     )
-    def test_negative_synchronize_private_registry_no_passwd(
+    def test_positive_create_docker_repo_with_private_registry_no_passwd(
         self, repo_options, module_product, target_sat
     ):
-        """Create and try to sync a Docker-type repository from a private
-        registry providing empty password and the sync must fail with
-        reasonable error message.
+        """Create a Docker-type repository from a private registry
+        with username but without password.
 
-        :id: 86bde2f1-4761-4045-aa54-c7be7715cd3a
+        :id: 9e4e2139-a990-4e76-a1db-a7be3fd3654b
 
         :parametrized: yes
 
-        :expectedresults: A repository is created with a private Docker \
-            repository and sync fails with reasonable error message.
+        :expectedresults: A Docker repository is created successfully
+            with a private registry using username but no password.
 
         :customerscenario: true
 
-        :BZ: 1475121, 1580510
-
         """
-        with pytest.raises(
-            HTTPError,
-            match='422 Client Error: Unprocessable Content for url: '
-            f'{target_sat.url}/katello/api/v2/repositories',
-        ):
-            target_sat.api.Repository(**repo_options).create()
+        repo = target_sat.api.Repository(**repo_options).create()
+        assert repo.id
+        assert repo.content_type == 'docker'
+        assert repo.docker_upstream_name == settings.docker.private_registry_name
+        assert repo.upstream_username == settings.docker.private_registry_username
+        assert repo.url == settings.docker.private_registry_url
 
     @pytest.mark.upgrade
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem Statement
The test `test_negative_synchronize_private_registry_no_passwd` expected a `422` **Unprocessable Content HTTP error** when creating a Docker repository from a private registry with a username but no password. This was originally a valid negative scenario (tracked by BZ 1475121, 1580510), but Satellite's behavior has since changed — it now allows creating such repositories without raising an error. As a result, the test was failing because the expected `HTTPError` was never raised.

### Solution
Converted the test from a negative to a positive scenario (`test_positive_create_docker_repo_with_private_registry_no_passwd`) that verifies the repository is successfully created. The updated test asserts that the returned repository has a valid id, correct `content_type` (`docker`), and the expected `docker_upstream_name`, `upstream_username`, and `url` from settings. Removed the obsolete `pytest.raises(HTTPError)` block and the outdated.

### Related Issues
Related Parent PR https://github.com/SatelliteQE/robottelo/pull/21932

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k 'test_positive_create_docker_repo_with_private_registry_no_passwd'

```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->