### PR TITLE
Skip test_positive_verify_updated_fdi_image

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -466,7 +466,7 @@ def test_positive_list_facts():
     :CaseImportance: High
     """
 
-
+@pytest.mark.skip(reason='We do not rebuild FDI every time new version of RHEL is released')
 def test_positive_verify_updated_fdi_image(target_sat):
     """Verify foreman-discovery-image is built on latest up-to-date RHEL
 


### PR DESCRIPTION
### Problem Statement

We do not update the FDI image every time a new version of RHEL is released.
This causes tests to fail over time, and it's failing for the `z` releases, where we don't cherry-pick newer FDI versions.

### Solution
Skip the test.

### Related Issues

https://redhat.atlassian.net/browse/SAT-48045 (failing Z stream run)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Mark test_positive_verify_updated_fdi_image as skipped due to FDI images not being rebuilt for every RHEL version.