### PR TITLE
Reduce Rocket parameterization

### DIFF
--- a/tests/foreman/api/test_computeprofile.py
+++ b/tests/foreman/api/test_computeprofile.py
@@ -12,20 +12,18 @@
 
 """
 
+import random
+
 import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.utils.datafactory import (
-    invalid_values_list,
-    parametrized,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 
 pytestmark = pytest.mark.foreman_installer
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_name(name, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_name(target_sat):
     """Create new Compute Profile using different names
 
     :id: 97d04911-9368-4674-92c7-1e3ff114bc18
@@ -33,15 +31,14 @@ def test_positive_create_with_name(name, target_sat):
     :expectedresults: Compute Profile is created
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    name = random.choice(list(valid_data_list().values()))
     profile = target_sat.api.ComputeProfile(name=name).create()
     assert name == profile.name
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create(name, target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create(target_sat):
     """Attempt to create Compute Profile using invalid names only
 
     :id: 2d34a1fd-70a5-4e59-b2e2-86fbfe8e31ab
@@ -49,15 +46,14 @@ def test_negative_create(name, target_sat):
     :expectedresults: Compute Profile is not created
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(HTTPError):
         target_sat.api.ComputeProfile(name=name).create()
 
 
-@pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-def test_positive_update_name(new_name, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_update_name(target_sat):
     """Update selected Compute Profile entity using proper names
 
     :id: c79193d7-2e0f-4ed9-b947-05feeddabfda
@@ -65,17 +61,16 @@ def test_positive_update_name(new_name, target_sat):
     :expectedresults: Compute Profile is updated.
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    new_name = random.choice(list(valid_data_list().values()))
     profile = target_sat.api.ComputeProfile().create()
     target_sat.api.ComputeProfile(id=profile.id, name=new_name).update(['name'])
     updated_profile = target_sat.api.ComputeProfile(id=profile.id).read()
     assert new_name == updated_profile.name
 
 
-@pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-def test_negative_update_name(new_name, target_sat):
+@pytest.mark.migration_candidate
+def test_negative_update_name(target_sat):
     """Attempt to update Compute Profile entity using invalid names only
 
     :id: 042b40d5-a78b-4e65-b5cb-5b270b800b37
@@ -83,9 +78,8 @@ def test_negative_update_name(new_name, target_sat):
     :expectedresults: Compute Profile is not updated.
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    new_name = random.choice(invalid_values_list())
     profile = target_sat.api.ComputeProfile().create()
     with pytest.raises(HTTPError):
         target_sat.api.ComputeProfile(id=profile.id, name=new_name).update(['name'])
@@ -93,8 +87,8 @@ def test_negative_update_name(new_name, target_sat):
     assert new_name != updated_profile.name
 
 
-@pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-def test_positive_delete(new_name, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_delete(target_sat):
     """Delete Compute Profile entity
 
     :id: 0a620e23-7ba6-4178-af7a-fd1e332f478f
@@ -102,9 +96,8 @@ def test_positive_delete(new_name, target_sat):
     :expectedresults: Compute Profile is deleted successfully.
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    new_name = random.choice(list(valid_data_list().values()))
     profile = target_sat.api.ComputeProfile(name=new_name).create()
     profile.delete()
     with pytest.raises(HTTPError):

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -16,6 +16,8 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 """
 
+import random
+
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError
@@ -24,11 +26,7 @@ from wait_for import wait_for
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.hosts import ContentHost
-from robottelo.utils.datafactory import (
-    invalid_values_list,
-    parametrized,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 
 pytestmark = [pytest.mark.skip_if_not_set('libvirt'), pytest.mark.foreman_installer]
 
@@ -93,9 +91,8 @@ def test_positive_crud_libvirt_cr(module_target_sat, module_org, module_location
     )
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 def test_positive_create_with_name_description(
-    name, request, module_target_sat, module_org, module_location, libvirt
+    request, module_target_sat, module_org, module_location, libvirt
 ):
     """Create compute resources with different names and descriptions
 
@@ -104,9 +101,8 @@ def test_positive_create_with_name_description(
     :expectedresults: Compute resources are created with expected names and descriptions
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    name = random.choice(list(valid_data_list().values()))
     compresource = module_target_sat.api.LibvirtComputeResource(
         name=name,
         description=name,
@@ -139,10 +135,7 @@ def test_positive_create_with_orgs_and_locs(request, module_target_sat, libvirt)
     assert {loc.name for loc in locs} == {loc.read().name for loc in compresource.location}
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_invalid_name(
-    name, module_target_sat, module_org, module_location, libvirt
-):
+def test_negative_create_with_invalid_name(module_target_sat, module_org, module_location, libvirt):
     """Attempt to create compute resources with invalid names
 
     :id: f73bf838-3ffd-46d3-869c-81b334b47b13
@@ -150,9 +143,8 @@ def test_negative_create_with_invalid_name(
     :expectedresults: Compute resources are not created
 
     :CaseImportance: High
-
-    :parametrized: yes
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(HTTPError):
         module_target_sat.api.LibvirtComputeResource(
             name=name,
@@ -188,8 +180,8 @@ def test_negative_create_with_same_name(
         ).create()
 
 
-@pytest.mark.parametrize('url', **parametrized({'random': gen_string('alpha'), 'empty': ''}))
-def test_negative_create_with_url(module_target_sat, module_org, module_location, url):
+@pytest.mark.migration_candidate
+def test_negative_create_with_url(module_target_sat, module_org, module_location):
     """Attempt to create compute resources with invalid url
 
     :id: 37e9bf39-382e-4f02-af54-d3a17e285c2a
@@ -197,18 +189,17 @@ def test_negative_create_with_url(module_target_sat, module_org, module_location
     :expectedresults: Compute resources are not created
 
     :CaseImportance: High
-
-    :parametrized: yes
     """
+    url = random.choice([gen_string('alpha'), ''])
     with pytest.raises(HTTPError):
         module_target_sat.api.LibvirtComputeResource(
             location=[module_location], organization=[module_org], url=url
         ).create()
 
 
-@pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
+@pytest.mark.migration_candidate
 def test_negative_update_invalid_name(
-    request, module_target_sat, module_org, module_location, new_name, libvirt
+    request, module_target_sat, module_org, module_location, libvirt
 ):
     """Attempt to update compute resource with invalid names
 
@@ -217,9 +208,8 @@ def test_negative_update_invalid_name(
     :expectedresults: Compute resource is not updated
 
     :CaseImportance: High
-
-    :parametrized: yes
     """
+    new_name = random.choice(invalid_values_list())
     name = gen_string('alphanumeric')
     compresource = module_target_sat.api.LibvirtComputeResource(
         location=[module_location], name=name, organization=[module_org], url=libvirt.url
@@ -231,6 +221,7 @@ def test_negative_update_invalid_name(
     assert compresource.read().name == name
 
 
+@pytest.mark.migration_candidate
 def test_negative_update_same_name(
     request, module_target_sat, module_org, module_location, libvirt
 ):
@@ -257,8 +248,8 @@ def test_negative_update_same_name(
     assert new_compresource.read().name != name
 
 
-@pytest.mark.parametrize('url', **parametrized({'random': gen_string('alpha'), 'empty': ''}))
-def test_negative_update_url(url, request, module_target_sat, module_org, module_location, libvirt):
+@pytest.mark.migration_candidate
+def test_negative_update_url(request, module_target_sat, module_org, module_location, libvirt):
     """Attempt to update a compute resource with invalid url
 
     :id: b5256090-2ceb-4976-b54e-60d60419fe50
@@ -266,9 +257,8 @@ def test_negative_update_url(url, request, module_target_sat, module_org, module
     :expectedresults: Compute resources is not updated
 
     :CaseImportance: High
-
-    :parametrized: yes
     """
+    url = random.choice([gen_string('alpha'), ''])
     compresource = module_target_sat.api.LibvirtComputeResource(
         location=[module_location], organization=[module_org], url=libvirt.url
     ).create()

--- a/tests/foreman/api/test_computeresource_ocpv.py
+++ b/tests/foreman/api/test_computeresource_ocpv.py
@@ -10,6 +10,8 @@
 :CaseImportance: High
 """
 
+import random
+
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError
@@ -18,11 +20,7 @@ from wait_for import wait_for
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS, FOREMAN_PROVIDERS_MODEL
 from robottelo.hosts import ContentHost
-from robottelo.utils.datafactory import (
-    invalid_values_list,
-    parametrized,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 
 pytestmark = [pytest.mark.skip_if_not_set('ocpv'), pytest.mark.foreman_installer]
 
@@ -157,18 +155,17 @@ def test_positive_userdata_image_provision_end_to_end(
     assert host.build_status_label == 'Installed'
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+@pytest.mark.migration_candidate
 def test_positive_create_with_name_description(
-    name, request, module_ocpv_sat, module_org, module_location
+    request, module_ocpv_sat, module_org, module_location
 ):
     """Create compute resources with different names and descriptions
 
     :id: 1e545c56-2f53-44c1-a17e-38c83f8fe0c8
 
     :expectedresults: Compute resources are created with expected names and descriptions
-
-    :parametrized: yes
     """
+    name = random.choice(list(valid_data_list().values()))
     cr = module_ocpv_sat.api.OCPVComputeResource(
         name=name,
         description=name,
@@ -186,16 +183,15 @@ def test_positive_create_with_name_description(
     assert cr.description == name
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_invalid_name(name, module_ocpv_sat, module_org, module_location):
+@pytest.mark.migration_candidate
+def test_negative_create_with_invalid_name(module_ocpv_sat, module_org, module_location):
     """Attempt to create compute resources with invalid names
 
     :id: f73bf838-3ffd-46d3-869c-81b334b47b15
 
     :expectedresults: Compute resources are not created
-
-    :parametrized: yes
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(HTTPError):
         module_ocpv_sat.api.OCPVComputeResource(
             name=name,
@@ -210,6 +206,7 @@ def test_negative_create_with_invalid_name(name, module_ocpv_sat, module_org, mo
         ).create()
 
 
+@pytest.mark.migration_candidate
 def test_negative_create_with_same_name(
     request,
     module_ocpv_sat,
@@ -251,16 +248,15 @@ def test_negative_create_with_same_name(
         ).create()
 
 
-@pytest.mark.parametrize('hostname', **parametrized({'random': gen_string('alpha'), 'empty': ''}))
-def test_negative_create_with_hostname(module_ocpv_sat, module_org, module_location, hostname):
+@pytest.mark.migration_candidate
+def test_negative_create_with_hostname(module_ocpv_sat, module_org, module_location):
     """Attempt to create compute resources with invalid hostname
 
     :id: 37e9bf39-382e-4f02-af54-d3a17e285c2h
 
     :expectedresults: Compute resources are not created
-
-    :parametrized: yes
     """
+    hostname = random.choice([gen_string('alpha'), ''])
     with pytest.raises(HTTPError):
         module_ocpv_sat.api.OCPVComputeResource(
             organization=[module_org],
@@ -274,18 +270,15 @@ def test_negative_create_with_hostname(module_ocpv_sat, module_org, module_locat
         ).create()
 
 
-@pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-def test_negative_update_invalid_name(
-    request, module_ocpv_sat, module_org, module_location, new_name
-):
+@pytest.mark.migration_candidate
+def test_negative_update_invalid_name(request, module_ocpv_sat, module_org, module_location):
     """Attempt to update compute resource with invalid names
 
     :id: a6554c1f-e52f-4614-9fc3-2127ced31479
 
     :expectedresults: Compute resource is not updated
-
-    :parametrized: yes
     """
+    new_name = random.choice(invalid_values_list())
     name = gen_string('alphanumeric')
     cr = module_ocpv_sat.api.OCPVComputeResource(
         name=name,
@@ -305,6 +298,7 @@ def test_negative_update_invalid_name(
     assert cr.read().name == name
 
 
+@pytest.mark.migration_candidate
 def test_negative_update_same_name(request, module_ocpv_sat, module_org, module_location):
     """Attempt to update a compute resource with already existing name
 
@@ -342,16 +336,15 @@ def test_negative_update_same_name(request, module_ocpv_sat, module_org, module_
     assert new_cr.read().name != name
 
 
-@pytest.mark.parametrize('hostname', **parametrized({'random': gen_string('alpha'), 'empty': ''}))
-def test_negative_update_hostname(hostname, request, module_ocpv_sat, module_org, module_location):
+@pytest.mark.migration_candidate
+def test_negative_update_hostname(request, module_ocpv_sat, module_org, module_location):
     """Attempt to update a compute resource with invalid url
 
     :id: b5256090-2ceb-4976-b54e-60d60419fe59
 
     :expectedresults: Compute resources is not updated
-
-    :parametrized: yes
     """
+    hostname = random.choice([gen_string('alpha'), ''])
     cr = module_ocpv_sat.api.OCPVComputeResource(
         organization=[module_org],
         location=[module_location],

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -19,11 +19,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.constants import OPERATING_SYSTEMS
-from robottelo.utils.datafactory import (
-    invalid_values_list,
-    parametrized,
-    valid_data_list,
-)
+from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 
 
 class TestOperatingSystem:
@@ -169,22 +165,22 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             module_target_sat.api.OperatingSystem(id=os.id).read()
 
-    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    def test_positive_create_with_name(self, name, target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_create_with_name(self, target_sat):
         """Create operating system with valid name only
 
         :id: e95707bf-3344-4d85-866f-4642a8f66cff
-
-        :parametrized: yes
 
         :expectedresults: Operating system entity is created and has proper
             name
 
         :CaseImportance: Critical
         """
+        name = random.choice(list(valid_data_list().values()))
         os = target_sat.api.OperatingSystem(name=name).create()
         assert os.name == name
 
+    @pytest.mark.migration_candidate
     def test_positive_create_with_archs(self, target_sat):
         """Create an operating system that points at multiple different
         architectures.
@@ -201,6 +197,7 @@ class TestOperatingSystem:
         assert len(operating_sys.architecture) == len(amount)
         assert {arch.id for arch in operating_sys.architecture} == {arch.id for arch in archs}
 
+    @pytest.mark.migration_candidate
     def test_positive_create_with_ptables(self, target_sat):
         """Create an operating system that points at multiple different
         partition tables.
@@ -217,22 +214,22 @@ class TestOperatingSystem:
         assert len(operating_sys.ptable) == len(amount)
         assert {ptable.id for ptable in operating_sys.ptable} == {ptable.id for ptable in ptables}
 
-    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-    def test_negative_create_with_invalid_name(self, name, target_sat):
+    @pytest.mark.migration_candidate
+    def test_negative_create_with_invalid_name(self, target_sat):
         """Try to create operating system entity providing an invalid
         name
 
         :id: cd4286fd-7128-4385-9c8d-ef979c22ee38
 
-        :parametrized: yes
-
         :expectedresults: Operating system entity is not created
 
         :CaseImportance: Critical
         """
+        name = random.choice(invalid_values_list())
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(name=name).create()
 
+    @pytest.mark.migration_candidate
     def test_negative_create_with_invalid_os_family(self, target_sat):
         """Try to create operating system entity providing an invalid
         operating system family
@@ -246,6 +243,7 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(family='NON_EXISTENT_OS').create()
 
+    @pytest.mark.migration_candidate
     def test_negative_create_with_too_long_description(self, target_sat):
         """Try to create operating system entity providing too long
         description value
@@ -261,15 +259,13 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(description=gen_string('alphanumeric', 256)).create()
 
-    @pytest.mark.parametrize('major_version', **parametrized((gen_string('numeric', 6), '', '-6')))
-    def test_negative_create_with_invalid_major_version(self, major_version, target_sat):
+    @pytest.mark.migration_candidate
+    def test_negative_create_with_invalid_major_version(self, target_sat):
         """Try to create operating system entity providing incorrect
         major version value (More than 5 characters, empty value, negative
         number)
 
         :id: f2646bc2-d639-4079-bdcb-ff76679f1457
-
-        :parametrized: yes
 
         :expectedresults: Operating system entity is not created
 
@@ -277,25 +273,26 @@ class TestOperatingSystem:
 
         :CaseImportance: Critical
         """
+        major_version = random.choice([gen_string('numeric', 6), '', '-6'])
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(major=major_version).create()
 
-    @pytest.mark.parametrize('minor_version', **parametrized((gen_string('numeric', 17), '-5')))
-    def test_negative_create_with_invalid_minor_version(self, minor_version, target_sat):
+    @pytest.mark.migration_candidate
+    def test_negative_create_with_invalid_minor_version(self, target_sat):
         """Try to create operating system entity providing incorrect
-        minor version value (More than 16 characters and negative number)
+        minor version value (More than 16 characters or negative number)
 
         :id: dec4b456-153c-4a66-8b8e-b12ac7800e51
-
-        :parametrized: yes
 
         :expectedresults: Operating system entity is not created
 
         :CaseImportance: Critical
         """
+        minor_version = random.choice([gen_string('numeric', 17), '-5'])
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(minor=minor_version).create()
 
+    @pytest.mark.migration_candidate
     def test_negative_create_with_invalid_password_hash(self, target_sat):
         """Try to create operating system entity providing invalid
         password hash value
@@ -309,6 +306,7 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(password_hash='INVALID_HASH').create()
 
+    @pytest.mark.migration_candidate
     def test_negative_create_with_same_name_and_version(self, target_sat):
         """Create operating system providing valid name and major
         version. Then try to create operating system using the same name and
@@ -345,23 +343,23 @@ class TestOperatingSystem:
         assert len(os.medium) == len(amount)
         assert {medium.id for medium in os.medium} == {medium.id for medium in media}
 
-    @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-    def test_negative_update_name(self, new_name, target_sat):
+    @pytest.mark.migration_candidate
+    def test_negative_update_name(self, target_sat):
         """Create operating system entity providing the initial name,
         then update its name to invalid one.
 
         :id: 3ba55d6e-99cb-4878-b41b-a59476d1db58
 
-        :parametrized: yes
-
         :expectedresults: Operating system entity is not updated
 
         :CaseImportance: Critical
         """
+        new_name = random.choice(invalid_values_list())
         os = target_sat.api.OperatingSystem().create()
         with pytest.raises(HTTPError):
             os = target_sat.api.OperatingSystem(id=os.id, name=new_name).update(['name'])
 
+    @pytest.mark.migration_candidate
     def test_negative_update_major_version(self, target_sat):
         """Create operating entity providing the initial major version,
         then update that version to invalid one.
@@ -378,6 +376,7 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(id=os.id, major='-20').update(['major'])
 
+    @pytest.mark.migration_candidate
     def test_negative_update_minor_version(self, target_sat):
         """Create operating entity providing the initial minor version,
         then update that version to invalid one.
@@ -392,6 +391,7 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(id=os.id, minor='INVALID_VERSION').update(['minor'])
 
+    @pytest.mark.migration_candidate
     def test_negative_update_os_family(self, target_sat):
         """Create operating entity providing the initial os family, then
         update that family to invalid one.

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -17,19 +17,17 @@ http://theforeman.org/api/apidoc/v2/1.15.html
 
 """
 
+import random
 import re
 
+from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.utils.datafactory import (
-    gen_string,
-    generate_strings_list,
-    invalid_values_list,
-    parametrized,
-)
+from robottelo.utils.datafactory import generate_strings_list, invalid_values_list
 
 
+@pytest.mark.migration_candidate
 def test_positive_create_with_parameter(target_sat):
     """Subnet can be created along with parameters
 
@@ -46,13 +44,11 @@ def test_positive_create_with_parameter(target_sat):
     assert subnet.subnet_parameters_attributes[0]['value'] == parameter[0]['value']
 
 
-@pytest.mark.parametrize('name', **parametrized(generate_strings_list()))
-def test_positive_add_parameter(name, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_add_parameter(target_sat):
     """Parameters can be created in subnet
 
     :id: c1dae6f4-45b1-45db-8529-d7918e41a99b
-
-    :parametrized: yes
 
     :steps:
 
@@ -63,6 +59,7 @@ def test_positive_add_parameter(name, target_sat):
 
     :CaseImportance: Medium
     """
+    name = random.choice(generate_strings_list())
     subnet = target_sat.api.Subnet().create()
     value = gen_string('utf8')
     subnet_param = target_sat.api.Parameter(subnet=subnet.id, name=name, value=value).create()
@@ -70,6 +67,7 @@ def test_positive_add_parameter(name, target_sat):
     assert subnet_param.value == value
 
 
+@pytest.mark.migration_candidate
 def test_positive_add_parameter_with_values_and_separator(target_sat):
     """Subnet parameters can be created with values separated by comma
 
@@ -94,15 +92,11 @@ def test_positive_add_parameter_with_values_and_separator(target_sat):
     assert subnet_param.value == values
 
 
-@pytest.mark.parametrize(
-    'separator', **parametrized({'comma': ',', 'slash': '/', 'dash': '-', 'pipe': '|'})
-)
-def test_positive_create_with_parameter_and_valid_separator(separator, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_parameter_and_valid_separator(target_sat):
     """Subnet parameters can be created with name with valid separators
 
     :id: d1e2d75a-a1e8-4767-93f1-0bb1b75e10a0
-
-    :parametrized: yes
 
     :steps:
         1. Create Subnet with all the details
@@ -114,6 +108,7 @@ def test_positive_create_with_parameter_and_valid_separator(separator, target_sa
 
     :CaseImportance: Low
     """
+    separator = random.choice([',', '/', '-', '|'])
     name = f'{separator}'.join(generate_strings_list())
     subnet = target_sat.api.Subnet().create()
     value = gen_string('utf8')
@@ -122,14 +117,12 @@ def test_positive_create_with_parameter_and_valid_separator(separator, target_sa
     assert subnet_param.value == value
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list() + ['name with space']))
-def test_negative_create_with_parameter_and_invalid_separator(name, target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_parameter_and_invalid_separator(target_sat):
     """Subnet parameters can not be created with name with invalid
     separators
 
     :id: 08d10b75-a0db-4a11-a915-965a2a207d16
-
-    :parametrized: yes
 
     :steps:
 
@@ -145,11 +138,13 @@ def test_negative_create_with_parameter_and_invalid_separator(name, target_sat):
 
     :CaseImportance: Low
     """
+    name = random.choice(invalid_values_list() + ['name with space'])
     subnet = target_sat.api.Subnet().create()
     with pytest.raises(HTTPError):
         target_sat.api.Parameter(name=name, subnet=subnet.id).create()
 
 
+@pytest.mark.migration_candidate
 def test_negative_create_with_duplicated_parameters(target_sat):
     """Attempt to create multiple parameters with same key name for the
     same subnet
@@ -272,6 +267,7 @@ def test_positive_subnet_parameters_override_impact_on_subnet(target_sat):
     assert org_subnet.read().subnet_parameters_attributes[0]['value'] == parameter[0]['value']
 
 
+@pytest.mark.migration_candidate
 def test_positive_update_parameter(target_sat):
     """Subnet parameter can be updated
 
@@ -296,13 +292,11 @@ def test_positive_update_parameter(target_sat):
     assert up_subnet.subnet_parameters_attributes[0]['value'] == update_parameter[0]['value']
 
 
-@pytest.mark.parametrize('new_name', **parametrized(invalid_values_list() + ['name with space']))
-def test_negative_update_parameter(new_name, target_sat):
+@pytest.mark.migration_candidate
+def test_negative_update_parameter(target_sat):
     """Subnet parameter can not be updated with invalid names
 
     :id: fcdbad13-ad96-4152-8e20-e023d61a2853
-
-    :parametrized: yes
 
     :steps:
 
@@ -317,6 +311,7 @@ def test_negative_update_parameter(new_name, target_sat):
 
     :CaseImportance: Medium
     """
+    new_name = random.choice(invalid_values_list() + ['name with space'])
     subnet = target_sat.api.Subnet().create()
     sub_param = target_sat.api.Parameter(
         name=gen_string('utf8'), subnet=subnet.id, value=gen_string('utf8')
@@ -435,6 +430,7 @@ def test_positive_delete_subnet_overridden_parameter_host_impact():
     """
 
 
+@pytest.mark.migration_candidate
 def test_positive_list_parameters(target_sat):
     """Satellite lists all the subnet parameters
 

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -12,23 +12,14 @@
 
 """
 
+import random
+
 from fauxfactory import gen_alphanumeric, gen_string
 import pytest
 
 from robottelo.constants import DEFAULT_ORG
 from robottelo.exceptions import CLIReturnCodeError
-from robottelo.utils.datafactory import (
-    filtered_datapoint,
-    invalid_values_list,
-    parametrized,
-    valid_data_list,
-)
-
-
-@filtered_datapoint
-def negative_delete_data():
-    """Returns a list of invalid data for operating system deletion"""
-    return [{'id': gen_string("alpha")}, {'id': None}, {'id': ""}, {}, {'id': -1}]
+from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 
 
 class TestOperatingSystem:
@@ -140,43 +131,35 @@ class TestOperatingSystem:
         with pytest.raises(CLIReturnCodeError):
             target_sat.cli.OperatingSys.info({'id': os['id']})
 
-    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-    def test_positive_create_with_name(self, name, target_sat):
+    def test_positive_create_with_name(self, target_sat):
         """Create Operating System for all variations of name
 
         :id: d36eba9b-ccf6-4c9d-a07f-c74eebada89b
-
-        :parametrized: yes
 
         :expectedresults: Operating System is created and can be found
 
         :CaseImportance: Critical
         """
+        name = random.choice(list(valid_data_list().values()))
         os = target_sat.cli_factory.make_os({'name': name})
         assert os['name'] == name
 
-    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-    def test_negative_create_with_name(self, name, target_sat):
+    def test_negative_create_with_name(self, target_sat):
         """Create Operating System using invalid names
 
         :id: 848a20ce-292a-47d8-beea-da5916c43f11
-
-        :parametrized: yes
 
         :expectedresults: Operating System is not created
 
         :CaseImportance: Critical
         """
         with pytest.raises(CLIReturnCodeError):
-            target_sat.cli.OperatingSys.create({'name': name})
+            target_sat.cli.OperatingSys.create({'name': random.choice(invalid_values_list())})
 
-    @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-    def test_negative_update_name(self, new_name, target_sat):
+    def test_negative_update_name(self, target_sat):
         """Negative update of system name
 
         :id: 4b18ff6d-7728-4245-a1ce-38e62c05f454
-
-        :parametrized: yes
 
         :expectedresults: Operating System name is not updated
 
@@ -184,22 +167,24 @@ class TestOperatingSystem:
         """
         os = target_sat.cli_factory.make_os({'name': gen_alphanumeric()})
         with pytest.raises(CLIReturnCodeError):
-            target_sat.cli.OperatingSys.update({'id': os['id'], 'name': new_name})
+            target_sat.cli.OperatingSys.update(
+                {'id': os['id'], 'name': random.choice(invalid_values_list())}
+            )
         result = target_sat.cli.OperatingSys.info({'id': os['id']})
         assert result['name'] == os['name']
 
-    @pytest.mark.parametrize('test_data', **parametrized(negative_delete_data()))
-    def test_negative_delete_by_id(self, test_data, target_sat):
+    def test_negative_delete_by_id(self, target_sat):
         """Delete Operating System using invalid data
 
         :id: d29a9c95-1fe3-4a7a-9f7b-127be065856d
-
-        :parametrized: yes
 
         :expectedresults: Operating System is not deleted
 
         :CaseImportance: Critical
         """
+        test_data = random.choice(
+            [{'id': gen_string('alpha')}, {'id': None}, {'id': ''}, {}, {'id': -1}]
+        )
         os = target_sat.cli_factory.make_os()
         # The delete method requires the ID which we will not pass
         with pytest.raises(CLIReturnCodeError):


### PR DESCRIPTION
### Problem Statement

See: https://github.com/SatelliteQE/robottelo/pull/22543#issue-5259511166

### Solution

See: https://github.com/SatelliteQE/robottelo/pull/22543#issue-5259511166

### Related Issues

See: https://github.com/SatelliteQE/robottelo/pull/22543#issue-5259511166

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Reduce Rocket test parameterization by replacing expanded input matrices with runtime-selected representative values and identifying migration candidates.

Enhancements:
- Reduce test-suite parameterization by selecting a single representative valid or invalid input at runtime across Compute Profile, Compute Resource, Operating System, Subnet, and CLI tests.
- Mark the affected API tests as migration candidates and simplify their datafactory imports and test metadata.

Tests:
- Update affected tests to retain coverage of representative input variations while running each test case only once.