### PR TITLE
Reduce Artemis parameterization

### DIFF
--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -13,6 +13,7 @@
 """
 
 from copy import copy
+import random
 
 from fauxfactory import gen_string
 import pytest
@@ -20,31 +21,27 @@ from requests import HTTPError
 
 from robottelo.constants import DataFile
 from robottelo.constants.repos import RHEL10_BASEOS_MLDSA
-from robottelo.utils.datafactory import (
-    invalid_values_list,
-    parametrized,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 
 key_content = DataFile.VALID_GPG_KEY_FILE.read_text()
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_name(module_org, name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_name(module_org, module_target_sat):
     """Create a GPG key with valid name.
 
     :id: 741d969b-28ef-481f-bcf7-ed4cd920b030
-
-    :parametrized: yes
 
     :expectedresults: A GPG key is created with the given name.
 
     :CaseImportance: Critical
     """
+    name = random.choice(list(valid_data_list().values()))
     gpg_key = module_target_sat.api.GPGKey(organization=module_org, name=name).create()
     assert name == gpg_key.name
 
 
+@pytest.mark.migration_candidate
 def test_positive_create_with_content(module_org, module_target_sat):
     """Create a GPG key with valid name and valid gpg key text.
 
@@ -58,24 +55,24 @@ def test_positive_create_with_content(module_org, module_target_sat):
     assert key_content == gpg_key.content
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_name(module_org, name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_name(module_org, module_target_sat):
     """Attempt to create GPG key with invalid names only.
 
     :id: 904a3ed0-7d50-495e-a700-b4f1ae913599
-
-    :parametrized: yes
 
     :expectedresults: A GPG key is not created and 422 error is raised.
 
     :CaseImportance: Critical
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(HTTPError) as error:
         module_target_sat.api.GPGKey(organization=module_org, name=name).create()
     assert error.value.response.status_code == 422
     assert 'Validation failed:' in error.value.response.text
 
 
+@pytest.mark.migration_candidate
 def test_negative_create_with_same_name(module_org, module_target_sat):
     """Attempt to create a GPG key providing a name of already existent
     entity
@@ -94,6 +91,7 @@ def test_negative_create_with_same_name(module_org, module_target_sat):
     assert 'Validation failed:' in error.value.response.text
 
 
+@pytest.mark.migration_candidate
 def test_negative_create_with_content(module_org, module_target_sat):
     """Attempt to create GPG key with empty content.
 
@@ -109,24 +107,24 @@ def test_negative_create_with_content(module_org, module_target_sat):
     assert 'Validation failed:' in error.value.response.text
 
 
-@pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-def test_positive_update_name(module_org, new_name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_update_name(module_org, module_target_sat):
     """Update GPG key name to another valid name.
 
     :id: 9868025d-5346-42c9-b850-916ce37a9541
-
-    :parametrized: yes
 
     :expectedresults: The GPG key name can be updated.
 
     :CaseImportance: Critical
     """
+    new_name = random.choice(list(valid_data_list().values()))
     gpg_key = module_target_sat.api.GPGKey(organization=module_org).create()
     gpg_key.name = new_name
     gpg_key = gpg_key.update(['name'])
     assert new_name == gpg_key.name
 
 
+@pytest.mark.migration_candidate
 def test_positive_update_content(module_org, module_target_sat):
     """Update GPG key content text to another valid one.
 
@@ -145,18 +143,17 @@ def test_positive_update_content(module_org, module_target_sat):
     assert key_content == gpg_key.content
 
 
-@pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-def test_negative_update_name(module_org, new_name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_update_name(module_org, module_target_sat):
     """Attempt to update GPG key name to invalid one
 
     :id: 1a43f610-8969-4f08-967f-fb6af0fca31b
-
-    :parametrized: yes
 
     :expectedresults: GPG key is not updated and 422 error is raised.
 
     :CaseImportance: Critical
     """
+    new_name = random.choice(invalid_values_list())
     gpg_key = module_target_sat.api.GPGKey(organization=module_org).create()
     gpg_key.name = new_name
     with pytest.raises(HTTPError) as error:
@@ -165,6 +162,7 @@ def test_negative_update_name(module_org, new_name, module_target_sat):
     assert 'Validation failed:' in error.value.response.text
 
 
+@pytest.mark.migration_candidate
 def test_negative_update_same_name(module_org, module_target_sat):
     """Attempt to update GPG key name to the name of existing GPG key
     entity
@@ -185,6 +183,7 @@ def test_negative_update_same_name(module_org, module_target_sat):
     assert 'Validation failed:' in error.value.response.text
 
 
+@pytest.mark.migration_candidate
 def test_negative_update_content(module_org, module_target_sat):
     """Attempt to update GPG key content to invalid one
 
@@ -203,6 +202,7 @@ def test_negative_update_content(module_org, module_target_sat):
     assert 'Validation failed:' in error.value.response.text
 
 
+@pytest.mark.migration_candidate
 def test_positive_delete(module_org, module_target_sat):
     """Create a GPG key with different names and then delete it.
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -41,11 +41,7 @@ from robottelo.constants import (
     DataFile,
 )
 from robottelo.constants.repos import CUSTOM_RPM_SHA_512, FEDORA_OSTREE_REPO, RHEL10_BASEOS_MLDSA
-from robottelo.utils.datafactory import (
-    invalid_names_list,
-    parametrized,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import invalid_names_list, valid_data_list
 
 # Some tests repeatedly publish content views or promote content view versions.
 # How many times should that be done? A higher number means a more interesting
@@ -609,7 +605,7 @@ class TestRollingContentView:
         assert read_cv == rolling_cv
 
         # Update rolling CV with Library environment and description
-        cv_desc = valid_data_list()['utf8']
+        cv_desc = random.choice(list(valid_data_list().values()))
         rolling_cv.description = cv_desc
         rolling_cv.environment = [function_org.library]
         update_cv = rolling_cv.update(['description', 'environment'])
@@ -1506,32 +1502,30 @@ class TestRollingContentView:
 class TestContentViewCreate:
     """Create tests for content views."""
 
-    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    def test_positive_create_with_name(self, name, target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_create_with_name(self, target_sat):
         """Create empty content-view with random names.
 
         :id: 80d36498-2e71-4aa9-b696-f0a45e86267f
-
-        :parametrized: yes
 
         :expectedresults: Content-view is created and had random name.
 
         :CaseImportance: Critical
         """
+        name = random.choice(list(valid_data_list().values()))
         assert target_sat.api.ContentView(name=name).create().name == name
 
-    @pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-    def test_positive_create_with_description(self, desc, target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_create_with_description(self, target_sat):
         """Create empty content view with random description.
 
         :id: 068e3e7c-34ac-47cb-a1bb-904d12c74cc7
-
-        :parametrized: yes
 
         :expectedresults: Content-view is created and has random description.
 
         :CaseImportance: High
         """
+        desc = random.choice(list(valid_data_list().values()))
         assert target_sat.api.ContentView(description=desc).create().description == desc
 
     def test_positive_clone(self, content_view, module_org, module_target_sat):
@@ -1553,18 +1547,17 @@ class TestContentViewCreate:
             del cloned_cv[key]
         assert cv_origin == cloned_cv
 
-    @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    def test_negative_create_with_invalid_name(self, name, target_sat):
+    @pytest.mark.migration_candidate
+    def test_negative_create_with_invalid_name(self, target_sat):
         """Create content view providing an invalid name.
 
         :id: 261376ca-7d12-41b6-9c36-5f284865243e
-
-        :parametrized: yes
 
         :expectedresults: Content View is not created
 
         :CaseImportance: High
         """
+        name = random.choice(invalid_names_list())
         with pytest.raises(HTTPError):
             target_sat.api.ContentView(name=name).create()
 
@@ -2591,37 +2584,35 @@ class TestContentViewUpdate:
         content_view = module_cv.update({key})
         assert getattr(content_view, key) == value
 
-    @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-    def test_positive_update_name(self, module_cv, new_name, module_target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_update_name(self, module_cv, module_target_sat):
         """Create content view providing the initial name, then update
         its name to another valid name.
 
         :id: 15e6fa3a-1a65-4e7d-8d32-3a81227ac1c8
 
-        :parametrized: yes
-
         :expectedresults: Content View is created, and its name can be updated.
 
         :CaseImportance: Critical
         """
+        new_name = random.choice(list(valid_data_list().values()))
         module_cv.name = new_name
         module_cv.update(['name'])
         updated = module_target_sat.api.ContentView(id=module_cv.id).read()
         assert new_name == updated.name
 
-    @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
-    def test_negative_update_name(self, module_cv, new_name, module_target_sat):
+    @pytest.mark.migration_candidate
+    def test_negative_update_name(self, module_cv, module_target_sat):
         """Create content view then update its name to an
         invalid name.
 
         :id: 69a2ce8d-19b2-49a3-97db-a1fdebbb16be
 
-        :parametrized: yes
-
         :expectedresults: Content View is created, and its name is not updated.
 
         :CaseImportance: Critical
         """
+        new_name = random.choice(invalid_names_list())
         module_cv.name = new_name
         with pytest.raises(HTTPError):
             module_cv.update(['name'])

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -17,6 +17,7 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 """
 
 from datetime import UTC, datetime
+import random
 from random import randint
 
 from fauxfactory import gen_integer, gen_string
@@ -25,10 +26,7 @@ from requests.exceptions import HTTPError
 
 from robottelo.config import settings
 from robottelo.constants import REPOS, TIMESTAMP_FMT_DATE
-from robottelo.utils.datafactory import (
-    parametrized,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import valid_data_list
 
 
 @pytest.fixture(scope='module')
@@ -64,35 +62,33 @@ def content_view_module_stream(module_org, sync_repo_module_stream, module_targe
 class TestContentViewFilter:
     """Tests for content view filters."""
 
-    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    def test_positive_create_erratum_with_name(self, name, content_view, target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_create_erratum_with_name(self, content_view, target_sat):
         """Create new erratum content filter using different inputs as a name
 
         :id: f78a133f-441f-4fcc-b292-b9eed228d755
-
-        :parametrized: yes
 
         :expectedresults: Content view filter created successfully and has
             correct name and type
 
         """
+        name = random.choice(list(valid_data_list().values()))
         cvf = target_sat.api.ErratumContentViewFilter(content_view=content_view, name=name).create()
         assert cvf.name == name
         assert cvf.type == 'erratum'
 
-    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    def test_positive_create_pkg_group_with_name(self, name, content_view, target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_create_pkg_group_with_name(self, content_view, target_sat):
         """Create new package group content filter using different inputs as a name
 
         :id: f9bfb6bf-a879-4f1a-970d-8f4df533cd59
-
-        :parametrized: yes
 
         :expectedresults: Content view filter created successfully and has
             correct name and type
 
         :CaseImportance: Medium
         """
+        name = random.choice(list(valid_data_list().values()))
         cvf = target_sat.api.PackageGroupContentViewFilter(
             content_view=content_view,
             name=name,
@@ -100,19 +96,18 @@ class TestContentViewFilter:
         assert cvf.name == name
         assert cvf.type == 'package_group'
 
-    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    def test_positive_create_rpm_with_name(self, name, content_view, target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_create_rpm_with_name(self, content_view, target_sat):
         """Create new RPM content filter using different inputs as a name
 
         :id: f1c88e72-7993-47ac-8fbc-c749d32bc768
-
-        :parametrized: yes
 
         :expectedresults: Content view filter created successfully and has
             correct name and type
 
         :CaseImportance: Medium
         """
+        name = random.choice(list(valid_data_list().values()))
         cvf = target_sat.api.RPMContentViewFilter(content_view=content_view, name=name).create()
         assert cvf.name == name
         assert cvf.type == 'rpm'
@@ -134,19 +129,18 @@ class TestContentViewFilter:
         ).create()
         assert cvf.inclusion == inclusion
 
-    @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
-    def test_positive_create_with_description(self, description, content_view, target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_create_with_description(self, content_view, target_sat):
         """Create new content filter using different inputs as a description
 
         :id: e057083f-e69d-46e7-b336-45faaf67fa52
-
-        :parametrized: yes
 
         :expectedresults: Content view filter created successfully and has
             correct description
 
         :CaseImportance: Low
         """
+        description = random.choice(list(valid_data_list().values()))
         cvf = target_sat.api.RPMContentViewFilter(
             content_view=content_view,
             description=description,
@@ -267,35 +261,33 @@ class TestContentViewFilter:
         with pytest.raises(HTTPError):
             cvf.read()
 
-    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    def test_positive_update_name(self, name, content_view, target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_update_name(self, content_view, target_sat):
         """Update content view filter with new name
 
         :id: f310c161-00d2-4281-9721-6e45cbc5e4ec
-
-        :parametrized: yes
 
         :expectedresults: Content view filter updated successfully and name was
             changed
 
         """
+        name = random.choice(list(valid_data_list().values()))
         cvf = target_sat.api.RPMContentViewFilter(content_view=content_view).create()
         cvf.name = name
         assert cvf.update(['name']).name == name
 
-    @pytest.mark.parametrize('description', **parametrized(valid_data_list()))
-    def test_positive_update_description(self, description, content_view, target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_update_description(self, content_view, target_sat):
         """Update content view filter with new description
 
         :id: f2c5db28-0163-4cf3-929a-16ba1cb98c34
-
-        :parametrized: yes
 
         :expectedresults: Content view filter updated successfully and
             description was changed
 
         :CaseImportance: Low
         """
+        description = random.choice(list(valid_data_list().values()))
         cvf = target_sat.api.RPMContentViewFilter(content_view=content_view).create()
         cvf.description = description
         cvf = cvf.update(['description'])

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -16,16 +16,14 @@ http://www.katello.org/docs/api/apidoc/lifecycle_environments.html
 
 """
 
+import random
+
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.constants import LIBRARY_LCE
-from robottelo.utils.datafactory import (
-    invalid_names_list,
-    parametrized,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import invalid_names_list, valid_data_list
 
 
 @pytest.fixture(scope='module')
@@ -40,8 +38,8 @@ def lce(module_org, module_target_sat):
     return module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_name(name, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_name(target_sat):
     """Create lifecycle environment with valid name only
 
     :id: ec1d985a-6a39-4de6-b635-c803ecedd832
@@ -49,14 +47,13 @@ def test_positive_create_with_name(name, target_sat):
     :expectedresults: Lifecycle environment is created and has proper name
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    name = random.choice(list(valid_data_list().values()))
     assert target_sat.api.LifecycleEnvironment(name=name).create().name == name
 
 
-@pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-def test_positive_create_with_description(desc, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_description(target_sat):
     """Create lifecycle environment with valid description
 
     :id: 0bc05510-afc7-4087-ab75-1065ab5ba1d3
@@ -65,9 +62,8 @@ def test_positive_create_with_description(desc, target_sat):
         description
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    desc = random.choice(list(valid_data_list().values()))
     assert target_sat.api.LifecycleEnvironment(description=desc).create().description == desc
 
 
@@ -86,8 +82,8 @@ def test_positive_create_prior(module_org, module_target_sat):
     assert lc_env.prior.read().name == LIBRARY_LCE
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-def test_negative_create_with_invalid_name(name, target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_invalid_name(target_sat):
     """Create lifecycle environment providing an invalid name
 
     :id: 7e8ea2e6-5927-4e86-8ea8-04c3feb524a6
@@ -95,32 +91,30 @@ def test_negative_create_with_invalid_name(name, target_sat):
     :expectedresults: Lifecycle environment is not created
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
+    name = random.choice(invalid_names_list())
     with pytest.raises(HTTPError):
         target_sat.api.LifecycleEnvironment(name=name).create()
 
 
-@pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-def test_positive_update_name(module_lce, new_name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_update_name(module_lce, module_target_sat):
     """Create lifecycle environment providing the initial name, then
     update its name to another valid name.
 
     :id: b6715e02-f15e-4ab8-8b13-18a3619fee9e
 
     :expectedresults: Lifecycle environment is created and updated properly
-
-    :parametrized: yes
     """
+    new_name = random.choice(list(valid_data_list().values()))
     module_lce.name = new_name
     module_lce.update(['name'])
     updated = module_target_sat.api.LifecycleEnvironment(id=module_lce.id).read()
     assert new_name == updated.name
 
 
-@pytest.mark.parametrize('new_desc', **parametrized(valid_data_list()))
-def test_positive_update_description(module_lce, new_desc, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_update_description(module_lce, module_target_sat):
     """Create lifecycle environment providing the initial
     description, then update its description to another one.
 
@@ -129,17 +123,16 @@ def test_positive_update_description(module_lce, new_desc, module_target_sat):
     :expectedresults: Lifecycle environment is created and updated properly
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
+    new_desc = random.choice(list(valid_data_list().values()))
     module_lce.description = new_desc
     module_lce.update(['description'])
     updated = module_target_sat.api.LifecycleEnvironment(id=module_lce.id).read()
     assert new_desc == updated.description
 
 
-@pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
-def test_negative_update_name(module_lce, new_name):
+@pytest.mark.migration_candidate
+def test_negative_update_name(module_lce):
     """Update lifecycle environment providing an invalid name
 
     :id: 55723382-9d98-43c8-85fb-df4702ca7478
@@ -148,9 +141,8 @@ def test_negative_update_name(module_lce, new_name):
         corresponding error is raised
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
+    new_name = random.choice(invalid_names_list())
     module_lce.name = new_name
     with pytest.raises(HTTPError):
         module_lce.update(['name'])
@@ -158,9 +150,9 @@ def test_negative_update_name(module_lce, new_name):
     assert lce.name != new_name
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 @pytest.mark.upgrade
-def test_positive_delete(lce, name, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_delete(lce, target_sat):
     """Create lifecycle environment and then delete it.
 
     :id: cd5a97ca-c1e8-41c7-8d6b-f908916b24e1
@@ -168,16 +160,14 @@ def test_positive_delete(lce, name, target_sat):
     :expectedresults: Lifecycle environment is deleted successfully
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
     lce.delete()
     with pytest.raises(HTTPError):
         target_sat.api.LifecycleEnvironment(id=lce.id).read()
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_search_in_org(name, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_search_in_org(target_sat):
     """Search for a lifecycle environment and specify an org ID.
 
     :id: 110e4777-c374-4365-b676-b1db4552fe51
@@ -190,8 +180,6 @@ def test_positive_search_in_org(name, target_sat):
 
     :expectedresults: Only "Library" and the lifecycle environment just
         created are in the search results.
-
-    :parametrized: yes
     """
     new_org = target_sat.api.Organization().create()
     lc_env = target_sat.api.LifecycleEnvironment(organization=new_org).create()

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -15,6 +15,8 @@ http://<sat6>/apidoc/v2/products.html
 
 """
 
+import random
+
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError
@@ -25,28 +27,25 @@ from robottelo.constants import (
     DataFile,
 )
 from robottelo.utils import datafactory
-from robottelo.utils.datafactory import (
-    invalid_values_list,
-    parametrized,
-)
+from robottelo.utils.datafactory import invalid_values_list
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_name(name, module_org, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_name(module_org, module_target_sat):
     """Create a product providing invalid names only
 
     :id: 76531f53-09ff-4ee9-89b9-09a697526fb1
-
-    :parametrized: yes
 
     :expectedresults: A product is not created
 
     :CaseImportance: Critical
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(HTTPError):
         module_target_sat.api.Product(name=name, organization=module_org).create()
 
 
+@pytest.mark.migration_candidate
 def test_negative_create_with_same_name(module_org, module_target_sat):
     """Create a product providing a name of already existent entity
 
@@ -62,6 +61,7 @@ def test_negative_create_with_same_name(module_org, module_target_sat):
         module_target_sat.api.Product(name=name, organization=module_org).create()
 
 
+@pytest.mark.migration_candidate
 def test_negative_create_with_label(module_org, module_target_sat):
     """Create a product providing invalid label
 
@@ -101,23 +101,23 @@ def test_positive_create_product_and_update_gpg(module_org, module_target_sat):
     assert product.gpg_key.id == gpg_key_2.id
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_update_name(name, module_org, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_update_name(module_org, module_target_sat):
     """Attempt to update product name to invalid one
 
     :id: 3eb61fa8-3524-4872-8f1b-4e88004f66f5
-
-    :parametrized: yes
 
     :expectedresults: Product is not updated
 
     :CaseImportance: Critical
     """
+    name = random.choice(invalid_values_list())
     product = module_target_sat.api.Product(organization=module_org).create()
     with pytest.raises(HTTPError):
         module_target_sat.api.Product(id=product.id, name=name).update(['name'])
 
 
+@pytest.mark.migration_candidate
 def test_negative_update_label(module_org, module_target_sat):
     """Attempt to update product label to another one.
 

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -17,6 +17,7 @@ API reference for sync plans can be found on your Satellite:
 """
 
 from datetime import UTC, datetime, timedelta
+import random
 from time import sleep
 
 from fauxfactory import gen_choice, gen_string
@@ -144,18 +145,17 @@ def test_positive_create_enabled_disabled(module_org, enabled, request, target_s
     assert sync_plan.enabled == enabled
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_name(module_org, name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_name(module_org, module_target_sat):
     """Create a sync plan with a random name.
 
     :id: c1263134-0d7c-425a-82fd-df5274e1f9ba
-
-    :parametrized: yes
 
     :expectedresults: A sync plan is created with the specified name.
 
     :CaseImportance: Critical
     """
+    name = random.choice(list(valid_data_list().values()))
     sync_plan = module_target_sat.api.SyncPlan(
         enabled=False, name=name, organization=module_org
     ).create()
@@ -163,19 +163,18 @@ def test_positive_create_with_name(module_org, name, module_target_sat):
     assert sync_plan.name == name
 
 
-@pytest.mark.parametrize('description', **parametrized(valid_data_list()))
-def test_positive_create_with_description(module_org, description, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_description(module_org, module_target_sat):
     """Create a sync plan with a random description.
 
     :id: 3e5745e8-838d-44a5-ad61-7e56829ad47c
-
-    :parametrized: yes
 
     :expectedresults: A sync plan is created with the specified
         description.
 
     :CaseImportance: Critical
     """
+    description = random.choice(list(valid_data_list().values()))
     sync_plan = module_target_sat.api.SyncPlan(
         enabled=False, description=description, organization=module_org
     ).create()
@@ -183,18 +182,17 @@ def test_positive_create_with_description(module_org, description, module_target
     assert sync_plan.description == description
 
 
-@pytest.mark.parametrize('interval', **parametrized(valid_sync_interval()))
-def test_positive_create_with_interval(module_org, interval, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_interval(module_org, module_target_sat):
     """Create a sync plan with a random interval.
 
     :id: d160ed1c-b698-42dc-be0b-67ac693c7840
-
-    :parametrized: yes
 
     :expectedresults: A sync plan is created with the specified interval.
 
     :CaseImportance: Critical
     """
+    interval = random.choice(['hourly', 'daily', 'weekly', 'custom cron'])
     sync_plan = module_target_sat.api.SyncPlan(
         enabled=False, description=gen_string('alpha'), organization=module_org, interval=interval
     )
@@ -225,40 +223,39 @@ def test_positive_create_with_sync_date(module_org, sync_delta, target_sat):
     assert sync_date.strftime('%Y-%m-%d %H:%M:%S +0000') == sync_plan.sync_date
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_invalid_name(module_org, name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_invalid_name(module_org, module_target_sat):
     """Create a sync plan with an invalid name.
 
     :id: a3a0f844-2f81-4f87-9f68-c25506c29ce2
-
-    :parametrized: yes
 
     :expectedresults: A sync plan can not be created with the specified
         name.
 
     :CaseImportance: Critical
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(HTTPError):
         module_target_sat.api.SyncPlan(name=name, organization=module_org).create()
 
 
-@pytest.mark.parametrize('interval', **parametrized(invalid_values_list()))
-def test_negative_create_with_invalid_interval(module_org, interval, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_invalid_interval(module_org, module_target_sat):
     """Create a sync plan with invalid interval specified.
 
     :id: f5844526-9f58-4be3-8a96-3849a465fc02
-
-    :parametrized: yes
 
     :expectedresults: A sync plan can not be created with invalid interval
         specified
 
     :CaseImportance: Critical
     """
+    interval = random.choice(invalid_values_list())
     with pytest.raises(HTTPError):
         module_target_sat.api.SyncPlan(interval=interval, organization=module_org).create()
 
 
+@pytest.mark.migration_candidate
 def test_negative_create_with_empty_interval(module_org, module_target_sat):
     """Create a sync plan with no interval specified.
 
@@ -296,19 +293,18 @@ def test_positive_update_enabled(module_org, enabled, request, target_sat):
     assert sync_plan.enabled == enabled
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_update_name(module_org, name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_update_name(module_org, module_target_sat):
     """Create a sync plan and update its name.
 
     :id: dbfadf4f-50af-4aa8-8d7d-43988dc4528f
-
-    :parametrized: yes
 
     :expectedresults: A sync plan is created and its name can be updated
         with the specified name.
 
     :CaseImportance: Critical
     """
+    name = random.choice(list(valid_data_list().values()))
     sync_plan = module_target_sat.api.SyncPlan(enabled=False, organization=module_org).create()
     sync_plan.name = name
     sync_plan.update(['name'])
@@ -316,17 +312,16 @@ def test_positive_update_name(module_org, name, module_target_sat):
     assert sync_plan.name == name
 
 
-@pytest.mark.parametrize('description', **parametrized(valid_data_list()))
-def test_positive_update_description(module_org, description, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_update_description(module_org, module_target_sat):
     """Create a sync plan and update its description.
 
     :id: 4769fe9c-9eec-40c8-b015-1e3d7e570bec
 
-    :parametrized: yes
-
     :expectedresults: A sync plan is created and its description can be
         updated with the specified description.
     """
+    description = random.choice(list(valid_data_list().values()))
     sync_plan = module_target_sat.api.SyncPlan(
         enabled=False, description=gen_string('alpha'), organization=module_org
     ).create()
@@ -417,44 +412,43 @@ def test_positive_update_sync_date(module_org, sync_delta, target_sat):
     assert sync_date.strftime('%Y-%m-%d %H:%M:%S +0000') == sync_plan.sync_date
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_update_name(module_org, name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_update_name(module_org, module_target_sat):
     """Try to update a sync plan with an invalid name.
 
     :id: ae502053-9d3c-4cad-aee4-821f846ceae5
-
-    :parametrized: yes
 
     :expectedresults: A sync plan can not be updated with the specified
         name.
 
     :CaseImportance: Critical
     """
+    name = random.choice(invalid_values_list())
     sync_plan = module_target_sat.api.SyncPlan(enabled=False, organization=module_org).create()
     sync_plan.name = name
     with pytest.raises(HTTPError):
         sync_plan.update(['name'])
 
 
-@pytest.mark.parametrize('interval', **parametrized(invalid_values_list()))
-def test_negative_update_interval(module_org, interval, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_update_interval(module_org, module_target_sat):
     """Try to update a sync plan with invalid interval.
 
     :id: 8c981174-6f55-49c0-8baa-40e5c3fc598c
-
-    :parametrized: yes
 
     :expectedresults: A sync plan can not be updated with empty interval
         specified.
 
     :CaseImportance: Critical
     """
+    interval = random.choice(invalid_values_list())
     sync_plan = module_target_sat.api.SyncPlan(enabled=False, organization=module_org).create()
     sync_plan.interval = interval
     with pytest.raises(HTTPError):
         sync_plan.update(['interval'])
 
 
+@pytest.mark.migration_candidate
 def test_positive_add_product(module_org, target_sat):
     """Create a sync plan and add one product to it.
 
@@ -474,6 +468,7 @@ def test_positive_add_product(module_org, target_sat):
     assert sync_plan.product[0].id == product.id
 
 
+@pytest.mark.migration_candidate
 def test_positive_add_products(module_org, target_sat):
     """Create a sync plan and add two products to it.
 
@@ -491,6 +486,7 @@ def test_positive_add_products(module_org, target_sat):
     assert {product.id for product in products} == {product.id for product in sync_plan.product}
 
 
+@pytest.mark.migration_candidate
 def test_positive_remove_product(module_org, target_sat):
     """Create a sync plan with two products and then remove one
     product from it.

--- a/tests/foreman/cli/test_contentcredentials.py
+++ b/tests/foreman/cli/test_contentcredentials.py
@@ -14,6 +14,7 @@ Satellite 6.8
 
 """
 
+import random
 from tempfile import mkstemp
 
 from fauxfactory import gen_alphanumeric, gen_choice, gen_integer, gen_string
@@ -21,11 +22,7 @@ import pytest
 
 from robottelo.constants import DataFile
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
-from robottelo.utils.datafactory import (
-    invalid_values_list,
-    parametrized,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 
 VALID_GPG_KEY_FILE_PATH = DataFile.VALID_GPG_KEY_FILE
 
@@ -155,20 +152,17 @@ def test_positive_block_delete_key_in_use(target_sat, module_org):
     assert repo_info['gpg-key']['id'] == gpg_key['id']
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_default_org(target_sat, name, default_org):
+def test_positive_create_with_default_org(target_sat, default_org):
     """Create gpg key with valid name and valid gpg key via file
     import using the default created organization
 
     :id: 4265dfd1-dc64-4119-8a64-8724b09d6fb7
 
-    :parametrized: yes
-
     :expectedresults: gpg key is created
 
     :CaseImportance: Critical
     """
-
+    name = random.choice(list(valid_data_list().values()))
     gpg_key = target_sat.cli_factory.make_content_credential(
         {'path': VALID_GPG_KEY_FILE_PATH, 'name': name, 'organization-id': default_org.id}
     )
@@ -180,19 +174,17 @@ def test_positive_create_with_default_org(target_sat, name, default_org):
     assert gpg_key[search_key] == result[search_key]
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_custom_org(target_sat, name, module_org):
+def test_positive_create_with_custom_org(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import using a new organization
 
     :id: 10dd9fc0-e088-4cf1-9fb6-24fe04df2895
 
-    :parametrized: yes
-
     :expectedresults: gpg key is created
 
     :CaseImportance: Critical
     """
+    name = random.choice(list(valid_data_list().values()))
     gpg_key = target_sat.cli_factory.make_content_credential(
         {
             'path': VALID_GPG_KEY_FILE_PATH,
@@ -233,35 +225,31 @@ def test_negative_create_with_same_name(target_sat, module_org):
         )
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_negative_create_with_no_gpg_key(name, target_sat, module_org):
+def test_negative_create_with_no_gpg_key(target_sat, module_org):
     """Create gpg key with valid name and no gpg key
 
     :id: bbfd5306-cfe7-40c1-a3a2-35834108163c
-
-    :parametrized: yes
 
     :expectedresults: gpg key is not created
 
     :CaseImportance: Critical
     """
+    name = random.choice(list(valid_data_list().values()))
     with pytest.raises(CLIReturnCodeError):
         target_sat.cli.ContentCredential.create({'name': name, 'organization-id': module_org.id})
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_invalid_name(target_sat, name, module_org):
+def test_negative_create_with_invalid_name(target_sat, module_org):
     """Create gpg key with invalid name and valid gpg key via
     file import
 
     :id: fbbaf8a5-1570-4910-9f6a-baa35b15d2ad
 
-    :parametrized: yes
-
     :expectedresults: gpg key is not created
 
     :CaseImportance: Critical
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(CLIFactoryError):
         # factory will provide a valid key
         target_sat.cli_factory.make_content_credential(
@@ -269,20 +257,18 @@ def test_negative_create_with_invalid_name(target_sat, name, module_org):
         )
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 @pytest.mark.upgrade
-def test_positive_delete(target_sat, name, module_org):
+def test_positive_delete(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then delete it
 
     :id: 9640cabc-e0c3-41a0-b4de-99b06bf51c02
 
-    :parametrized: yes
-
     :expectedresults: gpg key is deleted
 
     :CaseImportance: Critical
     """
+    name = random.choice(list(valid_data_list().values()))
     gpg_key = target_sat.cli_factory.make_content_credential(
         {'name': name, 'organization-id': module_org.id}
     )
@@ -299,19 +285,17 @@ def test_positive_delete(target_sat, name, module_org):
     assert (len(result)) == 0
 
 
-@pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-def test_positive_update_name(target_sat, new_name, module_org):
+def test_positive_update_name(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then update its name
 
     :id: f3bb254d-f831-4f86-944a-26d9a36bd906
 
-    :parametrized: yes
-
     :expectedresults: gpg key is updated
 
     :CaseImportance: Critical
     """
+    new_name = random.choice(list(valid_data_list().values()))
     gpg_key = target_sat.cli_factory.make_content_credential({'organization-id': module_org.id})
     target_sat.cli.ContentCredential.update(
         {
@@ -325,14 +309,11 @@ def test_positive_update_name(target_sat, new_name, module_org):
     )
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_update_key(name, module_org, target_sat):
+def test_positive_update_key(module_org, target_sat):
     """Create gpg key with valid name and valid gpg key via file
     import then update its gpg key file
 
     :id: d3a72892-3414-4178-98b7-e0780d9b6587
-
-    :parametrized: yes
 
     :expectedresults: gpg key is updated
 
@@ -354,19 +335,17 @@ def test_positive_update_key(name, module_org, target_sat):
     assert gpg_key['content'] == content
 
 
-@pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-def test_negative_update_name(target_sat, new_name, module_org):
+def test_negative_update_name(target_sat, module_org):
     """Create gpg key with valid name and valid gpg key via file
     import then fail to update its name
 
     :id: 98cda40a-49d0-42ce-91a6-31fa7b7f330b
 
-    :parametrized: yes
-
     :expectedresults: gpg key is not updated
 
     :CaseImportance: Critical
     """
+    new_name = random.choice(invalid_values_list())
     gpg_key = target_sat.cli_factory.make_content_credential({'organization-id': module_org.id})
     with pytest.raises(CLIReturnCodeError):
         target_sat.cli.ContentCredential.update(
@@ -782,18 +761,16 @@ def test_positive_list(module_target_sat, module_org):
     assert gpg_key['id'] in [gpg['id'] for gpg in gpg_key_list]
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_search(target_sat, name, module_org):
+def test_positive_search(target_sat, module_org):
     """Create gpg key and search for it
 
     :id: f72648f1-b468-4662-9653-3464e7d0c349
-
-    :parametrized: yes
 
     :expectedresults: gpg key can be found
 
     :CaseImportance: Critical
     """
+    name = random.choice(list(valid_data_list().values()))
     gpg_key = target_sat.cli_factory.make_content_credential(
         {
             'path': VALID_GPG_KEY_FILE_PATH,

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -33,7 +33,6 @@ from robottelo.logging import logger
 from robottelo.utils.datafactory import (
     generate_strings_list,
     invalid_names_list,
-    parametrized,
     valid_names_list,
 )
 
@@ -81,8 +80,7 @@ def _get_content_view_version_lce_names_set(content_view_id, version_id, sat):
 class TestContentView:
     """Content View CLI Tests"""
 
-    @pytest.mark.parametrize('name', **parametrized(valid_names_list()))
-    def test_positive_create_with_name(self, module_org, module_target_sat, name):
+    def test_positive_create_with_name(self, module_org, module_target_sat):
         """create content views with different names
 
         :id: a154308c-3982-4cf1-a236-3051e740970e
@@ -90,16 +88,14 @@ class TestContentView:
         :expectedresults: content views are created
 
         :CaseImportance: Critical
-
-        :parametrized: yes
         """
+        name = random.choice(valid_names_list())
         content_view = module_target_sat.cli_factory.make_content_view(
             {'name': name, 'organization-id': module_org.id}
         )
         assert content_view['name'] == name.strip()
 
-    @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-    def test_negative_create_with_invalid_name(self, module_org, module_target_sat, name):
+    def test_negative_create_with_invalid_name(self, module_org, module_target_sat):
         """create content views with invalid names
 
         :id: 83046271-76f9-4cda-b579-a2fe63493295
@@ -108,9 +104,8 @@ class TestContentView:
             and system handles it gracefully
 
         :CaseImportance: Critical
-
-        :parametrized: yes
         """
+        name = random.choice(invalid_names_list())
         with pytest.raises(CLIFactoryError):
             module_target_sat.cli_factory.make_content_view(
                 {'name': name, 'organization-id': module_org.id}
@@ -148,8 +143,7 @@ class TestContentView:
         )
         assert cv['yum-repositories'][0]['id'] == repo['id']
 
-    @pytest.mark.parametrize('new_name', **parametrized(valid_names_list()))
-    def test_positive_update_name_by_id(self, module_org, module_target_sat, new_name):
+    def test_positive_update_name_by_id(self, module_org, module_target_sat):
         """Find content view by its id and update its name afterwards
 
         :id: 35fccf2c-abc4-4ca8-a565-a7a6adaaf429
@@ -159,9 +153,8 @@ class TestContentView:
         :BZ: 1359665
 
         :CaseImportance: Critical
-
-        :parametrized: yes
         """
+        new_name = random.choice(valid_names_list())
         cv = module_target_sat.cli_factory.make_content_view(
             {'name': gen_string('utf8'), 'organization-id': module_org.id}
         )
@@ -169,8 +162,7 @@ class TestContentView:
         cv = module_target_sat.cli.ContentView.info({'id': cv['id']})
         assert cv['name'] == new_name.strip()
 
-    @pytest.mark.parametrize('new_name', **parametrized(valid_names_list()))
-    def test_positive_update_name_by_name(self, module_org, module_target_sat, new_name):
+    def test_positive_update_name_by_name(self, module_org, module_target_sat):
         """Find content view by its name and update it
 
         :id: aa9bced6-ee6c-4a18-90ac-874ab4979711
@@ -180,9 +172,8 @@ class TestContentView:
         :BZ: 1359665, 1416857
 
         :CaseImportance: Critical
-
-        :parametrized: yes
         """
+        new_name = random.choice(valid_names_list())
         cv = module_target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
         module_target_sat.cli.ContentView.update(
             {'name': cv['name'], 'organization-label': module_org.label, 'new-name': new_name}

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -20,11 +20,7 @@ import pytest
 from robottelo.cli.defaults import Defaults
 from robottelo.config import settings
 from robottelo.exceptions import CLIReturnCodeError
-from robottelo.utils.datafactory import (
-    invalid_values_list,
-    parametrized,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 
 
 @pytest.fixture(scope='module')
@@ -46,10 +42,9 @@ def content_view(module_org, sync_repo, module_target_sat):
 class TestContentViewFilter:
     """Content View Filter CLI tests"""
 
-    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
     @pytest.mark.parametrize('filter_content_type', ['rpm', 'package_group', 'erratum', 'modulemd'])
     def test_positive_create_with_name_by_cv_id(
-        self, name, filter_content_type, module_org, content_view, module_target_sat
+        self, filter_content_type, module_org, content_view, module_target_sat
     ):
         """Create new content view filter and assign it to existing content
         view by id. Use different value types as a name and random filter
@@ -64,6 +59,7 @@ class TestContentViewFilter:
 
         :CaseImportance: Critical
         """
+        name = random.choice(list(valid_data_list().values()))
         module_target_sat.cli.ContentView.filter.create(
             {
                 'content-view-id': content_view['id'],
@@ -448,20 +444,16 @@ class TestContentViewFilter:
         for repo in cvf['repositories']:
             assert repo['id'] in repos
 
-    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-    def test_negative_create_with_invalid_name(
-        self, name, module_org, content_view, module_target_sat
-    ):
+    def test_negative_create_with_invalid_name(self, module_org, content_view, module_target_sat):
         """Try to create content view filter using invalid names only
 
         :id: f3497a23-6e34-4fee-9964-f95762fc737c
-
-        :parametrized: yes
 
         :expectedresults: Content view filter is not created
 
         :CaseImportance: Low
         """
+        name = random.choice(invalid_values_list())
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.ContentView.filter.create(
                 {
@@ -556,21 +548,19 @@ class TestContentViewFilter:
                 },
             )
 
-    @pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-    def test_positive_update_name(self, new_name, module_org, content_view, module_target_sat):
+    def test_positive_update_name(self, module_org, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
         view by id. Try to update that filter using different value types as a
         name
 
         :id: 70ba8916-5898-4911-9de8-21d2e0fb3df9
 
-        :parametrized: yes
-
         :expectedresults: Content view filter updated successfully and has
             proper and expected name
 
         :CaseImportance: Critical
         """
+        new_name = random.choice(list(valid_data_list().values()))
         cvf_name = gen_string('utf8')
         cvf = module_target_sat.cli.ContentView.filter.create(
             {
@@ -735,18 +725,16 @@ class TestContentViewFilter:
         )
         assert cvf['inclusion'] == 'false'
 
-    @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-    def test_negative_update_with_name(self, new_name, content_view, module_target_sat):
+    def test_negative_update_with_name(self, content_view, module_target_sat):
         """Try to update content view filter using invalid names only
 
         :id: 6c40e452-f786-4e28-9f03-b1935b55b33a
-
-        :parametrized: yes
 
         :expectedresults: Content view filter is not updated
 
         :CaseImportance: Critical
         """
+        new_name = random.choice(invalid_values_list())
         cvf_name = gen_string('utf8')
         module_target_sat.cli.ContentView.filter.create(
             {'content-view-id': content_view['id'], 'name': cvf_name, 'type': 'rpm'}
@@ -826,20 +814,18 @@ class TestContentViewFilter:
                 }
             )
 
-    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    def test_positive_delete_by_name(self, name, module_org, content_view, module_target_sat):
+    def test_positive_delete_by_name(self, module_org, content_view, module_target_sat):
         """Create new content view filter and assign it to existing content
         view by id. Try to delete that filter using different value types as a
         name
 
         :id: a01baf17-9c3c-4923-bfe0-865a4cbc4223
 
-        :parametrized: yes
-
         :expectedresults: Content view filter deleted successfully
 
         :CaseImportance: Critical
         """
+        name = random.choice(list(valid_data_list().values()))
         module_target_sat.cli.ContentView.filter.create(
             {
                 'content-view-id': content_view['id'],

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -12,6 +12,8 @@
 
 """
 
+import random
+
 from fauxfactory import gen_alphanumeric, gen_integer, gen_string, gen_url
 import pytest
 
@@ -20,7 +22,6 @@ from robottelo.constants import FAKE_0_YUM_REPO_PACKAGES_COUNT
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.utils.datafactory import (
     invalid_values_list,
-    parametrized,
     valid_data_list,
     valid_labels_list,
 )
@@ -111,36 +112,32 @@ def test_positive_CRUD(module_org, target_sat):
         target_sat.cli.Product.info({'id': product['id'], 'organization-id': module_org.id})
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_name(name, module_org, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_name(module_org, module_target_sat):
     """Check that only valid names can be used
 
     :id: 2da26ab2-8d79-47ea-b4d2-defcd98a0649
 
-    :parametrized: yes
-
     :expectedresults: Product is not created
 
     :CaseImportance: High
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(CLIFactoryError):
         module_target_sat.cli_factory.make_product({'name': name, 'organization-id': module_org.id})
 
 
-@pytest.mark.parametrize(
-    'label', **parametrized([gen_string(e, 15) for e in ('latin1', 'utf8', 'html')])
-)
-def test_negative_create_with_label(label, module_org, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_label(module_org, module_target_sat):
     """Check that only valid labels can be used
 
     :id: 7cf970aa-48dc-425b-ae37-1e15dfab0626
-
-    :parametrized: yes
 
     :expectedresults: Product is not created
 
     :CaseImportance: High
     """
+    label = random.choice([gen_string(e, 15) for e in ('latin1', 'utf8', 'html')])
     with pytest.raises(CLIFactoryError):
         module_target_sat.cli_factory.make_product(
             {

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -13,6 +13,7 @@
 """
 
 from datetime import UTC, datetime, timedelta
+import random
 from time import sleep
 
 from fauxfactory import gen_string
@@ -23,7 +24,6 @@ from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.logging import logger
 from robottelo.utils.datafactory import (
     filtered_datapoint,
-    invalid_values_list,
     parametrized,
     valid_data_list,
 )
@@ -114,18 +114,16 @@ def validate_repo_content(sat, repo, content_types, after_sync=True):
         assert count > 0 if after_sync else count == 0
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_name(module_org, name, module_target_sat):
+def test_positive_create_with_name(module_org, module_target_sat):
     """Check if syncplan can be created with random names
 
     :id: dc0a86f7-4219-427e-92fd-29352dbdbfce
-
-    :parametrized: yes
 
     :expectedresults: Sync plan is created and has random name
 
     :CaseImportance: Critical
     """
+    name = random.choice(list(valid_data_list().values()))
     sync_plan = module_target_sat.cli_factory.sync_plan(
         {'enabled': 'false', 'name': name, 'organization-id': module_org.id}
     )
@@ -133,18 +131,16 @@ def test_positive_create_with_name(module_org, name, module_target_sat):
     assert result['name'] == name
 
 
-@pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-def test_positive_create_with_description(module_org, desc, module_target_sat):
+def test_positive_create_with_description(module_org, module_target_sat):
     """Check if syncplan can be created with random description
 
     :id: a1bbe81b-60f5-4a19-b400-a02a23fa1dfa
-
-    :parametrized: yes
 
     :expectedresults: Sync plan is created and has random description
 
     :CaseImportance: Critical
     """
+    desc = random.choice(list(valid_data_list().values()))
     new_sync_plan = module_target_sat.cli_factory.sync_plan(
         {'enabled': 'false', 'description': desc, 'organization-id': module_org.id}
     )
@@ -177,34 +173,30 @@ def test_positive_create_with_interval(module_org, test_data, module_target_sat)
     assert result['interval'] == test_data['interval']
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_name(module_org, name, module_target_sat):
+def test_negative_create_with_name(module_org, module_target_sat):
     """Check if syncplan can be created with random invalid names
 
     :id: 4c1aee35-271e-4ed8-9369-d2abfea8cfd9
-
-    :parametrized: yes
 
     :expectedresults: Sync plan is not created
 
     :CaseImportance: Critical
     """
+    name = gen_string('alpha', 300)
     with pytest.raises(CLIFactoryError, match='Could not create the sync plan:'):
         module_target_sat.cli_factory.sync_plan(
             {'enabled': 'false', 'name': name, 'organization-id': module_org.id}
         )
 
 
-@pytest.mark.parametrize('new_desc', **parametrized(valid_data_list()))
-def test_positive_update_description(module_org, new_desc, module_target_sat):
+def test_positive_update_description(module_org, module_target_sat):
     """Check if syncplan description can be updated
 
     :id: 00a279cd-1f49-4ebb-a59a-6f0b4e4cb83c
 
-    :parametrized: yes
-
     :expectedresults: Sync plan is created and description is updated
     """
+    new_desc = random.choice(list(valid_data_list().values()))
     new_sync_plan = module_target_sat.cli_factory.sync_plan(
         {'enabled': 'false', 'organization-id': module_org.id}
     )
@@ -313,19 +305,17 @@ def test_positive_create_sync_date_custom_timezone(module_org, request, target_s
     assert new_sync_plan['start-date'] == expected_date.strftime("%Y/%m/%d %H:%M:%S")
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 @pytest.mark.upgrade
-def test_positive_delete_by_id(module_org, module_target_sat, name):
+def test_positive_delete_by_id(module_org, module_target_sat):
     """Check if syncplan can be created and deleted
 
     :id: b5d97c6b-aead-422b-8d9f-4a192bbe4a3b
-
-    :parametrized: yes
 
     :expectedresults: Sync plan is created and then deleted
 
     :CaseImportance: Critical
     """
+    name = random.choice(list(valid_data_list().values()))
     new_sync_plan = module_target_sat.cli_factory.sync_plan(
         {'name': name, 'organization-id': module_org.id}
     )

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -13,18 +13,14 @@
 """
 
 from datetime import timedelta
+import random
 
-from fauxfactory import gen_choice
+from fauxfactory import gen_choice, gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.constants import REPO_TYPE, SYNC_INTERVAL, DataFile
-from robottelo.utils.datafactory import (
-    gen_string,
-    parametrized,
-    valid_cron_expressions,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import valid_cron_expressions, valid_data_list
 
 
 @pytest.fixture(scope='module')
@@ -94,17 +90,15 @@ def test_positive_end_to_end(session, module_org, module_target_sat):
         assert session.product.search(new_product_name)[0]['Name'] != new_product_name
 
 
-@pytest.mark.parametrize('product_name', **parametrized(valid_data_list('ui')))
-def test_positive_create_in_different_orgs(session, product_name, module_target_sat):
+def test_positive_create_in_different_orgs(session, module_target_sat):
     """Create Product with same name but in different organizations
 
     :id: 469fc036-a48a-4c0a-9da9-33e73f903479
 
-    :parametrized: yes
-
     :expectedresults: Product is created successfully in both
         organizations.
     """
+    product_name = random.choice(list(valid_data_list().values()))
     orgs = [module_target_sat.api.Organization().create() for _ in range(2)]
     with session:
         for org in orgs:


### PR DESCRIPTION
### Problem Statement

See: https://github.com/SatelliteQE/robottelo/pull/22543#issue-5259511166

### Solution

See: https://github.com/SatelliteQE/robottelo/pull/22543#issue-5259511166

### Related Issues

See: https://github.com/SatelliteQE/robottelo/pull/22543#issue-5259511166

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Replace broad data-driven test parameterization with randomized representative inputs to reduce the number of generated test cases.

Enhancements:
- Reduce test-suite parameterization across Foreman API, CLI, and UI tests by selecting a single random valid or invalid data point per test run.
- Mark the affected API tests as migration candidates while preserving coverage of create, update, delete, and validation scenarios.

Tests:
- Simplify affected test signatures and remove obsolete parametrization metadata while retaining representative input validation.