### PR TITLE
[6.16.z] Fix ohsnap to pick correct releases

### DIFF
--- a/robottelo/utils/ohsnap.py
+++ b/robottelo/utils/ohsnap.py
@@ -54,8 +54,11 @@ def ohsnap_repo_url(ohsnap, request_type, product, release, os_release, snap='')
             if (streams := [stream for stream in res.json() if stream['id'] == release]) and len(
                 streams[0]['release_ids']
             ) > 0:
-                # get the recent snap id (last in the list)
-                release = streams[0]['release_ids'][-1]
+                # get the release/stream snap id
+                if release == 'stream':
+                    release = streams[0]['release_ids']['stream']
+                else:
+                    release = streams[0]['ga_release_id']
             else:
                 logger.warning(f'Ohsnap returned no releases for the given stream: {release}')
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22502

Right now, based on the condition in the method, it always selects the [-1] version from release_ids, which results in selecting the oldest version. For example, for 6.17, the current logic selects 6.17.0.

Instead, it should select the GA release version. During Capsule upgrades on N-1 and N-2 versions, selecting the GA version ensures that the correct repositories are used rather than an older version.

This currently impacts the Capsule upgrade scenario because it attempts to use an older version whose packages are no longer available, causing the upgrade to fail. The proposed solution is to select the GA release version so that the appropriate repository and packages are available during the Capsule upgrade, allowing the installation to complete successfully.

<img width="230" height="368" alt="image" src="https://github.com/user-attachments/assets/c0f81beb-2195-4066-b389-ea45be1f5c5d" />
