### PR TITLE
Extend Openvox Agent testing matrix by RHEL10

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -51,17 +51,10 @@ def module_provisioning_rhel_content(
     custom_product = sat.api.Product(
         organization=module_sca_manifest_org, name=f'rhel{rhel_ver}_{gen_string("alpha")}'
     ).create()
-    client_repos_urls = [settings.repos.SATCLIENT_REPO[f'rhel{rhel_ver}']]
-    if (
-        rhel_ver in (8, 9)  # only RHEL 8 and 9 openvox-agent repositories are available
-        or (
-            rhel_ver == 10 and not is_open('SAT-30237')
-        )  # openvox-agent for EL10 is still not delivered
-        or (
-            rhel_ver == 7 and not is_open('SAT-44580')
-        )  # openvox-agent for EL7 is still not delivered
-    ):
-        client_repos_urls.append(settings.repos.OPENVOX_AGENT_REPO[f'rhel{rhel_ver}'])
+    client_repos_urls = [
+        settings.repos.SATCLIENT_REPO[f'rhel{rhel_ver}'],
+        settings.repos.OPENVOX_AGENT_REPO[f'rhel{rhel_ver}'],
+    ]
     client_repos = [
         sat.api.Repository(
             organization=module_sca_manifest_org,

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -97,8 +97,7 @@ def test_positive_puppet_bootstrap(
 
 @pytest.mark.on_premises_provisioning
 @pytest.mark.rhel_ver_match(
-    f'[{"" if is_open("SAT-41340") else "7"}89]'  # Skip EL7 for provisioning test as UEFI is not supported yet
-    f'{"" if is_open("SAT-30237") else "|10"}'  # Skip EL10 for provisioning test as openvox-agent is not delivered yet
+    f'[{"" if is_open("SAT-41340") else "7"}89]|10'  # Skip EL7 for provisioning test as UEFI is not supported yet
 )
 def test_host_provisioning_with_external_puppetserver(
     request,

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -18,7 +18,6 @@ import pytest
 from wait_for import wait_for
 
 from robottelo.exceptions import CLIReturnCodeError
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -84,9 +83,6 @@ def test_positive_install_configure_host(
 
     :Verifies: SAT-25418
     """
-    if agent == 'openvox' and content_hosts[0].os_version.major == 10 and is_open('SAT-30237'):
-        pytest.skip('Skipping as openvox-agent for EL10 is still not delivered')
-
     if agent == 'puppet' and content_hosts[0].os_version.major == 10:
         pytest.skip('Skipping as there is no puppet-agent for EL10')
 
@@ -145,9 +141,6 @@ def test_positive_run_puppet_agent_generate_report_when_no_message(
     :BZ: 2192939, 2257327, 2257314
     :parametrized: yes
     """
-    if agent == 'openvox' and rhel_contenthost.os_version.major == 10 and is_open('SAT-30237'):
-        pytest.skip('Skipping as openvox-agent for EL10 is still not delivered')
-
     if agent == 'puppet' and rhel_contenthost.os_version.major == 10:
         pytest.skip('Skipping as there is no puppet-agent for EL10')
 


### PR DESCRIPTION
### Problem Statement
There is now produced OpenVox agent el10 build on nightly compose server.

### Solution
Extend Openvox Agent testing matrix by RHEL10

### Related Issues
[SAT-45729](https://redhat.atlassian.net/browse/SAT-45729)
`satelliteqe/satellite-jenkins#2053` - CI is ready

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Enable OpenVox agent testing on RHEL 10 across provisioning and reporting scenarios.

New Features:
- Add RHEL 10 to the OpenVox agent provisioning and reporting test coverage.

Enhancements:
- Remove obsolete feature-flag exclusions now that the OpenVox agent is available for RHEL 10.