### PR TITLE
[6.20.z] Remove unused RHEL repo enabling from setup_rhel_repos

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -257,23 +257,6 @@ HASH_TYPE = {'sha256': "SHA256", 'sha512': "SHA512", 'base64': "Base64", 'md5': 
 
 REPO_TAB = {'rpms': "RPMs", 'kickstarts': "Kickstarts", 'isos': "ISOs", 'ostree': "OSTree"}
 
-OHSNAP_RHEL7_REPOS = (
-    'rhel-7-server-extras-rpms',
-    'rhel-7-server-rpms',
-    'rhel-server-rhscl-7-rpms',
-    'rhel-7-server-ansible-2.9-rpms',
-)
-
-OHSNAP_RHEL8_REPOS = (
-    'rhel-8-for-x86_64-baseos-rpms',
-    'rhel-8-for-x86_64-appstream-rpms',
-)
-
-OHSNAP_RHEL9_REPOS = (
-    'rhel-9-for-x86_64-baseos-rpms',
-    'rhel-9-for-x86_64-appstream-rpms',
-)
-
 # On importing manifests, Red Hat repositories are listed like this:
 # Product -> RepositorySet -> Repository
 # We need to first select the Product, then the reposet and then the repos

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1564,12 +1564,6 @@ class ContentHost(Host, ContentHostMixins):
             self.disable_repo("rhel-*")
             # add internal rhel repos
             self.create_custom_repos(**settings.repos.get(f'rhel{self.os_version.major}_os'))
-        else:
-            # enable cdn repos
-            for repo in getattr(constants, f"OHSNAP_RHEL{self.os_version.major}_REPOS"):
-                result = self.enable_repo(repo, force=True)
-                if result.status:
-                    raise ContentHostError(f'Enabling RHEL repos on host failed\n{result.stdout}')
 
     def setup_satellite_repos(self):
         """Setup Satellite repositories on host


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22533

### Problem Statement
With recent execution on RHEL10 we identificed, `setup_rhel_repos` fails on RHEL 10 with` AttributeError: module 'robottelo.constants' has no attribute 'OHSNAP_RHEL10_REPOS'`, because there's no OHSNAP_RHEL10_REPOS constant  defined. 
With SCA enabled by default, explicitly enabling CDN repos is unnecessary, repos are available after registration.

### Solution
- Remove the else branch from setup_rhel_repos that explicitly enabled CDN repos
- Remove unused OHSNAP_RHEL7_REPOS, OHSNAP_RHEL8_REPOS, OHSNAP_RHEL9_REPOS constants

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Simplify RHEL repository setup by relying on registered SCA repositories and removing obsolete repository configuration.

Bug Fixes:
- Prevent RHEL repository setup from failing on RHEL 10 due to missing repository constants.
- Stop explicitly enabling CDN repositories that are already available after registration with SCA enabled.

Enhancements:
- Remove obsolete RHEL repository constants no longer used by host setup.