### PR TITLE
Add ca_cert_file() that returns the CA cert file from the server

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1094,6 +1094,9 @@ PULP_HREF_PRN_MAP = {
     '/pulp/api/v3/acs/file/file': 'prn:file.filealternatecontentsource:',
 }
 
+FOREMANCTL_CA_CERT_PATH = '/var/lib/foremanctl/certs/certs/ca.crt'
+INSTALLER_CA_CERT_PATH = '/etc/pki/katello/certs/katello-default-ca.crt'
+
 PULP_PRN_TABLES = [
     {'name': 'katello_content_guards', 'href_key': 'pulp_href', 'prn_key': 'pulp_prn'},
     {'name': 'katello_repositories', 'href_key': 'remote_href', 'prn_key': 'remote_prn'},

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -135,11 +135,12 @@ class ContentInfo:
             reached or calculation was not successful).
         """
         filename = url.split('/')[-1]
-        result = self.execute(f'wget -q --spider {url}')
+        ca_opt = f'--ca-certificate={self.ca_cert_file}'
+        result = self.execute(f'wget -q --spider {ca_opt} {url}')
         if result.status != 0:
             raise AssertionError(f'Failed to get `{filename}` from `{url}`.')
         return self.execute(
-            f'wget -qO - {url} | tee {filename} | {sum_type} | awk \'{{print $1}}\''
+            f'wget -qO - {ca_opt} {url} | tee {filename} | {sum_type} | awk \'{{print $1}}\''
         ).stdout.strip()
 
     def upload_manifest(self, org_id, manifest=None, interface='API', timeout=None):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -45,7 +45,9 @@ from robottelo.constants import (
     CUSTOM_PUPPET_MODULE_REPOS,
     CUSTOM_PUPPET_MODULE_REPOS_PATH,
     CUSTOM_PUPPET_MODULE_REPOS_VERSION,
+    FOREMANCTL_CA_CERT_PATH,
     HAMMER_CONFIG,
+    INSTALLER_CA_CERT_PATH,
     KEY_CLOAK_CLI,
     RHBK_CLI,
     RHSSO_NEW_GROUP,
@@ -1781,11 +1783,10 @@ class Capsule(ContentHost, CapsuleMixins):
         - foremanctl: /var/lib/foremanctl/certs/certs/ca.crt
         - installer: /etc/pki/katello/certs/katello-default-ca.crt
         """
-        from robottelo.enums import InstallMethod
 
         if settings.server.install_method == InstallMethod.FOREMANCTL:
-            return '/var/lib/foremanctl/certs/certs/ca.crt'
-        return '/etc/pki/katello/certs/katello-default-ca.crt'
+            return FOREMANCTL_CA_CERT_PATH
+        return INSTALLER_CA_CERT_PATH
 
     @property
     def rex_pub_key(self):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1773,6 +1773,20 @@ class Capsule(ContentHost, CapsuleMixins):
         pub_url = urlunsplit(('http', self.hostname, 'pub/', '', ''))  # use url with https?
         return urljoin(pub_url, 'katello-ca-consumer-latest.noarch.rpm')
 
+    @cached_property
+    def ca_cert_file(self):
+        """Return the path to the CA certificate file on this server.
+
+        The path depends on the installation method:
+        - foremanctl: /var/lib/foremanctl/certs/certs/ca.crt
+        - installer: /etc/pki/katello/certs/katello-default-ca.crt
+        """
+        from robottelo.enums import InstallMethod
+
+        if settings.server.install_method == InstallMethod.FOREMANCTL:
+            return '/var/lib/foremanctl/certs/certs/ca.crt'
+        return '/etc/pki/katello/certs/katello-default-ca.crt'
+
     @property
     def rex_pub_key(self):
         if settings.server.install_method == InstallMethod.FOREMANCTL:

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -186,10 +186,11 @@ def test_content_validation_on_download(request, target_sat, function_org, funct
     # 4. Attempt to download the corrupted package from published_at URL,
     #    ensure 200 status on first and 404 status on second download.
     download_url = f"{repo.full_path}Packages/{pkg_name[0]}/{pkg_name}"
-    result = target_sat.execute(f'curl -O -w "%{{http_code}}" -s {download_url}')
+    ca_opt = f'--cacert {target_sat.ca_cert_file}'
+    result = target_sat.execute(f'curl -O -w "%{{http_code}}" -s {ca_opt} {download_url}')
     request.addfinalizer(lambda: target_sat.execute(f'rm -f {pkg_name}'))
     assert '200' in result.stdout, f'Expected 200 status, got: {result.stdout}'
-    result = target_sat.execute(f'curl -O -w "%{{http_code}}" -s {download_url}')
+    result = target_sat.execute(f'curl -O -w "%{{http_code}}" -s {ca_opt} {download_url}')
     assert '404' in result.stdout, f'Expected 404 status, got: {result.stdout}'
 
     # 5. Check the downloaded file content contains 404 message.

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -189,7 +189,7 @@ def test_content_validation_on_download(request, target_sat, function_org, funct
     ca_opt = f'--cacert {target_sat.ca_cert_file}'
     result = target_sat.execute(f'curl -O -w "%{{http_code}}" -s {ca_opt} {download_url}')
     request.addfinalizer(lambda: target_sat.execute(f'rm -f {pkg_name}'))
-    assert '200' in result.stdout, f'Expected 200 status, got: {result.stdout}'
+    assert result.stdout.strip() == '200'
     result = target_sat.execute(f'curl -O -w "%{{http_code}}" -s {ca_opt} {download_url}')
     assert '404' in result.stdout, f'Expected 404 status, got: {result.stdout}'
 


### PR DESCRIPTION
### Problem Statement

Content download verification in robottelo so that `wget` and `curl` commands executed on the containerized Satellite host do not work as expected.

### Solution
Create `ca_cert_file()` function that returns the CA cert path based on the host install method. Also updated related tests to include the CA cert in the `wget` or `curl` commands.


### Related Issues
[JIRA](https://redhat.atlassian.net/browse/SAT-47277)

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_artifacts.py::test_positive_artifact_repair tests/foreman/api/test_repository.py::TestRepository::test_positive_sync_with_treeinfo_ignore tests/foreman/api/test_repository.py::TestRepositorySync::test_positive_sync_kickstart_check_os tests/foreman/sys/test_pulp3_filesystem.py::test_content_validation_on_download
deployment_type: container
```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Add centralized access to the server CA certificate and use it for content download verification.

New Features:
- Introduce a ca_cert_file cached property that exposes the server CA certificate path based on the installation method.

Enhancements:
- Update Satellite host helpers to pass the server CA certificate to wget when validating artifact downloads.
- Update filesystem-based content validation to pass the server CA certificate to curl when downloading packages.

Tests:
- Adjust pulp3 filesystem content validation test to verify downloads using the appropriate server CA certificate.