### PR TITLE
Refactor Memory Assertion for Libvirt

### DIFF
--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -111,7 +111,7 @@ def test_positive_end_to_end(session, module_target_sat, module_org, module_loca
             == f'{new_cr_name} ({FOREMAN_PROVIDERS["libvirt"]})'
         )
         assert cr_profile_values['provider_content']['cpus'] == '16'
-        assert cr_profile_values['provider_content']['memory'] == '8192 MB'
+        assert cr_profile_values['provider_content']['memory'] == '8192'
         session.computeresource.delete(new_cr_name)
         assert not session.computeresource.search(new_cr_name)
 
@@ -359,7 +359,7 @@ def test_positive_associate_with_custom_profile(
         values = session.computeresource.read_computeprofile(cr_name, COMPUTE_PROFILE_SMALL)
         provider_content = values['provider_content']
         assert provider_content['cpus'] == "1"
-        assert provider_content['memory'] == '6144 MB'
+        assert provider_content['memory'] == '6144'
         assert provider_content['storage'][0]['storage_type'] == storage_data['storage_type']
         assert provider_content['storage'][0]['storage_pool'] == storage_data['storage_pool']
         assert provider_content['storage'][0]['size'] == storage_data['size']


### PR DESCRIPTION
The assertion for the libvirt memory field was failing due to a UI change. I updated the assertion accordingly.

## Summary by Sourcery

Bug Fixes:
- Adjust libvirt memory assertions in UI tests to align with the updated format returned by the application.