### PR TITLE
Exclude .crt from hostname grep in test_positive_rename_satellite

### DIFF
--- a/tests/foreman/destructive/test_rename.py
+++ b/tests/foreman/destructive/test_rename.py
@@ -127,7 +127,7 @@ def test_positive_rename_satellite(module_org, module_product, module_target_sat
 
     # check config files (except certs/keys and /etc/template) for occurrences of old hostname
     output = module_target_sat.execute(
-        f'grep "{old_hostname}" /etc -r --exclude=template --exclude-dir={{promtail,pki}} --exclude=*.{{pem,cert,bak}}'
+        f'grep "{old_hostname}" /etc -r --exclude=template --exclude-dir={{promtail,pki}} --exclude=*.{{pem,cert,bak,crt}}'
     ).stdout
     assert old_hostname not in output, (
         'there are remaining instances of the old hostname in the config files'


### PR DESCRIPTION
## Problem Statement

`test_positive_rename_satellite` fails after a successful `satellite-change-hostname` because the broad `/etc` grep for the old FQDN matches `/etc/candlepin/certs/tomcat.crt`.

After the rename, service certificates are reissued with the new hostname in the **Subject**, while the Katello CA (`katello-default-ca.crt`) retains the original FQDN as its CN. Child certificates, including `tomcat.crt`, therefore still contain the old CN in their **Issuer** metadata. This is expected PKIX behavior and is not a leftover configuration entry.

The grep already excludes `*.pem`, `*.cert`, and `*.bak`, but not `*.crt`, causing Jenkins and local stream runs to fail even when the rename and `hammer ping` succeed.

## Solution

Add `crt` to the grep `--exclude` pattern so certificate files are not scanned for the old hostname during the configuration check.

Certificate correctness remains covered by the existing OpenSSL **Subject** checks for the Foreman, Foreman Proxy, and Katello service certificates.


## PRT Test Cases

```text
trigger: test-robottelo
pytest: tests/foreman/destructive/test_rename.py::test_positive_rename_satellite
```

## Summary by Sourcery

Exclude certificate files from the hostname residue check in the satellite rename test.

Bug Fixes:
- Prevent the satellite rename test from falsely failing when the old hostname remains in certificate metadata.

Tests:
- Update the configuration scan in the satellite rename test to exclude .crt certificate files.