### PR TITLE
Update tests using all_hosts delete() entity

### DIFF
--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -212,7 +212,7 @@ def test_positive_provision_end_to_end(
             provisioning_host.wait_for_connection()
             assert 'SecureBoot enabled' in provisioning_host.execute('mokutil --sb-state').stdout
 
-        session.host_new.delete(name)
+        session.all_hosts.delete(name)
         assert not sat.api.Host().search(query={'search': f'name="{name}"'})
 
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -383,16 +383,6 @@ def test_positive_end_to_end(module_global_params, target_sat, host_ui_options, 
     new_name = f"new{gen_string('alpha').lower()}"
     new_host_name = f"{new_name}.{api_values['interfaces.interface.domain']}"
 
-    stripped_headers = None
-
-    @request.addfinalizer
-    def _finalize():
-        # Get table to original state
-        with target_sat.ui_session(user=ui_user.login, password=ui_user.password) as session:
-            session.organization.select(api_values['host.organization'])
-            session.location.select(api_values['host.location'])
-            session.all_hosts.manage_table_columns({header: True for header in stripped_headers})
-
     with target_sat.ui_session(user=ui_user.login, password=ui_user.password) as session:
         session.organization.select(api_values['host.organization'])
         session.location.select(api_values['host.location'])

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -422,13 +422,6 @@ def test_positive_end_to_end(module_global_params, target_sat, host_ui_options, 
         assert session.host.search(host_name)[0][0] == 'No Results'
         assert session.host.search(new_host_name)[0]['Name'] == new_host_name
         # delete
-        headers = session.all_hosts.get_displayed_table_headers()
-        stripped_headers = tuple(
-            header for header in headers if header is not None and header != 'Name'
-        )
-        wait_for(lambda: session.browser.refresh(), timeout=5)
-        # Make sure there is only Name column displayed
-        session.all_hosts.manage_table_columns({header: False for header in stripped_headers})
         assert session.all_hosts.delete(new_host_name)
         assert not target_sat.api.Host().search(query={'search': f'name="{new_host_name}"'})
 
@@ -2027,35 +2020,6 @@ def test_positive_tracer_enable_reload(tracer_install_host, target_sat):
         )
         tracer_title = session.host_new.get_tracer_tab_title(tracer_install_host.hostname)
         assert tracer_title == "No applications to restart"
-
-
-def test_all_hosts_delete(target_sat, function_org, function_location):
-    """Create a host and delete it through All Hosts UI
-
-    :id: 42b4560c-bb57-4c58-928e-e5fd5046b93f
-
-    :expectedresults: Successful deletion of a host through the table dropdown
-
-    :CaseComponent:Hosts
-
-    :Team: Proton
-    """
-    host = target_sat.api.Host(organization=function_org, location=function_location).create()
-    with target_sat.ui_session() as session:
-        session.organization.select(function_org.name)
-        session.location.select(function_location.name)
-        # Get current headers
-        headers = session.all_hosts.get_displayed_table_headers()
-        stripped_headers = tuple(
-            header for header in headers if header is not None and header != 'Name'
-        )
-        wait_for(lambda: session.browser.refresh(), timeout=5)
-        # Make sure there is only Name column displayed
-        session.all_hosts.manage_table_columns({header: False for header in stripped_headers})
-        assert session.all_hosts.delete(host.name)
-        # Get table to original state
-        wait_for(lambda: session.browser.refresh(), timeout=5)
-        session.all_hosts.manage_table_columns({header: True for header in stripped_headers})
 
 
 def test_all_hosts_bulk_delete(target_sat, function_org, function_location):

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -952,7 +952,7 @@ def test_positive_host_deletion_removes_from_lightspeed(
         assert has_recommendations, 'Host should report recommendation rule hits before deletion'
 
         # Delete the host from UI
-        session.host_new.delete(hostname)
+        session.all_hosts.delete(hostname)
 
         # Verify host no longer appears in the hosts list
         search_result = session.host_new.search(hostname)


### PR DESCRIPTION
[Airgun PR #2505](https://github.com/SatelliteQE/airgun/pull/2505) updates all_hosts `delete()` entity so it's more robust.

This PR removes `test_all_hosts_delete` as the all_hosts delete action is already tested in `ui/test_host.py:test_positive_end_to_end`.
Unnecessary code from `ui/test_host.py:test_positive_end_to_end` is also removed.
It also updates and fixes failing `test_positive_host_deletion_removes_from_lightspeed` so it uses the proper entity when doing an action on the all hosts page.

### PRT test Cases example
<img width="388" height="68" alt="image" src="https://github.com/user-attachments/assets/e1fe87ef-f089-4770-92fc-6a06476de47f" />
<img width="248" height="41" alt="image" src="https://github.com/user-attachments/assets/0d38cf10-5f4f-40a9-9243-53e7a505d6db" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_rhcloud_insights_vulnerability.py::test_positive_host_deletion_removes_from_lightspeed tests/foreman/ui/test_host.py::test_positive_end_to_end
airgun: 2505
```

## Summary by Sourcery

Streamline host deletion coverage and consistently use the All Hosts entity for UI deletion actions.

Bug Fixes:
- Use the All Hosts entity for host deletion workflows to ensure deletions operate correctly from the All Hosts page.

Enhancements:
- Remove redundant All Hosts deletion coverage and unnecessary table-column management from existing end-to-end host tests.

Tests:
- Update affected UI tests to validate host deletion through the All Hosts entity.

## Summary by Sourcery

Standardize host deletion tests on the All Hosts entity and eliminate redundant deletion coverage.

Bug Fixes:
- Use the All Hosts entity for host deletion workflows to ensure UI deletions operate correctly from the All Hosts page.

Enhancements:
- Remove redundant table-column management from the end-to-end host deletion test.

Tests:
- Remove the duplicate All Hosts deletion test while retaining bulk deletion coverage and updating affected tests to use the All Hosts entity.