### PR TITLE
[6.20.z] new subscriptions table

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -265,11 +265,11 @@ def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(
             ignore_error_messages=['Danger alert: Katello::Errors::UpstreamConsumerNotFound'],
         )
         headers = session.subscription.filter_columns(checkbox_dict)
-        assert headers == ('Select all rows', 'Name')
+        assert headers == ['Name']
         time.sleep(3)
         checkbox_dict.update((k, True) for k in checkbox_dict)
         col = session.subscription.filter_columns(checkbox_dict)
-        checkbox_dict.update({'Select all rows': '', 'Name': ''})
+        checkbox_dict.update({'Name': ''})
         assert set(col) == set(checkbox_dict)
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22362

### Problem Statement
adjusting to changes made in https://github.com/Katello/katello/pull/11806 
"Select all rows" is no longer a named columd
requires https://github.com/SatelliteQE/airgun/pull/2497

## Summary by Sourcery

Tests:
- Adjust subscription column selection test expectations to only assert on the 'Name' column now that 'Select all rows' is no longer present.