### PR TITLE
Update content source Hosts tests for foremanctl

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1072,7 +1072,7 @@ def test_positive_read_content_source_id(
 
     :BZ: 1339613, 1488130
     """
-    proxy = target_sat.api.SmartProxy().search(query={'url': f'{target_sat.url}:9090'})[0].read()
+    proxy = target_sat.get_default_smart_proxy().read()
     module_published_cv.version[0].promote(data={'environment_ids': module_lce.id, 'force': False})
     host = target_sat.api.Host(
         organization=module_org,
@@ -1106,7 +1106,7 @@ def test_positive_update_content_source_id(
 
     :BZ: 1339613, 1488130
     """
-    proxy = target_sat.api.SmartProxy().search(query={'url': f'{target_sat.url}:9090'})[0]
+    proxy = target_sat.get_default_smart_proxy()
     module_published_cv.version[0].promote(data={'environment_ids': module_lce.id, 'force': False})
     host = target_sat.api.Host(
         organization=module_org,

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2443,7 +2443,8 @@ def test_positive_create_and_update_with_content_source(
 
     host = target_sat.cli.Host.info({'name': rhel_contenthost.hostname})
     assert (
-        host['content-information']['content-source']['name'] == target_sat.hostname
+        host['content-information']['content-source']['name']
+        == target_sat.get_default_smart_proxy().name
         or host['content-information']['content-source']['name'] == ''
     )
 


### PR DESCRIPTION
### Problem Statement
Several host tests fail on foremanctl Satellite deployments due to assumptions that only hold for installer-based Satellite:
- Content source proxy lookup hardcodes hostname or :9090 URL, but containerized Satellite splits the content proxy into a separate <hostname>-pulp smart proxy.

### Solution
Use `target_sat.get_default_smart_proxy()` (which searches by feature=Pulpcore) instead of hardcoding the proxy hostname or URL.

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_host.py::test_positive_read_content_source_id tests/foreman/api/test_host.py::test_positive_update_content_source_id tests/foreman/cli/test_host.py::test_positive_create_and_update_with_content_source
deployment_type: container
```

## Summary by Sourcery

Make host content-source tests work across installer-based and containerized Satellite deployments.

Bug Fixes:
- Update host content-source tests to resolve the Pulpcore smart proxy dynamically, fixing assumptions that fail on containerized Satellite deployments.

Tests:
- Adapt API and CLI host tests to validate content sources against the default smart proxy.