### PR TITLE
Add smart proxy support for host collection module stream tests

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -258,6 +258,52 @@ def module_repos_collection_with_setup(request, module_target_sat, module_org, m
 
 
 @pytest.fixture(scope='module')
+def module_repos_collection_with_smart_proxy(
+    request, module_target_sat, smart_proxy_module_org, module_lce
+):
+    """Repository collection with smart proxy enabled organization for remote execution.
+
+    This fixture is similar to module_repos_collection_with_setup but uses
+    smart_proxy_module_org which has the default smart proxy assigned. This is
+    required for tests that use remote execution (REX) jobs.
+
+    Use this fixture when your test needs to:
+    - Execute remote commands via REX
+    - Perform package management operations remotely
+    - Upload package profiles via remote execution
+
+    Remember:
+        If you do not pass a repos request with valid 'distro' contained, we will attempt to fallback
+        on any fixture host, with attribute 'rhel_version' already parametrized.
+        Such as by using pytest.markers 'rhel_ver_match' or 'rhel_ver_list'.
+    """
+    # peek the first of prior parametrized fixtures (global scope),
+    # if a RHEL host is parametrized with distro, it will be at the top.
+    top_level_param = request._pyfuncitem.callspec.params
+    _, peek_val = next(iter(top_level_param.items()))
+    fixtures_distro = peek_val.get('rhel_version', None)
+
+    repos = getattr(request, 'param', [])
+    # no distro in repos request, fallback if top fixture marked with rhel_version
+    if 'distro' not in repos or repos['distro'] is None:
+        repos['distro'] = fixtures_distro
+    if repos['distro'] and 'rhel' not in str(repos['distro']):
+        repos['distro'] = f'rhel{repos["distro"]}'
+
+    repo_distro, repos = _simplify_repos(request, repos)
+    _repos_collection = module_target_sat.cli_factory.RepositoryCollection(
+        distro=repo_distro,
+        repositories=[
+            getattr(module_target_sat.cli_factory, repo_name)(**repo_params)
+            for repo in repos
+            for repo_name, repo_params in repo.items()
+        ],
+    )
+    _repos_collection.setup_content(smart_proxy_module_org.id, module_lce.id)
+    return _repos_collection
+
+
+@pytest.fixture(scope='module')
 def module_repos_collection_with_manifest(
     request, module_target_sat, module_sca_manifest_org, module_lce
 ):

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -226,6 +226,17 @@ def smart_proxy_location(module_org, module_target_sat, default_smart_proxy):
 
 
 @pytest.fixture
+def smart_proxy_function_sca_manifest_org(
+    function_org, function_sca_manifest, target_sat, default_smart_proxy
+):
+    """Function-scoped organization with smart proxy assigned and SCA manifest uploaded"""
+    default_smart_proxy.organization.append(target_sat.api.Organization(id=function_org.id))
+    default_smart_proxy.update(['organization'])
+    target_sat.upload_manifest(function_org.id, function_sca_manifest.content)
+    return function_org
+
+
+@pytest.fixture
 def upgrade_entitlement_manifest():
     """Returns a manifest in entitlement mode with subscriptions determined by the
     `manifest_category.entitlement` setting in conf/manifest.yaml. used only for

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -225,6 +225,14 @@ def smart_proxy_location(module_org, module_target_sat, default_smart_proxy):
     return location
 
 
+@pytest.fixture(scope='module')
+def smart_proxy_module_org(module_org, module_target_sat, default_smart_proxy):
+    """Module-scoped organization with smart proxy assigned"""
+    default_smart_proxy.organization.append(module_target_sat.api.Organization(id=module_org.id))
+    default_smart_proxy.update(['organization'])
+    return module_org
+
+
 @pytest.fixture
 def smart_proxy_function_sca_manifest_org(
     function_org, function_sca_manifest, target_sat, default_smart_proxy

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1799,9 +1799,6 @@ class Capsule(ContentHost, CapsuleMixins):
                 )
             else:
                 raise SatelliteHostError('remote-execution feature is not enabled')
-            if 'dynflow' not in self.list_foremanctl_features(enabled=True, internal=True):
-                dynflow_result = self.execute('foremanctl deploy --add-feature dynflow')
-                assert dynflow_result.status == 0, f"Failed to enable dynflow: {dynflow_result.stderr}"
         else:
             result = self.execute(f'cat {self.rex_key_path}')
         key = result.stdout.strip()

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1800,8 +1800,8 @@ class Capsule(ContentHost, CapsuleMixins):
             else:
                 raise SatelliteHostError('remote-execution feature is not enabled')
             if 'dynflow' not in self.list_foremanctl_features(enabled=True, internal=True):
-                result = self.execute('foremanctl deploy --add-feature dynflow')
-                assert result.status == 0, f"Failed to enable dynflow: {result.stderr}"
+                dynflow_result = self.execute('foremanctl deploy --add-feature dynflow')
+                assert dynflow_result.status == 0, f"Failed to enable dynflow: {dynflow_result.stderr}"
         else:
             result = self.execute(f'cat {self.rex_key_path}')
         key = result.stdout.strip()

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1799,6 +1799,9 @@ class Capsule(ContentHost, CapsuleMixins):
                 )
             else:
                 raise SatelliteHostError('remote-execution feature is not enabled')
+            if 'dynflow' not in self.list_foremanctl_features(enabled=True, internal=True):
+                result = self.execute('foremanctl deploy --add-feature dynflow')
+                assert result.status == 0, f"Failed to enable dynflow: {result.stderr}"
         else:
             result = self.execute(f'cat {self.rex_key_path}')
         key = result.stdout.strip()
@@ -2321,12 +2324,16 @@ class Capsule(ContentHost, CapsuleMixins):
 
         return deploy_features
 
-    def list_foremanctl_features(self, enabled=False):
-        """Get the list of features as a set of feature names"""
-        if enabled:
-            result = self.execute('foremanctl features --list-enabled')
-        else:
-            result = self.execute('foremanctl features')
+    def list_foremanctl_features(self, enabled=False, internal=False):
+        """Get the list of features as a set of feature names
+
+        :param enabled: If True, list only enabled features
+        :param internal: If True, include internal features in the list
+        """
+        cmd = 'foremanctl features --list-enabled' if enabled else 'foremanctl features'
+        if internal:
+            cmd = f'FOREMANCTL_FEATURES_LIST_INTERNAL=true {cmd}'
+        result = self.execute(cmd)
         assert result.status == 0, f'foremanctl features command failed: {result.stderr}'
         return {
             p[0]

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1800,7 +1800,11 @@ class Capsule(ContentHost, CapsuleMixins):
             else:
                 raise SatelliteHostError('remote-execution feature is not enabled')
             if 'dynflow' not in self.list_foremanctl_features(enabled=True, internal=True):
-                dynflow_result = self.execute('foremanctl deploy --add-feature dynflow')
+                dynflow_result = self.execute(
+                    'flock -w 1800 /var/lock/robottelo-foremanctl-deploy.lock '
+                    'foremanctl deploy --add-feature dynflow',
+                    timeout='30m',
+                )
                 assert dynflow_result.status == 0, (
                     f"Failed to enable dynflow: {dynflow_result.stderr}"
                 )

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1801,7 +1801,9 @@ class Capsule(ContentHost, CapsuleMixins):
                 raise SatelliteHostError('remote-execution feature is not enabled')
             if 'dynflow' not in self.list_foremanctl_features(enabled=True, internal=True):
                 dynflow_result = self.execute('foremanctl deploy --add-feature dynflow')
-                assert dynflow_result.status == 0, f"Failed to enable dynflow: {dynflow_result.stderr}"
+                assert dynflow_result.status == 0, (
+                    f"Failed to enable dynflow: {dynflow_result.stderr}"
+                )
         else:
             result = self.execute(f'cat {self.rex_key_path}')
         key = result.stdout.strip()

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2524,7 +2524,7 @@ def test_host_status_honors_taxonomies(
 
 
 @pytest.mark.parametrize(
-    'module_repos_collection_with_setup',
+    'module_repos_collection_with_smart_proxy',
     [
         {
             'distro': 'rhel8',
@@ -2553,7 +2553,7 @@ def test_positive_manage_packages(
     request,
     module_target_sat,
     mod_content_hosts,
-    module_repos_collection_with_setup,
+    module_repos_collection_with_smart_proxy,
     number_of_hosts,
     package_management_action,
     finish_via,
@@ -2590,12 +2590,12 @@ def test_positive_manage_packages(
 
     for host in mod_content_hosts:
         host.add_rex_key(module_target_sat)
-        module_repos_collection_with_setup.setup_virtual_machine(host)
+        module_repos_collection_with_smart_proxy.setup_virtual_machine(host)
 
-    product_name = module_repos_collection_with_setup.custom_product.name
+    product_name = module_repos_collection_with_smart_proxy.custom_product.name
 
     with module_target_sat.ui_session() as session:
-        session.organization.select(module_repos_collection_with_setup.organization['name'])
+        session.organization.select(module_repos_collection_with_smart_proxy.organization['name'])
 
         for host in mod_content_hosts:
             if (

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -31,9 +31,11 @@ def module_manifest():
 
 
 @pytest.fixture(scope='module')
-def module_org_with_parameter(module_target_sat, module_manifest):
+def module_org_with_parameter(module_target_sat, module_manifest, default_smart_proxy):
     # adding remote_execution_connect_by_ip=Yes at org level
     org = module_target_sat.api.Organization().create()
+    default_smart_proxy.organization.append(module_target_sat.api.Organization(id=org.id))
+    default_smart_proxy.update(['organization'])
     module_target_sat.api.Parameter(
         name='remote_execution_connect_by_ip',
         parameter_type='boolean',
@@ -79,6 +81,12 @@ def vm_content_hosts(smart_proxy_location, module_repos_collection, module_targe
             client.add_rex_key(satellite=module_target_sat)
             module_target_sat.api_factory.update_vm_host_location(client, smart_proxy_location.id)
         yield clients
+
+
+@pytest.fixture
+def function_sca_manifest_org(smart_proxy_function_sca_manifest_org):
+    """Override function_sca_manifest_org to use smart proxy enabled organization"""
+    return smart_proxy_function_sca_manifest_org
 
 
 @pytest.fixture


### PR DESCRIPTION
### Problem Statement
Tests requiring remote execution were failing with "Could not use any Capsule for the ["SSH", "Script"] job" because:
- Organizations didn't have the default smart proxy assigned
- The dynflow feature (required for remote execution jobs) was not being enabled automatically
- Both module-scoped and function-scoped tests lacked proper smart proxy infrastructure

### Solution
This PR adds comprehensive smart proxy support for remote execution tests at both scopes:

#### 1. Smart Proxy Fixtures (taxonomy.py)
- **`smart_proxy_module_org`**: Module-scoped organization with smart proxy assigned
- **`smart_proxy_function_sca_manifest_org`**: Function-scoped organization with smart proxy + SCA manifest
- Enables REX infrastructure for both test scopes

#### 2. REX-Enabled Repository Collection (repository.py)
- **`module_repos_collection_with_smart_proxy`**: New fixture for tests requiring remote execution
- Uses `smart_proxy_module_org` to ensure capsule availability
- Clear documentation on when to use vs standard `module_repos_collection_with_setup`

#### 3. Enhanced Feature Listing (hosts.py)
- Updated `list_foremanctl_features()` method to support `internal=True` parameter
- Uses `FOREMANCTL_FEATURES_LIST_INTERNAL=true` to list internal features like dynflow

#### 4. Automatic Dynflow Enablement (hosts.py)
- Modified `add_rex_key()` method to automatically check and enable dynflow if not present
- Ensures remote execution jobs work without manual intervention

#### 5. Test Updates
- **test_hostcollection.py**: Override `function_sca_manifest_org` to use smart-proxy version
- **test_host.py**: Update `test_positive_manage_packages` to use `module_repos_collection_with_smart_proxy`

### Testing Results

| Test | Before Changes | After Changes |
|------|---------------|---------------|
| **test_positive_manage_packages** (test_host.py) | ❌ FAILED - "Could not use any Capsule" | ✅ PASSED (12 min) |
| **test_positive_install_modular_errata** (test_hostcollection.py) | ❌ FAILED - UI/Capsule error | ✅ PASSED (20 min) |

Both tests now successfully execute remote execution jobs with proper smart proxy configuration.

### Impact
- ✅ Fixes REX failures in host collection tests
- ✅ Fixes REX failures in host management tests  
- ✅ Provides clear pattern for other tests needing REX support
- ✅ Makes smart proxy configuration automatic and consistent
- ✅ Enables dynflow feature transparently when needed

### Files Changed
```
pytest_fixtures/component/taxonomy.py       - Smart proxy fixtures (module & function scope)
pytest_fixtures/component/repository.py     - REX-enabled repository collection fixture
robottelo/hosts.py                          - Auto-enable dynflow + enhanced feature listing
tests/foreman/ui/test_hostcollection.py     - Override org fixture for smart proxy
tests/foreman/ui/test_host.py              - Use new REX-enabled fixture
```

### Related Issues
Addresses remote execution setup requirements for tests using REX jobs.

## Summary by Sourcery

Enable reliable remote execution in host-related tests by providing smart proxy-backed fixtures and automatic Dynflow configuration.

New Features:
- Add module- and function-scoped organization fixtures with default smart proxy assignments for remote execution tests.
- Provide a repository collection fixture configured for tests that require remote execution.

Bug Fixes:
- Fix host and host collection tests that failed because remote execution jobs could not find an available Capsule.

Enhancements:
- Support listing internal foremanctl features and automatically enable Dynflow when configuring remote execution.

Tests:
- Update host and host collection tests to use smart-proxy-enabled test infrastructure.