### PR TITLE
Add test for foremanctl --valkey-log-level

### DIFF
--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -460,3 +460,43 @@ def test_positive_foremanctl_log_level(module_target_sat):
         'foreman_proxy_log_level still present in parameters after reset'
     )
     assert 'log_level' not in params, 'log_level still present in parameters after reset'
+
+
+@pytest.mark.foremanctl
+def test_positive_foremanctl_valkey_log_level(module_target_sat):
+    """Verify foremanctl deploy --valkey-log-level persists and applies to Valkey.
+
+    :id: ebaa8b06-2e2a-4eb2-8d22-3dc1a8a8f58f
+
+    :steps:
+        1. Deploy with --valkey-log-level=debug
+        2. Verify valkey_log_level is persisted in parameters file
+        3. Trigger Valkey activity and verify debug output in valkey journal
+
+    :expectedresults:
+        1. valkey_log_level=debug is persisted correctly
+        2. valkey.service journal shows debug-level activity
+    """
+    sat = module_target_sat
+
+    result = sat.execute(
+        'foremanctl deploy --valkey-log-level=debug',
+        timeout='30m',
+    )
+    assert result.status == 0, (
+        f'foremanctl deploy --valkey-log-level=debug failed:\n{result.stderr}'
+    )
+
+    params = sat.load_remote_yaml_file(FOREMANCTL_PARAMETERS_FILE)
+    assert params.valkey_log_level == 'debug', (
+        f'valkey_log_level not persisted correctly: {params.get("valkey_log_level")}'
+    )
+
+    sat.execute('hammer host list')
+    sat.execute('podman exec valkey valkey-cli PING')
+    result = sat.execute(
+        r'journalctl --no-pager -u valkey.service --since "-2 min" | grep -iE "Accepted|debug"'
+    )
+    assert result.status == 0, (
+        'No debug-level messages found in valkey.service journal after activity'
+    )


### PR DESCRIPTION
## Problem Statement

`foremanctl` added the `--valkey-log-level` option in foremanctl#689 to configure Valkey logging (`debug`, `verbose`, `notice`, `warning`).
## Solution

Add `test_positive_foremanctl_valkey_log_level` to verify that:

- `foremanctl deploy --valkey-log-level=debug` persists `valkey_log_level` in `parameters.yaml`.
- The Valkey container command includes `--loglevel debug`.
- After triggering activity, the `valkey.service` journal contains debug-level output.

## Related Issues

- foremanctl: [#689](https://github.com/theforeman/foremanctl/pull/689)

## PRT Example

```yaml
trigger: test-robottelo
pytest: tests/foreman/cli/test_logging.py -k test_positive_foremanctl_valkey_log_level
deployment_type: container

## Summary by Sourcery

Tests:
- Add CLI test ensuring foremanctl deploy --valkey-log-level persists valkey_log_level and results in debug-level entries in valkey.service journal.