### PR TITLE
[6.16.z] Use sat and snap versions for fm update tuning test

### DIFF
--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -88,11 +88,14 @@ def test_negative_pre_update_tuning_profile_check(request, custom_host):
     :expectedresults: Pre-update check fails.
     """
     profile = request.node.callspec.id
-    sat_version = ".".join(settings.server.version.release.split('.')[0:2])
     # Register to CDN for RHEL repos, download and enable ohsnap repos,
     # and enable the satellite module and install it on the host
     custom_host.register_to_cdn()
-    custom_host.download_repofile(product='satellite', release=sat_version)
+    custom_host.download_repofile(
+        product='satellite',
+        release=settings.server.version.release,
+        snap=settings.server.version.snap,
+    )
     custom_host.install_satellite_or_capsule_package()
     # Install with development tuning profile to get around installer checks
     custom_host.execute(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/19975

### Problem Statement
Without snap version in download_repofile(), it fetches the wrong ohsnap URL for repository, and fails to install required packages

### Solution
Using sat version and snap version in download_repofile() for fm update tuning test

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->