### PR TITLE
Fix get_repo_files_urls_by_url to handle explicitly relative links too

### DIFF
--- a/robottelo/content_info.py
+++ b/robottelo/content_info.py
@@ -47,7 +47,7 @@ def get_repo_files_urls_by_url(url, extension='rpm'):
     if result.status_code != 200:
         raise requests.HTTPError(f'{url} is not accessible')
 
-    links = re.findall(r'(?<=href=")(?!\.\.).*?(?=">)', result.text)
+    links = [link.lstrip('./') for link in re.findall(r'(?<=href=")(?!\.\.).*?(?=">)', result.text)]
     if 'Packages/' not in links:
         files = sorted(line for line in links if extension in line)
         return [f'{url}{file}' for file in files]


### PR DESCRIPTION
### Problem Statement
At least since snap 202 the repository distribution path contains explicitly relative paths (like `./Packages/`)
<img width="567" height="243" alt="image" src="https://github.com/user-attachments/assets/a99955bd-a852-4f0d-a772-268cf25b5bff" />

while we expect implicitly relative paths (like `Packages/`)
<img width="588" height="243" alt="image" src="https://github.com/user-attachments/assets/fcc436d1-42a2-49f9-b125-fb36277cd543" />

This causes several tests to fail while acquiring content served at the distribution paths.


### Solution
Strip the leading `./` to make it's presence irrelevant.


### Related Issues
No issues, ad-hoc finding during Stream TFA


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k test_positive_mirroring_policy
```

## Summary by Sourcery

Bug Fixes:
- Normalize href links by stripping leading './' so repository file discovery works for both implicit and explicit relative paths.