### PR TITLE
test_negative_remove_satellite_packages update

### DIFF
--- a/tests/foreman/destructive/test_packages.py
+++ b/tests/foreman/destructive/test_packages.py
@@ -79,10 +79,14 @@ def test_negative_remove_satellite_packages(sat_maintain):
         protected_package = 'satellite'
         package_list = ['foreman', 'foreman-proxy', 'katello', 'wget', protected_package]
     else:
-        protected_package = 'satellite-capsule'
-        package_list = ['foreman-proxy', protected_package]
+        package_list = ['foreman-proxy', 'satellite-capsule']
+    # DNF reports either "removing the following protected packages" (direct removal)
+    # or "broken dependencies for the following protected packages" (dependency removal),
+    # so we match the common substring that covers both cases.
+    protected_pkg = sat_maintain.product_rpm_name
     for package in package_list:
         result = sat_maintain.execute(f'yum remove {package}')
         assert result.status != 0
-        # dnf may report "removing" (direct remove) or "broken dependencies" (dependency remove)
-        assert f'protected packages: {protected_package}' in str(result.stderr)
+        assert f'protected packages: {protected_pkg}' in str(result.stderr), (
+            f'Expected protection error for {protected_pkg}, got: {result.stderr}'
+        )


### PR DESCRIPTION
Proposing change of assert for both scenarios
- Removing the protected package itself (e.g., yum remove satellite)
- Removing a dependency of a protected package (e.g., yum remove foreman)

In result output messages can differ for example yum output can be

- removing the following protected packages: satellite
- broken dependencies for the following protected packages: satellite

Both should be valid.

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Relax negative package removal test to accept both direct protected package removal and dependency-based protection errors.

Bug Fixes:
- Fix test_negative_remove_satellite_packages to correctly handle yum/dnf messages for both direct protected package removal and broken dependency scenarios.

Tests:
- Update test_negative_remove_satellite_packages to assert on the product RPM name and accept multiple valid protected package error messages.