### PR TITLE
Fix cast_to_infra_host() to use __class__ reassignment

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1691,6 +1691,22 @@ class ContentHost(Host, ContentHostMixins):
         else:
             logger.warning(f'Podman is not logged into container registry {registry}')
 
+    def cast_to_infra_host(self):
+        """Re-type this ContentHost in-place to Capsule or Satellite based on installed RPMs.
+
+        Uses __class__ reassignment to preserve the existing SSH session and all broker state.
+        """
+        if self.execute('rpm -q satellite').status == 0:
+            self.__class__ = Satellite
+            return self
+        if self.execute('rpm -q satellite-capsule').status == 0:
+            self.__class__ = Capsule
+            return self
+        raise ContentHostError(
+            f'Unable to cast ContentHost {self.hostname} to Satellite or Capsule. '
+            'Neither satellite nor satellite-capsule RPMs are installed.'
+        )
+
 
 class Capsule(ContentHost, CapsuleMixins):
     rex_key_path = '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'


### PR DESCRIPTION
## Summary
- `cast_to_infra_host()` was passing `self` (a `ContentHost` instance) as the `hostname` argument to `Capsule()`/`Satellite()`, resulting in a broken object with a non-string hostname
- Fixed to use `__class__` reassignment instead — mutates the instance in-place, preserving the existing SSH session and all broker state with zero reconnection cost

## Problem
```python
# Before — broken: ContentHost instance passed as hostname string
return Capsule(self)  # self.hostname = <ContentHost object>
```

## Fix
```python
# After — correct: same object, same session, same broker state
self.__class__ = Capsule
return self
```

This works because `Capsule` inherits from `ContentHost`, and `Capsule.__init__` adds no required instance attributes beyond what `ContentHost` already provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct casting of ContentHost to infrastructure host types so the resulting host has a valid hostname and preserved connection state.