### PR TITLE
[6.20.z] Fix non-admin user creation in test_positive_access_non_admin_user

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -703,15 +703,16 @@ def test_positive_access_non_admin_user(session, test_name, target_sat):
     )[0]
     user_login = gen_string('alpha')
     user_password = gen_string('alpha')
-    target_sat.api.User(
+    user = target_sat.api.User(
         role=[role],
         admin=False,
         login=user_login,
         password=user_password,
         organization=[org],
         location=[default_loc],
-        default_organization=org,
     ).create()
+    user.default_organization = org
+    user.update(['default_organization'])
 
     with session:
         session.organization.select(org_name=org.name)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22468

### Problem Statement
The Satellite API validates that `default_organization` is already in the user's org list before the `organization` association is committed, causing a 422 error on `upgrade-fips` environments.

Verifies: [SAT-48906](https://redhat.atlassian.net/browse/SAT-48906)


### Solution
Split `User` creation into two steps: create the user first, then set `default_organization` in a separate `update` call. 



### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_activationkey.py::test_positive_access_non_admin_user
```

## Summary by Sourcery

Bug Fixes:
- Fix non-admin user creation in the activation-key access test by applying the default organization after the user is created.