### PR TITLE
Add network_sensitive marker for the IPv6 overlay

### DIFF
--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -25,6 +25,7 @@ def pytest_configure(config):
         "manifester: Tests that require manifester",
         "ldap: Tests related to ldap authentication",
         "no_compose : Skip the marked sanity test for nightly compose",
+        "network_sensitive: Address-family / multi-host protocol path (IPv6 overlay)",
         "foremanctl: Tests that require foremanctl; deselected when server.install_method is installer",
         "pqc: Post-Quantum Cryptography tests",
         "migration_candidate: Candidate for migration to Foreman, Katello or any other plugin; informative marker for filtering",

--- a/tests/foreman/api/test_acs.py
+++ b/tests/foreman/api/test_acs.py
@@ -31,6 +31,7 @@ from robottelo.constants.repos import PULP_FIXTURE_ROOT, PULP_SUBPATHS_COMBINED
         if not (acs == 'rhui' and cnt == 'file')  # invalid combination: 'rhui-file'
     ],
 )
+@pytest.mark.network_sensitive
 def test_positive_CRUD_all_types(
     request, module_target_sat, acs_type, cnt_type, module_yum_repo, module_file_repo
 ):

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -509,6 +509,7 @@ class TestCapsuleContentManagement:
         caps_files = get_repo_files_by_url(caps_repo_url)
         assert sat_files == caps_files
 
