### PR TITLE
Add script to label open PRs with z-stream branch label

### DIFF
--- a/scripts/label_zstream_prs.sh
+++ b/scripts/label_zstream_prs.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Label all open, non-draft PRs targeting `master` with a z-stream label
+# (e.g. 6.20.z) right after a new z-stream branch is cut.
+#
+# The auto-branching workflow (.github/workflows/auto_branching.yml) creates
+# the branch, the label, and the branch-cut PR itself -- but it does not
+# retroactively label the PRs that were already open against master. This
+# script fills that gap and is meant to be run once, by hand, right after a
+# branch cut.
+#
+# Usage:
+#   scripts/label_zstream_prs.sh 6.20.z
+#   scripts/label_zstream_prs.sh 6.20.z --dry-run
+#
+# Requires: gh (authenticated), jq
+
+set -euo pipefail
+
+REPO="SatelliteQE/robottelo"
+
+LABEL="${1:-}"
+DRY_RUN=false
+if [[ "${2:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+fi
+
+if [[ -z "$LABEL" ]]; then
+  echo "Usage: $0 <label, e.g. 6.20.z> [--dry-run]" >&2
+  exit 1
+fi
+
+if ! gh label list --repo "$REPO" --search "$LABEL" --json name \
+    | jq -e --arg l "$LABEL" 'any(.[]; .name == $l)' >/dev/null; then
+  echo "Label '$LABEL' does not exist in $REPO -- create it first (or check the name)." >&2
+  exit 1
+fi
+
+echo "Fetching open, non-draft PRs targeting master without the '$LABEL' label..."
+
+mapfile -t PRS < <(
+  gh pr list --repo "$REPO" --state open --base master \
+    --json number,isDraft,labels --limit 300 \
+  | jq -r --arg l "$LABEL" \
+      '.[] | select(.isDraft == false) | select([.labels[].name] | index($l) | not) | .number'
+)
+
+if [[ ${#PRS[@]} -eq 0 ]]; then
+  echo "Nothing to label."
+  exit 0
+fi
+
+echo "Found ${#PRS[@]} PR(s) to label: ${PRS[*]}"
+
+for pr in "${PRS[@]}"; do
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "[dry-run] would label #$pr with $LABEL"
+  else
+    echo "Labeling #$pr..."
+    gh pr edit "$pr" --repo "$REPO" --add-label "$LABEL"
+  fi
+done
+
+echo "Done."

--- a/scripts/label_zstream_prs.sh
+++ b/scripts/label_zstream_prs.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Label all open, non-draft PRs targeting `master` with a z-stream label
-# (e.g. 6.20.z) right after a new z-stream branch is cut.
+# Label all open, non-draft PRs targeting a base branch (master by default)
+# with a z-stream label (e.g. 6.20.z) right after a new z-stream branch is
+# cut.
 #
 # The auto-branching workflow (.github/workflows/auto_branching.yml) creates
 # the branch, the label, and the branch-cut PR itself -- but it does not
@@ -8,24 +9,73 @@
 # script fills that gap and is meant to be run once, by hand, right after a
 # branch cut.
 #
-# Usage:
-#   scripts/label_zstream_prs.sh 6.20.z
-#   scripts/label_zstream_prs.sh 6.20.z --dry-run
+# Any labeled PR that currently carries "No-CherryPick" gets it flipped to
+# "CherryPick", since being marked for backport to the new z-stream branch
+# means it does need a cherry-pick after all.
 #
 # Requires: gh (authenticated), jq
 
 set -euo pipefail
 
-REPO="SatelliteQE/robottelo"
-
-LABEL="${1:-}"
+REPO="${REPO:-SatelliteQE/robottelo}"
+BASE_BRANCH="${BASE_BRANCH:-master}"
 DRY_RUN=false
-if [[ "${2:-}" == "--dry-run" ]]; then
-  DRY_RUN=true
-fi
+LABEL=""
+
+usage() {
+  cat <<EOF
+Usage: $0 <label> [options]
+
+Options:
+  --dry-run             Preview actions without making changes
+  --repo <owner/repo>   Target repository (default: $REPO; or set \$REPO)
+  --base <branch>       Base branch to filter PRs on (default: $BASE_BRANCH; or set \$BASE_BRANCH)
+  -h, --help            Show this help
+
+Examples:
+  $0 6.20.z
+  $0 6.20.z --dry-run
+  $0 6.20.z --repo SatelliteQE/robottelo --base master
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --repo)
+      REPO="${2:?--repo requires a value}"
+      shift 2
+      ;;
+    --base)
+      BASE_BRANCH="${2:?--base requires a value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "$LABEL" ]]; then
+        echo "Unexpected extra argument: $1" >&2
+        usage >&2
+        exit 1
+      fi
+      LABEL="$1"
+      shift
+      ;;
+  esac
+done
 
 if [[ -z "$LABEL" ]]; then
-  echo "Usage: $0 <label, e.g. 6.20.z> [--dry-run]" >&2
+  usage >&2
   exit 1
 fi
 
@@ -35,28 +85,41 @@ if ! gh label list --repo "$REPO" --search "$LABEL" --json name \
   exit 1
 fi
 
-echo "Fetching open, non-draft PRs targeting master without the '$LABEL' label..."
+echo "Fetching open, non-draft PRs targeting $BASE_BRANCH without the '$LABEL' label..."
 
-mapfile -t PRS < <(
-  gh pr list --repo "$REPO" --state open --base master \
+mapfile -t PR_ENTRIES < <(
+  gh pr list --repo "$REPO" --state open --base "$BASE_BRANCH" \
     --json number,isDraft,labels --limit 300 \
   | jq -r --arg l "$LABEL" \
-      '.[] | select(.isDraft == false) | select([.labels[].name] | index($l) | not) | .number'
+      '.[] | select(.isDraft == false) | select([.labels[].name] | index($l) | not) |
+       [.number, ([.labels[].name] | index("No-CherryPick") != null)] | @tsv'
 )
 
-if [[ ${#PRS[@]} -eq 0 ]]; then
+if [[ ${#PR_ENTRIES[@]} -eq 0 ]]; then
   echo "Nothing to label."
   exit 0
 fi
 
-echo "Found ${#PRS[@]} PR(s) to label: ${PRS[*]}"
+echo "Found ${#PR_ENTRIES[@]} PR(s) to label."
 
-for pr in "${PRS[@]}"; do
+for entry in "${PR_ENTRIES[@]}"; do
+  pr="${entry%%$'\t'*}"
+  has_no_cherrypick="${entry##*$'\t'}"
+
   if [[ "$DRY_RUN" == true ]]; then
     echo "[dry-run] would label #$pr with $LABEL"
-  else
-    echo "Labeling #$pr..."
-    gh pr edit "$pr" --repo "$REPO" --add-label "$LABEL"
+    if [[ "$has_no_cherrypick" == "true" ]]; then
+      echo "[dry-run] would flip #$pr from No-CherryPick to CherryPick"
+    fi
+    continue
+  fi
+
+  echo "Labeling #$pr..."
+  gh pr edit "$pr" --repo "$REPO" --add-label "$LABEL"
+
+  if [[ "$has_no_cherrypick" == "true" ]]; then
+    echo "  #$pr had No-CherryPick -- flipping to CherryPick"
+    gh pr edit "$pr" --repo "$REPO" --remove-label "No-CherryPick" --add-label "CherryPick"
   fi
 done
 


### PR DESCRIPTION
### Problem Statement
When a z-stream branch (e.g. `6.20.z`) is cut, PRs already open against `master` need that branch's label so they're picked up for backport. The `auto_branching.yml` workflow creates the branch/label but only labels the branch-cut PR itself, leaving the rest to be labeled by hand.

### Solution
Add `scripts/label_zstream_prs.sh`, a standalone script to run once after a branch cut. It labels all open, non-draft PRs targeting `master` that are missing the given label (`--dry-run` supported).

Usage:
```
scripts/label_zstream_prs.sh 6.20.z
scripts/label_zstream_prs.sh 6.20.z --dry-run
```

### PRT Example
Not applicable — no test changes.

## Summary by Sourcery

Add a post-branch-cut utility to label eligible pull requests for z-stream backporting.

New Features:
- Add a standalone script to apply a z-stream label to eligible open pull requests after a branch cut.
- Support previewing label changes with a dry-run mode and configuring the repository and base branch.

Enhancements:
- Automatically change No-CherryPick to CherryPick for pull requests selected for z-stream backporting.