### PR TITLE
[6.19.z] EOL banner: accept abbreviated month name

### DIFF
--- a/tests/foreman/api/test_eol_banner.py
+++ b/tests/foreman/api/test_eol_banner.py
@@ -45,7 +45,7 @@ def test_positive_check_eol_date(target_sat):
             if p['name'] == 'Maintenance support'
         ]
         if api_date[0][0] == 'string':
-            assert eol_datetime.strftime("%B, %Y") in api_date[0][1]
+            assert any(eol_datetime.strftime(fmt) in api_date[0][1] for fmt in ("%b, %Y", "%B, %Y"))
         elif api_date[0][0] == 'date':
             assert eol_datetime.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + 'Z' == api_date[0][1]
         else:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22600

### Problem Statement

`test_positive_check_eol_date` asserted the EOL banner date string using only the full month-name format (`%B, %Y`, e.g. `September, 2026`).
When the API returns the date with an abbreviated month name (`%b, %Y`, e.g. `Sep, 2026`), the assertion fails even though the date is correct, causing a false negative.

### Solution

Update the assertion to accept either the abbreviated (`%b`) or the full (`%B`) month-name format, so the test passes regardless of which representation the API returns.

### PRT
```
trigger: test-robottelo
pytest: tests/foreman/api/test_eol_banner.py -k 'test_positive_check_eol_date'
```

## Summary by Sourcery

Make EOL banner date assertions accept either abbreviated or full month names.

Bug Fixes:
- Allow the EOL banner date test to recognize both abbreviated and full month-name formats returned by the API.

Tests:
- Update EOL banner date validation to avoid false failures when the API uses abbreviated month names.