### PR TITLE
Add migration_candidate marker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,7 @@ Pytest markers categorize and filter tests.
 - `@pytest.mark.rhel_ver_match()`: Filter by RHEL version using regex or N-x convention
 - `@pytest.mark.rhel_ver_list()`: Filter by specific RHEL version
 - `@pytest.mark.parametrize()`: Parameterize test inputs
+- `@pytest.mark.migration_candidate`: Candidate for migration to Foreman, Katello or any other plugin
 
 Example:
 
@@ -519,6 +520,7 @@ def function_sca_manifest():
 @pytest.mark.stubbed          # Not yet implemented
 @pytest.mark.destructive      # Forces deployment of a new Satellite instance for a particular test case (more expensive)
 @pytest.mark.skip_if_open()   # Skip if BZ/issue open
+@pytest.mark.migration_candidate # Candidate for migration to Foreman, Katello or any other plugin
 ```
 
 **Infrastructure Markers**:

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -27,6 +27,7 @@ def pytest_configure(config):
         "no_compose : Skip the marked sanity test for nightly compose",
         "foremanctl: Tests that require foremanctl; deselected when server.install_method is installer",
         "pqc: Post-Quantum Cryptography tests",
+        "migration_candidate: Candidate for migration to Foreman, Katello or any other plugin; informative marker for filtering",
     ]
     markers.extend(module_markers())
     for marker in markers:


### PR DESCRIPTION
### Problem Statement

As part of the ongoing effort for reducing feedback time of the test runs, some tests will be moved to upstream or just dropped in case the same functionality is being covered already.

### Solution

Instead of dropping tests as part of unrelated change, I propose mark such tests first, so we can deal with them later in a more granular way.

Another way could be simply adding a TODO comment instead of temporal marker.

The marker will be used in https://github.com/SatelliteQE/robottelo/pull/22543 and following PRs.

## Summary by Sourcery

Introduce the `migration_candidate` marker for tracking tests targeted for future upstream migration.

Enhancements:
- Add an informative `migration_candidate` pytest marker to identify tests that are candidates for migration to upstream Foreman/Katello.

Documentation:
- Document the `migration_candidate` marker in the project’s contributor guidance.