### PR TITLE
[master]: Changes for new 6.20.z branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: daily
     labels:
+      - '6.20.z'
       - '6.19.z'
       - '6.18.z'
       - '6.17.z'
@@ -26,6 +27,7 @@ updates:
     schedule:
       interval: daily
     labels:
+      - '6.20.z'
       - '6.19.z'
       - '6.18.z'
       - '6.17.z'

--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -15,7 +15,7 @@ ROBOTTELO:
   RUN_ONE_DATAPOINT: false
   # Satellite version supported by this branch
   # UNDR version is used for some URL composition
-  SATELLITE_VERSION: "6.20"
+  SATELLITE_VERSION: "6.21"
   # Update non-ga versions with each release
   SAT_NON_GA_VERSIONS:
     - '6.16'

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -6,7 +6,7 @@ from box import Box
 from nailgun import entities
 
 # This should be updated after each version branch
-SATELLITE_VERSION = "6.20"
+SATELLITE_VERSION = "6.21"
 SATELLITE_OS_VERSION = "9"
 
 # Default system ports


### PR DESCRIPTION
### Problem Statement
New 6.20.z downstream and master points to stream that is 6.21
### Solution
- Dependabot.yaml cherrypicks to 6.20.z
- Robottelo conf and constants now uses 6.21 and 6.20.z satellite versions

## Summary by Sourcery

Prepare the repository for the new 6.20.z branch and align master with the Satellite 6.21 stream.

Enhancements:
- Update Robottelo’s default Satellite version to 6.21 while retaining support for the new 6.20.z branch.

Chores:
- Add 6.20.z labels to Dependabot updates.