### PR TITLE
workaround/fix test podman push cert issue in export/import test

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -3200,10 +3200,12 @@ class TestExportImport:
         large_image_id = target_sat.execute(f'podman images {REPO_NAME} -q')
         assert large_image_id
         large_repo_cmd = f'{(function_org.label)}/{(function_product.label)}/{REPO_NAME}'.lower()
-        target_sat.execute(
-            f'podman push --creds {settings.server.admin_username}:{settings.server.admin_password}'
+        result = target_sat.execute(
+            f'podman push --tls-verify=false'
+            f' --creds {settings.server.admin_username}:{settings.server.admin_password}'
             f' {large_image_id.stdout.strip()} {target_sat.hostname}/{large_repo_cmd}'
         )
+        assert result.status == 0, f'podman push failed: {result.stderr}'
         repo = target_sat.cli.Repository.info(
             {
                 'organization-id': function_org.id,


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### Problem Statement
podman push fails because the export Satellite's CA certificate is not trusted by the local podman client. Since the push never succeeds, no repository is created on the Satellite. When the test then runs hammer repository list, it gets an empty list, causing the IndexError: list index out of range

### Solution
--tls-verify=false on the push, the cert workaround (bypasses TLS verification against the containerized Satellite's registry)

### Related Issues
NA

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py -k 'test_postive_export_import_podman_repo'
```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Allow the Podman export/import test to bypass registry certificate verification and report push failures clearly.

Bug Fixes:
- Ensure the Podman export/import test can push images to the containerized Satellite registry despite its untrusted CA certificate.
- Fail the test immediately with a useful error when the image push does not succeed.

Tests:
- Harden the Podman repository export/import test by validating the push command result before querying the created repository.