### PR TITLE
[6.16.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: check-yaml
     - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.3
     hooks:
       - id: codespell
         args:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2539,10 +2539,14 @@ class Satellite(Capsule, SatelliteMixins):
             data={'disconnected': disconnected}
         )
         wait_for(
-            lambda: self.api.ForemanTask()
-            .search(query={'search': f'{generate_report_task} and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
+            lambda: (
+                self.api.ForemanTask()
+                .search(
+                    query={'search': f'{generate_report_task} and started_at >= "{timestamp}"'}
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -2553,10 +2557,12 @@ class Satellite(Capsule, SatelliteMixins):
         """Perform inventory sync"""
         inventory_sync = self.api.Organization(id=org.id).rh_cloud_inventory_sync()
         wait_for(
-            lambda: self.api.ForemanTask()
-            .search(query={'search': f'id = {inventory_sync["task"]["id"]}'})[0]
-            .result
-            == 'success',
+            lambda: (
+                self.api.ForemanTask()
+                .search(query={'search': f'id = {inventory_sync["task"]["id"]}'})[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -124,12 +124,14 @@ def _assert_discovered_host(host, channel=None, user_config=None):
     default_config = entity_mixins.DEFAULT_SERVER_CONFIG
     try:
         wait_for(
-            lambda: len(
-                host.api.DiscoveredHost(user_config or default_config).search(
-                    query={'search': f'name={host.guest_name}'}
+            lambda: (
+                len(
+                    host.api.DiscoveredHost(user_config or default_config).search(
+                        query={'search': f'name={host.guest_name}'}
+                    )
                 )
-            )
-            > 0,
+                > 0
+            ),
             timeout=20,
             delay=2,
             logger=logger,

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -874,13 +874,15 @@ class TestAnsibleAAPIntegration:
         )
         assert sync_response.ok
         wait_for(
-            lambda: rhel_contenthost.hostname
-            in [
-                host['name']
-                for host in aap_client.get(
-                    f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={rhel_contenthost.hostname}'
-                ).json()['results']
-            ],
+            lambda: (
+                rhel_contenthost.hostname
+                in [
+                    host['name']
+                    for host in aap_client.get(
+                        f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={rhel_contenthost.hostname}'
+                    ).json()['results']
+                ]
+            ),
             timeout=180,
             delay=30,
         )
@@ -991,8 +993,10 @@ class TestAnsibleAAPIntegration:
         # Host should do call back to the Satellite reporting
         # the result of the installation. Wait until Satellite reports that the host is installed.
         wait_for(
-            lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
-            != 'Pending installation',
+            lambda: (
+                sat.cli.Host.info({'name': hostname})['status']['build-status']
+                != 'Pending installation'
+            ),
             timeout=1800,
             delay=30,
         )
@@ -1026,13 +1030,15 @@ class TestAnsibleAAPIntegration:
         assert sync_response.ok
 
         wait_for(
-            lambda: hostname
-            in [
-                host['name']
-                for host in aap_client.get(
-                    f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={hostname}'
-                ).json()['results']
-            ],
+            lambda: (
+                hostname
+                in [
+                    host['name']
+                    for host in aap_client.get(
+                        f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={hostname}'
+                    ).json()['results']
+                ]
+            ),
             timeout=180,
             delay=30,
         )
@@ -1048,10 +1054,10 @@ class TestAnsibleAAPIntegration:
         # when the callback service is started, the job sometimes starts with pending or waiting state before going to the running state
         filtered_job = jobs['id'] if jobs['status'] in ('running', 'pending', 'waiting') else None
         wait_for(
-            lambda: aap_client.get(f'{api_base}jobs/?id={filtered_job}').json()['results'][0][
-                'status'
-            ]
-            == 'successful',
+            lambda: (
+                aap_client.get(f'{api_base}jobs/?id={filtered_job}').json()['results'][0]['status']
+                == 'successful'
+            ),
             timeout=120,
         )
         # Verify user rocket and package tmux is installed via ansible-callback on provisioning host

--- a/tests/foreman/cli/test_artifacts.py
+++ b/tests/foreman/cli/test_artifacts.py
@@ -116,13 +116,17 @@ def test_positive_artifact_repair(
             repo=module_synced_content.repo.label,
         )
         wait_for(
-            lambda: len(
-                get_repo_files_urls_by_url(
-                    sat_repo_url,
-                    extension='rpm' if module_synced_content.repo.content_type == 'yum' else 'iso',
+            lambda: (
+                len(
+                    get_repo_files_urls_by_url(
+                        sat_repo_url,
+                        extension='rpm'
+                        if module_synced_content.repo.content_type == 'yum'
+                        else 'iso',
+                    )
                 )
-            )
-            > 0,
+                > 0
+            ),
             timeout=120,
             delay=15,
         )

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -447,8 +447,10 @@ def test_positive_provision_end_to_end(
     assert hostname in result.stdout
 
     wait_for(
-        lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
-        != 'Pending installation',
+        lambda: (
+            sat.cli.Host.info({'name': hostname})['status']['build-status']
+            != 'Pending installation'
+        ),
         timeout=1800,
         delay=30,
     )

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -144,8 +144,10 @@ def test_positive_provision_end_to_end(
     # check if vm is created on vmware
     assert vmwareclient.does_vm_exist(hostname) is True
     wait_for(
-        lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
-        != 'Pending installation',
+        lambda: (
+            sat.cli.Host.info({'name': hostname})['status']['build-status']
+            != 'Pending installation'
+        ),
         timeout=1800,
         delay=30,
     )
@@ -225,8 +227,10 @@ def test_positive_image_provision_end_to_end(
     # check if vm is created on vmware
     assert vmwareclient.does_vm_exist(hostname) is True
     wait_for(
-        lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
-        != 'Pending installation',
+        lambda: (
+            sat.cli.Host.info({'name': hostname})['status']['build-status']
+            != 'Pending installation'
+        ),
         timeout=1800,
         delay=30,
     )

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1738,12 +1738,14 @@ def test_positive_erratum_applicability(
     # verify that the applied erratum is not present in the list of installable errata
     try:
         applicable_erratum, _ = wait_for(
-            lambda: setup_custom_repo["security_errata"]
-            not in [
-                errata['erratum-id']
-                for errata in target_sat.cli.Host.errata_list({'host-id': host_info['id']})
-                if errata['installable'] == 'true'
-            ],
+            lambda: (
+                setup_custom_repo["security_errata"]
+                not in [
+                    errata['erratum-id']
+                    for errata in target_sat.cli.Host.errata_list({'host-id': host_info['id']})
+                    if errata['installable'] == 'true'
+                ]
+            ),
             handle_exception=True,
             timeout=300,
             delay=5,

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -28,8 +28,9 @@ from robottelo.utils import ohsnap
         {'source_version': RHEL8_VER, 'target_version': RHEL9_VER},
         {'source_version': RHEL9_VER, 'target_version': RHEL10_VER},
     ],
-    ids=lambda upgrade_path: f'{upgrade_path["source_version"]}'
-    f'_to_{upgrade_path["target_version"]}',
+    ids=lambda upgrade_path: (
+        f'{upgrade_path["source_version"]}_to_{upgrade_path["target_version"]}'
+    ),
 )
 @pytest.mark.parametrize('auth_type', ['admin', 'non-admin'])
 def test_positive_leapp_upgrade_rhel(
@@ -114,8 +115,9 @@ def test_positive_leapp_upgrade_rhel(
     [
         {'source_version': RHEL8_VER, 'target_version': RHEL9_VER},
     ],
-    ids=lambda upgrade_path: f'{upgrade_path["source_version"]}'
-    f'_to_{upgrade_path["target_version"]}',
+    ids=lambda upgrade_path: (
+        f'{upgrade_path["source_version"]}_to_{upgrade_path["target_version"]}'
+    ),
 )
 @pytest.mark.parametrize(
     'setting_update',

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -903,12 +903,14 @@ class TestRemoteExecution:
         )
         # wait for the third task to be planned which verifies the BZ
         wait_for(
-            lambda: int(
-                cli.RecurringLogic.info(
-                    {'id': cli.JobInvocation.info({'id': invocation.id})['recurring-logic-id']}
-                )['task-count']
-            )
-            > 2,
+            lambda: (
+                int(
+                    cli.RecurringLogic.info(
+                        {'id': cli.JobInvocation.info({'id': invocation.id})['recurring-logic-id']}
+                    )['task-count']
+                )
+                > 2
+            ),
             timeout=180,
             delay=10,
         )

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -81,8 +81,9 @@ def _validated_image_tags_count(repo, sat):
     immediately after synchronization), which was CLOSED WONTFIX
     """
     wait_for(
-        lambda: int(_get_image_tags_count(repo=repo, sat=sat)['content-counts']['container-tags'])
-        > 0,
+        lambda: (
+            int(_get_image_tags_count(repo=repo, sat=sat)['content-counts']['container-tags']) > 0
+        ),
         timeout=30,
         delay=2,
         logger=logger,

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -123,10 +123,12 @@ def test_positive_inventory_recommendation_sync(
     timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
     result = module_target_sat.execute(cmd)
     wait_for(
-        lambda: module_target_sat.api.ForemanTask()
-        .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
-        .result
-        == 'success',
+        lambda: (
+            module_target_sat.api.ForemanTask()
+            .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
+            .result
+            == 'success'
+        ),
         timeout=400,
         delay=15,
         silent_failure=True,
@@ -176,15 +178,17 @@ def test_positive_sync_inventory_status_missing_host_ip(
     assert success_msg in result.stdout
     # Check task details
     wait_for(
-        lambda: module_target_sat.api.ForemanTask()
-        .search(
-            query={
-                'search': f'{inventory_sync_task} and started_at >= "{timestamp}"',
-                'per_page': 'all',
-            }
-        )[0]
-        .result
-        == 'success',
+        lambda: (
+            module_target_sat.api.ForemanTask()
+            .search(
+                query={
+                    'search': f'{inventory_sync_task} and started_at >= "{timestamp}"',
+                    'per_page': 'all',
+                }
+            )[0]
+            .result
+            == 'success'
+        ),
         timeout=400,
         delay=15,
         silent_failure=True,
@@ -300,10 +304,14 @@ def test_positive_generate_all_reports_job(target_sat):
             time.sleep(3)  # sleep for the cmd execution
         timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         wait_for(
-            lambda: target_sat.api.ForemanTask()
-            .search(query={'search': f'{generate_report_jobs} and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
+            lambda: (
+                target_sat.api.ForemanTask()
+                .search(
+                    query={'search': f'{generate_report_jobs} and started_at >= "{timestamp}"'}
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,

--- a/tests/foreman/destructive/test_discoveredhost.py
+++ b/tests/foreman/destructive/test_discoveredhost.py
@@ -128,12 +128,14 @@ def _assert_discovered_host(host, channel=None, user_config=None, sat=None):
 
     try:
         wait_for(
-            lambda: len(
-                sat.api.DiscoveredHost(user_config or default_config).search(
-                    query={'search': f'name={host.guest_name}'}
+            lambda: (
+                len(
+                    sat.api.DiscoveredHost(user_config or default_config).search(
+                        query={'search': f'name={host.guest_name}'}
+                    )
                 )
-            )
-            > 0,
+                > 0
+            ),
             timeout=20,
             delay=2,
             logger=logger,

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -215,10 +215,12 @@ def test_positive_resource_vm_power_management(session, rhev_data):
 
         wait_for(
             lambda: (
-                session.browser.refresh(),
-                session.computeresource.vm_status(name, rhev_data['vm_name']),
-            )[1]
-            is not status,
+                (
+                    session.browser.refresh(),
+                    session.computeresource.vm_status(name, rhev_data['vm_name']),
+                )[1]
+                is not status
+            ),
             timeout=180,
             delay=1,
         )

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -194,10 +194,12 @@ def test_positive_gce_provision_end_to_end(
                 }
             )
             wait_for(
-                lambda: sat_gce.api.Host()
-                .search(query={'search': f'name={hostname}'})[0]
-                .build_status_label
-                != 'Pending installation',
+                lambda: (
+                    sat_gce.api.Host()
+                    .search(query={'search': f'name={hostname}'})[0]
+                    .build_status_label
+                    != 'Pending installation'
+                ),
                 timeout=600,
                 delay=15,
                 silent_failure=True,

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -180,8 +180,10 @@ def test_positive_provision_end_to_end(
         assert hostname in result.stdout
         # Wait for provisioning to complete and report status back to Satellite
         wait_for(
-            lambda: session.host.get_details(name)['properties']['properties_table']['Build']
-            != 'Pending installation clear',
+            lambda: (
+                session.host.get_details(name)['properties']['properties_table']['Build']
+                != 'Pending installation clear'
+            ),
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -306,10 +306,12 @@ def test_positive_resource_vm_power_management(session, vmware):
         try:
             wait_for(
                 lambda: (
-                    session.browser.refresh(),
-                    session.computeresource.vm_status(cr_name, vm_name),
-                )[1]
-                is not power_status,
+                    (
+                        session.browser.refresh(),
+                        session.computeresource.vm_status(cr_name, vm_name),
+                    )[1]
+                    is not power_status
+                ),
                 timeout=30,
                 delay=2,
             )
@@ -540,10 +542,12 @@ def test_positive_virt_card(session, target_sat, module_location, module_org, vm
             try:
                 wait_for(
                     lambda: (
-                        session.browser.refresh(),
-                        session.computeresource.vm_status(cr_name, settings.vmware.vm_name),
-                    )[1]
-                    is not power_status,
+                        (
+                            session.browser.refresh(),
+                            session.computeresource.vm_status(cr_name, settings.vmware.vm_name),
+                        )[1]
+                        is not power_status
+                    ),
                     timeout=30,
                     delay=2,
                 )
@@ -672,8 +676,10 @@ def test_positive_provision_end_to_end(
         host_fqdn = f'{host_name}.{module_vmware_hostgroup.domain.read().name}'
         request.addfinalizer(lambda: target_sat.provisioning_cleanup(host_fqdn))
         wait_for(
-            lambda: session.host_new.get_host_statuses(host_fqdn)['Build']['Status']
-            != 'Pending installation',
+            lambda: (
+                session.host_new.get_host_statuses(host_fqdn)['Build']['Status']
+                != 'Pending installation'
+            ),
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -111,8 +111,9 @@ def test_positive_provision_pxe_host(
         # Wait for provisioning to complete and report status back to Satellite
         pending_status = 'N/A' if is_open('SAT-22452') else 'Pending installation'
         wait_for(
-            lambda: session.host_new.get_host_statuses(host_name)['Build']['Status']
-            != pending_status,
+            lambda: (
+                session.host_new.get_host_statuses(host_name)['Build']['Status'] != pending_status
+            ),
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,
@@ -215,8 +216,9 @@ def test_positive_custom_provision_pxe_host(
         # Wait for provisioning to complete and report status back to Satellite
         pending_status = 'N/A' if is_open('SAT-22452') else 'Pending installation'
         wait_for(
-            lambda: session.host_new.get_host_statuses(host_name)['Build']['Status']
-            != pending_status,
+            lambda: (
+                session.host_new.get_host_statuses(host_name)['Build']['Status'] != pending_status
+            ),
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -634,8 +634,10 @@ def test_host_content_errata_tab_pagination(
         _invalid_pagination = ({}, _prior_pagination)
         session.browser.refresh()
         wait_for(
-            lambda: session.host_new.get_errata_pagination(_chost_name).read()
-            not in _invalid_pagination,
+            lambda: (
+                session.host_new.get_errata_pagination(_chost_name).read()
+                not in _invalid_pagination
+            ),
             timeout=30,
             delay=5,
         )

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1881,8 +1881,10 @@ def test_positive_tracer_enable_reload(tracer_install_host, target_sat):
         tracer = session.host_new.get_tracer(tracer_install_host.hostname)
         assert tracer['title'] == "Traces are being enabled"
         wait_for(
-            lambda: session.host_new.get_tracer(tracer_install_host.hostname)['title']
-            != "Traces are being enabled",
+            lambda: (
+                session.host_new.get_tracer(tracer_install_host.hostname)['title']
+                != "Traces are being enabled"
+            ),
             timeout=1800,
             delay=5,
             silent_failure=True,

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -363,9 +363,11 @@ def test_http_proxy_containing_special_characters(
             }
         )
         request.addfinalizer(
-            lambda: target_sat.api.HTTPProxy()
-            .search(query={'search': f'name={proxy_name}'})[0]
-            .delete()
+            lambda: (
+                target_sat.api.HTTPProxy()
+                .search(query={'search': f'name={proxy_name}'})[0]
+                .delete()
+            )
         )
 
         # Update settings to use the proxy for the content ops.

--- a/tests/foreman/ui/test_leapp_client.py
+++ b/tests/foreman/ui/test_leapp_client.py
@@ -22,8 +22,9 @@ from robottelo.constants import RHEL8_VER, RHEL9_VER
     [
         {'source_version': RHEL8_VER, 'target_version': RHEL9_VER},
     ],
-    ids=lambda upgrade_path: f'{upgrade_path["source_version"]}'
-    f'_to_{upgrade_path["target_version"]}',
+    ids=lambda upgrade_path: (
+        f'{upgrade_path["source_version"]}_to_{upgrade_path["target_version"]}'
+    ),
 )
 def test_leapp_preupgrade_report(
     module_target_sat,

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -366,19 +366,23 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
         # the last read time should not take more than 1/4 of the last left time
         assert job_left_time > 0
         wait_for(
-            lambda: session.jobinvocation.read(
-                f'Run {command_to_run}', hostname, 'overview.hosts_table'
-            )['overview']['hosts_table'][0]['Status']
-            == 'running',
+            lambda: (
+                session.jobinvocation.read(
+                    f'Run {command_to_run}', hostname, 'overview.hosts_table'
+                )['overview']['hosts_table'][0]['Status']
+                == 'running'
+            ),
             timeout=(job_left_time + 30),
             delay=1,
         )
         # wait the job to change status to "success"
         wait_for(
-            lambda: session.jobinvocation.read(
-                f'Run {command_to_run}', hostname, 'overview.hosts_table'
-            )['overview']['hosts_table'][0]['Status']
-            == 'success',
+            lambda: (
+                session.jobinvocation.read(
+                    f'Run {command_to_run}', hostname, 'overview.hosts_table'
+                )['overview']['hosts_table'][0]['Status']
+                == 'success'
+            ),
             timeout=30,
             delay=1,
         )

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -81,10 +81,12 @@ def test_rhcloud_insights_e2e(
         # Sync Insights recommendations
         session.cloudinsights.sync_hits()
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -102,10 +104,12 @@ def test_rhcloud_insights_e2e(
         timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.remediate(OPENSSH_RECOMMENDATION)
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(query={'search': f'{job_query} and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(query={'search': f'{job_query} and started_at >= "{timestamp}"'})[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -115,10 +119,12 @@ def test_rhcloud_insights_e2e(
         timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.sync_hits()
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -261,10 +267,12 @@ def test_host_details_page(
         timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.sync_hits()
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -92,15 +92,17 @@ def test_rhcloud_inventory_e2e(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -189,15 +191,17 @@ def test_rh_cloud_inventory_settings(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -243,15 +247,17 @@ def test_rh_cloud_inventory_settings(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -333,15 +339,17 @@ def test_rhcloud_inventory_without_manifest(session, module_org, target_sat):
         timestamp = (datetime.now(UTC) - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(module_org.name)
         wait_for(
-            lambda: target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -382,10 +390,14 @@ def test_sync_inventory_status(rhcloud_manifest_org, rhcloud_registered_hosts, m
         session.location.select(loc_name=DEFAULT_LOC)
         session.cloudinventory.sync_inventory_status()
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'})[
+                    0
+                ]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21842

Closes #22387

<!--pre-commit.ci start-->
updates:
- [github.com/astral-sh/ruff-pre-commit: v0.15.16 → v0.16.1](https://github.com/astral-sh/ruff-pre-commit/compare/v0.15.16...v0.16.1)
- [github.com/codespell-project/codespell: v2.4.2 → v2.4.3](https://github.com/codespell-project/codespell/compare/v2.4.2...v2.4.3)
<!--pre-commit.ci end-->

Automatic cherry-pick failed due to conflicting context (this branch was pinned to older ruff/codespell revs); resolved manually by taking the target revisions from master.