### PR TITLE
Fix test_positive_facts_end_to_end_for_foremanctl

### DIFF
--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -129,8 +129,7 @@ def test_positive_facts_end_to_end(
         'net::interface::eth1::ipv4_address': ip,
         'network::fqdn': rhel_contenthost.hostname,
         'lscpu::architecture': rhel_contenthost.arch,
-        'ansible_distribution_major_version': str(rhel_contenthost.os_version.major),
-        'ansible_fqdn': rhel_contenthost.hostname,
+        'distribution::version': f'{rhel_contenthost.os_version.major}.{rhel_contenthost.os_version.minor}',
     }
     for fact, expected_value in expected_values.items():
         actual_value = facts_dict.get(fact)


### PR DESCRIPTION
### Problem Statement
`test_positive_facts_end_to_end` fails with foremanctl Satellite because it asserts on ansible_distribution_major_version and ansible_fqdn fact names.
In containerized Satellite, ansible facts are no longer stored with the ansible_ prefix — they are merged into the system fact namespace (distribution::*, network::*, etc.).

### Solution
Replaced the two ansible-prefixed fact assertions with a distribution::version exact match check.
The network::fqdn assertion already covers what ansible_fqdn was verifying.
The test still validates the full e2e flow: interface creation, host registration, ansible role execution (task success), and fact correctness across interface, network, hardware, and distribution facts.


### PRT test Cases example
<img width="251" height="90" alt="image" src="https://github.com/user-attachments/assets/4b8c1e94-1e03-4605-ba75-e7368790a438" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_fact.py::test_positive_facts_end_to_end
deployment_type: container
```

## Summary by Sourcery

Align the end-to-end fact assertions with the fact namespace used by containerized Satellite deployments.

Bug Fixes:
- Update the end-to-end facts test to validate distribution version facts using the containerized Satellite fact namespace.

Enhancements:
- Retain coverage of FQDN validation through the existing network fact assertion while removing obsolete Ansible-prefixed fact checks.

Tests:
- Adjust the positive facts end-to-end test expectations for current Satellite fact naming and version format.