### PR TITLE
[6.16.z] Bump broker from 0.8.8 to 0.8.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Version updates managed by dependabot
 
 apypie==0.8.0
-broker[satlab,docker,ssh2_python]==0.8.8
+broker[satlab,docker,ssh2_python]==0.8.11
 cryptography==49.0.0
 deepdiff==9.1.0
 dynaconf[vault]==3.2.13


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22163

Bumps [broker](https://github.com/SatelliteQE/broker) from 0.8.8 to 0.8.11.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/SatelliteQE/broker/releases">broker's releases</a>.</em></p>
<blockquote>
<h2>The release that unbound dynaconf</h2>
<h2>What's Changed</h2>
<ul>
<li>Fix AttributeError in Host.to_dict() for directly-constructed hosts by <a href="https://github.com/lpramuk"><code>@​lpramuk</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/537">SatelliteQE/broker#537</a></li>
<li>Deep copy mutable values in Host.to_dict() by <a href="https://github.com/lpramuk"><code>@​lpramuk</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/538">SatelliteQE/broker#538</a></li>
<li>Refactor loader removal for dynaconf version changes by <a href="https://github.com/pondrejk"><code>@​pondrejk</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/530">SatelliteQE/broker#530</a></li>
<li>Bump actions/setup-python from 6 to 7 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/536">SatelliteQE/broker#536</a></li>
<li>[pre-commit.ci] pre-commit autoupdate by <a href="https://github.com/pre-commit-ci"><code>@​pre-commit-ci</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/539">SatelliteQE/broker#539</a></li>
<li>Bump actions/checkout from 7.0.0 to 7.0.1 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/541">SatelliteQE/broker#541</a></li>
<li>Bump github/gh-aw-actions/setup from 0.68.3 to 0.83.2 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/544">SatelliteQE/broker#544</a></li>
</ul>
<h2>New Contributors</h2>
<ul>
<li><a href="https://github.com/pondrejk"><code>@​pondrejk</code></a> made their first contribution in <a href="https://redirect.github.com/SatelliteQE/broker/pull/530">SatelliteQE/broker#530</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/SatelliteQE/broker/compare/0.8.10...0.8.11">https://github.com/SatelliteQE/broker/compare/0.8.10...0.8.11</a></p>
<h2>The release that scenario'd the execute locally</h2>
<h2>What's Changed</h2>
<ul>
<li>Implement Scenario Version 3 and introduce local_exec action by <a href="https://github.com/JacobCallahan"><code>@​JacobCallahan</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/531">SatelliteQE/broker#531</a></li>
<li>Bump actions/cache/save from 6.0.0 to 6.1.0 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/524">SatelliteQE/broker#524</a></li>
<li>Bump github/gh-aw-actions/setup from ba90f2186d7ad780ec640f364005fa24e797b360 to abea67e08ee83539ea33aaae67bf0cddaa0b03b5 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/522">SatelliteQE/broker#522</a></li>
<li>Bump actions/cache/restore from 6.0.0 to 6.1.0 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/525">SatelliteQE/broker#525</a></li>
<li>[pre-commit.ci] pre-commit autoupdate by <a href="https://github.com/pre-commit-ci"><code>@​pre-commit-ci</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/527">SatelliteQE/broker#527</a></li>
<li>Catch host not found exceptions when compiling host info from AnsibleTower by <a href="https://github.com/tpapaioa"><code>@​tpapaioa</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/532">SatelliteQE/broker#532</a></li>
<li>Widen console log width in non-terminal output to stop URLs from wrapping by <a href="https://github.com/JacobCallahan"><code>@​JacobCallahan</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/533">SatelliteQE/broker#533</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/SatelliteQE/broker/compare/0.8.9...0.8.10">https://github.com/SatelliteQE/broker/compare/0.8.9...0.8.10</a></p>
<h2>The release that iterated on scenarios</h2>
<h2>What's Changed</h2>
<ul>
<li>Fix keyboard interrupt resume logic for interactive prompts by <a href="https://github.com/JacobCallahan"><code>@​JacobCallahan</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/515">SatelliteQE/broker#515</a></li>
<li>Switch to the better supported version of dynaconf's loaders listing by <a href="https://github.com/JacobCallahan"><code>@​JacobCallahan</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/521">SatelliteQE/broker#521</a></li>
<li>Make dependabot ignore uv.lock by <a href="https://github.com/JacobCallahan"><code>@​JacobCallahan</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/520">SatelliteQE/broker#520</a></li>
<li>Bump actions/checkout from 6 to 7 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/517">SatelliteQE/broker#517</a></li>
<li>[pre-commit.ci] pre-commit autoupdate by <a href="https://github.com/pre-commit-ci"><code>@​pre-commit-ci</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/513">SatelliteQE/broker#513</a></li>
<li>Bump actions/cache from 5.0.5 to 6.0.0 by <a href="https://github.com/dependabot"><code>@​dependabot</code></a>[bot] in <a href="https://redirect.github.com/SatelliteQE/broker/pull/519">SatelliteQE/broker#519</a></li>
<li>Upgrade Broker scenarios to V2 with enhanced execution control and filtering by <a href="https://github.com/JacobCallahan"><code>@​JacobCallahan</code></a> in <a href="https://redirect.github.com/SatelliteQE/broker/pull/516">SatelliteQE/broker#516</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/SatelliteQE/broker/compare/0.8.8...0.8.9">https://github.com/SatelliteQE/broker/compare/0.8.8...0.8.9</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/SatelliteQE/broker/commit/38cc671ed9350829913168f782df5a9b3b80c907"><code>38cc671</code></a> Bump version to 0.8.11</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/0f0dc4923da43b89227d435b5baa4c3fbd0e537d"><code>0f0dc49</code></a> Modify dynaconf dependency version constraint</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/ef72ae1f6c57d0371bf2f41906b097f674da89e6"><code>ef72ae1</code></a> Bump github/gh-aw-actions/setup from 0.68.3 to 0.83.2</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/359076fdf827ab575dfa01afc44cf86425716e45"><code>359076f</code></a> Bump actions/checkout from 7.0.0 to 7.0.1</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/893b79a0f28723aaa521076b007b3c4a400ffd59"><code>893b79a</code></a> [pre-commit.ci] pre-commit autoupdate</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/0074a93839ecbfc2890425a3cd84d9112e987620"><code>0074a93</code></a> Bump actions/setup-python from 6 to 7</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/411d45666875990589ff4045d9c4f4dc0f58aa55"><code>411d456</code></a> Refactor loader removal for dynaconf version changes (<a href="https://redirect.github.com/SatelliteQE/broker/issues/530">#530</a>)</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/9b98e4f8ae7877dbc4aefb10500d72fff7a75039"><code>9b98e4f</code></a> Deep copy mutable values in Host.to_dict() (<a href="https://redirect.github.com/SatelliteQE/broker/issues/538">#538</a>)</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/8a99ea9012283d12c554d51b76738b7f1483bd24"><code>8a99ea9</code></a> Fix AttributeError in Host.to_dict() for directly-constructed hosts</li>
<li><a href="https://github.com/SatelliteQE/broker/commit/f613b5cc37bb43a694ab013e23c2868d10d73b2a"><code>f613b5c</code></a> Fix AttributeError in Host.to_dict() for directly-constructed hosts</li>
<li>Additional commits viewable in <a href="https://github.com/SatelliteQE/broker/compare/0.8.8...0.8.11">compare view</a></li>
</ul>
</details>
<br />