+    @pytest.mark.network_sensitive
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_iso_library_sync(
         self, module_capsule_configured, module_sca_manifest_org, module_target_sat
@@ -761,6 +762,7 @@ class TestCapsuleContentManagement:
         caps_files = get_repo_files_by_url(caps_repo_url)
         assert len(caps_files) == packages_count
 
+    @pytest.mark.network_sensitive
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_capsule_pub_url_accessible(self, module_capsule_configured):
         """Ensure capsule pub url is accessible
@@ -781,6 +783,7 @@ class TestCapsuleContentManagement:
             assert b'katello-server-ca.crt' in response.content
 
     @pytest.mark.upgrade
+    @pytest.mark.network_sensitive
     @pytest.mark.parametrize('endpoint', ['pulpcore', 'katello'])
     def test_flatpak_endpoint(self, target_sat, module_capsule_configured, endpoint):
         """Ensure the Capsules's local flatpak index endpoint is up after install or upgrade.
@@ -802,6 +805,7 @@ class TestCapsuleContentManagement:
         assert rq.ok, f'Expected 200 but got {rq.status_code} from {endpoint} registry index'
 
     @pytest.mark.e2e
+    @pytest.mark.network_sensitive
     @pytest.mark.skip_if_not_set('capsule')
     @pytest.mark.parametrize('distro', ['rhel7', 'rhel8_bos', 'rhel9_bos', 'rhel10_bos'])
     def test_positive_sync_kickstart_repo(
@@ -896,6 +900,7 @@ class TestCapsuleContentManagement:
         assert sat_pkgs == caps_pkgs
 
     @pytest.mark.e2e
+    @pytest.mark.network_sensitive
     @pytest.mark.pit_client
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_container_repo_end_to_end(
@@ -1029,6 +1034,7 @@ class TestCapsuleContentManagement:
             )
             assert result.status == 0
 
+    @pytest.mark.network_sensitive
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_collection_repo(
         self,
@@ -1115,6 +1121,7 @@ class TestCapsuleContentManagement:
         assert 'foreman' in result.stdout
         assert 'operations' in result.stdout
 
+    @pytest.mark.network_sensitive
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_file_repo(
         self, target_sat, module_capsule_configured, function_org, function_product, function_lce
@@ -1635,6 +1642,7 @@ class TestCapsuleContentManagement:
         cvv = cvv.read()
         assert len(cvv.environment) == 2
 
+    @pytest.mark.network_sensitive
     @pytest.mark.parametrize(
         'repos_collection',
         [
@@ -2431,6 +2439,7 @@ class TestPodman:
 
 @pytest.mark.pqc
 @pytest.mark.e2e
+@pytest.mark.network_sensitive
 @pytest.mark.rhel_ver_match('N-0')
 @pytest.mark.no_containers
 @pytest.mark.skip_if_not_set('capsule')

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -168,6 +168,7 @@ def discovered_host_cleanup(target_sat):
 class TestDiscoveredHost:
     """General Discovered Host tests."""
 
+    @pytest.mark.network_sensitive
     @pytest.mark.upgrade
     @pytest.mark.e2e
     @pytest.mark.on_premises_provisioning
@@ -221,6 +222,7 @@ class TestDiscoveredHost:
         assert_discovered_host_provisioned(shell, module_provisioning_rhel_content.ksrepo)
         request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
 
+    @pytest.mark.network_sensitive
     @pytest.mark.upgrade
     @pytest.mark.e2e
     @pytest.mark.on_premises_provisioning

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -395,6 +395,7 @@ def test_positive_end_to_end_with_puppet_class(
     }
 
 
+@pytest.mark.network_sensitive
 def test_positive_create_and_update_with_subnet(
     module_location, module_org, module_default_subnet, module_target_sat
 ):

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -26,6 +26,7 @@ from robottelo.utils.issue_handlers import is_open
 @pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
+@pytest.mark.network_sensitive
 @pytest.mark.parametrize(
     'use_ip',
     [False] if is_open('SAT-39098') else [False, True],
@@ -163,6 +164,7 @@ def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_sca_man
     indirect=True,
     ids=['auth_http_proxy', 'unauth_http_proxy'],
 )
+@pytest.mark.network_sensitive
 def test_positive_install_content_with_http_proxy(
     setup_http_proxy, module_target_sat, rhel_contenthost, function_sca_manifest_org
 ):
@@ -296,6 +298,7 @@ def test_positive_assign_http_proxy_to_products(target_sat, function_org):
     assert 'success' in product_a.sync()['result'], 'Product sync failed'
 
 
+@pytest.mark.network_sensitive
 def test_positive_sync_proxy_with_certificate(request, target_sat, module_org, module_product):
     """Assign http_proxy with cacert.crt to repository and test
        that http_proxy and cacert are used during sync.
@@ -360,6 +363,7 @@ def test_positive_sync_proxy_with_certificate(request, target_sat, module_org, m
     assert repo.read().content_counts['rpm'] >= 1
 
 
+@pytest.mark.network_sensitive
 def test_refresh_updates_remotes_proxy(module_target_sat, module_org, module_product):
     """Ensure that repo refresh updates the http-proxy of pulp remote.
 

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -24,7 +24,11 @@ from robottelo.enums import NetworkType
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
 
-pytestmark = pytest.mark.foreman_installer
+pytestmark = [
+    pytest.mark.foreman_installer,
+    # PXE/iPXE/HTTP Boot; curated IPv6 overlay (UEFI HTTP Boot is certified path).
+    pytest.mark.network_sensitive,
+]
 
 
 @pytest.mark.e2e

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -95,6 +95,7 @@ def test_positive_puppet_bootstrap(
     assert puppet_run in render
 
 
+@pytest.mark.network_sensitive
 @pytest.mark.on_premises_provisioning
 @pytest.mark.rhel_ver_match(
     f'[{"" if is_open("SAT-41340") else "7"}89]'  # Skip EL7 for provisioning test as UEFI is not supported yet

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -34,6 +34,7 @@ def test_positive_find_capsule_upgrade_playbook(target_sat):
     assert len(templates) > 0
 
 
+@pytest.mark.network_sensitive
 def test_positive_run_capsule_update_playbook(module_capsule_configured, target_sat):
     """Run Capsule Upgrade playbook against an External Capsule
 

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -255,6 +255,7 @@ class TestAnsibleCfgMgmt:
 
 
 @pytest.mark.upgrade
+@pytest.mark.network_sensitive
 class TestAnsibleREX:
     """Test class for remote execution via Ansible
 

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -825,6 +825,7 @@ def test_positive_repair_artifacts(
 
 
 @pytest.mark.e2e
+@pytest.mark.network_sensitive
 @pytest.mark.rhel_ver_match('9')
 @pytest.mark.parametrize('function_flatpak_remote', ['RedHat'], indirect=True)
 @pytest.mark.parametrize('setting_update', ['foreman_proxy_content_auto_sync=True'], indirect=True)
@@ -967,6 +968,7 @@ def test_sync_consume_flatpak_repo_via_library(
 
 
 @pytest.mark.e2e
+@pytest.mark.network_sensitive
 @pytest.mark.rhel_ver_match('10')
 @pytest.mark.parametrize('function_flatpak_remote', ['RedHat'], indirect=True)
 @pytest.mark.parametrize(

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2402,6 +2402,7 @@ def test_positive_update_host_owner_and_verify_puppet_class_name(
 @pytest.mark.run_in_one_thread
 @pytest.mark.rhel_ver_match('[9]')
 @pytest.mark.no_containers
+@pytest.mark.network_sensitive
 def test_positive_create_and_update_with_content_source(
     target_sat,
     module_capsule_configured,
@@ -2500,6 +2501,7 @@ def test_positive_create_host_with_lifecycle_environment_name(
 
 
 @pytest.mark.rhel_ver_match('^6')
+@pytest.mark.network_sensitive
 @pytest.mark.parametrize(
     'setting_update', ['validate_host_lce_content_source_coherence'], indirect=False
 )

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -97,6 +97,7 @@ def test_positive_create_update_delete(module_org, module_location, target_sat):
     indirect=True,
     ids=['auth_http_proxy', 'unauth_http_proxy'],
 )
+@pytest.mark.network_sensitive
 def test_insights_client_registration_with_http_proxy(
     module_target_sat_insights,
     setup_http_proxy,
@@ -140,6 +141,7 @@ def test_insights_client_registration_with_http_proxy(
 @pytest.mark.run_in_one_thread
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.skipif((not settings.http_proxy.UN_AUTH_PROXY_URL), reason='Missing un_auth_proxy_url')
+@pytest.mark.network_sensitive
 def test_positive_set_content_default_http_proxy(block_fake_repo_access, target_sat):
     """An http proxy can be set to be the global default for repositories.
 

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -33,6 +33,7 @@ from robottelo.utils.issue_handlers import is_open
     ['validate_host_lce_content_source_coherence=false'],
     indirect=True,
 )
+@pytest.mark.network_sensitive
 def test_host_registration_end_to_end(
     module_sca_manifest_org,
     module_location,

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -29,6 +29,9 @@ from robottelo.exceptions import CLIFactoryError
 from robottelo.utils import ohsnap
 from robottelo.utils.datafactory import filtered_datapoint, parametrized
 
+# REX connect_by_ip / prefer_ipv6; curated IPv6 overlay.
+pytestmark = pytest.mark.network_sensitive
+
 
 @filtered_datapoint
 def valid_feature_names():

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -3461,6 +3461,7 @@ class TestNetworkSync:
     """Implements Network Sync scenarios."""
 
     @pytest.mark.pit_server
+    @pytest.mark.network_sensitive
     @pytest.mark.parametrize(
         'function_synced_rh_repo',
         ['rhae2'],

--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -15,7 +15,11 @@ import pytest
 
 from robottelo.config import settings
 
-pytestmark = pytest.mark.destructive
+pytestmark = [
+    pytest.mark.destructive,
+    # Client ↔ Satellite/Capsule MQTT; curated IPv6 overlay.
+    pytest.mark.network_sensitive,
+]
 
 
 @pytest.mark.no_containers

--- a/tests/foreman/destructive/test_remoteexecution.py
+++ b/tests/foreman/destructive/test_remoteexecution.py
@@ -27,7 +27,11 @@ from robottelo.utils.installer import InstallerCommand
 
 CAPSULE_TARGET_VERSION = f'6.{get_sat_version().minor}.z'
 
-pytestmark = pytest.mark.destructive
+pytestmark = [
+    pytest.mark.destructive,
+    # REX connect_by_ip / prefer_ipv6; curated IPv6 overlay.
+    pytest.mark.network_sensitive,
+]
 
 
 def create_CA(host, path='/root/CA', name=None):

--- a/tests/foreman/foremanctl/test_install_foremanctl.py
+++ b/tests/foreman/foremanctl/test_install_foremanctl.py
@@ -173,6 +173,7 @@ def module_sat_foremanctl_tuning(request):
 @pytest.mark.e2e
 @pytest.mark.pit_server
 @pytest.mark.first_sanity
+@pytest.mark.network_sensitive
 @pytest.mark.parametrize('module_sat_ready_rhel', ['default'], indirect=True)
 def test_satellite_installation_with_foremanctl(module_sat_ready_rhel):
     """Run a basic Satellite installation
@@ -195,6 +196,7 @@ def test_satellite_installation_with_foremanctl(module_sat_ready_rhel):
 @pytest.mark.e2e
 @pytest.mark.pit_server
 @pytest.mark.build_sanity
+@pytest.mark.network_sensitive
 def test_capsule_installation_with_foremanctl(
     pytestconfig, module_sat_ready_rhel, module_cap_ready_rhel, module_sca_manifest
 ):

--- a/tests/foreman/longrun/test_remoteexecution.py
+++ b/tests/foreman/longrun/test_remoteexecution.py
@@ -14,6 +14,9 @@
 
 import pytest
 
+# REX long-running jobs; curated IPv6 overlay.
+pytestmark = pytest.mark.network_sensitive
+
 
 @pytest.mark.rhel_ver_list([9])
 def test_positive_run_long_job(module_org, rex_contenthost, module_target_sat):

--- a/tests/foreman/sys/test_capsule_loadbalancer.py
+++ b/tests/foreman/sys/test_capsule_loadbalancer.py
@@ -26,7 +26,11 @@ from robottelo.utils.datafactory import gen_string
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
 
-pytestmark = [pytest.mark.no_containers]
+pytestmark = [
+    pytest.mark.no_containers,
+    # Multi-capsule LB path; curated IPv6 overlay.
+    pytest.mark.network_sensitive,
+]
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -473,6 +473,7 @@ class TestAnsibleCfgMgmt:
 
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+    @pytest.mark.network_sensitive
     def test_positive_ansible_config_report_changes_notice_and_failed_tasks_errors(
         self,
         rhel_contenthost,
@@ -495,6 +496,8 @@ class TestAnsibleCfgMgmt:
         :expectedresults:
             1. Verify that any tasks that make changes on the host are listed as notice in the config report
             2. Verify that any task failures are listed as errors in the config report
+
+        :Verifies: SAT-45645
         """
         SELECTED_ROLE = 'theforeman.foreman_scap_client'
         rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2251,6 +2251,7 @@ def change_content_source_prep(
 
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('[789]')
+@pytest.mark.network_sensitive
 def test_change_content_source(session, change_content_source_prep, rhel_contenthost):
     """
     This test exercises different ways to change host's content source

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -531,6 +531,7 @@ def test_positive_repo_discovery(setup_http_proxy, module_target_sat, module_org
         )
 
 
+@pytest.mark.network_sensitive
 def test_authenticated_test_connection(target_sat, module_org, default_location):
     """Test connection doesn't throw any errors when run on an authenticated HTTP Proxy
 

--- a/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
+++ b/tests/foreman/ui/test_rhcloud_insights_vulnerability.py
@@ -187,6 +187,7 @@ def setup_content_for_iop(module_target_sat_insights, rhcloud_manifest_org):
 
 
 @pytest.mark.e2e
+@pytest.mark.network_sensitive
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match(r'^(?!7).*')
 @pytest.mark.parametrize('module_target_sat_insights', [False], ids=['local'], indirect=True)

--- a/tests/foreman/ui/test_rhcloud_iop.py
+++ b/tests/foreman/ui/test_rhcloud_iop.py
@@ -86,6 +86,7 @@ def create_rbac_user(
 
 
 @pytest.mark.e2e
+@pytest.mark.network_sensitive
 @pytest.mark.pit_server
 @pytest.mark.pit_client
 @pytest.mark.no_containers


### PR DESCRIPTION
### Problem Statement
- Jenkins cannot right-size IPv6 until robottelo can select only tests that actually care about network/address family.

### Solution
- Register pytest.mark.network_sensitive
- Mark subnet, HTTP proxy, registration, REX, capsule-content, provisioning, and related tests
- Promote ipv6_provisioning into network_sensitive at collect
- Overlay selection: -m 'network_sensitive and not destructive'

### Impact
- Enables the Jenkins IPv6 overlay (team + marker only — no hard component allowlist)
- Keeps real IPv6 coverage while dropping CRUD noise from the IPv6 path
- Easy to extend: mark more tests when escapes appear; do not restore full IPv6 grids



Team | Old IPv6 (component jobs) | New overlay (marker) | New as % of old
-- | -- | -- | --
artemis | 1664 | 40 | 2.4%
dragonfly | 404 | 27 | 6.7%
endeavour | 1420 | 116 | 8.2%
proton | 1210 | 21 | 1.7%
rocket | 584 | 0 | 0.0%
Total | 5282 | 204 | 3.9%

Note: Rocket is 0 on the team overlay (provisioning stays on ipv6-misc-provisioning). Collect is -m 'network_sensitive and not destructive' --team <team> without --include-onprem-provisioning.


### Related Issues
- satellite-jenkins#2022

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Create a focused IPv6 test overlay by marking network-sensitive scenarios and enabling marker-based collection.

New Features:
- Add a registered `network_sensitive` pytest marker for identifying tests relevant to address-family and multi-host networking coverage.
- Enable curated IPv6 overlay selection by combining the new marker with existing non-destructive filtering.

Enhancements:
- Classify provisioning, proxy, registration, remote execution, capsule-content, load-balancing, and related network-dependent scenarios for IPv6 coverage.

CI:
- Support Jenkins IPv6 overlays that run only network-sensitive tests instead of full component grids.