### PR TITLE
Update cli/test_fact.py for foremanctl

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -161,6 +161,25 @@ def mod_content_hosts(request):
         yield hosts
 
 
+@pytest.fixture(scope='module')
+def module_registered_contenthost(
+    module_target_sat,
+    module_rhel_contenthost,
+    module_sca_manifest_org,
+    module_location,
+    module_activation_key,
+):
+    """A module-level fixture that registers a content host to Satellite."""
+    result = module_rhel_contenthost.register(
+        target=module_target_sat,
+        org=module_sca_manifest_org,
+        loc=module_location,
+        activation_keys=[module_activation_key.name],
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    return module_rhel_contenthost
+
+
 @pytest.fixture
 def registered_host(
     rhel_contenthost,

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -20,17 +20,20 @@ from robottelo.enums import NetworkType
 
 
 @pytest.mark.upgrade
+@pytest.mark.rhel_ver_match([settings.content_host.default_rhel_version])
 @pytest.mark.parametrize(
     'fact',
     [
-        'system_uptime',
-        'os::family',
-        'system_uptime::seconds',
-        'memory::system::total',
-        'networking::ip6' if settings.server.network_type == NetworkType.IPV6 else 'networking::ip',
+        'distribution::name',
+        'distribution::version',
+        'memory::memtotal',
+        'lscpu::architecture',
+        'network::ipv6_address'
+        if settings.server.network_type == NetworkType.IPV6
+        else 'network::ipv4_address',
     ],
 )
-def test_positive_list_by_name(fact, module_target_sat):
+def test_positive_list_by_name(fact, module_registered_contenthost, module_target_sat):
     """Test Fact List
 
     :id: 83794d97-d21b-4482-9522-9b41053e595f


### PR DESCRIPTION
### Problem Statement
In containerized (foremanctl) Satellite, the Satellite host itself does not report Puppet facts.
`test_positive_list_by_name` was searching for Puppet facts (system_uptime, os::family, memory::system::total, networking::ip) that only exist on installer-based Satellite and Puppet is not even supported on 6.20, causing the test to fail on foremanctl deployments.

### Solution
- Added a reusable `module_registered_contenthost` fixture to `pytest_fixtures/core/contenthosts.py` that registers a content host to Satellite, ensuring subscription-manager facts are available in the system.
- Updated `test_positive_list_by_name` to use this fixture and switched the parametrized facts from Puppet facts to subscription-manager facts reported by registered hosts (distribution::name, distribution::version, memory::memtotal, lscpu::architecture, network::ipv4_address).
- This makes the test work on both installer-based and foremanctl Satellite deployments.

### PRT test Cases example
<img width="290" height="198" alt="image" src="https://github.com/user-attachments/assets/77296808-b379-44b2-bef0-230ad01251f0" />


```
trigger: test-robottelo
pytest: tests/foreman/cli/test_fact.py::test_positive_list_by_name
deployment_type: container
```

## Summary by Sourcery

Make CLI fact-listing tests compatible with both installer-based and foremanctl Satellite deployments.

Bug Fixes:
- Update fact-listing coverage to use subscription-manager facts available on registered content hosts, preventing failures on containerized Satellite deployments.

Enhancements:
- Add a reusable module-scoped fixture that registers a RHEL content host for fact-related tests.
- Align fact validation with the configured content-host RHEL version and deployment network type.

Tests:
- Revise the CLI fact test to validate distribution, memory, CPU architecture, and network address facts from a registered content host.