### PR TITLE
[6.19.z] Add test for IoP services with alternate hostname fact

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2481,6 +2481,7 @@ WEBHOOK_METHODS = [
 LIFECYCLE_METADATA_FILE = '/usr/share/satellite/lifecycle-metadata.yml'
 
 OPENSSH_RECOMMENDATION = 'Decreased security: OpenSSH config permissions'
+INCORRECT_PERM_RECOMMENDATION = 'Incorrect permissions on sensitive files'
 DNF_RECOMMENDATION = (
     'The dnf installs lower versions of packages when the "best" '
     'option is not present in the /etc/dnf/dnf.conf'

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -17,9 +17,91 @@ from datetime import UTC, datetime, timedelta
 import json
 
 import pytest
-from wait_for import wait_for
+from selenium.common.exceptions import NoSuchElementException
+from wait_for import TimedOutError, wait_for
 
 from robottelo import constants
+from robottelo.constants import INCORRECT_PERM_RECOMMENDATION, OPENSSH_RECOMMENDATION
+from robottelo.utils.datafactory import gen_string
+
+
+def _safe_ui_call(fn, *fn_args):
+    """Call a UI getter and return None on expected UI errors.
+
+    Args:
+        fn: Callable to invoke (for example, a session.host_new getter).
+        *fn_args: Positional arguments passed through to fn.
+    """
+    try:
+        return fn(*fn_args)
+    except (TimedOutError, NoSuchElementException):
+        return None
+
+
+def trigger_cve_sync(satellite, best_effort=False, assert_start=False):
+    """Start CVE sync services and wait for each to complete.
+
+    Args:
+        satellite: Satellite instance used to run IoP sync services.
+        best_effort: If True, ignore service wait timeouts.
+        assert_start: If True, assert that each `systemctl start` succeeds.
+    """
+    for service in ('iop-cvemap-download', 'iop-service-vuln-vmaas-sync'):
+        start_result = satellite.execute(f'systemctl start {service}')
+        if assert_start:
+            assert start_result.status == 0, f'Failed to start {service}: {start_result.stderr}'
+        try:
+            wait_for(
+                lambda svc=service: satellite.execute(f'systemctl is-active {svc}').status != 0,
+                timeout=300,
+                delay=10,
+                handle_exception=True,
+            )
+        except TimedOutError:
+            if not best_effort:
+                raise
+
+
+def upload_and_check_recommendation_diagnosis(client, expected_rule_ids=None):
+    """Upload host data and verify recommendation rule hit via diagnosis output."""
+    if client.execute('insights-client').status != 0:
+        return False
+    diagnosis = client.execute('insights-client --diagnosis')
+    if diagnosis.status != 0:
+        return False
+    diagnosis_text = f'{diagnosis.stdout}\n{diagnosis.stderr}'.upper()
+    if expected_rule_ids:
+        if isinstance(expected_rule_ids, str):
+            expected_rule_ids = [expected_rule_ids]
+        return any(rule_id.upper() in diagnosis_text for rule_id in expected_rule_ids)
+    return all(
+        marker not in diagnosis_text
+        for marker in (
+            'NO POTENTIAL RECOMMENDATIONS FOUND',
+            'NO RECOMMENDATIONS FOUND',
+            '0 RULE HITS',
+        )
+    )
+
+
+def cleanup_stale_insights_state(client):
+    """Clean up stale insights-client state, re-register, and collect data.
+
+    This handles the case where a previous registration left behind
+    a stale machine-id that causes insights-client to fail.
+
+    Args:
+        client: ContentHost instance to clean up
+
+    Returns:
+        Result of the final insights-client command (data collection/upload)
+    """
+    client.execute('insights-client --unregister')
+    client.execute('rm -f /etc/insights-client/machine-id')
+    client.execute('rm -f /etc/insights-client/.registered')
+    client.execute('insights-client --register')
+    # Run insights-client again to collect and upload data after re-registration
+    return client.execute('insights-client')
 
 
 @pytest.fixture
@@ -775,3 +857,716 @@ def test_export_vulnerability_data(
         assert cve['impact'] == 'Moderate'
         assert bool(cve['advisory_available'])
         assert vulnerable_rhel_host.os_distribution_version in cve['rhel_versions']
+
+
+@pytest.mark.e2e
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+def test_positive_host_deletion_removes_from_lightspeed(
+    vulnerable_rhel_host_with_recommendations,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+    setup_content_for_iop,
+):
+    """Verify that after deleting a host from UI, the host no longer shows in
+    Red Hat Lightspeed Recommendations and Vulnerability pages.
+
+    :id: 05634f32-bc15-409d-9c8f-4babb3d9ca59
+
+    :steps:
+        1. Register a host with insights and create vulnerabilities and recommendations
+        2. Verify the host appears in Vulnerability page with CVEs
+        3. Verify the host has recommendations displayed
+        4. Delete the host from Satellite UI
+        5. Verify the host no longer appears in hosts list
+        6. Verify the host no longer appears in Vulnerability affected hosts
+        7. Verify the host no longer appears in Recommendations page
+
+    :expectedresults:
+        1. Host is successfully deleted from Satellite
+        2. After host deletion, host no longer appears in Vulnerability page
+        3. After host deletion, host no longer appears in Recommendations page
+
+    :Verifies: SAT-32545
+    """
+    satellite = module_target_sat_insights
+    client = vulnerable_rhel_host_with_recommendations
+    hostname = client.hostname
+
+    with satellite.ui_session() as session:
+        session.organization.select(org_name=rhcloud_manifest_org.name)
+
+        # Verify host has vulnerabilities before deletion.
+        # Avoid strict coupling to a single CVE link in global table.
+        def _has_vulnerabilities():
+            if client.execute('insights-client').status != 0:
+                return False
+            session.browser.refresh()
+            return bool(_safe_ui_call(session.host_new.get_vulnerabilities, hostname))
+
+        has_vulnerabilities, _ = wait_for(
+            _has_vulnerabilities,
+            timeout=600,
+            delay=30,
+            handle_exception=True,
+        )
+        assert has_vulnerabilities, 'Host should have vulnerabilities before deletion'
+
+        # Verify host has recommendations before deletion.
+        has_recommendations, _ = wait_for(
+            lambda: upload_and_check_recommendation_diagnosis(client),
+            timeout=600,
+            delay=30,
+            handle_exception=True,
+        )
+        assert has_recommendations, 'Host should report recommendation rule hits before deletion'
+
+        # Delete the host from UI
+        session.host_new.delete(hostname)
+
+        # Verify host no longer appears in the hosts list
+        search_result = session.host_new.search(hostname)
+        assert not search_result or search_result[0].get('Name') == 'No Results', (
+            f'Host {hostname} should not appear in hosts list after deletion'
+        )
+
+        # Verify host no longer appears in Vulnerability affected hosts
+        # After deletion, the CVE may no longer appear if this was the only affected host
+        try:
+            affected_hosts_after = session.cloudvulnerability.get_affected_hosts_by_cve(
+                constants.RHEL10_VULNERABILITY_CVE_ID
+            )
+            assert not any(host['Name'] == hostname for host in affected_hosts_after), (
+                f'Host {hostname} should not appear in affected hosts for CVE after deletion'
+            )
+        except (NoSuchElementException, TimedOutError):
+            # CVE not found or view timed out means no hosts are affected - expected after deletion
+            pass
+
+        # Verify host no longer appears in Recommendations page for the OPENSSH recommendation
+        # After deletion, the recommendation may no longer appear if this was the only affected host
+        try:
+            recommendations_after = session.recommendationstab.search(OPENSSH_RECOMMENDATION)
+            # After deletion, either no recommendations exist or the "No recommendations" message appears
+            has_no_recommendations = (
+                not recommendations_after
+                or 'No recommendations' in recommendations_after[0].get('Name', '')
+            )
+            assert has_no_recommendations, (
+                f'Recommendations should be empty after host deletion, but found: {recommendations_after}'
+            )
+        except (NoSuchElementException, TimedOutError):
+            # Recommendation not found or view timed out - expected after deletion
+            pass
+
+
+@pytest.mark.e2e
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+def test_positive_insights_reregistration_restores_host_data(
+    vulnerable_rhel_host,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+    setup_content_for_iop,
+):
+    """Verify that after unregistering and re-registering with insights-client,
+    recommendations and CVE data reappear for the host.
+
+    :id: ccbb6185-44a8-4769-809b-301cf37d0fcf
+
+    :steps:
+        1. Register a host with insights and create vulnerabilities and recommendations
+        2. Verify host has CVE vulnerabilities and recommendations displayed
+        3. Unregister from insights-client
+        4. Verify recommendations and vulnerabilities are empty
+        5. Re-register to insights-client
+        6. Verify recommendations and CVEs reappear
+
+    :expectedresults:
+        1. After unregistering, recommendations and CVE data are cleared
+        2. After re-registering with insights-client, recommendations and CVEs reappear
+        3. Red Hat Lightspeed status returns to Reporting
+
+    :Verifies: SAT-32545
+    """
+    satellite = module_target_sat_insights
+    client = vulnerable_rhel_host
+    hostname = client.hostname
+
+    # Ensure latest host data is uploaded and processed before first UI validation.
+    result = client.execute('insights-client')
+    assert result.status == 0, f'Failed to run insights-client before validation: {result.stderr}'
+    trigger_cve_sync(satellite)
+
+    with satellite.ui_session() as session:
+        session.organization.select(org_name=rhcloud_manifest_org.name)
+
+        # Verify host has vulnerabilities before adding recommendation.
+        # Use non-empty vulnerability data to avoid strict coupling to a
+        # particular CVE set on a specific image snapshot.
+        def _has_vulnerabilities():
+            if client.execute('insights-client').status != 0:
+                return False
+            session.browser.refresh()
+            return bool(_safe_ui_call(session.host_new.get_vulnerabilities, hostname))
+
+        has_vulnerabilities, _ = wait_for(
+            _has_vulnerabilities,
+            timeout=600,
+            delay=30,
+            handle_exception=False,
+        )
+        assert has_vulnerabilities, 'Host should have vulnerabilities before unregistering'
+        # Add misconfigurations to trigger stable recommendation data.
+        assert (
+            client.execute('dnf update -y dnf; sed -i -e "/^best/d" /etc/dnf/dnf.conf').status == 0
+        )
+        assert client.execute('chmod 777 /etc/shadow').status == 0
+        # Run insights-client to report the recommendations
+        assert client.execute('insights-client').status == 0
+
+        # Wait for at least one expected recommendation to appear
+        has_recommendations, _ = wait_for(
+            lambda: upload_and_check_recommendation_diagnosis(client),
+            timeout=1200,
+            delay=30,
+            handle_exception=True,
+        )
+        assert has_recommendations, (
+            'Host should report recommendation rule hits before unregistering'
+        )
+
+        # Unregister from insights-client
+        result = client.execute('insights-client --unregister')
+        assert result.status == 0, f'Failed to unregister from insights: {result.stderr}'
+
+        # Refresh and verify data is empty
+        session.browser.refresh()
+        recommendations_after = _safe_ui_call(session.host_new.get_recommendations, hostname)
+        vulnerabilities_after = _safe_ui_call(session.host_new.get_vulnerabilities, hostname)
+        assert (
+            recommendations_after is None
+            or not recommendations_after
+            or 'No matching' in str(recommendations_after)
+            or 'No recommendations' in str(recommendations_after)
+        ), 'Recommendations should be empty after unregistering'
+        assert (
+            vulnerabilities_after is None
+            or not vulnerabilities_after
+            or 'No matching' in str(vulnerabilities_after)
+            or 'No vulnerabilities' in str(vulnerabilities_after)
+        ), 'Vulnerabilities should be empty after unregistering'
+
+        # Re-register to insights-client (keep machine-id to maintain host identity)
+        result = client.execute('insights-client --register')
+        assert result.status == 0, f'Failed to re-register to insights: {result.stderr}'
+
+        # Verify vulnerable package is still installed
+        result = client.execute(f'rpm -q {constants.RHEL10_VULNERABLE_MARIADB_RPM.split("-")[0]}')
+        assert result.status == 0, (
+            f'Vulnerable package should still be installed after re-registration: {result.stderr}'
+        )
+
+        # Run insights-client to upload data (run twice to ensure data is fully uploaded)
+        result = client.execute('insights-client')
+        assert result.status == 0, f'Failed to run insights-client: {result.stderr}'
+        result = client.execute('insights-client')
+        assert result.status == 0, f'Failed to run insights-client second time: {result.stderr}'
+
+        # Wait for host to return to Reporting state after re-registration.
+        has_reporting_status, _ = wait_for(
+            lambda: (
+                session.host_new.get_host_statuses(hostname)
+                .get('Red Hat Lightspeed', {})
+                .get('Status')
+                == 'Reporting'
+            ),
+            timeout=600,
+            delay=30,
+            handle_exception=True,
+        )
+        assert has_reporting_status, (
+            'Host should return to Reporting state before checking restored recommendations'
+        )
+
+        # Trigger CVE download and vulnerability sync to process re-registered host data.
+        trigger_cve_sync(satellite)
+
+        # Verify at least one expected recommendation reappears after re-registration
+        # wait_for with refresh_before_check=True ensures fresh data is fetched on each iteration
+        has_recommendations_after, _ = wait_for(
+            lambda: upload_and_check_recommendation_diagnosis(client),
+            timeout=1200,
+            delay=30,
+            handle_exception=True,
+        )
+        assert has_recommendations_after, (
+            'Host should report recommendation rule hits after re-registering'
+        )
+
+        # Verify Red Hat Lightspeed status is reporting again
+        status = session.host_new.get_host_statuses(hostname)
+        assert status['Red Hat Lightspeed']['Status'] == 'Reporting', (
+            'Host should be reporting to Red Hat Lightspeed after re-registration'
+        )
+
+
+@pytest.mark.e2e
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+def test_positive_subscription_manager_reregistration_restores_host_data(
+    rhel_contenthost,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+    rhcloud_activation_key,
+    setup_content_for_iop,
+):
+    """Verify that after unregistering with subscription-manager and re-registering,
+    recommendations and CVE data reappear for the host.
+
+    :id: 4772d79b-16e6-4bfb-b9c3-b7cac9638c2d
+
+    :steps:
+        1. Register a host with insights via subscription-manager
+        2. Create vulnerabilities and recommendations on the host
+        3. Verify host has CVE vulnerabilities and recommendations displayed
+        4. Unregister with subscription-manager
+        5. Verify recommendations and vulnerabilities are empty
+        6. Re-register with subscription-manager and insights-client
+        7. Verify recommendations and CVEs reappear
+
+    :expectedresults:
+        1. After unregistering, recommendations and CVE data are cleared
+        2. After re-registering with subscription-manager and insights-client,
+           recommendations and CVEs reappear
+        3. Red Hat Lightspeed status returns to Reporting
+
+    :Verifies: SAT-32545
+    """
+    satellite = module_target_sat_insights
+    client = rhel_contenthost
+    org = rhcloud_manifest_org
+    hostname = client.hostname
+
+    # Configure and register the host with insights
+    client.configure_rex(satellite=satellite, org=org, register=False)
+    client.configure_insights_client(
+        satellite=satellite,
+        activation_key=rhcloud_activation_key,
+        org=org,
+        rhel_distro=f'rhel{client.os_version.major}',
+    )
+
+    # Remove static repos and update packages
+    assert (
+        client.execute(
+            'find /etc/yum.repos.d/ -type f | grep -vF redhat.repo | xargs -I \'{}\' rm \'{}\''
+        ).status
+        == 0
+    )
+    assert client.execute('dnf -y update').status == 0
+
+    # Install vulnerable mariadb version to create vulnerabilities
+    assert client.execute(f'dnf install -y {constants.RHEL10_VULNERABLE_MARIADB_RPM}').status == 0
+
+    # Add permission misconfiguration to create a recommendation.
+    assert client.execute('chmod 777 /etc/shadow').status == 0
+
+    # Run insights-client to report vulnerabilities and recommendations
+    assert client.execute('insights-client').status == 0
+
+    # Trigger CVE download and vulnerability sync to ensure data is processed.
+    trigger_cve_sync(satellite)
+
+    with satellite.ui_session() as session:
+        session.organization.select(org_name=org.name)
+
+        # Verify host has vulnerabilities before unregistering.
+        # Use generic vulnerability presence because exact CVE can vary.
+        def _has_vulnerabilities():
+            if client.execute('insights-client').status != 0:
+                return False
+            session.browser.refresh()
+            return bool(_safe_ui_call(session.host_new.get_vulnerabilities, hostname))
+
+        has_vulnerabilities, _ = wait_for(
+            _has_vulnerabilities,
+            timeout=600,
+            delay=30,
+            handle_exception=True,
+        )
+        assert has_vulnerabilities, 'Host should have vulnerabilities before unregistering'
+        baseline_cve_ids = [
+            vuln.get('CVE ID')
+            for vuln in (_safe_ui_call(session.host_new.get_vulnerabilities, hostname) or [])
+            if vuln.get('CVE ID')
+        ]
+
+        # Verify host has recommendations before unregistering
+        # wait_for is needed because recommendation data takes time to propagate through IoP
+        has_recommendations, _ = wait_for(
+            lambda: upload_and_check_recommendation_diagnosis(client),
+            timeout=600,
+            delay=30,
+            handle_exception=True,
+        )
+        assert has_recommendations, (
+            'Host should report recommendation rule hits before unregistering'
+        )
+
+        # Unregister with subscription-manager
+        result = client.unregister()
+        assert result.status == 0, (
+            f'Failed to unregister from subscription-manager: {result.stderr}'
+        )
+        result = client.execute('subscription-manager clean')
+        assert result.status == 0, f'Failed to clean subscription-manager: {result.stderr}'
+
+        # Refresh and verify data is empty
+        session.browser.refresh()
+        recommendations_after = _safe_ui_call(session.host_new.get_recommendations, hostname)
+        vulnerabilities_after = _safe_ui_call(session.host_new.get_vulnerabilities, hostname)
+        assert (
+            recommendations_after is None
+            or not recommendations_after
+            or 'No matching' in str(recommendations_after)
+            or 'No recommendations' in str(recommendations_after)
+        ), 'Recommendations should be empty after subscription-manager unregister'
+        assert (
+            vulnerabilities_after is None
+            or not vulnerabilities_after
+            or 'No matching' in str(vulnerabilities_after)
+            or 'No vulnerabilities' in str(vulnerabilities_after)
+        ), 'Vulnerabilities should be empty after subscription-manager unregister'
+
+        # Re-register with subscription-manager using the activation key
+        # Use setup_insights=True to also register with insights-client
+        # Keep machine-id to maintain host identity for vulnerability data
+        result = client.register(
+            org=org,
+            loc=None,
+            activation_keys=[rhcloud_activation_key.name],
+            target=satellite,
+            setup_insights=True,
+        )
+        assert result.status == 0, (
+            f'Failed to re-register with subscription-manager: {result.stderr}'
+        )
+
+        # Verify vulnerable package is still installed
+        result = client.execute(f'rpm -q {constants.RHEL10_VULNERABLE_MARIADB_RPM.split("-")[0]}')
+        assert result.status == 0, (
+            f'Vulnerable package should still be installed after re-registration: {result.stderr}'
+        )
+
+        result = client.execute('insights-client')
+        assert result.status == 0, f'Failed to run insights-client: {result.stderr}'
+
+        # Verify recommendations reappear after re-registration
+        # wait_for with refresh_before_check=True ensures fresh data is fetched on each iteration
+        has_recommendations_after, _ = wait_for(
+            lambda: upload_and_check_recommendation_diagnosis(client),
+            timeout=600,
+            delay=30,
+            handle_exception=True,
+        )
+        assert has_recommendations_after, (
+            'Host should report recommendation rule hits after re-registering'
+        )
+
+        # Run insights-client again to ensure vulnerability data is uploaded
+        result = client.execute('insights-client')
+        assert result.status == 0, (
+            f'Failed to run insights-client before vulnerability check: {result.stderr}'
+        )
+
+        # Verify vulnerabilities reappear after re-registration.
+        # Use baseline CVEs collected before unregistering for stability across
+        # content snapshots and avoid hard-coded CVE coupling.
+        def _has_restored_vulnerabilities():
+            if client.execute('insights-client').status != 0:
+                return False
+            trigger_cve_sync(satellite, best_effort=True)
+            session.browser.refresh()
+            vulnerabilities = _safe_ui_call(session.host_new.get_vulnerabilities, hostname) or []
+            if not vulnerabilities:
+                return False
+            current_cve_ids = {
+                vulnerability.get('CVE ID')
+                for vulnerability in vulnerabilities
+                if vulnerability.get('CVE ID')
+            }
+            return bool(current_cve_ids & set(baseline_cve_ids))
+
+        has_vulnerabilities_after, _ = wait_for(
+            _has_restored_vulnerabilities,
+            timeout=900,
+            delay=30,
+            handle_exception=True,
+        )
+        assert has_vulnerabilities_after, 'Host should show vulnerabilities after re-registering'
+
+        # Verify Red Hat Lightspeed status is reporting again
+        status = session.host_new.get_host_statuses(hostname)
+        assert status['Red Hat Lightspeed']['Status'] == 'Reporting', (
+            'Host should be reporting to Red Hat Lightspeed after re-registration'
+        )
+
+
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('10')
+@pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)
+def test_positive_iop_services_with_alternate_hostname_fact(
+    rhel_contenthost,
+    rhcloud_manifest_org,
+    module_target_sat_insights,
+    rhcloud_activation_key,
+    setup_content_for_iop,
+    request,
+):
+    """Verify IoP Advisor and Vulnerability services work correctly when using alternate hostname fact.
+
+    This test validates that when Satellite and Insights are configured to use
+    the same alternate display name (via custom RHSM fact), the host registration,
+    IoP services, and re-registration all function correctly without creating
+    duplicate host records.
+
+    :id: 390a69a4-5079-4070-9f24-3bfd7004d759
+
+    :steps:
+        1. Configure Satellite to assign registering host's hostname via register_hostname_fact (network.hostname-override)
+        2. Create custom RHSM fact on the client with alternate hostname
+        3. Configure Insights to use the same alternate display name
+        4. Verify the alternate hostname is resolvable from Satellite
+        5. Register the host using global registration with setup_insights=true
+        6. Verify the host appears in Satellite using the alternate display name
+        7. Verify the host appears in Insights using the alternate display name
+        8. Verify successful IoP registration
+        9. Create vulnerabilities and recommendations on the host
+        10. Verify Vulnerability service displays data correctly
+        11. Verify Advisor service shows recommendations correctly
+        12. Force re-register using global registration with force=true
+        13. Verify the host continues to use the alternate display name
+        14. Verify successful IoP registration after re-registration
+        15. Re-verify Vulnerability and Advisor services
+        16. Verify no duplicate host records were created
+        17. Verify no stale IoP entries exist
+        18. Unregister from insights-client
+        19. Verify Vulnerability and Advisor data is cleared after unregistering
+
+    :expectedresults:
+        1. Satellite accepts and uses the alternate hostname fact
+        2. Host registers successfully with alternate display name
+        3. IoP services (Vulnerability and Advisor) work correctly with alternate hostname
+        4. Re-registration maintains the alternate hostname without duplicates
+        5. No stale IoP entries are left after re-registration
+        6. After unregistering, Vulnerability and Advisor data is cleared
+
+    :customerscenario: true
+
+    :Verifies: SAT-44011
+    """
+    CVE_ID = 'CVE-2018-10896'
+    satellite = module_target_sat_insights
+    client = rhel_contenthost
+    org = rhcloud_manifest_org
+
+    # Define the alternate hostname with a meaningful prefix and random suffix
+    hostname_prefix = f'alt-insights-{gen_string("alpha", 6).lower()}'
+    alternate_hostname = f'{hostname_prefix}.{client.hostname.split(".", 1)[-1]}'
+
+    # Save original register_hostname_fact value for cleanup
+    original_setting = satellite.cli.Settings.info({'name': 'register_hostname_fact'})
+    original_value = original_setting['value']
+
+    # Step 1: Configure Satellite to use alternate hostname fact
+    result = satellite.execute(
+        'hammer settings set --name register_hostname_fact --value network.hostname-override'
+    )
+    assert result.status == 0, f'Failed to configure Satellite hostname fact: {result.stderr}'
+
+    # Step 2: Create custom RHSM fact on the client with alternate hostname
+    rhsm_fact_content = f'{{"network.hostname-override":"{alternate_hostname}"}}'
+    assert client.execute('mkdir -p /etc/rhsm/facts').status == 0
+    result = client.execute(f'echo \'{rhsm_fact_content}\' > /etc/rhsm/facts/hostname.facts')
+    assert result.status == 0, f'Failed to create RHSM fact file: {result.stderr}'
+
+    # Step 3: Configure Insights to use the same alternate display name
+    # Remove any existing display_name entries to make this idempotent
+    client.execute('sed -i "/^display_name=/d" /etc/insights-client/insights-client.conf')
+    result = client.execute(
+        f'echo "display_name={alternate_hostname}" >> /etc/insights-client/insights-client.conf'
+    )
+    assert result.status == 0, f'Failed to configure Insights display name: {result.stderr}'
+
+    # Step 4: Verify the alternate hostname is resolvable from Satellite
+    # Add entry to /etc/hosts for resolution
+    client_ip = client.execute('hostname -I | awk \'{print $1}\'').stdout.strip()
+    result = satellite.execute(f'echo "{client_ip} {alternate_hostname}" >> /etc/hosts')
+    assert result.status == 0, f'Failed to add hosts entry on Satellite: {result.stderr}'
+
+    def cleanup_sat():
+        satellite.execute(f'sed -i "/{alternate_hostname}/d" /etc/hosts')
+        satellite.execute(
+            f'hammer settings set --name register_hostname_fact --value "{original_value}"'
+        )
+
+    request.addfinalizer(cleanup_sat)
+
+    # Verify resolution
+    result = satellite.execute(f'ping -c 1 {alternate_hostname}')
+    assert result.status == 0, (
+        f'Alternate hostname {alternate_hostname} is not resolvable from Satellite'
+    )
+
+    # Step 5: Register the host using global registration with setup_insights=true
+    result = client.register(
+        org=org,
+        loc=None,
+        activation_keys=[rhcloud_activation_key.name],
+        target=satellite,
+        setup_insights=True,
+    )
+    assert result.status == 0, f'Failed to register host with global registration: {result.stderr}'
+
+    # Step 6-7: Verify the host appears in Satellite and Insights using alternate display name
+    with satellite.ui_session() as session:
+        session.organization.select(org_name=org.name)
+
+        # Search for host by alternate hostname
+        search_result = session.host_new.search(alternate_hostname)
+        assert search_result, f'Host not found with alternate hostname {alternate_hostname}'
+        assert len(search_result) > 0, (
+            f'Search returned empty results for alternate hostname {alternate_hostname}'
+        )
+        assert alternate_hostname in search_result[0]['Name'], (
+            f'Host name does not match alternate hostname. '
+            f'Expected: {alternate_hostname}, Got: {search_result[0]["Name"]}'
+        )
+
+        # Step 8: Verify successful IoP registration
+        status = session.host_new.get_host_statuses(alternate_hostname)
+        assert status['Red Hat Lightspeed']['Status'] == 'Reporting', (
+            'IoP registration failed - Red Hat Lightspeed status is not Reporting'
+        )
+
+        # Step 9: Create recommendations on the host (lightweight, no package operations)
+        # Add permission misconfiguration to trigger recommendation
+        assert client.execute('chmod 777 /etc/shadow').status == 0
+
+        # Run insights-client to report recommendations
+        result = client.execute('insights-client')
+        assert result.status == 0, f'insights-client failed: {result.stdout}'
+
+        # Step 10: Verify Vulnerability service displays data correctly
+
+        vulnerabilities = session.host_new.get_vulnerabilities(alternate_hostname)
+        # Verify we have vulnerability data (checking for any CVE, not a specific one)
+        assert len(vulnerabilities) > 0, 'Vulnerabilities list should not be empty'
+        assert any(CVE_ID in vuln.get('CVE ID') for vuln in vulnerabilities), (
+            'No CVE IDs found in vulnerabilities'
+        )
+
+        # Step 11: Verify Advisor service shows recommendations correctly
+        recs = session.host_new.get_recommendations(alternate_hostname)
+        assert any(row.get('Description') == INCORRECT_PERM_RECOMMENDATION for row in recs), (
+            f"No row found with Recommendation == {INCORRECT_PERM_RECOMMENDATION}"
+        )
+        # Step 12: Force re-register using global registration with force=true
+        result = client.register(
+            org=org,
+            loc=None,
+            activation_keys=[rhcloud_activation_key.name],
+            target=satellite,
+            setup_insights=True,
+            force=True,
+        )
+        assert result.status == 0, f'Failed to force re-register host: {result.stderr}'
+
+        # Step 13: Verify the host continues to use the alternate display name
+        session.browser.refresh()
+        search_result = session.host_new.search(alternate_hostname)
+        assert len(search_result) > 0, (
+            f'Search returned empty results for alternate hostname {alternate_hostname} after re-registration'
+        )
+        assert alternate_hostname in search_result[0]['Name'], (
+            f'Host name changed after re-registration. '
+            f'Expected: {alternate_hostname}, Got: {search_result[0]["Name"]}'
+        )
+
+        # Step 14: Verify successful IoP registration after re-registration
+        status = session.host_new.get_host_statuses(alternate_hostname)
+        assert status['Red Hat Lightspeed']['Status'] == 'Reporting', (
+            'IoP registration failed after re-registration'
+        )
+
+        # Step 15: Re-verify Vulnerability and Advisor services
+        # Run insights-client to refresh data
+        result = client.execute('insights-client')
+        assert result.status == 0, f'insights-client failed after re-registration: {result.stdout}'
+
+        # # Verify vulnerabilities still show
+        vulnerabilities = session.host_new.get_vulnerabilities(alternate_hostname)
+        # Verify we have vulnerability data (checking for any CVE, not a specific one)
+        assert len(vulnerabilities) > 0, 'Vulnerabilities list should not be empty'
+        assert any(CVE_ID in vuln.get('CVE ID') for vuln in vulnerabilities), (
+            'No CVE IDs found in vulnerabilities'
+        )
+
+        # # Verify recommendations still show
+        recs = session.host_new.get_recommendations(alternate_hostname)
+        assert any(row.get('Description') == INCORRECT_PERM_RECOMMENDATION for row in recs), (
+            f"No row found with Recommendation == {INCORRECT_PERM_RECOMMENDATION}"
+        )
+
+        # Step 18: Verify no duplicate host records were created
+        # Search by domain to find all hosts that might match (original or alternate)
+        domain = client.hostname.split('.', 1)[-1] if '.' in client.hostname else ''
+        all_hosts_with_domain = session.host_new.search(domain) if domain else []
+
+        # Filter for hosts that match either original or alternate hostname
+        matching_hosts = [
+            host
+            for host in all_hosts_with_domain
+            if client.hostname in host.get('Name', '') or alternate_hostname in host.get('Name', '')
+        ]
+
+        # Should only find one host (with the alternate hostname)
+        assert len(matching_hosts) == 1, (
+            f'Expected 1 host, found {len(matching_hosts)}. '
+            f'Possible duplicate or missing host. Matching hosts: {[h["Name"] for h in matching_hosts]}'
+        )
+
+        assert alternate_hostname in matching_hosts[0]['Name'], (
+            f'Host should use alternate hostname {alternate_hostname}, '
+            f'but found {matching_hosts[0]["Name"]}'
+        )
+
+        # Step 19: Verify no stale IoP entries exist
+        # Verify that vulnerabilities are still associated with the alternate hostname
+        vulnerabilities_final = session.host_new.get_vulnerabilities(alternate_hostname)
+        assert len(vulnerabilities_final) == len(vulnerabilities), (
+            'Vulnerabilities should still be present after re-registration with alternate hostname'
+        )
+
+        # Step 20: Unregister from insights-client and verify data is cleared
+        result = client.execute('insights-client --unregister')
+        assert result.status == 0, f'Failed to unregister from insights: {result.stderr}'
+
+        session.browser.refresh()
+        vulnerabilities_after_unreg = _safe_ui_call(
+            session.host_new.get_vulnerabilities, alternate_hostname
+        )
+        assert vulnerabilities_after_unreg is None, (
+            'Vulnerabilities should be empty after unregistering from insights'
+        )
+
+        recommendations_after_unreg = _safe_ui_call(
+            session.host_new.get_recommendations, alternate_hostname
+        )
+        assert 'No matching' in str(recommendations_after_unreg), (
+            'Recommendations should be empty after unregistering from insights'
+        )


### PR DESCRIPTION
## Summary
- Cherry-pick of #22081 to 6.19.z branch
- Adds test for IoP Advisor and Vulnerability services with alternate hostname fact (`register_hostname_fact`)
- Adds tests for host deletion removing Lightspeed data, insights re-registration restoring host data, and subscription-manager re-registration restoring host data
- Adds helper functions (`_safe_ui_call`, `trigger_cve_sync`, `upload_and_check_recommendation_diagnosis`, `cleanup_stale_insights_state`) and `INCORRECT_PERM_RECOMMENDATION` constant

## Test plan
- [ ] PRT: `pytest tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_positive_iop_services_with_alternate_hostname_fact`
- [ ] PRT: `pytest tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_positive_host_deletion_removes_from_lightspeed`
- [ ] PRT: `pytest tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_positive_insights_reregistration_restores_host_data`
- [ ] PRT: `pytest tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_positive_subscription_manager_reregistration_restores_host_data`

🤖 Generated with [Claude Code](https://claude.com/claude-code)