### PR TITLE
[6.20.z] Add CLI tests for duplicate CV environments dedup

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1598,6 +1598,53 @@ def test_positive_multi_cv_info_and_remove_all_cv_envs(
     assert ak_info['content-view-environment-labels'] == {}
 
 
+def test_positive_update_ak_with_duplicate_cv_envs(module_target_sat, module_org):
+    """Verify that updating an activation key with duplicate content view environments
+    deduplicates them and does not create duplicate entries.
+
+    :id: 603197c5-6c64-43ee-8d15-e8e1c69eb058
+
+    :steps:
+        1. Create two lifecycle environments and two content views, publish/promote each
+        2. Create an activation key
+        3. Update the activation key with duplicate content view environments
+           (e.g., cv1/lce1,cv2/lce2,cv1/lce1)
+
+    :expectedresults: The activation key is updated successfully with only the unique
+        content view environments, duplicates are silently ignored.
+
+    :Verifies: SAT-42052
+    """
+    lces = [
+        module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
+        for _ in range(2)
+    ]
+    cvs = [module_target_sat.api.ContentView(organization=module_org).create() for _ in range(2)]
+    for i in range(2):
+        cvs[i].publish()
+        cvs[i] = cvs[i].read()
+        cvs[i].version[0].promote(data={'environment_ids': lces[i].id})
+
+    ak = module_target_sat.cli_factory.make_activation_key({'organization-id': module_org.id})
+    cv_envs_with_dup = (
+        f'{lces[0].name}/{cvs[0].name},{lces[1].name}/{cvs[1].name},{lces[0].name}/{cvs[0].name}'
+    )
+    ret_val = module_target_sat.cli.ActivationKey.update(
+        {
+            'id': ak['id'],
+            'organization-id': module_org.id,
+            'content-view-environments': cv_envs_with_dup,
+        }
+    )
+    assert ret_val[0]['message'] == 'Activation key updated.'
+
+    ak_info = module_target_sat.cli.ActivationKey.info({'id': ak['id']})
+    assert len(ak_info['content-view-environments']) == 2
+    expected_labels = {f'{lces[0].label}/{cvs[0].label}', f'{lces[1].label}/{cvs[1].label}'}
+    actual_labels = {cve['label'] for cve in ak_info['content-view-environments']}
+    assert actual_labels == expected_labels
+
+
 @pytest.mark.rhel_ver_match('9')
 @pytest.mark.pit_client
 @pytest.mark.pit_server

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3231,6 +3231,67 @@ class TestContentView:
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
         assert content_view['versions'] == existing_versions
 
+    def test_positive_host_update_with_duplicate_cv_envs(self, module_org, module_target_sat):
+        """Verify that updating a host with duplicate content view environments
+        deduplicates them and does not create duplicate entries.
+
+        :id: 07675375-d292-4b41-8259-aa932e185026
+
+        :steps:
+            1. Create two lifecycle environments and two content views
+            2. Publish and promote each content view to its respective lifecycle environment
+            3. Create a fake host associated with the first content view environment
+            4. Update the host with duplicate content view environments
+               (e.g., cv1/lce1,cv2/lce2,cv1/lce1)
+
+        :expectedresults: The host is updated successfully with only the unique
+            content view environments, duplicates are silently deduplicated.
+
+        :Verifies: SAT-42052
+        """
+        lce1 = module_target_sat.cli_factory.make_lifecycle_environment(
+            {'organization-id': module_org.id}
+        )
+        lce2 = module_target_sat.cli_factory.make_lifecycle_environment(
+            {'organization-id': module_org.id}
+        )
+        cv1 = module_target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
+        cv2 = module_target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
+        for cv, lce in [(cv1, lce1), (cv2, lce2)]:
+            module_target_sat.cli.ContentView.publish({'id': cv['id']})
+            cv_info = module_target_sat.cli.ContentView.info({'id': cv['id']})
+            module_target_sat.cli.ContentView.version_promote(
+                {
+                    'id': cv_info['versions'][0]['id'],
+                    'to-lifecycle-environment-id': lce['id'],
+                }
+            )
+
+        host = module_target_sat.cli_factory.make_fake_host(
+            {
+                'content-view-environment-ids': module_target_sat.api_factory.get_cvenv_id(
+                    cv1['id'], lce1['id']
+                ),
+                'name': gen_alphanumeric(),
+                'organization-id': module_org.id,
+            }
+        )
+
+        cv_envs_with_dup = (
+            f'{lce1["name"]}/{cv1["name"]},'
+            f'{lce2["name"]}/{cv2["name"]},'
+            f'{lce1["name"]}/{cv1["name"]}'
+        )
+        module_target_sat.cli.Host.update(
+            {'id': host['id'], 'content-view-environments': cv_envs_with_dup}
+        )
+
+        host_info = module_target_sat.cli.Host.info({'id': host['id']})
+        cve_info = host_info['content-information']['content-view-environments']
+        assert len(cve_info) == 2
+        actual_cv_names = {cve_info[key]['content-view-name'] for key in cve_info}
+        assert actual_cv_names == {cv1['name'], cv2['name']}
+
 
 class TestRollingContentView:
     """Hammer testing for Rolling Content Views."""


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22352

## Summary
- Adds `test_positive_update_ak_with_duplicate_cv_envs` in `tests/foreman/cli/test_activationkey.py` to verify that updating an activation key with duplicate content-view-environments deduplicates them silently
- Adds `test_positive_host_update_with_duplicate_cv_envs` in `tests/foreman/cli/test_contentview.py` to verify that updating a host with duplicate content-view-environments deduplicates them silently
- Both tests verify SAT-42052 (upstream fix: https://github.com/Katello/katello/pull/11813)

## Test plan
- [x] Both tests collected successfully
- [x] Both tests passed against Satellite with the fix applied

### PRT
```
pytest tests/foreman/cli/test_activationkey.py::test_positive_update_ak_with_duplicate_cv_envs tests/foreman/cli/test_contentview.py::TestContentView::test_positive_host_update_with_duplicate_cv_envs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add CLI tests ensuring duplicate content view environments are silently deduplicated when updating activation keys and hosts.

Tests:
- Add high-importance regression test for activation key updates with duplicate content view environments.
- Add high-importance regression test for host updates with duplicate content view environments.