### PR TITLE
Remove test_installed_packages_with_versions from test_bvt as it no l…

### DIFF
--- a/tests/foreman/sanity/test_bvt.py
+++ b/tests/foreman/sanity/test_bvt.py
@@ -21,52 +21,6 @@ from robottelo.utils.ohsnap import ohsnap_snap_rpms
 
 pytestmark = [pytest.mark.build_sanity]
 
-
-@pytest.mark.no_compose
-def test_installed_packages_with_versions(target_sat):
-    """Compare the packages that suppose to be installed from repo vs installed packages
-
-    :id: 08913caa-5084-444f-a37d-63da205acc74
-
-    :expectedresults: All the satellite packages and their installed versions should be
-        identical to ohsnap as SOT
-    """
-    # Raw Data from Ohsnap and Satellite Server
-    ohsnap_rpms = ohsnap_snap_rpms(
-        ohsnap=settings.ohsnap,
-        sat_version=settings.server.version.release,
-        snap_version=settings.server.version.snap,
-        os_major=settings.server.version.rhel_version,
-    )
-    # Suggested Comment:
-    # rpm -qa --queryformat "<you-choose-the-format>"
-    installed_rpms = target_sat.execute('rpm -qa').stdout
-    installed_rpms = installed_rpms.splitlines()
-
-    # Changing both the data to comparable formats
-
-    # Formatting Regex Patterns
-    split_by_version = r'-\d+[-._]*\d*'
-    namever_pattern = r'.*-\d+[-._]*\d*'
-
-    # Formatted Ohsnap Data
-    ohsnp_rpm_names = [re.split(split_by_version, rpm)[0] for rpm in ohsnap_rpms]
-    ohsnap_rpm_name_vers = [re.findall(namever_pattern, rpm)[0] for rpm in ohsnap_rpms]
-
-    # Comparing installed rpms with ohsnap data
-    mismatch_versions = []
-    for rpm in installed_rpms:
-        installed_rpm_name = re.split(split_by_version, rpm)[0]
-        if installed_rpm_name in ohsnp_rpm_names:
-            installed_rpm_name_ver = re.findall(namever_pattern, rpm)[0]
-            if installed_rpm_name_ver not in ohsnap_rpm_name_vers:
-                mismatch_versions.append(rpm)
-
-    if mismatch_versions:
-        pytest.fail(f'Some RPMs are found with mismatch versions. They are {mismatch_versions}')
-    assert not mismatch_versions
-
-
 def test_all_interfaces_are_accessible(target_sat):
     """API, CLI and UI interfaces are accessible
 


### PR DESCRIPTION
…onger makes sense for containerized installation

### Problem Statement
test_installed_packages_with_versions doesn't make sense with containerized installations. It will always fail as it checks to see if the packages we brought are installed on the base system. That means if there are any packages that conflict with the packages we have on the base system if will fail. This is exactly the case with libcomps. We have to bring a newer version of libcomps so that we can build it into a container, but we do not install it on the base system. Every base rhel has libcomps installed for dnf, which will mean failure on every run.

### Solution
This test does not make sense for this version anymore, remove it.


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->