### PR TITLE
Support capsule deploy via foremanctl with dedicated test and fixture updates

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1698,6 +1698,7 @@ class Capsule(ContentHost, CapsuleMixins):
     rex_key_path = '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
     product_rpm_name = 'satellite-capsule'
     upstream_rpm_name = 'foreman-proxy'
+    container_rpm_name = 'satellitectl'
 
     def __init__(self, hostname, **kwargs):
         kwargs.setdefault('net_type', settings.capsule.network_type)
@@ -2017,7 +2018,30 @@ class Capsule(ContentHost, CapsuleMixins):
         """
         self.register_to_cdn()
         self.setup_rhel_repos()
-        self.setup_capsule_repos(release=release)
+        product_rpm_name = (
+            self.container_rpm_name if self.is_foremanctl_available() else self.product_rpm_name
+        )
+        # TODO: Remove this condition once foremanctl is available in capsule repos
+        if settings.server.install_method == InstallMethod.INSTALLER:
+            self.setup_capsule_repos(release=release)
+        else:
+            self.setup_satellite_repos()
+            # Enable Packit repos
+            pull_requests = settings.server.get('deploy_arguments', {}).get('pull_requests', [])
+            if pull_requests:
+                Broker(
+                    job_template='upstream-pr-install',
+                    target_vm=self.name,
+                    pull_requests=pull_requests,
+                    deploy_network_type=settings.server.network_type,
+                ).execute()
+            assert self.execute(f'dnf install -y {product_rpm_name}').status == 0, (
+                f'Failed to install {product_rpm_name}'
+            )
+
+        result = self.execute(f'rpm -q {product_rpm_name}')
+        if result.status:
+            raise CapsuleHostError(f'The {product_rpm_name} package was not found\n{result.stdout}')
 
         # After capsule registration to cdn, it should be initialized with the Satellite.
         self._satellite = sat_host or Satellite()
@@ -2033,31 +2057,49 @@ class Capsule(ContentHost, CapsuleMixins):
         ), "firewalld is not present and can't be installed"
         self.execute('firewall-cmd --add-service RH-Satellite-6-capsule')
         self.execute('firewall-cmd --runtime-to-permanent')
-        result = self.execute('rpm -q satellite-capsule')
-        if result.status:
-            raise CapsuleHostError(f'The satellite-capsule package was not found\n{result.stdout}')
 
         # Generate certificate, copy it to Capsule, run installer, check it succeeds
         if not capsule_cert_opts:
             capsule_cert_opts = {}
         certs_tar, _, installer = self.satellite.capsule_certs_generate(self, **capsule_cert_opts)
         self.satellite.session.remote_copy(certs_tar, self)
-        installer.update(**installer_kwargs)
-        result = self.install(installer)
-        if result.status:
-            # before exit download the capsule log file
-            self.session.sftp_read(
-                '/var/log/foreman-installer/capsule.log',
-                f'{settings.robottelo.tmp_dir}/capsule-{self.ip_addr}.log',
-            )
-            raise CapsuleHostError(
-                f'Foreman installer failed at capsule host\n{result.stdout}\n{result.stderr}'
-            )
-        result = self.execute('satellite-maintain service status')
-        if 'inactive (dead)' in '\n'.join(result.stdout):
-            raise CapsuleHostError(
-                f'A core service is not running at capsule host\n{result.stdout}'
-            )
+
+        if settings.server.install_method == InstallMethod.INSTALLER:
+            installer.update(**installer_kwargs)
+            result = self.install(installer)
+            if result.status:
+                # before exit download the capsule log file
+                self.session.sftp_read(
+                    '/var/log/foreman-installer/capsule.log',
+                    f'{settings.robottelo.tmp_dir}/capsule-{self.ip_addr}.log',
+                )
+                raise CapsuleHostError(
+                    f'Foreman installer failed at capsule host\n{result.stdout}\n{result.stderr}'
+                )
+            result = self.execute('satellite-maintain service status')
+            if 'inactive (dead)' in '\n'.join(result.stdout):
+                raise CapsuleHostError(
+                    f'A core service is not running at capsule host\n{result.stdout}'
+                )
+        if settings.server.install_method == InstallMethod.FOREMANCTL:
+            result = self.execute(installer)
+            if result.status:
+                # before exit download the logs file for further investigation
+                self.execute(
+                    'journalctl --since "1 hour ago" -u foreman-proxy -u pulp-api -u pulp-content -u httpd -u postgresql -u valkey > /tmp/deploy-proxy-failure.log'
+                )
+                self.session.sftp_read(
+                    '/tmp/deploy-proxy-failure.log',
+                    f'{settings.robottelo.tmp_dir}/deploy-proxy-failure-{self.ip_addr}.log',
+                )
+                raise CapsuleHostError(
+                    f'foremanctl deploy-proxy failed at capsule host\n{result.stdout}\n{result.stderr}'
+                )
+            result = self.execute('systemctl status foreman-proxy.service foreman.target')
+            if 'inactive (dead)' in '\n'.join(result.stdout):
+                raise CapsuleHostError(
+                    f'A core service is not running at capsule host\n{result.stdout}'
+                )
 
     def update_download_policy(self, policy):
         """Updates capsule's download policy to desired value"""
