### PR TITLE
[6.18.z] Drop dualstack network type (#22454)

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -12,7 +12,7 @@ CAPSULE:
     # The base os rhel version where the capsule installed
     # RHEL_VERSION:
   # Network type on which the Satellite Capsule server is deployed
-  # could be one of ["ipv4", "ipv6", "dualstack"]
+  # could be one of ["ipv4", "ipv6"]
   NETWORK_TYPE: '@jinja {{ this.server.network_type }}'
   # The Ansible Tower workflow used to deploy a capsule
   DEPLOY_WORKFLOWS:

--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -1,5 +1,5 @@
 content_host:
-  network_type: ipv4  # could be one of ["ipv4", "ipv6", "dualstack"]
+  network_type: ipv4  # could be one of ["ipv4", "ipv6"]
   default_rhel_version: 9
   rhel6:
     vm:

--- a/conf/rh_cloud.yaml.template
+++ b/conf/rh_cloud.yaml.template
@@ -1,9 +1,5 @@
 RH_CLOUD:
   TOKEN: this-isnt-the-token
-  INSTALL_RHC: false
-  ORGANIZATION:
-  ACTIVATION_KEY: ak_name
-  CRC_ENV: prod
   IOP:
     IMAGE_PATH:   # For 6.17 IoP
     IMAGE_PATHS:  # For 6.18+ IoP

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -14,7 +14,7 @@ SERVER:
     # The RHEL Base OS Version(x.y) where the Satellite is installed
     RHEL_VERSION: '9'
   # Network type on which the Satellite server deployed
-  NETWORK_TYPE: ipv4  # could be one of ["ipv4", "ipv6", "dualstack"]
+  NETWORK_TYPE: ipv4  # could be one of ["ipv4", "ipv6"]
   # run-on-one - All xdist runners default to the first satellite
   # balance - xdist runners will be split between available satellites
   # on-demand - any xdist runner without a satellite will have a new one provisioned.

--- a/docs/agents_docs/PRT_DOCS.MD
+++ b/docs/agents_docs/PRT_DOCS.MD
@@ -170,20 +170,12 @@ Katello:
     katello: 10977
 ```
 
-### Example 12: Running Tests with IPv6 or Dualstack Environment
+### Example 12: Running Tests with IPv6 Environment
 
-
-IPV6
 ```
 trigger: test-robottelo
 pytest: tests/foreman/ui/test_repository.py::test_positive_sync_custom_repo_yum
 network_type: ipv6
-```
-DUALSTACK
-```
-trigger: test-robottelo
-pytest: tests/foreman/ui/test_repository.py::test_positive_sync_custom_repo_yum
-network_type: dualstack
 ```
 
 ---

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -1,10 +1,7 @@
 from inspect import getmembers, isfunction
 import re
 
-import pytest
-
 from robottelo.config import settings
-from robottelo.enums import NetworkType
 
 TARGET_FIXTURES = {
     'rhel_contenthost',
@@ -68,45 +65,10 @@ def pytest_generate_tests(metafunc):
         for ver in filtered_versions or settings.supportability.content_hosts.rhel.versions:
             rhel_params.append(dict(rhel_version=ver, no_containers=no_containers))
 
-        # Determine the default network type based on settings
-        if settings.content_host.network_type == NetworkType.DUALSTACK:
-            network_params = [NetworkType.IPV4.value, NetworkType.IPV6.value]
-        else:  # rely on network_type setting to be either ipv4 or ipv6
-            network_params = [settings.content_host.network_type]
-
-        # Check for the network marker
-        network_marker = metafunc.definition.get_closest_marker("network")
-
-        # If network marker is present, validate its arguments and use it to filter network types
-        if network_marker:
-            marker_network_types = network_marker.args[0] if network_marker.args else network_params
-            # Validate the network marker arguments
-            for nt in marker_network_types:
-                if nt not in [NetworkType.IPV4, NetworkType.IPV6]:
-                    raise ValueError(
-                        f"Invalid network type '{nt}' in network marker "
-                        f"for test {metafunc.function.name}. "
-                        f"Must be '{NetworkType.IPV4.value}' or '{NetworkType.IPV6.value}'."
-                    )
-            network_params = [nt for nt in marker_network_types if nt in network_params]
-            # do not parametrize if no network types are common, test
-            # should be skipped in pytest_collection_modifyitems
-
-        # Check whether server could connect with client looking up settings.server.network_type
-        if settings.server.network_type == NetworkType.IPV6:
-            network_params = [
-                nt for nt in network_params if nt in [NetworkType.IPV6, NetworkType.DUALSTACK]
-            ]
-        elif settings.server.network_type == NetworkType.IPV4:
-            network_params = [
-                nt for nt in network_params if nt in [NetworkType.IPV4, NetworkType.DUALSTACK]
-            ]
-        elif settings.server.network_type == NetworkType.DUALSTACK:
-            network_params = [
-                nt
-                for nt in network_params
-                if nt in [NetworkType.IPV4, NetworkType.IPV6, NetworkType.DUALSTACK]
-            ]
+        # Content-host network type is ipv4 or ipv6
+        network_params = [settings.content_host.network_type]
+        # Keep client network types the Satellite can reach
+        network_params = [nt for nt in network_params if nt == settings.server.network_type]
 
         # Create combinations of rhel_params and network_params as dictionaries
         if rhel_params:
@@ -176,25 +138,6 @@ def pytest_collection_modifyitems(session, items, config):
                 client_property = ('ClientOS', str(settings.content_host.default_rhel_version))
             item.user_properties.append(client_property)
             item.add_marker('content_host')
-
-        if network_marker := item.get_closest_marker("network"):
-            marker_network_types = network_marker.args[0] if network_marker.args else []
-            # Skip the test if network_type setting is not set to ipv4 and network marker is set to ipv6
-            if 'ipv6' in marker_network_types and settings.content_host.network_type not in [
-                'ipv6',
-                'dualstack',
-            ]:
-                item.add_marker(
-                    pytest.mark.skip(reason=f"Skipping {item.name} due to network type mismatch")
-                )
-            # Skip the test if network_type setting is not set to ipv6 and network marker is set to ipv4
-            if 'ipv4' in marker_network_types and settings.content_host.network_type not in [
-                'ipv4',
-                'dualstack',
-            ]:
-                item.add_marker(
-                    pytest.mark.skip(reason=f"Skipping {item.name} due to network type mismatch")
-                )
 
 
 def pytest_addoption(parser):

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -24,7 +24,6 @@ def pytest_configure(config):
         "manifester: Tests that require manifester",
         "ldap: Tests related to ldap authentication",
         "no_compose : Skip the marked sanity test for nightly compose",
-        "network: Restrict test to specific network environments",
     ]
     markers.extend(module_markers())
     for marker in markers:

--- a/robottelo/enums.py
+++ b/robottelo/enums.py
@@ -16,21 +16,20 @@ class NetworkType(StrEnum):
     """
     Enumeration of host network addressing types.
 
-    This enum represents the different network addressing modes that can be
-    configured for a host.
+    Supported modes are ipv4 and ipv6. Dual-stack Satellite installs are no
+    longer a first-class network type.
     """
 
     IPV4 = 'ipv4'
     IPV6 = 'ipv6'
-    DUALSTACK = 'dualstack'
 
     @property
     def has_ipv4(self):
-        return self in (self.IPV4, self.DUALSTACK)
+        return self == self.IPV4
 
     @property
     def has_ipv6(self):
-        return self in (self.IPV6, self.DUALSTACK)
+        return self == self.IPV6
 
     @classmethod
     def to_yaml(cls, representer, node):

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -877,8 +877,7 @@ def test_positive_apply_for_all_hosts(
         workflow='deploy-template',
         host_class=ContentHost,
         _count=num_hosts,
-        # TODO(@SatelliteQE/team-artemis): this is best effort for dualstack. This host deployment
-        # should be a part of a fixture
+        # TODO(@SatelliteQE/team-artemis): this host deployment should be a part of a fixture
         deploy_network_type=settings.content_host.network_type,
     ) as hosts:
         if not isinstance(hosts, list) or len(hosts) != num_hosts:

--- a/tests/robottelo/test_enum.py
+++ b/tests/robottelo/test_enum.py
@@ -10,19 +10,16 @@ class TestNetworkType:
         """Test that the enum has the expected values."""
         assert NetworkType.IPV4 == 'ipv4'
         assert NetworkType.IPV6 == 'ipv6'
-        assert NetworkType.DUALSTACK == 'dualstack'
 
     def test_str_representation(self):
         """Test the string representation of enum members."""
         assert str(NetworkType.IPV4) == 'ipv4'
         assert str(NetworkType.IPV6) == 'ipv6'
-        assert str(NetworkType.DUALSTACK) == 'dualstack'
 
     def test_equality_with_string(self):
         """Test equality comparison between enum members and strings."""
         assert NetworkType.IPV4 == 'ipv4'
         assert NetworkType.IPV6 == 'ipv6'
-        assert NetworkType.DUALSTACK == 'dualstack'
         assert NetworkType.IPV4 != 'ipv6'
         assert NetworkType.IPV6 != 'ipv4'
 
@@ -30,16 +27,13 @@ class TestNetworkType:
         """Test equality comparison between enum members."""
         assert NetworkType.IPV4 == NetworkType.IPV4
         assert NetworkType.IPV4 != NetworkType.IPV6
-        assert NetworkType.IPV6 != NetworkType.DUALSTACK
 
     def test_has_ipv4_property(self):
         """Test the has_ipv4 property for all network types."""
         assert NetworkType.IPV4.has_ipv4 is True
         assert NetworkType.IPV6.has_ipv4 is False
-        assert NetworkType.DUALSTACK.has_ipv4 is True
 
     def test_has_ipv6_property(self):
         """Test the has_ipv6 property for all network types."""
         assert NetworkType.IPV4.has_ipv6 is False
         assert NetworkType.IPV6.has_ipv6 is True
-        assert NetworkType.DUALSTACK.has_ipv6 is True


### PR DESCRIPTION
### Problem Statement
Cherry-pick for https://github.com/SatelliteQE/robottelo/pull/22454
Fixes https://github.com/SatelliteQE/robottelo/issues/22517

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->