### PR TITLE
Add fixes for new inc update dep solving default: false

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1012,6 +1012,27 @@ FAKE_9_YUM_SECURITY_ERRATUM = [
 ]
 FAKE_9_YUM_SECURITY_ERRATUM_COUNT = len(FAKE_9_YUM_SECURITY_ERRATUM)
 
+# Packages listed directly in the 3 security errata above
+FAKE_9_YUM_SECURITY_ERRATUM_PACKAGES = [
+    'bear-4.1-1.noarch',
+    'crow-0.8-1.noarch',
+    'duck-0.6-1.noarch',
+    'penguin-0.9.1-1.noarch',
+    'shark-0.1-1.noarch',
+    'stork-0.12-2.noarch',
+    'walrus-5.21-1.noarch',
+]
+
+# Transitive dependencies of the security erratum packages:
+# penguin->dolphin->{lion,tiger}, duck->{cockateel,lion}, cockateel->wolf, lion->wolf
+FAKE_9_YUM_SECURITY_ERRATUM_DEPS = [
+    'cockateel-3.1-1.noarch',
+    'dolphin-3.10.232-1.noarch',
+    'lion-0.4-1.noarch',
+    'tiger-1.0-4.noarch',
+    'wolf-9.4-2.noarch',
+]
+
 FAKE_10_YUM_BUGFIX_ERRATUM = [
     'RHBA-2012:1030',
 ]

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -30,6 +30,9 @@ from robottelo.constants import (
     FAKE_1_CUSTOM_PACKAGE_NAME,
     FAKE_1_ERRATA_ID,
     FAKE_2_CUSTOM_PACKAGE,
+    FAKE_9_YUM_SECURITY_ERRATUM,
+    FAKE_9_YUM_SECURITY_ERRATUM_DEPS,
+    FAKE_9_YUM_SECURITY_ERRATUM_PACKAGES,
     PERMISSIONS,
     PRDS,
     REPOS,
@@ -2475,6 +2478,93 @@ class TestContentViewPublishPromote:
         assert '2.0' in [v.read().version for v in cv_custom.version]
         ccv = ccv.read()
         assert set(v.read().version for v in ccv.version) == {'1.0'}
+
+    @pytest.mark.parametrize(
+        'resolve_dependencies',
+        [True, False, None],
+        ids=['dep_solving_enabled', 'dep_solving_disabled', 'dep_solving_default'],
+    )
+    def test_positive_inc_update_resolve_dependencies(
+        self,
+        target_sat,
+        module_org,
+        module_product,
+        resolve_dependencies,
+    ):
+        """Verify that the resolve_dependencies parameter controls whether
+        dependency packages are included in an incremental content view update.
+
+        :id: fa45c92d-d1df-4805-833a-bc6c25b8747c
+
+        :parametrized: yes
+
+        :steps:
+            1. Create and sync a custom yum repository containing errata
+               whose packages have known dependency chains.
+            2. Create a content view with the repository, add an erratum
+               inclusion filter with no rules to exclude all errata and
+               their packages, then publish.
+            3. Perform an incremental update to add 3 security errata back,
+               with resolve_dependencies set to True, False, or omitted
+               entirely to test the server default.
+
+        :expectedresults:
+            1. With resolve_dependencies=True, the incremental version includes
+               the direct errata packages and their transitive dependency
+               packages (12 total).
+            2. With resolve_dependencies=False, the incremental version includes
+               only the direct errata packages (7 total).
+            3. With resolve_dependencies omitted, the server default (False)
+               applies and only direct errata packages are included (7 total).
+        """
+        repo = target_sat.api.Repository(
+            product=module_product,
+            url=settings.repos.yum_9.url,
+        ).create()
+        repo.sync()
+
+        cv = target_sat.api.ContentView(
+            organization=module_org,
+            repository=[repo],
+        ).create()
+        # Erratum inclusion filter with no rules: excludes all errata and
+        # their associated packages from the published version.
+        target_sat.api.ErratumContentViewFilter(
+            content_view=cv,
+            inclusion=True,
+        ).create()
+        cv.publish()
+        cv = cv.read()
+        cvv = cv.version[0]
+
+        inc_data = {
+            'content_view_version_environments': [
+                {
+                    'content_view_version_id': cvv.id,
+                    'environment_ids': [module_org.library.id],
+                }
+            ],
+            'add_content': {'errata_ids': FAKE_9_YUM_SECURITY_ERRATUM},
+        }
+        if resolve_dependencies is not None:
+            inc_data['resolve_dependencies'] = resolve_dependencies
+
+        response = target_sat.api.ContentViewVersion().incremental_update(data=inc_data)
+        assert response['result'] == 'success'
+
+        added_errata = response['output']['changed_content'][0]['added_units']['erratum']
+        added_packages = set(response['output']['changed_content'][0]['added_units']['rpm'])
+        # All 3 security errata are added regardless of resolve_dependencies
+        assert set(added_errata) == set(FAKE_9_YUM_SECURITY_ERRATUM)
+
+        expected = set(FAKE_9_YUM_SECURITY_ERRATUM_PACKAGES)
+        if resolve_dependencies:
+            expected |= set(FAKE_9_YUM_SECURITY_ERRATUM_DEPS)
+
+        assert added_packages == expected, (
+            f'Expected {"direct + dependency" if resolve_dependencies else "only direct errata"} '
+            f'packages, got {sorted(added_packages)}'
+        )
 
 
 class TestContentViewUpdate:

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -30,6 +30,8 @@ from robottelo.constants import (
     FAKE_5_CUSTOM_PACKAGE,
     FAKE_9_YUM_OUTDATED_PACKAGES,
     FAKE_9_YUM_SECURITY_ERRATUM,
+    FAKE_9_YUM_SECURITY_ERRATUM_DEPS,
+    FAKE_9_YUM_SECURITY_ERRATUM_PACKAGES,
     FAKE_9_YUM_UPDATED_PACKAGES,
     PRDS,
     REAL_RHEL8_1_ERRATA_ID,
@@ -1568,6 +1570,7 @@ def test_positive_incremental_update_apply_to_envs_cvs(
                 }
             ],
             'add_content': {'errata_ids': FAKE_9_YUM_SECURITY_ERRATUM},
+            'resolve_dependencies': True,
         }
     )
     assert response['result'] == 'success'