@@ -2394,6 +2436,7 @@ class Capsule(ContentHost, CapsuleMixins):
 class Satellite(Capsule, SatelliteMixins):
     product_rpm_name = 'satellite'
     upstream_rpm_name = 'foreman'
+    container_rpm_name = 'satellitectl'
 
     def __init__(self, hostname=None, **kwargs):
         hostname = hostname or settings.server.hostname  # instance attr set by broker.Host
@@ -2720,17 +2763,32 @@ class Satellite(Capsule, SatelliteMixins):
 
     def capsule_certs_generate(self, capsule, cert_path=None, **extra_kwargs):
         """Generate capsule certs, returning the cert path, installer command stdout and args"""
-        cert_file_path = cert_path or f'/root/{capsule.hostname}-certs.tar'
-        result = self.install(
-            InstallerCommand(
-                command='capsule-certs-generate',
-                foreman_proxy_fqdn=capsule.hostname,
-                certs_tar=cert_file_path,
-                installer_args=['no-colors'],
-                **extra_kwargs,
+        if settings.server.install_method == InstallMethod.FOREMANCTL:
+            cert_file_path = f'/var/lib/foremanctl/certs/bundles/{capsule.hostname}.tar.gz'
+            result = self.execute(
+                f'satellitectl certificate-bundle {capsule.hostname}', timeout='10m'
             )
-        )
-        install_cmd = InstallerCommand.from_cmd_str(cmd_str=result.stdout)
+            if result.status:
+                raise SatelliteHostError(
+                    f'satellitectl certificate-bundle failed\n{result.stdout}\n{result.stderr}'
+                )
+            install_cmd = (
+                f'satellitectl deploy-proxy --flavor foreman-proxy-content'
+                f' --certificate-bundle {cert_file_path}'
+                f' --foreman-fqdn {self.hostname}'
+            )
+        else:
+            cert_file_path = cert_path or f'/root/{capsule.hostname}-certs.tar'
+            result = self.install(
+                InstallerCommand(
+                    command='capsule-certs-generate',
+                    foreman_proxy_fqdn=capsule.hostname,
+                    certs_tar=cert_file_path,
+                    installer_args=['no-colors'],
+                    **extra_kwargs,
+                )
+            )
+            install_cmd = InstallerCommand.from_cmd_str(cmd_str=result.stdout)
         return cert_file_path, result, install_cmd
 
     def __enter__(self):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2765,16 +2765,14 @@ class Satellite(Capsule, SatelliteMixins):
         """Generate capsule certs, returning the cert path, installer command stdout and args"""
         if settings.server.install_method == InstallMethod.FOREMANCTL:
             cert_file_path = f'/var/lib/foremanctl/certs/bundles/{capsule.hostname}.tar.gz'
-            result = self.execute(
-                f'satellitectl certificate-bundle {capsule.hostname}', timeout='10m'
-            )
+            result = self.execute(f'satellitectl auth-bundle {capsule.hostname}', timeout='10m')
             if result.status:
                 raise SatelliteHostError(
-                    f'satellitectl certificate-bundle failed\n{result.stdout}\n{result.stderr}'
+                    f'satellitectl auth-bundle failed\n{result.stdout}\n{result.stderr}'
                 )
             install_cmd = (
                 f'satellitectl deploy-proxy --flavor foreman-proxy-content'
-                f' --certificate-bundle {cert_file_path}'
+                f' --auth-bundle {cert_file_path}'
                 f' --foreman-fqdn {self.hostname}'
             )
         else:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2019,7 +2019,9 @@ class Capsule(ContentHost, CapsuleMixins):
         self.register_to_cdn()
         self.setup_rhel_repos()
         product_rpm_name = (
-            self.container_rpm_name if self.is_foremanctl_available() else self.product_rpm_name
+            self.container_rpm_name
+            if settings.server.install_method == InstallMethod.FOREMANCTL
+            else self.product_rpm_name
         )
         # TODO: Remove this condition once foremanctl is available in capsule repos
         if settings.server.install_method == InstallMethod.INSTALLER:
@@ -2077,7 +2079,7 @@ class Capsule(ContentHost, CapsuleMixins):
                     f'Foreman installer failed at capsule host\n{result.stdout}\n{result.stderr}'
                 )
             result = self.execute('satellite-maintain service status')
