### PR TITLE
[6.19.z] HTTPProxy: fix CA cert. parameter

### DIFF
--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -342,7 +342,7 @@ def test_positive_sync_proxy_with_certificate(request, target_sat, module_org, m
         username=settings.http_proxy.username,
         password=settings.http_proxy.password,
         organization=[module_org],
-        cacert=cacert_path,
+        cacert=cacert,
     ).create()
     repo = target_sat.api.Repository(
         product=module_product,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22565

### Problem Statement

Test `tests/foreman/api/test_http_proxy.py::test_positive_sync_proxy_with_certificatetest_positive_sync_proxy_with_certificate` fails
with error `No ca_cert specified in string /root/cacert.crt`
because of `target_sat.api.HTTPProxy(..., cacert=cacert_path)`.

### Solution

`cacert` parameter should contain the certificate content, not the path to it.

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_http_proxy.py -k test_positive_sync_proxy_with_certificate
```

## Summary by Sourcery

Bug Fixes:
- Pass the CA certificate content when creating the HTTP proxy so certificate-based proxy synchronization succeeds.