### PR TITLE
Auto-enable REX feature(remote-execution) and fix SSH key validation for foremanctl

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1793,12 +1793,20 @@ class Capsule(ContentHost, CapsuleMixins):
     @property
     def rex_pub_key(self):
         if settings.server.install_method == InstallMethod.FOREMANCTL:
-            if 'remote-execution' in self.list_foremanctl_features(enabled=True):
-                result = self.execute(
-                    f"podman exec foreman-proxy bash -c 'cat {self.rex_key_path}'"
-                )
-            else:
-                raise SatelliteHostError('remote-execution feature is not enabled')
+            if 'remote-execution' not in self.list_foremanctl_features(enabled=True):
+                # Enable remote-execution feature if not present
+                logger.info('remote-execution feature not enabled, enabling it now...')
+                enable_result = self.execute('foremanctl deploy --add-feature remote-execution')
+                if enable_result.status != 0:
+                    raise SatelliteHostError(
+                        f'Failed to enable remote-execution feature. '
+                        f'Status: {enable_result.status}, Error: {enable_result.stderr}'
+                    )
+                logger.info('remote-execution feature enabled successfully')
+
+            result = self.execute(
+                f"podman exec foreman-proxy bash -c 'cat {self.rex_key_path}'"
+            )
         else:
             result = self.execute(f'cat {self.rex_key_path}')
         key = result.stdout.strip()

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1804,9 +1804,7 @@ class Capsule(ContentHost, CapsuleMixins):
                     )
                 logger.info('remote-execution feature enabled successfully')
 
-            result = self.execute(
-                f"podman exec foreman-proxy bash -c 'cat {self.rex_key_path}'"
-            )
+            result = self.execute(f"podman exec foreman-proxy bash -c 'cat {self.rex_key_path}'")
         else:
             result = self.execute(f'cat {self.rex_key_path}')
         key = result.stdout.strip()

--- a/robottelo/utils/__init__.py
+++ b/robottelo/utils/__init__.py
@@ -33,10 +33,12 @@ def validate_ssh_pub_key(key):
     if not isinstance(key, str):
         raise ValueError(f"Key should be a string type, received: {type(key)}")
 
-    # 1) a valid pub key has 3 parts separated by space
+    # 1) a valid pub key has 2 or 3 parts separated by space (comment is optional)
     # 2) The second part (key string) should be a valid base64
     try:
-        key_type, key_string, _ = key.split()  # need more than one value to unpack
+        # Use extended unpacking: works with both 2 and 3 parts
+        # *_ captures any additional parts (comment, etc.) into a list
+        key_type, key_string, *_ = key.split()
         base64.decodebytes(key_string.encode('ascii'))
         return key_type in ('ecdsa-sha2-nistp256', 'ssh-dss', 'ssh-rsa', 'ssh-ed25519')
     except (ValueError, base64.binascii.Error):


### PR DESCRIPTION
### Problem Statement
When using foremanctl-based Satellite installations, the `rex_pub_key` property would fail if the remote-execution feature was not explicitly enabled. Additionally, SSH key validation was too strict, requiring exactly 3 parts (type, key, comment) when the comment field is actually optional per SSH key standards.

### Solution
1. **Auto-enable remote-execution feature**: Modified `Capsule.rex_pub_key` to automatically enable the remote-execution feature if it's not present, rather than raising an error
2. **Fix SSH key validation**: Updated `validate_ssh_pub_key()` to accept SSH keys with or without the optional comment field using extended unpacking

### Changes
- `robottelo/hosts.py`: Auto-enable remote-execution feature in foremanctl deployments
- `robottelo/utils/__init__.py`: Fix SSH key validation to handle optional comment field

### Testing
Manual testing confirmed:
- REX feature auto-enables when not present
- SSH keys validate correctly with and without comments

### Note
It addresses all failure from `Host collection` component in containerized satellite which were failing due to REX job

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Ensure REX public key retrieval works without prior feature configuration and relax SSH public key validation to follow the optional-comment format.

New Features:
- Automatically enable the remote-execution feature when retrieving the REX public key from foremanctl deployments.

Bug Fixes:
- Accept valid SSH public keys both with and without optional comments.

## Summary by Sourcery

Ensure REX public key retrieval succeeds without prior feature configuration and validate SSH keys according to the optional-comment format.

New Features:
- Automatically enable the remote-execution feature when retrieving the REX public key on foremanctl deployments.

Bug Fixes:
- Accept valid SSH public keys with or without the optional comment field.