### PR TITLE
[6.19.z] Skip REX verification in FIPS provisioning test for SAT-48015

### DIFF
--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -592,6 +592,9 @@ def test_rhel_pxe_provisioning_fips_enabled(
     assert int(result.stdout) == 1
 
     # Run a command on the host using REX to verify that Satellite's SSH key is present on the host
+    # SAT-48015: non-FIPS Satellite on RHEL 9.8+ generates ed25519 key, rejected by FIPS hosts
+    if is_open('SAT-48015'):
+        pytest.skip('REX broken for FIPS hosts due to ed25519 SSH key on RHEL 9.8+ (SAT-48015)')
     # Add workaround for SAT-32007 and SAT-32006
     if is_open('SAT-32007') and is_open('SAT-32006'):
         assert sat.execute('cat /dev/null > /usr/share/foreman-proxy/.ssh/known_hosts').status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22297

### Problem Statement

Non-FIPS Satellite on RHEL 9.8+ generates an ed25519 SSH key for foreman-proxy. FIPS-enabled hosts reject ed25519 because it is not in the FIPS crypto policy's
  PubkeyAcceptedAlgorithms (only RSA and ECDSA are allowed). This causes all test_rhel_pxe_provisioning_fips_enabled variants to fail at the REX verification step with Permission denied
  (publickey).

### Solution

Skip the REX verification step in test_rhel_pxe_provisioning_fips_enabled using is_open('SAT-48015') while the product bug is open. The provisioning and FIPS enablement assertions
  still run — only the REX SSH check is skipped.

### Related Issues

[SAT-48015](https://redhat.atlassian.net/browse/SAT-48015) — Remote execution and cockpit webconsole broken for FIPS hosts due to ed25519 SSH key on RHEL 9.8+

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Tests:
- Guard the RHEL FIPS PXE provisioning test with a conditional skip of the REX SSH verification step tied to SAT-48015.