### PR TITLE
[6.20.z] Skip puppet related tests until it is implemented in foremanctl

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -77,7 +77,6 @@ from robottelo.logging import logger
 from robottelo.utils import validate_ssh_pub_key
 from robottelo.utils.datafactory import valid_emails_list
 from robottelo.utils.installer import InstallerCommand
-from robottelo.utils.issue_handlers import is_open
 
 POWER_OPERATIONS = {
     VmState.RUNNING: 'running',

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -312,6 +312,8 @@ def test_positive_create_and_update_with_puppet_proxy(
 
     :expectedresults: Both hosts are associated with expected puppet proxy assigned
 
+    :BlockedBy: SAT-40445
+
     :CaseImportance: Critical
     """
     # TODO Define the default capsule/SP port + URL on hosts.Capsule
@@ -332,6 +334,8 @@ def test_positive_create_with_puppet_ca_proxy(
     :id: 1b73dd35-c2e8-44bd-b8f8-9e51428a6239
 
     :expectedresults: Both hosts are associated with expected puppet CA proxy assigned
+
+    :BlockedBy: SAT-40445
 
     :CaseImportance: Critical
     """
@@ -358,6 +362,8 @@ def test_positive_end_to_end_with_puppet_class(
     with same associated puppet classes
 
     :id: 2690d6b0-441b-44c5-b7d2-4093616e037e
+
+    :BlockedBy: SAT-40445
 
     :BZ: 2046573
 
@@ -904,6 +910,8 @@ def test_positive_create_and_update_env(
     :id: 87a08dbf-fd4c-4b6c-bf73-98ab70756fc6
 
     :expectedresults: A host is created and updated with expected environment
+
+    :BlockedBy: SAT-40445
     """
     host = session_puppet_enabled_sat.api.Host(
         organization=module_puppet_org,
@@ -1139,6 +1147,8 @@ def test_positive_read_enc_information(
 
     :expectedresults: host ENC information read successfully
 
+    :BlockedBy: SAT-40445
+
     :BZ: 1362372
     """
     lce = (
@@ -1357,6 +1367,8 @@ def test_positive_read_puppet_proxy_name(session_puppet_enabled_sat, session_pup
 
     :expectedresults: Field 'puppet_proxy_name' is returned
 
+    :BlockedBy: SAT-40445
+
     :BZ: 1371900
 
     :CaseImportance: Critical
@@ -1379,6 +1391,8 @@ def test_positive_read_puppet_ca_proxy_name(
     :id: 8941395f-8040-4705-a981-5da21c47efd1
 
     :expectedresults: Field 'puppet_ca_proxy_name' is returned
+
+    :BlockedBy: SAT-40445
 
     :BZ: 1371900
 

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -57,6 +57,8 @@ class TestHostGroup:
         :expectedresults: Host inherited 'all_puppetclasses' details from
             HostGroup that was used for such Host create procedure
 
+        :BlockedBy: SAT-40445
+
         :BZ: 1107708, 1222118, 1487586
 
         """
@@ -240,6 +242,8 @@ class TestHostGroup:
 
         :expectedresults: A hostgroup is created with expected properties,
             updated and deleted
+
+        :BlockedBy: SAT-40445
 
         :CaseImportance: High
         """
@@ -462,6 +466,8 @@ class TestHostGroup:
 
         :expectedresults: A hostgroup is updated with expected puppet CA proxy
 
+        :BlockedBy: SAT-40445
+
         :CaseImportance: Medium
 
         """
@@ -508,6 +514,8 @@ class TestHostGroup:
         """Update a hostgroup with a new puppet proxy
 
         :id: 86eca603-2cdd-4563-b6f6-aaa5cea1a723
+
+        :BlockedBy: SAT-40445
 
         :CaseImportance: Medium
 
@@ -829,6 +837,8 @@ class TestHostGroupMissingAttr:
 
         :id: f93d0866-0073-4577-8777-6d645b63264f
 
+        :BlockedBy: SAT-40445
+
         :CaseImportance: Medium
 
         :expectedresults: Field 'puppet_proxy_name' is returned
@@ -848,6 +858,8 @@ class TestHostGroupMissingAttr:
         response
 
         :id: ab151e09-8e64-4377-95e8-584629750659
+
+        :BlockedBy: SAT-40445
 
         :CaseImportance: Medium
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2197,6 +2197,8 @@ def test_positive_host_with_puppet(
 
     :expectedresults: puppet environment
 
+    :BlockedBy: SAT-40445
+
     :CaseImportance: Critical
     """
     update_smart_proxy(session_puppet_enabled_sat, module_puppet_loc, session_puppet_enabled_proxy)
@@ -2278,6 +2280,8 @@ def test_positive_list_scparams(
 
     :expectedresults: Overridden sc-param from puppet
         class are listed
+
+    :BlockedBy: SAT-40445
     """
     update_smart_proxy(session_puppet_enabled_sat, module_puppet_loc, session_puppet_enabled_proxy)
     # Create hostgroup with associated puppet class
@@ -2328,6 +2332,8 @@ def test_positive_create_with_puppet_class_name(
 
     :expectedresults: Host is created and has puppet class assigned
 
+    :BlockedBy: SAT-40445
+
     :CaseImportance: Critical
     """
     update_smart_proxy(session_puppet_enabled_sat, module_puppet_loc, session_puppet_enabled_proxy)
@@ -2368,6 +2374,8 @@ def test_positive_update_host_owner_and_verify_puppet_class_name(
 
     :expectedresults: Host is updated with new owner
         and puppet class is still assigned and shown
+
+    :BlockedBy: SAT-40445
 
     :CaseImportance: Medium
 

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -107,6 +107,8 @@ def test_positive_create_with_multiple_entities_and_delete(
     :expectedresults: Hostgroup should be created, has all defined
         entities assigned and deleted
 
+    :BlockedBy: SAT-40445
+
     :BZ: 1395254, 1313056
 
     :CaseImportance: Critical
@@ -230,6 +232,8 @@ def test_positive_update_hostgroup_with_puppet(
     :id: c22218a1-4d86-4ac1-ad4b-79b10c9adcde
 
     :customerscenario: true
+
+    :BlockedBy: SAT-40445
 
     :BZ: 1260697, 1313056
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1815,6 +1815,8 @@ def test_positive_create_with_puppet_class(
     :id: d883f169-1105-435c-8422-a7160055734a
 
     :expectedresults: Host is created and contains correct puppet class
+
+    :BlockedBy: SAT-40445
     """
 
     host_template = session_puppet_enabled_sat.api.Host(
@@ -1871,6 +1873,8 @@ def test_positive_inherit_puppet_env_from_host_group_when_create(
 
     :expectedresults: Expected puppet environment is inherited to the form
 
+    :BlockedBy: SAT-40445
+
     :BZ: 1414914
     """
 
@@ -1915,6 +1919,8 @@ def test_positive_set_multi_line_and_with_spaces_parameter_value(
     :id: d72b481d-2279-4478-ab2d-128f92c76d9c
 
     :customerscenario: true
+
+    :BlockedBy: SAT-40445
 
     :expectedresults:
         1. parameter is correctly represented in yaml format without

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -102,6 +102,8 @@ def test_create_with_config_group(module_puppet_org, module_puppet_loc, session_
 
     :CaseImportance: Medium
 
+    :BlockedBy: SAT-40445
+
     :expectedresults: Host group created and contains proper config group
     """
     name = gen_string('alpha')
@@ -132,6 +134,8 @@ def test_create_with_puppet_class(module_puppet_org, module_puppet_loc, session_
     :id: 166ca6a6-c0f7-4fa0-a3f2-b0d6980cf50d
 
     :CaseImportance: Medium
+
+    :BlockedBy: SAT-40445
 
     :expectedresults: Host group created and contains proper puppet class
     """


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22631

### Problem Statement
All 24 puppet-dependent tests in `HostGroup` and `Hosts` components fail on foremanctl Satellite runs.
The root cause is `enable_puppet_satellite()` which runs `satellite-installer --enable-puppet` - a command that doesn't exist on foremanctl systems.
Puppet/OpenVox integration in foremanctl is tracked by [SAT-40445](https://issues.redhat.com/browse/SAT-40445) (status: New, not started).

### Solution
Added `:BlockedBy: SAT-40445` docstring to all 24 affected puppet tests across 6 files.

Affected files:
- `tests/foreman/api/test_host.py` - 7 tests
- `tests/foreman/api/test_hostgroup.py` - 6 tests
- `tests/foreman/cli/test_host.py` - 4 tests
- `tests/foreman/cli/test_hostgroup.py` - 2 tests
- `tests/foreman/ui/test_host.py` - 3 tests
- `tests/foreman/ui/test_hostgroup.py` - 2 tests

## Summary by Sourcery

Tests:
- Mark 24 Puppet-dependent Host and HostGroup tests across API, CLI, and UI suites as blocked by SAT-40445 until Puppet/OpenVox support is implemented in foremanctl.