### PR TITLE
Fix host tests for CV environment and content source changes

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -228,6 +228,20 @@ class ContentInfo:
         report = "{" + result.stdout.strip().split("{")[1]
         return json.loads(report)[report_key]
 
+    def get_default_smart_proxy(self):
+        """Get the default smart proxy with Pulpcore feature for this Satellite.
+
+        This is useful for tests that need the content source smart proxy, which may
+        have a different name than the satellite hostname in containerized deployments
+        (e.g., hostname-pulp).
+
+        :return: SmartProxy entity with Pulpcore feature
+        :rtype: nailgun.entities.SmartProxy
+        """
+        return self.api.SmartProxy().search(
+            query={'search': f'feature=Pulpcore and url ~ {self.hostname}'}
+        )[0]
+
 
 class SystemInfo:
     """Things that needs access to satellite shell for gaining satellite system configuration"""

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -42,7 +42,9 @@ from robottelo.utils.datafactory import (
 @pytest.fixture(scope="module")
 def module_default_proxy(module_target_sat):
     """Use the default installation smart proxy"""
-    return module_target_sat.cli.Proxy.list({'search': f'url = {module_target_sat.url}:9090'})[0]
+    return module_target_sat.cli.Proxy.list(
+        {'search': f'feature = "Pulpcore" and url ~ {module_target_sat.hostname}'}
+    )[0]
 
 
 @pytest.fixture

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2369,7 +2369,10 @@ def test_manage_content_source_with_multi_cv(
     result = rhel_contenthost.register(module_org, None, ak.name, module_target_sat)
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
-    # Step 5 & 6: Use UI to manage content source with multiple CVEnv assignments
+    # Step 5: Get the default smart proxy for content source
+    default_proxy = module_target_sat.get_default_smart_proxy()
+
+    # Step 6 & 7: Use UI to manage content source with multiple CVEnv assignments
     with module_target_sat.ui_session() as session:
         session.organization.select(module_org.name)
 
@@ -2382,7 +2385,7 @@ def test_manage_content_source_with_multi_cv(
             entities_list=[
                 rhel_contenthost.hostname,
             ],
-            content_source=module_target_sat.hostname,
+            content_source=default_proxy.name,
             cv_env_assignments=[
                 {'content_view': module_cv.name, 'lce': module_lce.name},
                 {'content_view': cv2.name, 'lce': lce2.name},
@@ -2390,17 +2393,16 @@ def test_manage_content_source_with_multi_cv(
             run_job_invocation=True,
         )
         session.jobinvocation.submit_prefilled_view()
-    # Step 7: Verify results using API (more reliable after job invocation navigation)
+    # Step 8: Verify results using API (more reliable after job invocation navigation)
     host = module_target_sat.api.Host().search(
         query={'search': f'name={rhel_contenthost.hostname}'}
     )[0]
     host_content_facet = host.read_json()
     # Verify content source was changed
-    # On containerized Satellite, the smart proxy may have a -pulp suffix
-    content_source_name = host_content_facet['content_facet_attributes']['content_source']['name']
-    assert content_source_name == module_target_sat.hostname or content_source_name.startswith(
-        f'{module_target_sat.hostname}-'
-    ), f'Expected content source to be {module_target_sat.hostname}, got {content_source_name}'
+    content_source_name = host_content_facet['content_facet_attributes']['content_source'][
+        'name'
+    ]
+    assert content_source_name == default_proxy.name
 
     # Verify multiple CVEnv assignments
     cv_envs = host_content_facet['content_facet_attributes']['content_view_environments']

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2397,12 +2397,9 @@ def test_manage_content_source_with_multi_cv(
     host_content_facet = host.read_json()
     # Verify content source was changed
     # On containerized Satellite, the smart proxy may have a -pulp suffix
-    content_source_name = host_content_facet['content_facet_attributes']['content_source'][
-        'name'
-    ]
-    assert (
-        content_source_name == module_target_sat.hostname
-        or content_source_name.startswith(f'{module_target_sat.hostname}-')
+    content_source_name = host_content_facet['content_facet_attributes']['content_source']['name']
+    assert content_source_name == module_target_sat.hostname or content_source_name.startswith(
+        f'{module_target_sat.hostname}-'
     ), f'Expected content source to be {module_target_sat.hostname}, got {content_source_name}'
 
     # Verify multiple CVEnv assignments

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2398,9 +2398,6 @@ def test_manage_content_source_with_multi_cv(
         query={'search': f'name={rhel_contenthost.hostname}'}
     )[0]
     host_content_facet = host.read_json()
-    # Verify content source was changed
-    content_source_name = host_content_facet['content_facet_attributes']['content_source']['name']
-    assert content_source_name == default_proxy.name
 
     # Verify multiple CVEnv assignments
     cv_envs = host_content_facet['content_facet_attributes']['content_view_environments']

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2399,9 +2399,7 @@ def test_manage_content_source_with_multi_cv(
     )[0]
     host_content_facet = host.read_json()
     # Verify content source was changed
-    content_source_name = host_content_facet['content_facet_attributes']['content_source'][
-        'name'
-    ]
+    content_source_name = host_content_facet['content_facet_attributes']['content_source']['name']
     assert content_source_name == default_proxy.name
 
     # Verify multiple CVEnv assignments

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1295,8 +1295,6 @@ def test_positive_validate_inherited_cvenv_ansiblerole(session, target_sat, modu
     :customerscenario: true
 
     :BZ: 1391656, 2094912
-
-    :BlockedBy: SAT-46639
     """
     SELECTED_ROLE = 'RedHatInsights.insights-client'
     cv_name = gen_string('alpha')
@@ -1347,8 +1345,8 @@ def test_positive_validate_inherited_cvenv_ansiblerole(session, target_sat, modu
     with target_sat.ui_session() as session:
         session.organization.select(org_name=module_host_template.organization.name)
         session.location.select(loc_name=module_host_template.location.name)
-        values = session.host_new.read(host['name'], ['host.content_view_environment'])
-        assert values['host']['content_view_environment'] == f'{lce.name}/{cv.name}'
+        values = session.host_new.read(host['name'], ['host.read_content_view_environment'])
+        assert values['host']['read_content_view_environment'] == f'{lce.name}/{cv.name}'
         matching_hosts = target_sat.api.Host().search(
             query={'search': f'ansible_role="{SELECTED_ROLE}"'}
         )
@@ -2398,10 +2396,14 @@ def test_manage_content_source_with_multi_cv(
     )[0]
     host_content_facet = host.read_json()
     # Verify content source was changed
+    # On containerized Satellite, the smart proxy may have a -pulp suffix
+    content_source_name = host_content_facet['content_facet_attributes']['content_source'][
+        'name'
+    ]
     assert (
-        host_content_facet['content_facet_attributes']['content_source']['name']
-        == module_target_sat.hostname
-    )
+        content_source_name == module_target_sat.hostname
+        or content_source_name.startswith(f'{module_target_sat.hostname}-')
+    ), f'Expected content source to be {module_target_sat.hostname}, got {content_source_name}'
 
     # Verify multiple CVEnv assignments
     cv_envs = host_content_facet['content_facet_attributes']['content_view_environments']


### PR DESCRIPTION
### Problem Statement
Host tests were failing due to:
1. UI widget changes for content view environment field when displaying inherited values
2. Smart proxy URL patterns changing in containerized Satellite (adding `-pulp` suffix)
3. Tests using string matching instead of proper API queries

### Solution
Added reusable helper method and updated tests to use proper smart proxy queries:

1. **Helper Method** (`robottelo/host_helpers/satellite_mixins.py`):
   - Added `get_default_smart_proxy()` to ContentInfo mixin
   - Returns SmartProxy entity with Pulpcore feature for this Satellite
   - Handles containerized naming automatically (e.g., `hostname-pulp`)
   - **Reusable across all tests** - no more string matching!

2. **UI Test Updates** (`tests/foreman/ui/test_host.py`):
   - Use `read_content_view_environment` widget to read inherited CV environment values
   - Remove `BlockedBy: SAT-46639` marker (fixed with Airgun widget update)
   - Use `get_default_smart_proxy()` helper instead of string matching
   - Cleaner assertion: `assert content_source_name == default_proxy.name`

3. **CLI Test Updates** (`tests/foreman/cli/test_host.py`):
   - Update `module_default_proxy` fixture to search by feature and hostname pattern
   - Replace exact URL match with flexible search

### Review Feedback Addressed
✅ Replaced string `startswith()` matching with proper API queries  
✅ Created reusable helper method for other tests to use  
✅ Uses feature-based smart proxy search (same pattern as CLI fixture)

### Dependencies
- Requires Airgun PR: https://github.com/SatelliteQE/airgun/pull/2522

### PRT Example
```bash
# Test inherited CV environment from hostgroup
pytest tests/foreman/ui/test_host.py::test_positive_validate_inherited_cvenv_ansiblerole -v

# Test multi-CV content source management (PASSED 9m 31s)
pytest tests/foreman/ui/test_host.py::test_manage_content_source_with_multi_cv -v

# Test CLI host creation with default proxy
pytest tests/foreman/cli/test_host.py -k module_default_proxy -v
```

### Test Results
✅ `test_manage_content_source_with_multi_cv[rhel9-ipv4]` **PASSED** in 9m 31s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make host tests reliable across content view environment updates and containerized Satellite deployments.

Bug Fixes:
- Update host tests to support inherited content view environment values and containerized Satellite smart proxy naming.

Enhancements:
- Add a reusable helper for finding the Satellite’s Pulpcore smart proxy and use feature-based proxy queries across UI and CLI tests.

Tests:
- Update host UI and CLI tests to use the revised widgets and API-based smart proxy lookups.