### PR TITLE
[6.20.z] Update test_positive_populate_future_date_subcription

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -380,7 +380,7 @@ def test_positive_populate_future_date_subcription(
         # Get subscription Start Date and compare with current date
         subscriptions = session.subscription.read_subscriptions()
         if not any(
-            datetime.strptime(sub['Start date'], '%b %d, %Y').date() > current_date
+            datetime.strptime(sub['Start date'], '%B %d, %Y at %I:%M %p').date() > current_date
             for sub in subscriptions
         ):
             raise AssertionError('Subscription start date is not in the future')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22613

### Problem Statement
`test_positive_populate_future_date_subcription` fails on stream because the Satellite UI now returns subscription dates in a different format.
The test expected abbreviated month without time (Jan 29, 2027) but the UI now returns full month name with time (January 29, 2027 at 05:00 AM).

### Solution
Updated the strptime format string from '%b %d, %Y' to '%B %d, %Y at %I:%M %p' to match the new UI date format.

### Related Issues


### PRT test Cases example
<img width="344" height="46" alt="image" src="https://github.com/user-attachments/assets/348a05af-510b-463f-8fb5-ccf811d75c5e" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py::test_positive_populate_future_date_subcription
deployment_type: container
```

## Summary by Sourcery

Bug Fixes:
- Update subscription date validation to parse the Satellite UI’s full month, date, time, and meridiem format.