### PR TITLE
verify auto capsule sync task

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -2246,6 +2246,113 @@ class TestCapsuleContentManagement:
         sync_status = nailgun_capsule.content_sync(timeout='90m')
         assert sync_status['result'] == 'success'
 
+    @pytest.mark.e2e
+    @pytest.mark.parametrize('module_autosync_setting', [True], indirect=True)
+    def test_positive_capsule_with_rolling_content_source(
+        self,
+        module_target_sat,
+        module_autosync_setting,
+        module_capsule_configured,
+        function_org,
+        function_product,
+        function_lce_library,
+    ):
+        """Auto capsule sync is triggered when a rolling content view is refreshed
+        by a repository sync or content upload, not just during initial creation.
+
+        :id: 496d197c-d1c4-48f1-96f5-b958bf29867b
+
+        :steps:
+            1. Create a rolling CV with a custom repository and assign it to Library LCE.
+            2. Associate Library LCE with the capsule.
+            3. Sync the repository to trigger initial rolling CV refresh.
+            4. Verify auto capsule sync is triggered and content reaches the capsule.
+            5. Upload a new RPM to the repository.
+            6. Verify auto capsule sync is triggered automatically and the new package
+               is present on the capsule.
+
+        :expectedresults:
+            1. Initial repo sync triggers rolling CV refresh and auto capsule sync.
+            2. Uploading new content triggers rolling CV refresh and auto capsule sync
+               without requiring a manual repo sync.
+            3. The newly uploaded RPM is present on the capsule after the automatic sync.
+
+        :Verifies: SAT-45316
+
+        :customerscenario: true
+
+        """
+        repo = module_target_sat.api.Repository(
+            product=function_product, url=settings.repos.yum_1.url
+        ).create()
+        module_target_sat.wait_for_tasks(
+            search_query='Actions::Katello::Repository::MetadataGenerate'
+            f' and resource_id = {repo.id}'
+            ' and resource_type = Katello::Repository',
+            max_tries=6,
+            search_rate=10,
+        )
+        rolling_cv = module_target_sat.api.ContentView(
+            organization=function_org,
+            repository=[repo],
+            rolling=True,
+            environment=[function_lce_library],
+        ).create()
+        rolling_cv = rolling_cv.read()
+        assert len(rolling_cv.version) == 1
+        assert len(rolling_cv.environment) == 1
+
+        module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
+            data={'environment_id': function_lce_library.id}
+        )
+        result = module_capsule_configured.nailgun_capsule.content_lifecycle_environments()
+        assert function_lce_library.id in [capsule_lce['id'] for capsule_lce in result['results']]
+
+        # Initial repo sync triggers rolling CV refresh and auto capsule sync
+        timestamp = datetime.now(UTC).replace(microsecond=0)
+        repo.sync()
+        repo = repo.read()
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
+
+        rolling_cv = rolling_cv.read()
+        rolling_version = rolling_cv.version[0].read()
+
+        caps_repo_url = module_capsule_configured.get_published_repo_url(
+            org=function_org.label,
+            lce=function_lce_library.label,
+            cv=rolling_cv.label,
+            prod=function_product.label,
+            repo=repo.label,
+        )
+        sat_repo_url = module_target_sat.get_published_repo_url(
+            org=function_org.label,
+            lce=function_lce_library.label,
+            cv=rolling_cv.label,
+            prod=function_product.label,
+            repo=repo.label,
+        )
+        sat_files = get_repo_files_by_url(sat_repo_url)
+        caps_files = get_repo_files_by_url(caps_repo_url)
+        assert sat_files == caps_files
+
+        # Upload a new RPM to trigger automatic capsule sync via rolling CV refresh
+        with open(DataFile.RPM_TO_UPLOAD, 'rb') as handle:
+            repo.upload_content(files={'content': handle})
+
+        timestamp = datetime.now(UTC).replace(microsecond=0)
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
+
+        rolling_cv = rolling_cv.read()
+        new_rolling_version = rolling_cv.version[0].read()
+        assert new_rolling_version.id == rolling_version.id
+        assert repo.read().content_counts['rpm'] > FAKE_1_YUM_REPOS_COUNT
+
+        caps_files_after = get_repo_files_by_url(caps_repo_url)
+        sat_files_after = get_repo_files_by_url(sat_repo_url)
+        assert sat_files_after == caps_files_after
+        assert len(caps_files_after) == FAKE_1_YUM_REPOS_COUNT + 1
+        assert RPM_TO_UPLOAD in caps_files_after
+
 
 class TestPodman:
     """Tests specific to using podman push/pull on Satellite

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -29,6 +29,7 @@ from robottelo.constants import (
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_1_CUSTOM_PACKAGE_NAME,
     FAKE_1_ERRATA_ID,
+    FAKE_1_YUM_REPOS_COUNT,
     FAKE_2_CUSTOM_PACKAGE,
     FAKE_9_YUM_SECURITY_ERRATUM,
     FAKE_9_YUM_SECURITY_ERRATUM_DEPS,
@@ -37,10 +38,12 @@ from robottelo.constants import (
     PRDS,
     REPOS,
     REPOSET,
+    RPM_TO_UPLOAD,
     TIMESTAMP_FMT_ZONE,
     DataFile,
 )
 from robottelo.constants.repos import CUSTOM_RPM_SHA_512, FEDORA_OSTREE_REPO, RHEL10_BASEOS_MLDSA
+from robottelo.content_info import get_repo_files_by_url
 from robottelo.utils.datafactory import (
     invalid_names_list,
     parametrized,
@@ -1488,19 +1491,106 @@ class TestRollingContentView:
         """
         # TODO
 
