### PR TITLE
Bump GitHub Actions and dependencies for 6.17.z

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -49,7 +49,7 @@ jobs:
           swap-size-gb: 10
 
       ## Robottelo Repo Checkout
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
         if: ${{ startsWith(matrix.label, '6.') && matrix.label != github.base_ref }}
         with:
           fetch-depth: 0
@@ -87,7 +87,7 @@ jobs:
 
       - name: is autoMerging enabled for Auto CherryPicked PRs ?
         if: ${{ always() && steps.cherrypick.outcome == 'success' && contains(github.event.pull_request.labels.*.name, 'AutoMerge_Cherry_Picked') }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.CHERRYPICK_PAT }}
           script: |

--- a/.github/workflows/auto_cherry_pick_merge.yaml
+++ b/.github/workflows/auto_cherry_pick_merge.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Wait for other status checks to Pass
         id: waitforstatuschecks
-        uses: lewagon/wait-on-check-action@v1.4.0
+        uses: lewagon/wait-on-check-action@v1.8.1
         with:
           ref: ${{ github.head_ref }}
           repo-token: ${{ secrets.CHERRYPICK_PAT }}

--- a/.github/workflows/auto_cherry_pick_merge.yaml
+++ b/.github/workflows/auto_cherry_pick_merge.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Wait for other status checks to Pass
         id: waitforstatuschecks
-        uses: lewagon/wait-on-check-action@v1.8.1
+        uses: lewagon/wait-on-check-action@v1.9.0
         with:
           ref: ${{ github.head_ref }}
           repo-token: ${{ secrets.CHERRYPICK_PAT }}

--- a/.github/workflows/auto_cherry_pick_merged.yaml
+++ b/.github/workflows/auto_cherry_pick_merged.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Find parent PR details
         id: parentPR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.CHERRYPICK_PAT }}
           script: |
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: Convert String to List
         id: conversion
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const branches = "${{ github.event.inputs.branches }}";
@@ -104,7 +104,7 @@ jobs:
           swap-size-gb: 10
 
       ## Robottelo Repo Checkout
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
         if: ${{ startsWith(matrix.branch, '6.') && matrix.branch != needs.get-parentPR-details.outputs.base_ref }}
         with:
           fetch-depth: 0
@@ -143,7 +143,7 @@ jobs:
 
       - name: is autoMerging enabled for Auto CherryPicked PRs ?
         if: ${{ always() && steps.cherrypick.outcome == 'success' && contains(needs.get-parentPR-details.outputs.labels.*.name, 'AutoMerge_Cherry_Picked') }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.CHERRYPICK_PAT }}
           script: |

--- a/.github/workflows/dependency_merge.yml
+++ b/.github/workflows/dependency_merge.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Wait for other status checks to Pass
         id: waitforstatuschecks
-        uses: lewagon/wait-on-check-action@v1.4.0
+        uses: lewagon/wait-on-check-action@v1.8.1
         with:
           ref: ${{ github.head_ref }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency_merge.yml
+++ b/.github/workflows/dependency_merge.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Wait for other status checks to Pass
         id: waitforstatuschecks
-        uses: lewagon/wait-on-check-action@v1.8.1
+        uses: lewagon/wait-on-check-action@v1.9.0
         with:
           ref: ${{ github.head_ref }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prt_labels.yml
+++ b/.github/workflows/prt_labels.yml
@@ -11,7 +11,7 @@ jobs:
     if: "(contains(github.event.pull_request.labels.*.name, 'PRT-Passed'))"
     steps:
       - name: remove the PRT Passed label, for new commit
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.CHERRYPICK_PAT }}
           script: |

--- a/.github/workflows/prt_result.yml
+++ b/.github/workflows/prt_result.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Add the PRT passed/failed labels
         id: prt-status
         if: ${{ always() && github.event.inputs.build_status != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.CHERRYPICK_PAT }}
           script: |
@@ -61,7 +61,7 @@ jobs:
             });
       - name: Remove failed label on test pass or vice-versa
         if: ${{ always() && github.event.inputs.build_status != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.CHERRYPICK_PAT }}
           script: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,10 +22,10 @@ jobs:
       UV_SYSTEM_PYTHON: 1
     steps:
       - name: Checkout Robottelo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7.0.1
 
       - name: Set Up Python-${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -33,7 +33,7 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Restore uv cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /tmp/.uv-cache
           key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -42,7 +42,7 @@ jobs:
             uv-${{ runner.os }}
 
       - name: Restore Jira Status Cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           # If the path is changed in the validator or jira.yaml.template, it should be changed here too
           path: jira_status_cache.json

--- a/.github/workflows/update_robottelo_image.yml
+++ b/.github/workflows/update_robottelo_image.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build Robottelo image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@v3
         with:
           image: robottelo
           tags: ${{ steps.image_tag.outputs.IMAGE_TAG }}

--- a/.github/workflows/update_robottelo_image.yml
+++ b/.github/workflows/update_robottelo_image.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7.0.1
         with:
           # do not store the auth token in git config
           persist-credentials: false

--- a/.github/workflows/update_robottelo_image.yml
+++ b/.github/workflows/update_robottelo_image.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Push Robottelo image to quay.io
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@v3
         with:
           image: robottelo
           tags: ${{ steps.image_tag.outputs.IMAGE_TAG }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -23,10 +23,10 @@ jobs:
       UV_SYSTEM_PYTHON: 1
     steps:
       - name: Checkout Robottelo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7.0.1
 
       - name: Set Up Python-${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -34,7 +34,7 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Restore uv cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /tmp/.uv-cache
           key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Save Jira Status Cache
         if: always()
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           # If the path is changed in the validator or jira.yaml.template, it should be changed here too
           path: jira_status_cache.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ broker[satlab,docker,ssh2_python]==0.8.8
 cryptography==49.0.0
 deepdiff==9.1.0
 dynaconf[vault]==3.2.13
-fastmcp==3.3.1
-fauxfactory==4.2.1
+fastmcp-slim[client]==3.4.4
+fauxfactory==4.2.3
 jira==3.10.5
 jinja2==3.1.6
 manifester==0.2.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ broker[satlab,docker,ssh2_python]==0.8.8
 cryptography==49.0.0
 deepdiff==9.1.0
 dynaconf[vault]==3.2.13
-fastmcp-slim[client]==3.4.4
+fastmcp-slim[client]==3.4.5
 fauxfactory==4.2.3
 jira==3.10.5
 jinja2==3.1.6


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v5 to v7.0.1
- Bump `actions/setup-python` from v6 to v7
- Bump `actions/cache` from v4 to v6 (including `cache/restore` and `cache/save`)
- Bump `actions/github-script` from v7 to v9
- Bump `lewagon/wait-on-check-action` from v1.4.0 to v1.9.0
- Bump `redhat-actions/buildah-build` from v2 to v3
- Bump `redhat-actions/push-to-registry` from v2 to v3
- Bump `fastmcp` 3.3.1 → `fastmcp-slim[client]` 3.4.5
- Bump `fauxfactory` from 4.2.1 to 4.2.3

Closes #21737 #21752 #21770 #21885 #21905 #21941 #21993 #21997 #22047 #22061 #22106 #22178 #22185 #22191 #22252 #22267 #22271 #22285

## Test plan
- [ ] Verify CI workflows run successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)