### PR TITLE
[6.20.z] Fix more HostGroup tests for foremanctl

### DIFF
--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -64,6 +64,7 @@ def test_positive_end_to_end(session, module_org, module_location, module_target
         assert not module_target_sat.api.HostGroup().search(query={'search': f'name={new_name}'})
 
 
+@pytest.mark.foreman_installer
 def test_negative_delete_with_discovery_rule(
     session, module_org, module_location, module_target_sat
 ):
@@ -197,7 +198,9 @@ def test_positive_create_new_host(
     """
     name = gen_string('alpha')
     description = gen_string('alpha')
-    capsule = target_sat.nailgun_smart_proxy
+    capsule = target_sat.api.SmartProxy().search(
+        query={'search': f'feature = "Pulpcore" and url ~ {target_sat.hostname}'}
+    )[0]
     capsule.location = [smart_proxy_location]
     capsule.update(['location'])
     capsule.organization = [module_org]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22658

### Problem Statement
Two HostGroup tests fail on foremanctl Satellite deployments:
1. `test_negative_delete_with_discovery_rule` — creates a DiscoveryRule via API, but the Discovery plugin is not available on foremanctl (404 Not Found on /api/v2/discovery_rules).
All dedicated discovery test modules already have `pytestmark = pytest.mark.foreman_installer `but this test was missed because it lives in `test_hostgroup.py`.
2. `test_positive_create_new_host` — uses `target_sat.nailgun_smart_proxy` to find the content source, which searches by name={hostname}.
On foremanctl, the content source proxy is <hostname>-pulp, not <hostname>, so the test selects the wrong proxy and the UI can't find it in the content source dropdown.

### Solution
1. Added `@pytest.mark.foreman_installer` to `test_negative_delete_with_discovery_rule` to deselect it on foremanctl, matching the pattern used by all other discovery tests.
2. Replaced `target_sat.nailgun_smart_proxy with SmartProxy().search(feature = "Pulpcore" and url ~ hostname)` in `test_positive_create_new_host`.
This returns the correct content source proxy on both installer-based and foremanctl deployments.


### PRT test Cases example
<img width="238" height="46" alt="image" src="https://github.com/user-attachments/assets/f7e71574-36c8-4f37-95af-128eecc239a4" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostgroup.py::test_positive_create_new_host
deployment_type: container
```

## Summary by Sourcery

Make HostGroup UI tests compatible with foremanctl deployments.

Bug Fixes:
- Prevent HostGroup tests from failing on foremanctl deployments by excluding the discovery-rule test where the Discovery plugin is unavailable.
- Select the correct Pulpcore content source proxy when creating a host across installer-based and foremanctl deployments.