-            if 'inactive (dead)' in '\n'.join(result.stdout):
+            if 'inactive (dead)' in result.stdout:
                 raise CapsuleHostError(
                     f'A core service is not running at capsule host\n{result.stdout}'
                 )
@@ -2096,7 +2098,7 @@ class Capsule(ContentHost, CapsuleMixins):
                     f'foremanctl deploy-proxy failed at capsule host\n{result.stdout}\n{result.stderr}'
                 )
             result = self.execute('systemctl status foreman-proxy.service foreman.target')
-            if 'inactive (dead)' in '\n'.join(result.stdout):
+            if 'inactive (dead)' in result.stdout:
                 raise CapsuleHostError(
                     f'A core service is not running at capsule host\n{result.stdout}'
                 )
@@ -2251,7 +2253,9 @@ class Capsule(ContentHost, CapsuleMixins):
             )
 
         # Install foremanctl
-        assert self.execute('dnf install -y foremanctl').status == 0, 'Failed to install foremanctl'
+        assert self.execute('dnf install -y satellitectl').status == 0, (
+            'Failed to install satellitectl'
+        )
 
         if enable_fapolicyd:
             assert self.execute('dnf -y install fapolicyd').status == 0

--- a/tests/foreman/foremanctl/test_install_foremanctl.py
+++ b/tests/foreman/foremanctl/test_install_foremanctl.py
@@ -28,7 +28,7 @@ from robottelo.constants import (
     InstallationServices,
 )
 from robottelo.exceptions import CapsuleHostError
-from robottelo.hosts import Satellite, Capsule
+from robottelo.hosts import Capsule, Satellite
 from robottelo.utils.issue_handlers import is_open
 from robottelo.utils.ohsnap import dogfood_repository
 
@@ -226,6 +226,7 @@ def module_sat_ready_rhel(request):
             parameters=deploy_args,
         )
         yield sat
+
 
 @pytest.fixture(scope='module')
 def module_cap_ready_rhel(request):
@@ -832,26 +833,18 @@ def test_positive_foremanctl_auth_bundle(module_sat_ready_rhel):
 
     :steps:
         1. Deploy Satellite with foremanctl using default certificates
-        2. Generate an auth bundle via
-           foremanctl auth-bundle
+        2. Generate an auth bundle via foremanctl auth-bundle
         3. Extract the bundle tarball and verify it contains capsule server and
            client certificate files and oauth credentials
-        4. Verify capsule server and client certificates have default validity
-           (7300 days)
+        4. Verify capsule server and client certificates have default validity (7300 days)
         5. Verify capsule server and client certificates are signed by the bundle CA
-        6. Capture SHA256 fingerprints of the CA, capsule server, and capsule
-           client certificates
-        7. Renew the capsule auth bundle with foremanctl auth-bundle
-           --certificate-renew
+        6. Capture SHA256 fingerprints of the CA, capsule server and capsule client certificates
+        7. Renew the capsule auth bundle with foremanctl auth-bundle --certificate-renew
         8. Extract the renewed bundle tarball and verify its contents
-        9. Verify renewed capsule server and client certificates retain default
-           validity (7300 days)
-        10. Verify renewed capsule certificates chain to both the original and
-            renewed bundle CA
-        11. Verify CA fingerprint is unchanged between the original and renewed
-            bundle
-        12. Verify capsule server and client certificate fingerprints changed after
-            renewal
+        9. Verify renewed capsule server and client certificates retain default validity(7300 days)
+        10. Verify renewed capsule certificates chain to both the original and renewed bundle CA
+        11. Verify CA fingerprint is unchanged between the original and renewed bundle
+        12. Verify capsule server and client certificate fingerprints changed after renewal
 
     :expectedresults:
         1. foremanctl auth-bundle succeeds and produces a tarball
@@ -863,8 +856,7 @@ def test_positive_foremanctl_auth_bundle(module_sat_ready_rhel):
         6. Renewed capsule certificates retain 7300-day validity
         7. CA identity is preserved across renewal (fingerprint unchanged)
         8. Capsule server and client certificates are regenerated (fingerprints change)
