### PR TITLE
Remove vendor overrides

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2287,16 +2287,6 @@ class Capsule(ContentHost, CapsuleMixins):
             == 0
         )
 
-        if is_open('SAT-48790'):
-            # This belongs into the downstream packaging, which isn't ready yet
-            overrides_dir = '/usr/share/foremanctl/src/playbooks/_vendor_overrides/'
-            self.execute(f'mkdir -p {overrides_dir}/deploy/')
-            self.put(
-                'variables:\n  flavor:\n    choices:\n      - satellite',
-                f'{overrides_dir}/deploy/metadata.obsah.yaml',
-                temp_file=True,
-            )
-
         # Install Satellite and return result
 
         default_parameters = [
@@ -2824,15 +2814,7 @@ class Satellite(Capsule, SatelliteMixins):
                 raise SatelliteHostError(
                     f'satellitectl auth-bundle failed\n{result.stdout}\n{result.stderr}'
                 )
-            if is_open('SAT-49003'):
-                # This belongs into the downstream packaging, which isn't ready yet
-                overrides_dir = '/usr/share/foremanctl/src/playbooks/_vendor_overrides/'
-                capsule.execute(f'mkdir -p {overrides_dir}/deploy-proxy/')
-                capsule.put(
-                    'variables:\n  flavor:\n    choices:\n      - capsule',
-                    f'{overrides_dir}/deploy-proxy/metadata.obsah.yaml',
-                    temp_file=True,
-                )
+
             install_cmd = (
                 f'satellitectl deploy-proxy --flavor capsule'
                 f' --auth-bundle {cert_file_path}'


### PR DESCRIPTION
### Problem Statement
These overrides were introduce when satellitectl did not included the vendor override

### Solution
Cleanup the logic for vendor overrides from tests as satellitectl take care of it

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Enhancements:
- Remove test-side vendor override setup from Satellite and Capsule installation workflows now that satellitectl handles these overrides.