### PR TITLE
Configure podman to trust katello CA on containerized Satellite

### DIFF
--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -3,6 +3,8 @@ from urllib.parse import urlparse
 import pytest
 
 from robottelo.config import settings
+from robottelo.constants import CONTAINER_CERTS_PATH
+from robottelo.enums import InstallMethod
 from robottelo.exceptions import SatelliteHostError
 
 
@@ -49,6 +51,16 @@ def puppet_proxy_port_range(session_puppet_enabled_sat):
             session_puppet_enabled_sat.execute(
                 f'semanage port -a -t websm_port_t -p tcp {port_pool_range}'
             )
+
+
+@pytest.fixture(autouse=True, scope='session')
+def configure_podman_ca_trust(session_target_sat):
+    """Configure podman on containerized Satellite to trust its own katello CA."""
+    if session_target_sat and session_target_sat.install_method == InstallMethod.FOREMANCTL:
+        certs_dir = f'{CONTAINER_CERTS_PATH}{session_target_sat.hostname}'
+        session_target_sat.execute(
+            f'mkdir -p {certs_dir} && cp {session_target_sat.ca_cert_file} {certs_dir}/ca.crt'
+        )
 
 
 @pytest.fixture(scope='class')


### PR DESCRIPTION
### Problem Statement
Podman on foremanctl-deployed (containerized) Satellites doesn't trust the katello server CA by default. This causes TLS verification failures (x509: certificate signed by unknown authority) when tests use podman push/podman pull against the Satellite's own container registry.


### Solution
Add a session-scoped autouse fixture `configure_podman_ca_trust` in `pytest_fixtures/core/sys.py` that copies the katello CA cert into `/etc/containers/certs.d/<hostname>/` on containerized Satellites, following the upstream documentation. The fixture only runs for foremanctl-installed Satellites and reuses existing helpers (ca_cert_file, CONTAINER_CERTS_PATH).


### Related Issues
No issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_docker.py::TestPodman -k test_cv_podman
```

## Summary by Sourcery

New Features:
- Add a session-scoped autouse fixture that sets up podman CA trust for containerized Satellites using the katello CA certificate.