-        9. Renewed certificates maintain chain integrity against both the original
-           and renewed CA
+        9. Renewed certificates maintain chain integrity against both the original and renewed CA
 
     :verifies: SAT-43475
     """

--- a/tests/foreman/foremanctl/test_install_foremanctl.py
+++ b/tests/foreman/foremanctl/test_install_foremanctl.py
@@ -358,7 +358,7 @@ def test_capsule_installation_with_foremanctl(
         f'satellitectl deploy-proxy failed at capsule host\n{result.stdout}\n{result.stderr}'
     )
 
-    assert module_sat_ready_rhel.api.Capsule().search(
+    assert module_sat_ready_rhel.api.SmartProxy().search(
         query={'search': f'name={module_cap_ready_rhel.hostname}'}
     )[0]
 

--- a/tests/foreman/foremanctl/test_install_foremanctl.py
+++ b/tests/foreman/foremanctl/test_install_foremanctl.py
@@ -19,18 +19,13 @@ import pytest
 from robottelo.cli import hammer
 from robottelo.config import settings
 from robottelo.constants import (
-    DEFAULT_ARCHITECTURE,
     FOREMANCTL_PARAMETERS_FILE,
     FOREMANCTL_POSTGRESQL_TUNING_PROFILES,
-    PRDS,
-    REPOS,
-    REPOSET,
     InstallationServices,
 )
 from robottelo.exceptions import CapsuleHostError
 from robottelo.hosts import Capsule, Satellite
 from robottelo.utils.issue_handlers import is_open
-from robottelo.utils.ohsnap import dogfood_repository
 
 pytestmark = [pytest.mark.foremanctl, pytest.mark.upgrade]
 
@@ -90,121 +85,6 @@ def assert_postgresql_tuning(sat, tuning):
         )
 
 
-def sync_capsule_repos(satellite, capsule_host, org, ak):
-    """
-    On Satellite enable and synchronize content required for Capsule installation.
-    1. Enable RHEL repositories based on configuration
-    2. Enable capsule repositories based on configuration
-    3. Synchronize repositories
-    """
-    # List of sync tasks - all repos will be synced asynchronously
-    sync_tasks = []
-
-    # Enable and sync RHEL BaseOS and AppStream repos
-    if settings.robottelo.rhel_source == "internal":
-        # Configure internal sources as custom repositories
-        product_rhel = satellite.api.Product(organization=org.id).create()
-        for repourl in settings.repos.get(f'rhel{capsule_host.os_version.major}_os').values():
-            repo = satellite.api.Repository(
-                organization=org.id, product=product_rhel, content_type='yum', url=repourl
-            ).create()
-            # custom repos need to be explicitly enabled
-            ak.content_override(
-                data={
-                    'content_overrides': [
-                        {
-                            'content_label': '_'.join([org.label, product_rhel.label, repo.label]),
-                            'value': '1',
-                        }
-                    ]
-                }
-            )
-    else:
-        # use AppStream and BaseOS from CDN
-        for rh_repo_key in [
-            f'rhel{capsule_host.os_version.major}_bos',
-            f'rhel{capsule_host.os_version.major}_aps',
-        ]:
-            satellite.api_factory.enable_rhrepo_and_fetchid(
-                basearch=DEFAULT_ARCHITECTURE,
-                org_id=org.id,
-                product=PRDS[f'rhel{capsule_host.os_version.major}'],
-                repo=REPOS[rh_repo_key]['name'],
-                reposet=REPOSET[rh_repo_key],
-                releasever=REPOS[rh_repo_key]['releasever'],
-            )
-        product_rhel = satellite.api.Product(
-            name=PRDS[f'rhel{capsule_host.os_version.major}'], organization=org.id
-        ).search()[0]
-    sync_tasks.append(satellite.api.Product(id=product_rhel.id).sync(synchronous=False))
-
-    # Enable and sync Capsule repos
-    if settings.capsule.version.source == "ga":
-        # enable Capsule repos from CDN
-        for repo in capsule_host.CAPSULE_CDN_REPOS.values():
-            reposet = satellite.api.RepositorySet(organization=org.id).search(
-                query={'search': repo}
-            )[0]
-            reposet.enable()
-            # repos need to be explicitly enabled in AK
-            ak.content_override(
-                data={
-                    'content_overrides': [
-                        {
-                            'content_label': reposet.label,
-                            'value': '1',
-                        }
-                    ]
-                }
-            )
-            sync_tasks.append(satellite.api.Product(id=reposet.product.id).sync(synchronous=False))
-    else:
-        # configure internal source as custom repos
-        product_capsule = satellite.api.Product(organization=org.id).create()
-        for repo_variant, repo_default_url in [
-            ('capsule', 'capsule_repo'),
-            ('maintenance', 'satmaintenance_repo'),
-        ]:
-            if settings.capsule.version.source == 'nightly':
-                repo_url = getattr(settings.repos, repo_default_url)
-            else:
-                repo_url = dogfood_repository(
-                    ohsnap=settings.ohsnap,
-                    repo=repo_variant,
-                    product="capsule",
-                    release=settings.capsule.version.release,
-                    os_release=capsule_host.os_version.major,
-                    snap=settings.capsule.version.snap,
-                ).baseurl
-            repo = satellite.api.Repository(
-                organization=org.id,
-                product=product_capsule,
-                content_type='yum',
-                url=repo_url,
-            ).create()
-
-            # custom repos need to be explicitly enabled
-            ak.content_override(
-                data={
-                    'content_overrides': [
-                        {
-                            'content_label': '_'.join(
-                                [org.label, product_capsule.label, repo.label]
-                            ),
-                            'value': '1',
-                        }
-                    ]
-                }
-            )
-        sync_tasks.append(satellite.api.Product(id=product_capsule.id).sync(synchronous=False))
-
-    # Wait for asynchronous sync tasks
-    satellite.wait_for_tasks(
-        search_query=(f'id ^ "{",".join(task["id"] for task in sync_tasks)}"'),
-        poll_timeout=1800,
-    )
-
-
 @pytest.fixture(scope='module')
 def module_sat_ready_rhel(request):
     """Deploy bare RHEL system ready for Satellite installation."""
@@ -234,6 +114,7 @@ def module_cap_ready_rhel(request):
         deploy_flavor=settings.flavors.default,
         deploy_network_type=settings.server.network_type,
         host_class=Capsule,
+        use_dynamic_inventories_wf_level=False,
     ) as cap:
         # Add IPv6 proxy for IPv6 communication
         cap.enable_ipv6_dnf_and_rhsm_proxy()
@@ -348,7 +229,7 @@ def test_capsule_installation_with_foremanctl(
     ak = module_sat_ready_rhel.api.ActivationKey(
         organization=org, content_view_environment_ids=[cvenv_id]
     ).create()
-    sync_capsule_repos(module_sat_ready_rhel, module_cap_ready_rhel, org, ak)
+    module_sat_ready_rhel.api_factory.sync_capsule_repos(module_cap_ready_rhel, org, ak)
 
     module_cap_ready_rhel.register(org, None, ak.name, module_sat_ready_rhel)
 

--- a/tests/foreman/foremanctl/test_install_foremanctl.py
+++ b/tests/foreman/foremanctl/test_install_foremanctl.py
@@ -19,12 +19,18 @@ import pytest
 from robottelo.cli import hammer
 from robottelo.config import settings
 from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
     FOREMANCTL_PARAMETERS_FILE,
     FOREMANCTL_POSTGRESQL_TUNING_PROFILES,
+    PRDS,
+    REPOS,
+    REPOSET,
     InstallationServices,
 )
-from robottelo.hosts import Capsule, Satellite
+from robottelo.exceptions import CapsuleHostError
+from robottelo.hosts import Satellite, Capsule
 from robottelo.utils.issue_handlers import is_open
+from robottelo.utils.ohsnap import dogfood_repository
 
 pytestmark = [pytest.mark.foremanctl, pytest.mark.upgrade]
 
@@ -47,6 +53,27 @@ def common_sat_install_assertions(satellite):
     assert 'WARNING' not in httpd_log.stdout
 
 
+def common_cap_install_assertions(capsule):
+    result = capsule.execute('systemctl status foreman-proxy.service foreman.target')
+    if 'inactive (dead)' in '\n'.join(result.stdout):
+        raise CapsuleHostError(
+            f'foreman-proxy service is not running on the capsule:\n{result.stdout}'
+        )
+    # no errors/failures in journald
+    result = capsule.execute(
+        r'journalctl --quiet --no-pager --boot --grep ERROR -u "foreman-proxy" -u "httpd" -u "postgresql" -u "pulp-api" -u "pulp-content" -u "pulp-worker*" -u "valkey"'
+    )
+    if is_open('SAT-21086'):
+        assert not list(filter(lambda x: 'PG::' not in x, result.stdout.splitlines()))
+    else:
+        assert not result.stdout
+    # no errors/failures in /var/log/httpd/*
+    result = capsule.execute(r'grep -iR "error" /var/log/httpd/*')
+    assert not result.stdout
+    httpd_log = capsule.execute('journalctl --unit=httpd')
+    assert 'WARNING' not in httpd_log.stdout
+
+
 def assert_hammer_ping_ok(result):
     assert result.status == 0, 'hammer ping failed'
     services = hammer.parse_ping(result.stdout)
@@ -66,9 +93,125 @@ def assert_postgresql_tuning(sat, tuning):
         )
 
 
+def sync_capsule_repos(satellite, capsule_host, org, ak):
+    """
+    On Satellite enable and synchronize content required for Capsule installation.
+    1. Enable RHEL repositories based on configuration
+    2. Enable capsule repositories based on configuration
+    3. Synchronize repositories
+    """
+    # List of sync tasks - all repos will be synced asynchronously
+    sync_tasks = []
+
+    # Enable and sync RHEL BaseOS and AppStream repos
+    if settings.robottelo.rhel_source == "internal":
+        # Configure internal sources as custom repositories
+        product_rhel = satellite.api.Product(organization=org.id).create()
+        for repourl in settings.repos.get(f'rhel{capsule_host.os_version.major}_os').values():
+            repo = satellite.api.Repository(
+                organization=org.id, product=product_rhel, content_type='yum', url=repourl
+            ).create()
+            # custom repos need to be explicitly enabled
+            ak.content_override(
+                data={
+                    'content_overrides': [
+                        {
+                            'content_label': '_'.join([org.label, product_rhel.label, repo.label]),
+                            'value': '1',
+                        }
+                    ]
+                }
+            )
+    else:
+        # use AppStream and BaseOS from CDN
+        for rh_repo_key in [
+            f'rhel{capsule_host.os_version.major}_bos',
+            f'rhel{capsule_host.os_version.major}_aps',
+        ]:
+            satellite.api_factory.enable_rhrepo_and_fetchid(
+                basearch=DEFAULT_ARCHITECTURE,
+                org_id=org.id,
+                product=PRDS[f'rhel{capsule_host.os_version.major}'],
+                repo=REPOS[rh_repo_key]['name'],
+                reposet=REPOSET[rh_repo_key],
+                releasever=REPOS[rh_repo_key]['releasever'],
+            )
+        product_rhel = satellite.api.Product(
+            name=PRDS[f'rhel{capsule_host.os_version.major}'], organization=org.id
+        ).search()[0]
+    sync_tasks.append(satellite.api.Product(id=product_rhel.id).sync(synchronous=False))
+
+    # Enable and sync Capsule repos
+    if settings.capsule.version.source == "ga":
+        # enable Capsule repos from CDN
+        for repo in capsule_host.CAPSULE_CDN_REPOS.values():
+            reposet = satellite.api.RepositorySet(organization=org.id).search(
+                query={'search': repo}
+            )[0]
+            reposet.enable()
+            # repos need to be explicitly enabled in AK
+            ak.content_override(
+                data={
+                    'content_overrides': [
+                        {
+                            'content_label': reposet.label,
+                            'value': '1',
+                        }
+                    ]
+                }
+            )
+            sync_tasks.append(satellite.api.Product(id=reposet.product.id).sync(synchronous=False))
+    else:
+        # configure internal source as custom repos
+        product_capsule = satellite.api.Product(organization=org.id).create()
+        for repo_variant, repo_default_url in [
+            ('capsule', 'capsule_repo'),
+            ('maintenance', 'satmaintenance_repo'),
+        ]:
+            if settings.capsule.version.source == 'nightly':
+                repo_url = getattr(settings.repos, repo_default_url)
+            else:
+                repo_url = dogfood_repository(
+                    ohsnap=settings.ohsnap,
+                    repo=repo_variant,
+                    product="capsule",
+                    release=settings.capsule.version.release,
+                    os_release=capsule_host.os_version.major,
+                    snap=settings.capsule.version.snap,
+                ).baseurl
+            repo = satellite.api.Repository(
+                organization=org.id,
+                product=product_capsule,
+                content_type='yum',
+                url=repo_url,
+            ).create()
+
+            # custom repos need to be explicitly enabled
+            ak.content_override(
+                data={
+                    'content_overrides': [
+                        {
+                            'content_label': '_'.join(
+                                [org.label, product_capsule.label, repo.label]
+                            ),
+                            'value': '1',
+                        }
+                    ]
+                }
+            )
+        sync_tasks.append(satellite.api.Product(id=product_capsule.id).sync(synchronous=False))
+
+    # Wait for asynchronous sync tasks
+    satellite.wait_for_tasks(
+        search_query=(f'id ^ "{",".join(task["id"] for task in sync_tasks)}"'),
+        poll_timeout=1800,
+    )
+
+
 @pytest.fixture(scope='module')
 def module_sat_ready_rhel(request):
-    param = request.param
+    """Deploy bare RHEL system ready for Satellite installation."""
+    param = getattr(request, 'param', 'default')
     deploy_args = param.get('deploy_args', '') if isinstance(param, dict) else ''
     with Broker(
         workflow=settings.server.deploy_workflows.os,
@@ -83,6 +226,40 @@ def module_sat_ready_rhel(request):
             parameters=deploy_args,
         )
         yield sat
+
+@pytest.fixture(scope='module')
+def module_cap_ready_rhel(request):
+    """Deploy bare RHEL system ready for Capsule installation."""
+    with Broker(
+        workflow=settings.server.deploy_workflows.os,
+        deploy_rhel_version=settings.server.version.rhel_version,
+        deploy_flavor=settings.flavors.default,
+        deploy_network_type=settings.server.network_type,
+        host_class=Capsule,
+    ) as cap:
+        # Add IPv6 proxy for IPv6 communication
+        cap.enable_ipv6_dnf_and_rhsm_proxy()
+        cap.enable_ipv6_system_proxy()
+        # Add IPv6 proxy for podman to pull from registry & install podman if not pre-installed
+        cap.ensure_podman_installed(enable_ipv6_proxy=True)
+        # Unregister capsule in case it's registered to CDN
+        cap.unregister()
+
+        # Install satellitectl package on Capsule
+        cap.setup_satellite_repos()  # Remove this when satellitectl is available in capsule repos
+        # Enable Packit repos for upstream testing
+        pull_requests = settings.server.get('deploy_arguments', {}).get('pull_requests', [])
+        if pull_requests:
+            Broker(
+                job_template='upstream-pr-install',
+                target_vm=cap.name,
+                pull_requests=pull_requests,
+                deploy_network_type=settings.server.network_type,
+            ).execute()
+        assert cap.execute('dnf install -y satellitectl').status == 0, (
+            'Failed to install satellitectl'
+        )
+        yield cap
 
 
 @pytest.fixture(scope='module')
@@ -103,6 +280,8 @@ def module_sat_foremanctl_tuning(request):
         yield sat
 
 
+@pytest.mark.e2e
+@pytest.mark.pit_server
 @pytest.mark.first_sanity
 @pytest.mark.parametrize('module_sat_ready_rhel', ['default'], indirect=True)
 def test_satellite_installation_with_foremanctl(module_sat_ready_rhel):
@@ -121,6 +300,67 @@ def test_satellite_installation_with_foremanctl(module_sat_ready_rhel):
         2. no unexpected errors in logs
     """
     common_sat_install_assertions(module_sat_ready_rhel)
