### PR TITLE
[6.19.z] Update Grid video filename

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 from tempfile import NamedTemporaryFile
 import time
-from urllib.parse import urljoin, urlparse, urlunsplit
+from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
 
 import apypie
 from box import Box
@@ -2201,9 +2201,9 @@ class Satellite(Capsule, SatelliteMixins):
                 yield ui_session
         finally:
             if self.record_property is not None and settings.ui.record_video:
-                video_url = settings.ui.grid_url.replace(
-                    ':4444', f'/videos/{ui_session.ui_session_id}/video.mp4'
-                )
+                grid_url = urlsplit(settings.ui.grid_url)
+                video_path = f'/videos/{ui_session.ui_session_id}/{ui_session.ui_session_id}.mp4'
+                video_url = urlunsplit((grid_url.scheme, grid_url.hostname, video_path, '', ''))
                 self.record_property('video_url', video_url)
                 self.record_property('session_id', ui_session.ui_session_id)
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22446

### Problem Statement

- The video file path for UI tests will be changing from `/videos/{session_id}/video.mp4` to `/videos/{session_id}/{session_id}.mp4`.
- The `Satellite.ui_session` context manager keeps track of the video file URL. This URL gets passed to the `pytest_runtest_makereport` hook in `pytest_plugins/video_cleanup.py` during test teardown, and ends up getting saved in Jenkins / CI artifacts if the test failed, for later reference.
 
### Solution

- Update `Satellite.ui_session` to save the new video file URL, so that CI artifacts contain the correct links for any failed UI test recordings.

### Related Issues

SAT-47895

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Update recorded UI test artifact links to point to the new Grid video filename and path.