### PR TITLE
[6.16.z] Update RHEL9 & RHEL10 version in constants

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -598,16 +598,16 @@ REPOS = {
         },
         'rhel9_bos': {
             'id': 'rhel-9-for-x86_64-baseos-kickstart',
-            'name': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Kickstart 9.7',
-            'version': '9.7',
+            'name': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Kickstart 9.8',
+            'version': '9.8',
             'reposet': REPOSET['kickstart']['rhel9_bos'],
             'product': PRDS['rhel9'],
             'distro': 'rhel9',
         },
         'rhel9_aps': {
             'id': 'rhel-9-for-x86_64-appstream-kickstart',
-            'name': 'Red Hat Enterprise Linux 9 for x86_64 - AppStream Kickstart 9.7',
-            'version': '9.7',
+            'name': 'Red Hat Enterprise Linux 9 for x86_64 - AppStream Kickstart 9.8',
+            'version': '9.8',
             'reposet': REPOSET['kickstart']['rhel9_aps'],
             'product': PRDS['rhel9'],
             'distro': 'rhel9',
@@ -704,8 +704,8 @@ REPOS = {
 # RHEL versions for LEAPP testing
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
-RHEL9_VER = '9.7'
-RHEL10_VER = '10.1'
+RHEL9_VER = '9.8'
+RHEL10_VER = '10.2'
 
 BULK_REPO_LIST = [
     REPOS['rhel7_optional'],


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21635

### Problem Statement
RHEL9 and RHEL10 version constants are outdated on 6.16.z (RHEL9 at 9.7, RHEL10 at 10.1)

### Solution
Update RHEL9 kickstart versions (9.7 → 9.8), RHEL9_VER (9.7 → 9.8), and RHEL10_VER (10.1 → 10.2). Skipped rhel10_bos/rhel10_aps kickstart entries as they don't exist on 6.16.z.

Closes #21636