+
+
+@pytest.mark.e2e
+@pytest.mark.pit_server
+@pytest.mark.build_sanity
+def test_capsule_installation_with_foremanctl(
+    pytestconfig, module_sat_ready_rhel, module_cap_ready_rhel, module_sca_manifest
+):
+    """Run a basic Capsule installation with foremanctl
+
+    :id: 64fa85b6-96e6-4fea-bea4-a30539d59e69
+
+    :steps:
+        1. Use Satellite deployed with foremanctl.
+        2. Configure RHEL and Capsule repos on Satellite
+        3. Register Capsule machine to consume Satellite content
+        4. Install and setup Capsule server using foremanctl
+
+    :expectedresults:
+        1. Capsule is installed and setup correctly
+        2. no unexpected errors in logs
+        3. health check runs successfully
+    """
+    # Setup Capsule Hostname for further sanity capsule testing
+    if 'build_sanity' in pytestconfig.option.markexpr:
+        settings.capsule.hostname = module_cap_ready_rhel.hostname
+        module_cap_ready_rhel._skip_context_checkin = True
+        pytest.capsule_sanity = True
+
+    # Create testing organization
+    org = module_sat_ready_rhel.api.Organization().create()
+
+    # Add a manifest to the Satellite
+    module_sat_ready_rhel.upload_manifest(org.id, module_sca_manifest.content)
+    # Create capsule certs and activation key
+    file, _, cmd_args = module_sat_ready_rhel.capsule_certs_generate(module_cap_ready_rhel)
+    module_sat_ready_rhel.session.remote_copy(file, module_cap_ready_rhel)
+    cvenv_id = module_sat_ready_rhel.api_factory.get_cvenv_id(org.default_content_view, org.library)
+    ak = module_sat_ready_rhel.api.ActivationKey(
+        organization=org, content_view_environment_ids=[cvenv_id]
+    ).create()
+    sync_capsule_repos(module_sat_ready_rhel, module_cap_ready_rhel, org, ak)
+
+    module_cap_ready_rhel.register(org, None, ak.name, module_sat_ready_rhel)
+
+    # Setup Capsule
+    result = module_cap_ready_rhel.execute(cmd_args)
+    assert result.status == 0, (
+        f'satellitectl deploy-proxy failed at capsule host\n{result.stdout}\n{result.stderr}'
+    )
+
+    assert module_sat_ready_rhel.api.Capsule().search(
+        query={'search': f'name={module_cap_ready_rhel.hostname}'}
+    )[0]
+
+    common_cap_install_assertions(module_cap_ready_rhel)
+
+    result = module_cap_ready_rhel.execute('satellitectl health')
+    assert result.status == 0
+    assert 'FAIL' not in result.stdout
+    assert 'Some services are not running' not in result.stdout
 
 
 @pytest.mark.parametrize('module_sat_ready_rhel', ['default'], indirect=True)

