### PR TITLE
[6.19.z] Fix test_positive_dump_enc_yaml: accept both RSA and Ed25519 SSH keys

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2115,7 +2115,8 @@ def test_positive_dump_enc_yaml(target_sat):
     assert f'fqdn: {target_sat.hostname}' in enc_dump
     ip_prefix = 'ip6' if target_sat.network_type == NetworkType.IPV6 else 'ip'
     assert f'{ip_prefix}: {target_sat.ip_addr}' in enc_dump
-    assert 'ssh-rsa' in enc_dump
+    # Check for SSH key (either RSA or Ed25519)
+    assert 'ssh-rsa' in enc_dump or 'ssh-ed25519' in enc_dump
 
 
 # -------------------------- HOST TRACE SUBCOMMAND SCENARIOS -------------------------


### PR DESCRIPTION
## Summary
- Cherry-pick of #21896 (e75d79ffa) to 6.19.z
- Satellite/Foreman moved from RSA to Ed25519 SSH keys for remote execution
- Updated assertion to accept both `ssh-rsa` and `ssh-ed25519` in the ENC dump

## Test plan
- [ ] Run `pytest tests/foreman/cli/test_host.py -k test_positive_dump_enc_yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)