### PR TITLE
Fix cloud connector enable by passing organization-id

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -685,7 +685,7 @@ def test_positive_config_on_sat_without_network_protocol(
         target_sat.unregister()
 
     # Enable cloud connector
-    result = target_sat.cli.Insights.cloud_connector_enable({})
+    result = target_sat.cli.Insights.cloud_connector_enable({'organization-id': function_org.id})
     assert "Cloud connector enable task started" in result
 
     # Find the job invocation for the 'Configure Cloud Connector' template


### PR DESCRIPTION
### Problem Statement
The `hammer insights cloud-connector enable` command fails with a 500 Internal Server Error when executed in tests that create a new organization and register the Satellite to itself.

**Root Cause:**
The cloud connector API endpoint tries to find `Host::Managed` with `id=1` in the organization/location scope:
```
Couldn't find Host::Managed with 'id'=1 
[WHERE "hosts"."type" = $1 AND "hosts"."organization_id" = $2 AND "hosts"."location_id" = $3]
```

In test environments where multiple organizations are created/deleted, the Satellite host is registered with a higher ID (e.g., 27), causing the lookup to fail.

### Solution
Pass the `organization-id` parameter to `hammer insights cloud-connector enable` to ensure it operates within the correct organization scope and finds the registered host.

**Change:**
```python
# Before
result = target_sat.cli.Insights.cloud_connector_enable({})

# After  
result = target_sat.cli.Insights.cloud_connector_enable({'organization-id': function_org.id})
```

This follows the same pattern used by other insights CLI commands like `inventory_sync`:
```python
result = module_target_sat.cli.Insights.inventory_sync({'organization-id': org.id})
```

### PRT Example
```bash
pytest tests/foreman/cli/test_rhcloud_inventory.py::test_positive_config_on_sat_without_network_protocol -v
```

**Expected:** Test passes without 500 Internal Server Error when enabling cloud connector.