--- a/tests/foreman/foremanctl/test_install_foremanctl.py
+++ b/tests/foreman/foremanctl/test_install_foremanctl.py
@@ -55,7 +55,7 @@ def common_sat_install_assertions(satellite):
 
 def common_cap_install_assertions(capsule):
     result = capsule.execute('systemctl status foreman-proxy.service foreman.target')
-    if 'inactive (dead)' in '\n'.join(result.stdout):
+    if 'inactive (dead)' in result.stdout:
         raise CapsuleHostError(
             f'foreman-proxy service is not running on the capsule:\n{result.stdout}'
         )
@@ -63,10 +63,7 @@ def common_cap_install_assertions(capsule):
     result = capsule.execute(
         r'journalctl --quiet --no-pager --boot --grep ERROR -u "foreman-proxy" -u "httpd" -u "postgresql" -u "pulp-api" -u "pulp-content" -u "pulp-worker*" -u "valkey"'
     )
-    if is_open('SAT-21086'):
-        assert not list(filter(lambda x: 'PG::' not in x, result.stdout.splitlines()))
-    else:
-        assert not result.stdout
+    assert not result.stdout
     # no errors/failures in /var/log/httpd/*
     result = capsule.execute(r'grep -iR "error" /var/log/httpd/*')
     assert not result.stdout
