### PR TITLE
Update content source naming scheme for host group tests

### DIFF
--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -532,7 +532,7 @@ class TestHostGroup:
 
         """
         new_content_source = target_sat.api.SmartProxy().search(
-            query={'search': f'url = {target_sat.url}:9090'}
+            query={'search': f'feature = "Pulpcore" and url ~ {target_sat.hostname}'}
         )[0]
         hostgroup.content_source = new_content_source
         hostgroup = hostgroup.update(['content_source'])
@@ -699,7 +699,7 @@ class TestHostGroup:
 
         # Get content source, architecture, and operating system objects for hostgroup creation
         content_source = module_target_sat.api.SmartProxy().search(
-            query={'search': f'url = {module_target_sat.url}:9090'}
+            query={'search': f'feature = "Pulpcore" and url ~ {module_target_sat.hostname}'}
         )[0]
         old_os_id = (
             module_target_sat.api.OperatingSystem()

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -70,7 +70,9 @@ def puppet_content_source(session_puppet_enabled_sat):
 @pytest.fixture(scope='module')
 def content_source(module_target_sat):
     """Return the proxy."""
-    return module_target_sat.cli.Proxy.list({'search': f'url = {module_target_sat.url}:9090'})[0]
+    return module_target_sat.cli.Proxy.list(
+        {'search': f'feature = "Pulpcore" and url ~ {module_target_sat.hostname}'}
+    )[0]
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Foremanctl introduces a new naming scheme for smart proxies, which (among other failures) causes host group tests to fail if they use the old content source smart proxy naming scheme (`satellite.example.com:9090`). This PR updates the naming scheme for content source smart proxies in host group tests.

## Summary by Sourcery

Update host group tests to use the current content source smart proxy naming scheme.

Bug Fixes:
- Update host group tests to locate Pulpcore content source smart proxies using the current hostname-based naming scheme.

Tests:
- Align API and CLI host group test content source lookups with the updated smart proxy naming scheme.