### PR TITLE
[6.17.z] Fix content host pytest hook

### DIFF
--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -1,5 +1,7 @@
-from inspect import getmembers, isfunction
+from inspect import getmembers
 import re
+
+from _pytest.fixtures import FixtureFunctionDefinition
 
 from robottelo.config import settings
 
@@ -116,19 +118,24 @@ def pytest_configure(config):
 def pytest_collection_modifyitems(session, items, config):
     from pytest_fixtures.core import contenthosts
 
-    def chost_rhelver(params):
+    def chost_rhelver(params, matching_fixtures):
         """Helper to retrieve the rhel_version of a client from test params"""
         for param in params:
-            if 'contenthost' in param:
+            if param in matching_fixtures:
                 return params[param].get('rhel_version')
         return None
 
-    content_host_fixture_names = [m[0] for m in getmembers(contenthosts, isfunction)]
+    content_host_fixture_names = {
+        m[0] for m in getmembers(contenthosts, lambda x: isinstance(x, FixtureFunctionDefinition))
+    }
     for item in items:
-        if set(item.fixturenames).intersection(set(content_host_fixture_names)):
+        if matching_fixtures := set(item.fixturenames).intersection(content_host_fixture_names):
             # TODO check param for indirect version parametrization
             if hasattr(item, 'callspec'):
-                client_property = ('ClientOS', str(chost_rhelver(item.callspec.params)))
+                client_property = (
+                    'ClientOS',
+                    str(chost_rhelver(item.callspec.params, matching_fixtures)),
+                )
             else:
                 client_property = ('ClientOS', str(settings.content_host.default_rhel_version))
             item.user_properties.append(client_property)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22536

### Problem Statement

- `pytest_plugins/fixture_markers.py` has a `pytest_collection_modifyitems` hook that is supposed to add the `content_host` marker, as well as a `ClientOS: <rhel_version>` key/value property to the test's JUnit report output.
- The hook isn't working, because it doesn't correctly get the list of content host fixture names

### Solution

- Fix the hook, so that tests using content host fixtures are identified correctly

### Related Issues

Verify that the `content_host` marker is added:

```
# Before:

$ pytest tests/foreman/cli/test_activationkey.py --co -q -k test_positive_usage_limit -m content_host
[...]
no tests collected (144 deselected) in 2.58s

# After:

$ pytest tests/foreman/cli/test_activationkey.py --co -q -k test_positive_usage_limit -m content_host
tests/foreman/cli/test_activationkey.py::test_positive_usage_limit[rhel9-ipv4]

1/144 tests collected (143 deselected) in 0.20s
```

Verify that the `ClientOS` property is added:

```
$ pytest tests/foreman/cli/test_activationkey.py -k test_positive_usage_limit --junit-xml=content_host_report.xml
$ xmllint --format  content_host_report.xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites name="pytest tests">
  <testsuite name="pytest" errors="0" failures="0" skipped="0" tests="1" time="538.067" timestamp="2026-08-25T14:05:44.393391-04:00" hostname="XXXX">
[...]
    <testcase classname="tests.foreman.cli.test_activationkey" name="test_positive_usage_limit[rhel9-ipv4]" time="73.097">
      <properties>
        <property name="start_time" value="2026-08-25T18:05:45"/>
        <property name="rhel_ver_list" value="[9]"/>
        <property name="upgrade" value="None"/>
        <property name="importance" value="critical"/>
        <property name="component" value="activationkeys"/>
        <property name="team" value="proton"/>
        <property name="markers" value="rhel_ver_list=[9], upgrade, importance=critical, component=activationkeys, team=proton"/>
        <property name="BaseOS" value="9"/>
        <property name="SatelliteVersion" value="stream"/>
        <property name="SnapVersion" value="202.0"/>
        <property name="SatelliteNetworkType" value="ipv4"/>
        <property name="endpoint" value="cli"/>
        <property name="ClientOS" value="9"/>
      </properties>
```

Note that the `content_host` marker isn't added to the `markers` property, as that property is set by a hook that runs before this one. This PR doesn't address that issue.

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Bug Fixes:
- Correctly identify tests using content host fixtures so the `content_host` marker and `ClientOS` JUnit property are applied.