@@ -242,10 +239,8 @@ def module_cap_ready_rhel(request):
         cap.enable_ipv6_dnf_and_rhsm_proxy()
         cap.enable_ipv6_system_proxy()
         # Add IPv6 proxy for podman to pull from registry & install podman if not pre-installed
+        cap.register_to_cdn()
         cap.ensure_podman_installed(enable_ipv6_proxy=True)
-        # Unregister capsule in case it's registered to CDN
-        cap.unregister()
-
         # Install satellitectl package on Capsule
         cap.setup_satellite_repos()  # Remove this when satellitectl is available in capsule repos
         # Enable Packit repos for upstream testing
@@ -260,6 +255,17 @@ def module_cap_ready_rhel(request):
         assert cap.execute('dnf install -y satellitectl').status == 0, (
             'Failed to install satellitectl'
         )
+        # Unregister capsule in case it's registered to CDN
+        cap.unregister()
+        # Setup firewall to allow Satellite-Capsule communication
+        assert (
+            cap.execute(
+                'which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld'
+            ).status
+            == 0
+        ), "firewalld is not present and can't be installed"
+        cap.execute('firewall-cmd --add-service RH-Satellite-6-capsule')
+        cap.execute('firewall-cmd --runtime-to-permanent')
         yield cap
 
 


