### PR TITLE
Update image creation test to include taxonomy parameters

### DIFF
--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -130,6 +130,8 @@ class TestAzureRMComputeResourceTestCase:
         module_azurerm_cr,
         sat_azure_default_os,
         image,
+        sat_azure_loc,
+        sat_azure_org,
     ):
         """Finish template/Cloud_init image along with username is being Create, Read, Update and
         Delete in AzureRm compute resources
@@ -164,6 +166,8 @@ class TestAzureRMComputeResourceTestCase:
                 'compute-resource': module_azurerm_cr.name,
                 'username': username,
                 'user-data': 'no',
+                'organization-id': sat_azure_org.id,
+                'location-id': sat_azure_loc.id,
             }
         )[0]
         assert img_ft['message'] == 'Image created.'


### PR DESCRIPTION
### Problem Statement

Existing Robottelo tests for compute resource image creation do not include `--organization-id` or `--location-id` parameters in hammer commands. This leaves the taxonomy validation code path untested, which is the code path affected by [`SAT-41269`](https://redhat.atlassian.net/browse/SAT-41269).


### Solution

Updated the CLI image creation test to include organization and location parameters in the hammer command. This ensures the taxonomy validation logic is properly exercised during test execution.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Exercise taxonomy validation when creating AzureRM compute resource images.

Enhancements:
- Expand AzureRM compute resource image CRUD coverage to exercise organization and location taxonomy validation.

Tests:
- Update the AzureRM image creation test to provide organization and location parameters.