@@ -1603,9 +1606,10 @@ def test_positive_incremental_update_apply_to_envs_cvs(
     # newly added errata from incremental version are now applicable to host
     post_app_errata_ids = errata_id_set(_fetch_available_errata_instances(target_sat, chost))
     assert set(FAKE_9_YUM_SECURITY_ERRATUM) == post_app_errata_ids
-    # expected packages from the security erratum were added to host
+    # expected packages from the security erratum and their deps were added
     added_packages = response['output']['changed_content'][0]['added_units']['rpm']
-    assert len(added_packages) == 12
+    expected_packages = set(FAKE_9_YUM_SECURITY_ERRATUM_PACKAGES + FAKE_9_YUM_SECURITY_ERRATUM_DEPS)
+    assert set(added_packages) == expected_packages
     # expected that not all of the added packages will be applicable
     assert 8 == host_app_packages == chost.applicable_package_count
     # install all of the newly added packages, recalculate applicability


### PR DESCRIPTION
### Problem Statement
Incremental updates no longer use dependency solving by default.

### Solution

Adds testing for the new incremental update default for no dependency solving. Also fixes `test_positive_incremental_update_apply_to_envs_cvs` which would fail due to a lack of dependency solving.

### Related Issues
https://redhat.atlassian.net/browse/SAT-46503

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Add API tests verifying incremental content view updates honor the resolve_dependencies flag and server default, and update existing errata incremental update test to explicitly enable dependency solving.

Tests:
- Add a parametrized incremental update test covering resolve_dependencies=True, False, and default behavior for content view versions.
- Update the incremental errata apply-to-envs-and-CVs test to set resolve_dependencies=True so dependency packages are included as expected.