### PR TITLE
[6.20.z] Detect Version Change, Stream in Satellitectl

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1704,6 +1704,11 @@ class Capsule(ContentHost, CapsuleMixins):
     def __init__(self, hostname, **kwargs):
         kwargs.setdefault('net_type', settings.capsule.network_type)
         super().__init__(hostname=hostname, **kwargs)
+        self.product_rpm_name = (
+            self.container_rpm_name
+            if settings.server.install_method == InstallMethod.FOREMANCTL
+            else self.product_rpm_name
+        )
 
     @property
     def nailgun_capsule(self):
@@ -1808,17 +1813,17 @@ class Capsule(ContentHost, CapsuleMixins):
             )
         return key
 
-    def is_foremanctl_available(self):
-        """Check if foremanctl is installed on the system.
+    def is_satellitectl_available(self):
+        """Check if satellitectl is installed on the system.
 
         Only checks if the command exists, not if the package is available in repos.
         This ensures auto-detection defaults to satellite-installer on clean systems.
 
-        :return: True if foremanctl command is installed
+        :return: True if satellitectl command is installed
         :rtype: bool
         """
-        # Check if foremanctl command exists (already installed)
-        result = self.execute('which foremanctl')
+        # Check if satellitectl command exists (already installed)
+        result = self.execute(f'which {self.container_rpm_name}')
         return result.status == 0
 
     def detect_install_method(self):
@@ -1860,8 +1865,8 @@ class Capsule(ContentHost, CapsuleMixins):
             return InstallMethod.INSTALLER
 
         # Availability detection
-        if self.is_foremanctl_available():
-            logger.info('foremanctl available, using foremanctl method')
+        if self.is_satellitectl_available():
+            logger.info('satellitectl package available, using foremanctl method')
             return InstallMethod.FOREMANCTL
 
         logger.info('Defaulting to satellite-installer method')
@@ -2253,7 +2258,7 @@ class Capsule(ContentHost, CapsuleMixins):
                 'Set CONTAINER_REGISTRY.USERNAME and CONTAINER_REGISTRY.PASSWORD in conf/server.yaml'
             )
 
-        # Install foremanctl
+        # Install satellitectl
         assert self.execute('dnf install -y satellitectl').status == 0, (
             'Failed to install satellitectl'
         )


### PR DESCRIPTION
### Problem Statement

product_rpm_name, is_stream, version, and assert_install_assertions assume satellite-installer and break on foremanctl deployments — wrong RPM name, missing log paths, and noisy journald checks cause false failures.

### Solution

- Resolve product_rpm_name to satellitectl in Capsule.__init__ when install method is foremanctl
- Update method names and comments: foremanctl → satellitectl

**Note:** This PR is a **manual cherry-pick** of #22150 for the 6.20.z branch. The workaround using `is_open('SAT-49552')` is **not included** in this version, as the delivery team should fix the satellitectl package naming issue (SAT-49552) before this is merged.

### Related Issues

- Manual cherry-pick of: https://github.com/SatelliteQE/robottelo/pull/22150
- Related Jira: https://redhat.atlassian.net/browse/SAT-49552

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_installer.py tests/foreman/installer/
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->