### PR TITLE
correct misspelled from robottelo test directory

### DIFF
--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -449,7 +449,7 @@ class TestOpenScap:
             module_target_sat.cli.Scapcontent.info({'title': scap_content['title']})
 
     @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    def test_postive_create_scap_policy_with_valid_name(
+    def test_positive_create_scap_policy_with_valid_name(
         self, name, scap_content, module_target_sat
     ):
         """Create scap policy with valid name

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -742,7 +742,7 @@ class TestExport:
         assert "Generated" in result
         assert target_sat.validate_pulp_filepath(module_org, PULP_EXPORT_DIR) != ''
 
-    def test_postive_export_cv_syncable_with_permissions(
+    def test_positive_export_cv_syncable_with_permissions(
         self,
         request,
         target_sat,
@@ -1436,7 +1436,7 @@ class TestExportImport:
     @pytest.mark.e2e
     @pytest.mark.rhel_ver_match('9')
     @pytest.mark.parametrize('function_flatpak_remote', ['RedHat'], indirect=True)
-    def test_postive_export_import_cv_with_mixed_content_repos(
+    def test_positive_export_import_cv_with_mixed_content_repos(
         self,
         request,
         target_sat,
@@ -1698,7 +1698,7 @@ class TestExportImport:
         assert res.status == 0
         assert 'installed successfully' in res.stdout
 
-    def test_postive_export_import_cv_with_mixed_content_syncable(
+    def test_positive_export_import_cv_with_mixed_content_syncable(
         self,
         target_sat,
         function_org,
@@ -1815,7 +1815,7 @@ class TestExportImport:
         assert import_list[0]['content-view-version'] == importing_cvv['name']
         assert import_list[0]['content-view-version-id'] == importing_cvv['id']
 
-    def test_postive_export_import_cv_with_file_content(
+    def test_positive_export_import_cv_with_file_content(
         self,
         target_sat,
         function_org,
@@ -1989,7 +1989,7 @@ class TestExportImport:
         )['versions']
         assert len(importing_cvv) == 1
 
-    def test_postive_export_import_ansible_collection_repo(
+    def test_positive_export_import_ansible_collection_repo(
         self,
         target_sat,
         function_org,
@@ -2054,7 +2054,7 @@ class TestExportImport:
         assert len(import_product['content']) == 1
         assert import_product['content'][0]['content-type'] == "ansible_collection"
 
-    def test_postive_export_import_repo_with_GPG(
+    def test_positive_export_import_repo_with_GPG(
         self,
         target_sat,
         function_org,
@@ -2121,7 +2121,7 @@ class TestExportImport:
         assert imported_gpg
         assert imported_gpg['content'] == gpg_key.content
 
-    def test_postive_export_import_chunked_repo(
+    def test_positive_export_import_chunked_repo(
         self,
         target_sat,
         function_org,
@@ -2418,7 +2418,7 @@ class TestExportImport:
                 f'{repomd_refs - drive_files}'
             )
 
-    def test_postive_export_import_with_long_name(
+    def test_positive_export_import_with_long_name(
         self,
         target_sat,
         module_org,
@@ -2529,7 +2529,7 @@ class TestExportImport:
             f'Only in import: {sorted(imported_packages - exported_packages)}'
         )
 
-    def test_postive_export_import_large_cv(
+    def test_positive_export_import_large_cv(
         self,
         request,
         target_sat,
@@ -3170,7 +3170,7 @@ class TestExportImport:
         res = rhel_contenthost.execute(f'dnf -y install {filtered_pkg}')
         assert res.status == 0, f'Installation from the import failed:\n{res.stdout}'
 
-    def test_postive_export_import_podman_repo(
+    def test_positive_export_import_podman_repo(
         self,
         target_sat,
         function_org,


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

### Problem Statement
 There are 11 robottelo tests with the misspelling `test_postive` (should be `test_positive`) present in CLI test files.
`robottelo/tests/foreman/cli/test_satellitesync.py`
`robottelo/tests/foreman/cli/test_oscap.py`

### Solution
This PR will correct the test case names

### Related Issues
N/A

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Enhancements:
- Correct misspelled `test_postive` names to `test_positive` across the affected Robottelo CLI tests.