### PR TITLE
Add test for HostInventoryReportJob task handling

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -3108,7 +3108,7 @@ class Satellite(Capsule, SatelliteMixins):
 
         return new_fqdn
 
-    def generate_inventory_report(self, org, disconnected='false'):
+    def generate_inventory_report(self, org, disconnected='false', timeout=400, delay=15):
         """Function to perform inventory upload."""
         generate_report_task = 'ForemanInventoryUpload::Async::HostInventoryReportJob'
         timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
@@ -3124,8 +3124,8 @@ class Satellite(Capsule, SatelliteMixins):
                 .result
                 == 'success'
             ),
-            timeout=400,
-            delay=15,
+            timeout=timeout,
+            delay=delay,
             silent_failure=True,
             handle_exception=True,
         )

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -12,6 +12,8 @@
 
 """
 
+from datetime import UTC, datetime
+
 from fauxfactory import gen_alphanumeric, gen_string
 import pytest
 
@@ -364,3 +366,32 @@ def test_rhcloud_compliance_policies(
     virtual_host.execute("dnf install -y openscap openscap-scanner scap-security-guide")
     results = virtual_host.execute('insights-client --compliance-policies')
     assert results.status == 0
+
+
+def test_task_completion_on_skipped_report_upload(module_target_sat, function_org):
+    """Verify that the HostInventoryReportJob stops successfully instead of timing out when a report
+    cannot be uploaded.
+
+    :id: 58b37733-7cd4-48cd-8073-9ccdd9aed895
+
+    :steps:
+        1. Deploy a Satellite and create an org with no manifest uploaded.
+        2. Attempt to generate and upload an inventory report.
+        3. Observe the status of the ForemanInventoryUpload::Async::HostInventoryReportJob task.
+
+    :expectedresults:
+        If an organization does not have a manifest, the HostInventoryReportJob task stop successfully instead of retrying until it times out.
+
+    :verifies: SAT-47463
+    """
+    timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
+    module_target_sat.generate_inventory_report(function_org, timeout=10, delay=5)
+    TASK_NAME = f'Host inventory report job organization \'{function_org.name}\''
+    task = (
+        module_target_sat.api.ForemanTask()
+        .search(query={'search': f'{TASK_NAME} and started_at >= "{timestamp}"'})[0]
+        .read()
+    )
+    assert task.state == 'stopped'
+    assert task.result == 'success'
+    assert task.input['organization']['id'] == function_org.id


### PR DESCRIPTION
Previously, in cases where an organization had no manifest, attempting to generate and upload an inventory report would cause a task to run until timing out. With https://github.com/theforeman/foreman_rh_cloud/pull/1228, the attempt to upload the report is skipped and the associated task immediately terminates successfully.

This PR adds a test to ensure that the task terminates as expected. It also modifies the `generate_inventory_report` helper method to take `timeout` and `delay` as keyword arguments to support cases such as the current one in which longer timeout and delay values are neither needed nor desired.

## Summary by Sourcery

Add coverage to ensure HostInventoryReportJob completes successfully when inventory report upload is skipped, and make inventory report generation timeout and delay configurable.

Enhancements:
- Allow generate_inventory_report helper to accept configurable timeout and delay parameters instead of using hardcoded values.

Tests:
- Add functional test verifying HostInventoryReportJob stops successfully instead of timing out when an inventory report cannot be uploaded for orgs without a manifest.