### PR TITLE
[6.17.z] Fix OSP compute resource cleanup

### DIFF
--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -29,15 +29,12 @@ OSP_SETTINGS = Box(
 class TestOSPComputeResourceTestCase:
     """OSPComputeResource CLI tests."""
 
-    def cr_cleanup(self, cr_id, id_type, target_sat):
+    def cr_cleanup(self, id_type, value, target_sat):
         """Finalizer for removing CR from Satellite.
         This should remove ssh key pairs from OSP in case of test fail.
         """
-        try:
-            target_sat.cli.ComputeResource.delete({id_type: cr_id})
-            assert not target_sat.cli.ComputeResource.exists(search=(id_type, cr_id))
-        except CLIReturnCodeError:
-            pass
+        target_sat.cli.ComputeResource.delete({id_type: value})
+        assert not target_sat.cli.ComputeResource.exists(search=(id_type, value))
 
     @pytest.fixture
     def osp_version(request):
@@ -76,7 +73,9 @@ class TestOSPComputeResourceTestCase:
                 'url': osp_version,
             }
         )
-        request.addfinalizer(lambda: self.cr_cleanup(compute_resource['id'], id_type, target_sat))
+        request.addfinalizer(
+            lambda: self.cr_cleanup(id_type, compute_resource[id_type], target_sat)
+        )
         assert compute_resource['name'] == name
         assert target_sat.cli.ComputeResource.exists(search=(id_type, compute_resource[id_type]))
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22170

### Problem Statement

The OSP compute resource cleanup finalizer was buggy: it always received the CR numeric id, but used the parametrized id_type (id or name) as the delete/search key. For the name parametrization this became delete({'name': '<numeric_id>'}), so cleanup could fail silently. Failed deletes were swallowed with bare pass, which made leaked Satellite CRs (and related OSP SSH key pairs) hard to notice.

### Solution
Always delete and verify the compute resource by id in cr_cleanup, and log a warning when deletion fails so leftover CRs/key pairs are visible in test logs.

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_computeresource_osp.py -k test_crud_and_duplicate_name



<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Fix OSP compute resource cleanup in tests to always delete by numeric ID and surface failures via logging.

Bug Fixes:
- Ensure OSP compute resources are always deleted and verified by numeric ID instead of a parameterized identifier that could be incorrect.

Enhancements:
- Log a warning when OSP compute resource deletion fails so potential SSH key pair leaks are visible in test output.

Tests:
- Update OSP compute resource CLI test finalizer wiring to use the corrected cleanup helper signature.