### PR TITLE
Fix flaky protected-package stderr assertion for dnf on Satellite  (#…

### DIFF
--- a/tests/foreman/destructive/test_packages.py
+++ b/tests/foreman/destructive/test_packages.py
@@ -76,13 +76,13 @@ def test_negative_remove_satellite_packages(sat_maintain):
     # Packages include satellite direct dependencies like foreman,
     # but also dependency of dependencies like wget for foreman
     if isinstance(sat_maintain, Satellite):
-        package_list = ['foreman', 'foreman-proxy', 'katello', 'wget', 'satellite']
+        protected_package = 'satellite'
+        package_list = ['foreman', 'foreman-proxy', 'katello', 'wget', protected_package]
     else:
-        package_list = ['foreman-proxy', 'satellite-capsule']
+        protected_package = 'satellite-capsule'
+        package_list = ['foreman-proxy', protected_package]
     for package in package_list:
         result = sat_maintain.execute(f'yum remove {package}')
         assert result.status != 0
-        assert (
-            'Problem: The operation would result in removing the following protected packages: satellite'
-            in str(result.stderr)
-        )
+        # dnf may report "removing" (direct remove) or "broken dependencies" (dependency remove)
+        assert f'protected packages: {protected_package}' in str(result.stderr)


### PR DESCRIPTION
…21806)

Fix flaky protected-package stderr assertion for dnf on Satellite 6.19.2

(cherry picked from commit 445809fc74cd9ec3eccb6423cd5037da61c11eca)

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->