### PR TITLE
[6.20.z] Fix katello_reimport & grep_foreman_log & foreman_log setter

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2465,6 +2465,41 @@ class Satellite(Capsule, SatelliteMixins):
         self._apidoc = None
         self.record_property = None
 
+    def set_foreman_logging_level(self, level='debug', reset=False):
+        """Set (or reset) the Foreman logging level in an install-method-aware way.
+
+        - satellite-installer: uses ``--foreman-logging-level`` /
+          ``--reset-foreman-logging-level``.
+        - foremanctl: re-runs ``foremanctl deploy`` with ``--foreman-log-level``.
+          foremanctl persists parameters between runs (loaded from
+          ``/var/lib/foremanctl/parameters.yaml``), so re-deploying only changes the
+          log level. The default Foreman log level is ``info``, which is used to reset.
+
+        :param str level: Log level to set (e.g. 'debug'). Ignored when ``reset`` is True.
+        :param bool reset: Reset the Foreman logging level back to the default.
+        :return: The command result.
+        """
+        if self.install_method == InstallMethod.FOREMANCTL:
+            level = 'info' if reset else level
+            return self.execute(f'foremanctl deploy --foreman-log-level {level}', timeout=0)
+        if reset:
+            return self.execute('satellite-installer --reset-foreman-logging-level', timeout=0)
+        return self.execute(f'satellite-installer --foreman-logging-level {level}', timeout=0)
+
+    def grep_foreman_log(self, pattern):
+        """Search Foreman's production log for a pattern, install-method-aware.
+
+        - satellite-installer: greps ``/var/log/foreman/production.log``.
+        - foremanctl: Foreman runs as a quadlet container (systemd unit ``foreman``)
+          that logs to journald, so we grep the journal for that unit instead.
+
+        :param str pattern: The pattern to grep for.
+        :return: The command result.
+        """
+        if self.install_method == InstallMethod.FOREMANCTL:
+            return self.execute(f'journalctl --no-pager --unit foreman | grep "{pattern}"')
+        return self.execute(f'grep "{pattern}" /var/log/foreman/production.log')
+
     def _swap_nailgun(self, new_version):
         """Install a different version of nailgun from GitHub and invalidate the module cache."""
 

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -224,9 +224,8 @@ def test_negative_check_katello_reimport(request, target_sat, function_org):
     target_sat.cli.Subscription.upload({'organization-id': function_org.id, 'file': remote_path})
     with pytest.raises(CLIReturnCodeError):
         target_sat.cli.Subscription.refresh_manifest({'organization-id': function_org.id})
-    exec_val = target_sat.execute(
-        'grep -i "Katello::HttpErrors::BadRequest: This Organization\'s subscription '
-        'manifest has expired. Please import a new manifest" /var/log/foreman/production.log'
+    exec_val = target_sat.grep_foreman_log(
+        "Katello::HttpErrors::BadRequest: This Organization.s subscription manifest has expired. Please import a new manifest"
     )
     assert exec_val.status == 0
     # Delete expired manifest
@@ -241,7 +240,12 @@ def test_negative_check_katello_reimport(request, target_sat, function_org):
     ret_val = target_sat.cli.Subscription.refresh_manifest({'organization-id': function_org.id})
     assert 'Candlepin job status: SUCCESS' in ret_val
     # Additional check, katello:reimport trace should not fail with TypeError
-    trace_output = target_sat.execute("foreman-rake katello:reimport --trace")
+    # On foremanctl, foreman-rake is a wrapper that rejects tasks not on its allowlist
+    # (katello:reimport is not listed); ALLOW_UNSUPPORTED=true lets it through. The var
+    # is harmless on satellite-installer, where foreman-rake has no such allowlist.
+    trace_output = target_sat.execute(
+        "ALLOW_UNSUPPORTED=true foreman-rake katello:reimport --trace"
+    )
     assert 'TypeError: no implicit conversion of String into Integer' not in trace_output.stdout
     assert trace_output.status == 0
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22558

### Problem Statement
`test_negative_check_katello_reimport` broke with foremanctl, as the test was hardcoded for satellite-installer.

### Solution
As part of the fix for this test, I am adding 2 new helpers to `robottelo/hosts.py`.
Both are installer-aware.
1. `set_foreman_logging_level` - as the name suggests, the user can set the logging level of their satellite
2. `grep_foreman_log` - returns results of grep in foreman log based on installer type

### PRT test Cases example
<img width="289" height="70" alt="image" src="https://github.com/user-attachments/assets/ad5527a2-ad30-4c8d-89dd-65d59a20f109" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_subscription.py -k 'test_negative_check_katello_reimport'
deployment_type: container
```

## Summary by Sourcery

Support Foreman logging and Katello reimport validation across satellite-installer and foremanctl deployments.

New Features:
- Add installer-aware helpers for setting Foreman logging levels and searching Foreman logs.

Bug Fixes:
- Make the Katello reimport subscription test compatible with both satellite-installer and foremanctl deployments.

Tests:
- Update the Katello reimport coverage to use installer-aware log searches and support foremanctl task execution.