### PR TITLE
[6.19.z] Add ArfReport to BOOKMARK_ENTITIES_SELECTION for API bookmark coverage (#21539)

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2047,6 +2047,12 @@ BOOKMARK_ENTITIES_SELECTION = [
         'controller': 'provisioning_templates',
         'session_name': 'provisioningtemplate',
     },
+    {
+        'name': 'ArfReport',
+        'controller': 'arf_reports',
+        'session_name': 'arfreport',
+        'skip_for_ui': True,  # search bar is only available when reports exist; otherwise the welcome page renders
+    },
 ]
 
 STRING_TYPES = ['alpha', 'numeric', 'alphanumeric', 'latin1', 'utf8', 'cjk', 'html']


### PR DESCRIPTION
Cherry pick of https://github.com/SatelliteQE/robottelo/pull/21539

* Add ArfReport to BOOKMARK_ENTITIES_SELECTION for API bookmark coverage

Adds ArfReport with skip_for_ui to enable API-level bookmark tests
against the arf_reports controller. UI tests are skipped because the
ARF reports page requires an existing report for the search bar to appear.

* Add inline comment explaining ArfReport skip_for_ui

The search bar is only available when reports exist; otherwise the
welcome page renders, making bookmark UI testing infeasible.

---------

Co-authored-by: Cursor <cursoragent@cursor.com>

(cherry picked from commit 8e951de3befd62f25468d8e063b175f01b916d9b)