-    @pytest.mark.stubbed
     @pytest.mark.e2e
-    def test_positive_capsule_with_rolling_content_source(self, module_capsule_configured):
-        """We can use the rolling content view as a content source for a capsule.
+    def test_positive_capsule_with_rolling_content_source(
+        self,
+        target_sat,
+        module_capsule_configured,
+        function_org,
+        function_product,
+        function_lce_library,
+    ):
+        """Auto capsule sync is triggered when a rolling content view is refreshed
+        by a subsequent repository sync, not just during initial creation.
 
         :id: b3d3d90a-cfb0-45a3-9e4a-d928190180be
 
-        :CaseImportance: High
+        :steps:
+            1. Create a rolling CV with a custom repository and assign it to Library LCE.
+            2. Associate Library LCE with the capsule.
+            3. Sync the repository to trigger initial rolling CV refresh.
+            4. Verify auto capsule sync is triggered and content reaches the capsule.
+            5. Upload a new RPM to the repository and sync again.
+            6. Verify auto capsule sync is triggered and the new package is present on the capsule.
+
+        :expectedresults:
+            1. Initial repo sync triggers rolling CV refresh and auto capsule sync.
+            2. Subsequent repo sync with new content also triggers rolling CV refresh
+               and auto capsule sync.
+            3. The newly uploaded RPM is present on the capsule after the second sync.
+
+        :Verifies: SAT-45316
+
+        :CaseImportance: Critical
 
         :customerscenario: true
 
         """
-        # TODO
+        repo = target_sat.api.Repository(
+            product=function_product, url=settings.repos.yum_1.url
+        ).create()
+        rolling_cv = target_sat.api.ContentView(
+            organization=function_org,
+            repository=[repo],
+            rolling=True,
+            environment=[function_lce_library],
+        ).create()
+        rolling_cv = rolling_cv.read()
+        assert len(rolling_cv.version) == 1
+        assert len(rolling_cv.environment) == 1
+
+        module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
+            data={'environment_id': function_lce_library.id}
+        )
+        result = module_capsule_configured.nailgun_capsule.content_lifecycle_environments()
+        assert function_lce_library.id in [capsule_lce['id'] for capsule_lce in result['results']]
+
+        # Initial repo sync triggers rolling CV refresh and auto capsule sync
+        timestamp = datetime.now(UTC).replace(microsecond=0)
+        repo.sync()
+        repo = repo.read()
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
+
+        rolling_cv = rolling_cv.read()
+        rolling_version = rolling_cv.version[0].read()
+
+        caps_repo_url = module_capsule_configured.get_published_repo_url(
+            org=function_org.label,
+            lce=function_lce_library.label,
+            cv=rolling_cv.label,
+            prod=function_product.label,
+            repo=repo.label,
+        )
+        sat_repo_url = target_sat.get_published_repo_url(
+            org=function_org.label,
+            lce=function_lce_library.label,
+            cv=rolling_cv.label,
+            prod=function_product.label,
+            repo=repo.label,
+        )
+        sat_files = get_repo_files_by_url(sat_repo_url)
+        caps_files = get_repo_files_by_url(caps_repo_url)
+        assert sat_files == caps_files
+
+        # Upload a new RPM and sync again to trigger another rolling CV refresh
+        with open(DataFile.RPM_TO_UPLOAD, 'rb') as handle:
+            repo.upload_content(files={'content': handle})
+
+        timestamp = datetime.now(UTC).replace(microsecond=0)
+        repo.sync()
+        repo = repo.read()
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
+
+        rolling_cv = rolling_cv.read()
+        new_rolling_version = rolling_cv.version[0].read()
+        assert new_rolling_version.id == rolling_version.id
+        assert repo.content_counts['rpm'] > FAKE_1_YUM_REPOS_COUNT
+
+        caps_files_after = get_repo_files_by_url(caps_repo_url)
+        sat_files_after = get_repo_files_by_url(sat_repo_url)
+        assert sat_files_after == caps_files_after
+        assert len(caps_files_after) == FAKE_1_YUM_REPOS_COUNT + 1
+        assert RPM_TO_UPLOAD in caps_files_after
 
 
 class TestContentViewCreate:


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### Problem Statement
In Satellite 6.18, the Rolling Content View feature does not trigger automatic Capsule synchronization during subsequent repository syncs. While the initial creation of a Rolling CV correctly initiates Capsule sync, any subsequent repository updates (via Sync Plans or manual syncs) that refresh the Rolling CV do not trigger the corresponding Capsule sync. This leaves Capsule servers with stale content, requiring manual intervention to keep them up to date.

### Solution
Added an automated test case (`test_positive_capsule_with_rolling_content_source`) to verify that auto Capsule sync is triggered not only during the initial Rolling CV creation but also during subsequent Rolling CV refreshes caused by repository syncs.

### Related Issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k 'test_positive_capsule_with_rolling_content_source'
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Verify that Rolling Content View refreshes trigger automatic Capsule synchronization and deliver newly uploaded content.

Enhancements:
- Add end-to-end coverage confirming that Rolling Content View refreshes automatically synchronize updated repository content to Capsules.

Tests:
- Verify automatic Capsule synchronization after both the initial repository sync and subsequent RPM uploads, including content parity and package availability.