### PR TITLE
Move certificate bundle to auth bundle

### DIFF
--- a/tests/foreman/foremanctl/test_install_foremanctl.py
+++ b/tests/foreman/foremanctl/test_install_foremanctl.py
@@ -566,18 +566,18 @@ def foremanctl_host_cert_paths(hostname):
 
 
 def foremanctl_capsule_cert_paths(sat, capsule, result, extract_dir):
-    """Return server and client certificate paths for a foremanctl capsule bundle."""
+    """Return server and client certificate paths for a foremanctl capsule auth bundle."""
     sat.execute(f'mkdir -p {extract_dir}')
 
     bundle_path = re.search(r'/\S+?\.tar\.gz', result.stdout).group(0)
     sat.execute(f'tar xf {bundle_path} -C {extract_dir}')
 
     result = sat.execute(f'tar -tzf {bundle_path}')
-    assert result.status == 0, (
-        f'Certificate bundle tarball not found at {bundle_path}: {result.stderr}'
-    )
+    assert result.status == 0, f'Auth bundle tarball not found at {bundle_path}: {result.stderr}'
     assert f'certs/{capsule.hostname}.crt' in result.stdout
     assert f'certs/{capsule.hostname}-client.crt' in result.stdout
+    assert 'oauth/foreman-oauth-consumer-key' in result.stdout
+    assert 'oauth/foreman-oauth-consumer-secret' in result.stdout
 
     return [
         f'{extract_dir}/certs/{capsule.hostname}.crt',
@@ -587,23 +587,23 @@ def foremanctl_capsule_cert_paths(sat, capsule, result, extract_dir):
 
 @pytest.mark.parametrize('module_sat_ready_rhel', ['default'], indirect=True)
 @pytest.mark.rhel_ver_match('9')
-def test_positive_foremanctl_certificate_bundle(module_sat_ready_rhel, rhel_contenthost):
-    """Verify foremanctl certificate-bundle generation and renewal for a capsule.
+def test_positive_foremanctl_auth_bundle(module_sat_ready_rhel, rhel_contenthost):
+    """Verify foremanctl auth-bundle generation and renewal for a capsule.
 
     :id: 9bd1d8d8-a22a-4917-9522-22b7165d224c
 
     :steps:
         1. Deploy Satellite with foremanctl using default certificates
-        2. Generate a certificate bundle via
-           foremanctl certificate-bundle
+        2. Generate an auth bundle via
+           foremanctl auth-bundle
         3. Extract the bundle tarball and verify it contains capsule server and
-           client certificate files
+           client certificate files and oauth credentials
         4. Verify capsule server and client certificates have default validity
            (7300 days)
         5. Verify capsule server and client certificates are signed by the bundle CA
         6. Capture SHA256 fingerprints of the CA, capsule server, and capsule
            client certificates
-        7. Renew the capsule certificate bundle with foremanctl certificate-bundle
+        7. Renew the capsule auth bundle with foremanctl auth-bundle
            --certificate-renew
         8. Extract the renewed bundle tarball and verify its contents
         9. Verify renewed capsule server and client certificates retain default
@@ -616,12 +616,12 @@ def test_positive_foremanctl_certificate_bundle(module_sat_ready_rhel, rhel_cont
             renewal
 
     :expectedresults:
-        1. foremanctl certificate-bundle succeeds and produces a tarball
+        1. foremanctl auth-bundle succeeds and produces a tarball
         2. Extracted tarball contains the expected server and client certificate
-           files
+           files and oauth credentials
         3. Initial capsule certificate validity is 7300 days
         4. Capsule certificates validate against the bundle CA
-        5. foremanctl certificate-bundle --certificate-renew succeeds
+        5. foremanctl auth-bundle --certificate-renew succeeds
         6. Renewed capsule certificates retain 7300-day validity
         7. CA identity is preserved across renewal (fingerprint unchanged)
         8. Capsule server and client certificates are regenerated (fingerprints change)
@@ -639,8 +639,8 @@ def test_positive_foremanctl_certificate_bundle(module_sat_ready_rhel, rhel_cont
     capsule = rhel_contenthost
 
     # Generate bundle
-    result = sat.execute(f'foremanctl certificate-bundle {capsule.hostname}', timeout='10m')
-    assert result.status == 0, f'foremanctl certificate-bundle failed:\n{result.stderr}'
+    result = sat.execute(f'foremanctl auth-bundle {capsule.hostname}', timeout='10m')
+    assert result.status == 0, f'foremanctl auth-bundle failed:\n{result.stderr}'
 
     # Phase 1: initial capsule validity
     capsule_certs = foremanctl_capsule_cert_paths(sat, capsule, result, extract_dir)
@@ -658,10 +658,10 @@ def test_positive_foremanctl_certificate_bundle(module_sat_ready_rhel, rhel_cont
 
     # Renew bundle
     result = sat.execute(
-        f'foremanctl certificate-bundle --certificate-renew {capsule.hostname}',
+        f'foremanctl auth-bundle --certificate-renew {capsule.hostname}',
         timeout='10m',
     )
-    assert result.status == 0, f'Capsule certificate renewal failed: {result.stderr}'
+    assert result.status == 0, f'Capsule auth-bundle renewal failed: {result.stderr}'
 
     # Phase 2: renew capsule validate
     capsule_certs = foremanctl_capsule_cert_paths(sat, capsule, result, renewed_extract_dir)


### PR DESCRIPTION
### Problem Statement
https://github.com/theforeman/foremanctl/pull/698 changes the old certificate bundle command and adds oauth/ credentials into the bundle

### Solution
Change according to https://github.com/theforeman/foremanctl/pull/698

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Adapt capsule bundle integration test from certificate-bundle to auth-bundle, including generation and renewal flows and expectations for OAuth credentials in the bundle contents.