### PR TITLE
use satellite flavor when deploying using foremanctl

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -77,6 +77,7 @@ from robottelo.logging import logger
 from robottelo.utils import validate_ssh_pub_key
 from robottelo.utils.datafactory import valid_emails_list
 from robottelo.utils.installer import InstallerCommand
+from robottelo.utils.issue_handlers import is_open
 
 POWER_OPERATIONS = {
     VmState.RUNNING: 'running',
@@ -2236,6 +2237,16 @@ class Capsule(ContentHost, CapsuleMixins):
             ).status
             == 0
         )
+
+        if is_open('SAT-48790'):
+            # This belongs into the downstream packaging, which isn't ready yet
+            overrides_dir = '/usr/share/foremanctl/src/playbooks/_vendor_overrides/'
+            self.execute(f'mkdir -p {overrides_dir}/deploy/')
+            self.put(
+                'variables:\n  flavor:\n    choices:\n      - satellite',
+                f'{overrides_dir}/deploy/metadata.obsah.yaml',
+                temp_file=True,
+            )
 
         # Install Satellite and return result
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2240,6 +2240,7 @@ class Capsule(ContentHost, CapsuleMixins):
         # Install Satellite and return result
 
         default_parameters = [
+            '--flavor satellite',
             f'--initial-admin-username {settings.server.admin_username}',
             f'--initial-admin-password {settings.server.admin_password}',
         ]

--- a/tests/foreman/foremanctl/test_install_foremanctl.py
+++ b/tests/foreman/foremanctl/test_install_foremanctl.py
@@ -472,16 +472,16 @@ def test_foremanctl_deploy_add_remove_feature(module_sat_ready_rhel):
     :id: ec1e8b03-5b29-450a-887d-3a75ab707336
 
     :steps:
-        1. Deploy Satellite with remote-execution feature
-        2. Verify the remote-execution feature is enabled
-        3. Remove 'remote-execution' feature
-        4. Verify the remote-execution feature is disabled
+        1. Deploy Satellite with bmc feature
+        2. Verify the bmc feature is enabled
+        3. Remove 'bmc' feature
+        4. Verify the bmc feature is disabled
 
     :expectedresults:
-        1. The remote-execution feature is enabled
-        2. The remote-execution feature is disabled
+        1. The bmc feature is enabled
+        2. The bmc feature is disabled
     """
-    FEATURE_NAME = 'remote-execution'
+    FEATURE_NAME = 'bmc'
     sat = module_sat_ready_rhel
     result = sat.execute(
         f'foremanctl deploy --add-feature {FEATURE_NAME}',

--- a/tests/foreman/foremanctl/test_install_foremanctl.py
+++ b/tests/foreman/foremanctl/test_install_foremanctl.py
@@ -76,6 +76,7 @@ def module_sat_ready_rhel(request):
         deploy_flavor=settings.flavors.default,
         deploy_network_type=settings.server.network_type,
         host_class=Satellite,
+        use_dynamic_inventories_wf_level=False,
     ) as sat:
         sat.install_satellite_foremanctl(
             enable_fapolicyd=(param == 'fapolicyd'),
@@ -94,6 +95,7 @@ def module_sat_foremanctl_tuning(request):
         deploy_flavor=settings.flavors.large,
         deploy_network_type=settings.server.network_type,
         host_class=Satellite,
+        use_dynamic_inventories_wf_level=False,
     ) as sat:
         sat.install_satellite_foremanctl(
             parameters=[
@@ -164,6 +166,7 @@ def module_sat_foremanctl_custom_certs():
         deploy_flavor=settings.flavors.default,
         deploy_network_type=settings.server.network_type,
         host_class=Satellite,
+        use_dynamic_inventories_wf_level=False,
     ) as sat:
         sat.custom_cert_generate(sat.hostname)
         sat.install_satellite_foremanctl(


### PR DESCRIPTION
### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

New Features:
- Add support for specifying the Satellite flavor in foremanctl-based installations.