### PR TITLE
Deploy capsule flavor

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2786,8 +2786,17 @@ class Satellite(Capsule, SatelliteMixins):
                 raise SatelliteHostError(
                     f'satellitectl auth-bundle failed\n{result.stdout}\n{result.stderr}'
                 )
+            if is_open('SAT-49003'):
+                # This belongs into the downstream packaging, which isn't ready yet
+                overrides_dir = '/usr/share/foremanctl/src/playbooks/_vendor_overrides/'
+                capsule.execute(f'mkdir -p {overrides_dir}/deploy-proxy/')
+                capsule.put(
+                    'variables:\n  flavor:\n    choices:\n      - capsule',
+                    f'{overrides_dir}/deploy-proxy/metadata.obsah.yaml',
+                    temp_file=True,
+                )
             install_cmd = (
-                f'satellitectl deploy-proxy --flavor foreman-proxy-content'
+                f'satellitectl deploy-proxy --flavor capsule'
                 f' --auth-bundle {cert_file_path}'
                 f' --foreman-fqdn {self.hostname}'
             )


### PR DESCRIPTION
### Problem Statement

use capsule flavor
### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Switch proxy deployment to use the capsule flavor and add a temporary vendor override for capsule flavor metadata when SAT-49003 is open.

Enhancements:
- Update satellitectl proxy deployment to use the capsule flavor instead of foreman-proxy-content.
- Introduce a conditional vendor override that injects capsule flavor metadata until downstream packaging supports it.