### PR DESCRIPTION
### Problem Statement
Robottelo currently only supports capsule setup via `satellite-installer`. With the introduction of `foremanctl` the test framework needs to support deploying and testing capsules using `satellitectl deploy-proxy` alongside the traditional installer path.

### Solution
- Extended `Capsule.capsule_setup()` in robottelo/hosts.py to support both InstallMethod.INSTALLER and InstallMethod.FOREMANCTL paths:
    - FOREMANCTL path: uses satellitectl package, sets up satellite repos, enables Packit PRs, and runs satellitectl deploy-proxy
    - INSTALLER path: unchanged existing behavior
- Updated `Satellite.capsule_certs_generate()` to use `satellitectl auth-bundle` for certificate generation under FOREMANCTL, returning the appropriate cert path and deploy command
- Added `container_rpm_name = 'satellitectl'` class attribute to both Capsule and Satellite
- Added a new test `test_capsule_installation_with_foremanctl` with fixtures for bare RHEL capsule deply, repo sync, and post-install assertions
- Added @pytest.mark.e2e and @pytest.mark.pit_server markers to the satellite and capsule installation tests
- Renamed `certificate-bundle` with `auth-bundle` in tests 

### Related Issues
https://github.com/theforeman/foremanctl/pull/571
https://github.com/theforeman/foremanctl/pull/698

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Add support for deploying and testing capsules via foremanctl alongside the existing installer-based workflow.

New Features:
- Introduce a foremanctl-based Capsule installation workflow using satellitectl deploy-proxy and auth bundles.
- Add a new end-to-end test that installs a Capsule with foremanctl, including repo sync, registration, and health checks.

Enhancements:
- Extend Capsule and Satellite host helpers to select the appropriate package (installer vs satellitectl) and handle both installation methods.
- Update capsule certificate generation to use satellitectl auth-bundle and adapt tests to the new bundle contents and CLI.
- Add shared assertions and fixtures for validating Capsule services, logs, and repository configuration in foremanctl scenarios.

Tests:
- Add fixtures for provisioning bare RHEL Capsule hosts, syncing Capsule-related content, and running Capsule installation via foremanctl.
- Mark Satellite and Capsule foremanctl installation tests as e2e and pit_server for targeted execution.
- Rename and update certificate bundle tests to cover the new foremanctl auth-bundle generation and renewal flow.