### PR TITLE
[6.19.z] 38951 was partly fixed but a followup 42049 still causes the test to fail

### DIFF
--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -20,10 +20,12 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import HAMMER_CONFIG
 from robottelo.exceptions import CLIReturnCodeError
+from robottelo.utils.issue_handlers import is_open
 
 LOGEDIN_MSG = "Session exists, currently logged in as '{0}'"
 NOTCONF_MSG = "Credentials are not configured."
 ACCESS_DENIED_MSG = "Access denied"
+SESSION_EXPIRED_MSG = "Unable to authenticate user"
 password = gen_string('alpha')
 
 
@@ -66,7 +68,7 @@ def test_positive_create_session(admin_user, target_sat, setting_update):
 
     :id: fcee7f5f-1040-41a9-bf17-6d0c24a93e22
 
-    :Verifies: SAT-38951
+    :Verifies: SAT-38951, SAT-42049
 
     :setup:
 
@@ -95,9 +97,13 @@ def test_positive_create_session(admin_user, target_sat, setting_update):
     sleep(70)
     with pytest.raises(CLIReturnCodeError) as err:
         target_sat.cli.Org.with_user().list()
-    assert ACCESS_DENIED_MSG in str(err.value)
     result = target_sat.cli.Auth.with_user().status()
-    assert LOGEDIN_MSG.format('') in result[0]['message']
+    if is_open('SAT-42049'):
+        assert ACCESS_DENIED_MSG in str(err.value)
+        assert LOGEDIN_MSG.format('') in result[0]['message']
+    else:
+        assert SESSION_EXPIRED_MSG in str(err.value)
+        assert NOTCONF_MSG in result[0]['message']
 
 
 @pytest.mark.upgrade


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/20711

## Summary by Sourcery

Update the test metadata to mark the authentication CLI test as blocked by issue SAT-42049 instead of SAT-38951.