### PR TITLE
[6.18.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: check-yaml
     - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --target-version=py310]
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.3
     hooks:
       - id: codespell
         args:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2726,10 +2726,14 @@ class Satellite(Capsule, SatelliteMixins):
             data={'disconnected': disconnected}
         )
         wait_for(
-            lambda: self.api.ForemanTask()
-            .search(query={'search': f'{generate_report_task} and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
+            lambda: (
+                self.api.ForemanTask()
+                .search(
+                    query={'search': f'{generate_report_task} and started_at >= "{timestamp}"'}
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -2740,10 +2744,12 @@ class Satellite(Capsule, SatelliteMixins):
         """Perform inventory sync"""
         inventory_sync = self.api.Organization(id=org.id).rh_cloud_inventory_sync()
         wait_for(
-            lambda: self.api.ForemanTask()
-            .search(query={'search': f'id = {inventory_sync["task"]["id"]}'})[0]
-            .result
-            == 'success',
+            lambda: (
+                self.api.ForemanTask()
+                .search(query={'search': f'id = {inventory_sync["task"]["id"]}'})[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -123,12 +123,14 @@ def _assert_discovered_host(host, channel=None, user_config=None):
     default_config = entity_mixins.DEFAULT_SERVER_CONFIG
     try:
         wait_for(
-            lambda: len(
-                host.api.DiscoveredHost(user_config or default_config).search(
-                    query={'search': f'name={host.guest_name}'}
+            lambda: (
+                len(
+                    host.api.DiscoveredHost(user_config or default_config).search(
+                        query={'search': f'name={host.guest_name}'}
+                    )
                 )
-            )
-            > 0,
+                > 0
+            ),
             timeout=20,
             delay=2,
             logger=logger,

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -310,10 +310,12 @@ def test_positive_candlepin_events_processed_by_stomp(
     # Wait for candlepin to process the manifest upload events
     # Use polling instead of fixed sleep to avoid flakiness
     wait_for(
-        lambda: parse(
-            target_sat.api.Ping().search_json()['services']['candlepin_events']['message']
-        )['Processed']
-        > pre_processed_count,
+        lambda: (
+            parse(target_sat.api.Ping().search_json()['services']['candlepin_events']['message'])[
+                'Processed'
+            ]
+            > pre_processed_count
+        ),
         timeout=60,
         delay=5,
         handle_exception=True,

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -886,13 +886,15 @@ class TestAnsibleAAPIntegration:
         )
         assert sync_response.ok
         wait_for(
-            lambda: rhel_contenthost.hostname
-            in [
-                host['name']
-                for host in aap_client.get(
-                    f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={rhel_contenthost.hostname}'
-                ).json()['results']
-            ],
+            lambda: (
+                rhel_contenthost.hostname
+                in [
+                    host['name']
+                    for host in aap_client.get(
+                        f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={rhel_contenthost.hostname}'
+                    ).json()['results']
+                ]
+            ),
             timeout=180,
             delay=30,
         )
@@ -1003,8 +1005,10 @@ class TestAnsibleAAPIntegration:
         # Host should do call back to the Satellite reporting
         # the result of the installation. Wait until Satellite reports that the host is installed.
         wait_for(
-            lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
-            != 'Pending installation',
+            lambda: (
+                sat.cli.Host.info({'name': hostname})['status']['build-status']
+                != 'Pending installation'
+            ),
             timeout=1800,
             delay=30,
         )
@@ -1038,13 +1042,15 @@ class TestAnsibleAAPIntegration:
         assert sync_response.ok
 
         wait_for(
-            lambda: hostname
-            in [
-                host['name']
-                for host in aap_client.get(
-                    f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={hostname}'
-                ).json()['results']
-            ],
+            lambda: (
+                hostname
+                in [
+                    host['name']
+                    for host in aap_client.get(
+                        f'{api_base}inventories/{inv_list["results"][0]["id"]}/hosts/?search={hostname}'
+                    ).json()['results']
+                ]
+            ),
             timeout=180,
             delay=30,
         )
@@ -1060,10 +1066,10 @@ class TestAnsibleAAPIntegration:
         # when the callback service is started, the job sometimes starts with pending or waiting state before going to the running state
         filtered_job = jobs['id'] if jobs['status'] in ('running', 'pending', 'waiting') else None
         wait_for(
-            lambda: aap_client.get(f'{api_base}jobs/?id={filtered_job}').json()['results'][0][
-                'status'
-            ]
-            == 'successful',
+            lambda: (
+                aap_client.get(f'{api_base}jobs/?id={filtered_job}').json()['results'][0]['status']
+                == 'successful'
+            ),
             timeout=120,
         )
         # Verify user rocket and package tmux is installed via ansible-callback on provisioning host

--- a/tests/foreman/cli/test_artifacts.py
+++ b/tests/foreman/cli/test_artifacts.py
@@ -116,13 +116,17 @@ def test_positive_artifact_repair(
             repo=module_synced_content.repo.label,
         )
         wait_for(
-            lambda: len(
-                get_repo_files_urls_by_url(
-                    sat_repo_url,
-                    extension='rpm' if module_synced_content.repo.content_type == 'yum' else 'iso',
+            lambda: (
+                len(
+                    get_repo_files_urls_by_url(
+                        sat_repo_url,
+                        extension='rpm'
+                        if module_synced_content.repo.content_type == 'yum'
+                        else 'iso',
+                    )
                 )
-            )
-            > 0,
+                > 0
+            ),
             timeout=120,
             delay=15,
         )

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -151,8 +151,10 @@ def test_positive_provision_end_to_end(
     # check if vm is created on vmware
     assert vmwareclient.does_vm_exist(hostname) is True
     wait_for(
-        lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
-        != 'Pending installation',
+        lambda: (
+            sat.cli.Host.info({'name': hostname})['status']['build-status']
+            != 'Pending installation'
+        ),
         timeout=1800,
         delay=30,
     )
@@ -243,8 +245,10 @@ def test_positive_image_provision_end_to_end(
         assert 'VirtualTPM' in vm.get_virtual_device_type_names()
 
     wait_for(
-        lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
-        != 'Pending installation',
+        lambda: (
+            sat.cli.Host.info({'name': hostname})['status']['build-status']
+            != 'Pending installation'
+        ),
         timeout=1800,
         delay=30,
     )

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -55,12 +55,14 @@ def test_rhel_pxe_discovery_provisioning(
     org = provisioning_hostgroup.organization[0].read()
     loc = provisioning_hostgroup.location[0].read()
     wait_for(
-        lambda: sat.api.DiscoveredHost().search(
-            query={
-                'mac': mac,
-            }
-        )
-        != [],
+        lambda: (
+            sat.api.DiscoveredHost().search(
+                query={
+                    'mac': mac,
+                }
+            )
+            != []
+        ),
         timeout=1500,
         delay=20,
     )
@@ -143,12 +145,14 @@ def test_rhel_pxeless_discovery_provisioning(
     org = provisioning_hostgroup.organization[0].read()
     loc = provisioning_hostgroup.location[0].read()
     wait_for(
-        lambda: sat.api.DiscoveredHost().search(
-            query={
-                'mac': mac,
-            }
-        )
-        != [],
+        lambda: (
+            sat.api.DiscoveredHost().search(
+                query={
+                    'mac': mac,
+                }
+            )
+            != []
+        ),
         timeout=1500,
         delay=40,
     )

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1765,12 +1765,14 @@ def test_positive_erratum_applicability(
     # Verify that the applied erratum is no longer in applicable errata list
     try:
         applicable_erratum, _ = wait_for(
-            lambda: security_errata
-            not in [
-                errata['erratum-id']
-                for errata in target_sat.cli.Host.errata_list({'host-id': host_info['id']})
-                if errata['installable'] == 'true'
-            ],
+            lambda: (
+                security_errata
+                not in [
+                    errata['erratum-id']
+                    for errata in target_sat.cli.Host.errata_list({'host-id': host_info['id']})
+                    if errata['installable'] == 'true'
+                ]
+            ),
             handle_exception=True,
             timeout=300,
             delay=5,

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -28,8 +28,9 @@ from robottelo.utils import ohsnap
         {'source_version': RHEL8_VER, 'target_version': RHEL9_VER},
         {'source_version': RHEL9_VER, 'target_version': RHEL10_VER},
     ],
-    ids=lambda upgrade_path: f'{upgrade_path["source_version"]}'
-    f'_to_{upgrade_path["target_version"]}',
+    ids=lambda upgrade_path: (
+        f'{upgrade_path["source_version"]}_to_{upgrade_path["target_version"]}'
+    ),
 )
 @pytest.mark.parametrize('auth_type', ['admin', 'non-admin'])
 def test_positive_leapp_upgrade_rhel(
@@ -114,8 +115,9 @@ def test_positive_leapp_upgrade_rhel(
     [
         {'source_version': RHEL8_VER, 'target_version': RHEL9_VER},
     ],
-    ids=lambda upgrade_path: f'{upgrade_path["source_version"]}'
-    f'_to_{upgrade_path["target_version"]}',
+    ids=lambda upgrade_path: (
+        f'{upgrade_path["source_version"]}_to_{upgrade_path["target_version"]}'
+    ),
 )
 @pytest.mark.parametrize(
     'setting_update',

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -959,12 +959,14 @@ class TestRemoteExecution:
         )
         # wait for the third task to be planned which verifies the BZ
         wait_for(
-            lambda: int(
-                cli.RecurringLogic.info(
-                    {'id': cli.JobInvocation.info({'id': invocation.id})['recurring-logic-id']}
-                )['task-count']
-            )
-            > 2,
+            lambda: (
+                int(
+                    cli.RecurringLogic.info(
+                        {'id': cli.JobInvocation.info({'id': invocation.id})['recurring-logic-id']}
+                    )['task-count']
+                )
+                > 2
+            ),
             timeout=180,
             delay=10,
         )

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -81,8 +81,9 @@ def _validated_image_tags_count(repo, sat):
     immediately after synchronization), which was CLOSED WONTFIX
     """
     wait_for(
-        lambda: int(_get_image_tags_count(repo=repo, sat=sat)['content-counts']['container-tags'])
-        > 0,
+        lambda: (
+            int(_get_image_tags_count(repo=repo, sat=sat)['content-counts']['container-tags']) > 0
+        ),
         timeout=30,
         delay=2,
         logger=logger,

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -126,10 +126,12 @@ def test_positive_inventory_recommendation_sync(
     timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
     result = module_target_sat.execute(cmd)
     wait_for(
-        lambda: module_target_sat.api.ForemanTask()
-        .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
-        .result
-        == 'success',
+        lambda: (
+            module_target_sat.api.ForemanTask()
+            .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
+            .result
+            == 'success'
+        ),
         timeout=400,
         delay=15,
         silent_failure=True,
@@ -179,15 +181,17 @@ def test_positive_sync_inventory_status_missing_host_ip(
     assert success_msg in result.stdout
     # Check task details
     wait_for(
-        lambda: module_target_sat.api.ForemanTask()
-        .search(
-            query={
-                'search': f'{inventory_sync_task} and started_at >= "{timestamp}"',
-                'per_page': 'all',
-            }
-        )[0]
-        .result
-        == 'success',
+        lambda: (
+            module_target_sat.api.ForemanTask()
+            .search(
+                query={
+                    'search': f'{inventory_sync_task} and started_at >= "{timestamp}"',
+                    'per_page': 'all',
+                }
+            )[0]
+            .result
+            == 'success'
+        ),
         timeout=400,
         delay=15,
         silent_failure=True,
@@ -232,10 +236,12 @@ def test_positive_sync_inventory_status_cli(
     assert success_msg in result
     # Check task details
     wait_for(
-        lambda: module_target_sat.api.ForemanTask()
-        .search(query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'})[0]
-        .result
-        == 'success',
+        lambda: (
+            module_target_sat.api.ForemanTask()
+            .search(query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'})[0]
+            .result
+            == 'success'
+        ),
         timeout=400,
         delay=15,
         silent_failure=True,
@@ -362,10 +368,14 @@ def test_positive_generate_all_reports_job(target_sat):
             time.sleep(3)  # sleep for the cmd execution
         timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         wait_for(
-            lambda: target_sat.api.ForemanTask()
-            .search(query={'search': f'{generate_report_jobs} and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
+            lambda: (
+                target_sat.api.ForemanTask()
+                .search(
+                    query={'search': f'{generate_report_jobs} and started_at >= "{timestamp}"'}
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -576,10 +586,12 @@ def generate_report(rhcloud_manifest_org, module_target_sat, disconnected=False)
     # Check task details
     generate_job_name = 'ForemanInventoryUpload::Async::GenerateReportJob'
     wait_for(
-        lambda: module_target_sat.api.ForemanTask()
-        .search(query={'search': f'{generate_job_name} and started_at >= "{timestamp}"'})[0]
-        .result
-        == 'success',
+        lambda: (
+            module_target_sat.api.ForemanTask()
+            .search(query={'search': f'{generate_job_name} and started_at >= "{timestamp}"'})[0]
+            .result
+            == 'success'
+        ),
         timeout=400,
         delay=15,
         silent_failure=True,

--- a/tests/foreman/destructive/test_discoveredhost.py
+++ b/tests/foreman/destructive/test_discoveredhost.py
@@ -128,12 +128,14 @@ def _assert_discovered_host(host, channel=None, user_config=None, sat=None):
 
     try:
         wait_for(
-            lambda: len(
-                sat.api.DiscoveredHost(user_config or default_config).search(
-                    query={'search': f'name={host.guest_name}'}
+            lambda: (
+                len(
+                    sat.api.DiscoveredHost(user_config or default_config).search(
+                        query={'search': f'name={host.guest_name}'}
+                    )
                 )
-            )
-            > 0,
+                > 0
+            ),
             timeout=20,
             delay=2,
             logger=logger,

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -194,10 +194,12 @@ def test_positive_gce_provision_end_to_end(
                 }
             )
             wait_for(
-                lambda: sat_gce.api.Host()
-                .search(query={'search': f'name={hostname}'})[0]
-                .build_status_label
-                != 'Pending installation',
+                lambda: (
+                    sat_gce.api.Host()
+                    .search(query={'search': f'name={hostname}'})[0]
+                    .build_status_label
+                    != 'Pending installation'
+                ),
                 timeout=600,
                 delay=15,
                 silent_failure=True,

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -194,8 +194,10 @@ def test_positive_provision_end_to_end(
         assert hostname in result.stdout
         # Wait for provisioning to complete and report status back to Satellite
         wait_for(
-            lambda: session.host_new.get_host_statuses(name)['Build']['Status']
-            != 'Pending installation',
+            lambda: (
+                session.host_new.get_host_statuses(name)['Build']['Status']
+                != 'Pending installation'
+            ),
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,
@@ -501,8 +503,10 @@ def test_positive_image_provision_end_to_end(
         # The host should transition from 'Pending installation' to 'Installed'
         host_fqdn = f'{hostname}.{module_libvirt_provisioning_sat.domain.name}'
         wait_for(
-            lambda: session.host_new.get_host_statuses(host_fqdn)['Build']['Status']
-            != 'Pending installation',
+            lambda: (
+                session.host_new.get_host_statuses(host_fqdn)['Build']['Status']
+                != 'Pending installation'
+            ),
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -309,10 +309,12 @@ def test_positive_resource_vm_power_management(session, vmware):
         try:
             wait_for(
                 lambda: (
-                    session.browser.refresh(),
-                    session.computeresource.vm_status(cr_name, vm_name),
-                )[1]
-                is not power_status,
+                    (
+                        session.browser.refresh(),
+                        session.computeresource.vm_status(cr_name, vm_name),
+                    )[1]
+                    is not power_status
+                ),
                 timeout=30,
                 delay=2,
             )
@@ -542,10 +544,12 @@ def test_positive_virt_card(session, target_sat, module_location, module_org, vm
             try:
                 wait_for(
                     lambda: (
-                        session.browser.refresh(),
-                        session.computeresource.vm_status(cr_name, settings.vmware.vm_name),
-                    )[1]
-                    is not power_status,
+                        (
+                            session.browser.refresh(),
+                            session.computeresource.vm_status(cr_name, settings.vmware.vm_name),
+                        )[1]
+                        is not power_status
+                    ),
                     timeout=30,
                     delay=2,
                 )
@@ -679,9 +683,11 @@ def test_positive_provision_end_to_end(
         host_fqdn = f'{host_name}.{module_vmware_hostgroup.domain.read().name}'
         request.addfinalizer(lambda: target_sat.provisioning_cleanup(host_fqdn))
         wait_for(
-            lambda: session.host_new.get_host_statuses(host_fqdn)['Build']['Status']
-            != 'Pending installation'
-            and session.host_new.get_host_statuses(host_fqdn)['Execution']['Status'] != 'N/A',
+            lambda: (
+                session.host_new.get_host_statuses(host_fqdn)['Build']['Status']
+                != 'Pending installation'
+                and session.host_new.get_host_statuses(host_fqdn)['Execution']['Status'] != 'N/A'
+            ),
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -111,8 +111,9 @@ def test_positive_provision_pxe_host(
         # Wait for provisioning to complete and report status back to Satellite
         pending_status = 'N/A' if is_open('SAT-22452') else 'Pending installation'
         wait_for(
-            lambda: session.host_new.get_host_statuses(host_name)['Build']['Status']
-            != pending_status,
+            lambda: (
+                session.host_new.get_host_statuses(host_name)['Build']['Status'] != pending_status
+            ),
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,
@@ -215,8 +216,9 @@ def test_positive_custom_provision_pxe_host(
         # Wait for provisioning to complete and report status back to Satellite
         pending_status = 'N/A' if is_open('SAT-22452') else 'Pending installation'
         wait_for(
-            lambda: session.host_new.get_host_statuses(host_name)['Build']['Status']
-            != pending_status,
+            lambda: (
+                session.host_new.get_host_statuses(host_name)['Build']['Status'] != pending_status
+            ),
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -630,8 +630,10 @@ def test_host_content_errata_tab_pagination(
         _invalid_pagination = ({}, _prior_pagination)
         session.browser.refresh()
         wait_for(
-            lambda: session.host_new.get_errata_pagination(_chost_name).read()
-            not in _invalid_pagination,
+            lambda: (
+                session.host_new.get_errata_pagination(_chost_name).read()
+                not in _invalid_pagination
+            ),
             timeout=30,
             delay=5,
         )

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -432,9 +432,11 @@ def test_http_proxy_containing_special_characters(
             }
         )
         request.addfinalizer(
-            lambda: target_sat.api.HTTPProxy()
-            .search(query={'search': f'name={proxy_name}'})[0]
-            .delete()
+            lambda: (
+                target_sat.api.HTTPProxy()
+                .search(query={'search': f'name={proxy_name}'})[0]
+                .delete()
+            )
         )
 
         # Update settings to use the proxy for the content ops.

--- a/tests/foreman/ui/test_leapp_client.py
+++ b/tests/foreman/ui/test_leapp_client.py
@@ -27,8 +27,9 @@ from robottelo.utils.issue_handlers import is_open
     [
         {'source_version': RHEL8_VER, 'target_version': RHEL9_VER},
     ],
-    ids=lambda upgrade_path: f'{upgrade_path["source_version"]}'
-    f'_to_{upgrade_path["target_version"]}',
+    ids=lambda upgrade_path: (
+        f'{upgrade_path["source_version"]}_to_{upgrade_path["target_version"]}'
+    ),
 )
 def test_leapp_preupgrade_report(
     module_target_sat,

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -363,19 +363,23 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
         # the last read time should not take more than 1/4 of the last left time
         assert job_left_time > 0
         wait_for(
-            lambda: session.jobinvocation.read(f'Run {command_to_run}', hostname, 'hosts')['hosts'][
-                0
-            ]['Status']
-            == 'Pending',
+            lambda: (
+                session.jobinvocation.read(f'Run {command_to_run}', hostname, 'hosts')['hosts'][0][
+                    'Status'
+                ]
+                == 'Pending'
+            ),
             timeout=(job_left_time + 30),
             delay=1,
         )
         # wait the job to change status to "Succeeded"
         wait_for(
-            lambda: session.jobinvocation.read(f'Run {command_to_run}', hostname, 'hosts')['hosts'][
-                0
-            ]['Status']
-            == 'Succeeded',
+            lambda: (
+                session.jobinvocation.read(f'Run {command_to_run}', hostname, 'hosts')['hosts'][0][
+                    'Status'
+                ]
+                == 'Succeeded'
+            ),
             timeout=30,
             delay=1,
         )

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -146,15 +146,17 @@ def test_rhcloud_inventory_e2e(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -264,15 +266,17 @@ def test_rh_cloud_inventory_settings(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -313,15 +317,17 @@ def test_rh_cloud_inventory_settings(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -401,15 +407,17 @@ def test_rhcloud_inventory_without_manifest(session, module_org, target_sat):
         timestamp = (datetime.now(UTC) - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(module_org.name)
         wait_for(
-            lambda: target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -467,15 +475,17 @@ def test_rhcloud_global_parameters(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -503,15 +513,17 @@ def test_rhcloud_global_parameters(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -630,15 +642,17 @@ def test_rh_cloud_minimal_report(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,
@@ -697,10 +711,14 @@ def test_sync_inventory_status(rhcloud_manifest_org, rhcloud_registered_hosts, m
         session.location.select(loc_name=DEFAULT_LOC)
         session.cloudinventory.sync_inventory_status()
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'})[
+                    0
+                ]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -740,15 +740,17 @@ class TestVirtwhoConfigforEsx:
         org_session.cloudinventory.generate_report(module_sca_manifest_org.name)
         # wait_for_tasks report generation task to finish
         wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
+            lambda: (
+                module_target_sat.api.ForemanTask()
+                .search(
+                    query={
+                        'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                        f'and started_at >= "{timestamp}"'
+                    }
+                )[0]
+                .result
+                == 'success'
+            ),
             timeout=400,
             delay=15,
             silent_failure=True,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/21842

Closes #22384

<!--pre-commit.ci start-->
updates:
- [github.com/astral-sh/ruff-pre-commit: v0.15.16 → v0.16.1](https://github.com/astral-sh/ruff-pre-commit/compare/v0.15.16...v0.16.1)
- [github.com/codespell-project/codespell: v2.4.2 → v2.4.3](https://github.com/codespell-project/codespell/compare/v2.4.2...v2.4.3)
<!--pre-commit.ci end-->

Automatic cherry-pick failed due to conflicting context (this branch was pinned to older ruff/codespell revs); resolved manually by taking the target revisions from master.