### PR TITLE
Add helper to configure stage registry override for foremanctl deploy

### DIFF
--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -120,6 +120,20 @@ class VersionedContent:
         product, release, v_major, repo = self._dogfood_helper(product, release, repo)
         return dogfood_repository(settings.ohsnap, repo, product, release, v_major, snap, self.arch)
 
+    def configure_stage_registry_override(self):
+        """Configure Podman to pull stage container images from the production registry.
+
+        Runs the Ohsnap-hosted ``configure-stage-registry.sh`` script, which overrides the
+        stage registry names with the production ones in
+        ``/etc/containers/registries.conf.d/stage-registry.conf`` so that stage images can
+        be pulled despite the ``registry.redhat.io`` signature policy.
+        """
+        url = f'{settings.ohsnap.host}/assets/scripts/configure-stage-registry.sh'
+        logger.info(f'Configuring stage registry override using Ohsnap script: {url}')
+        result = self.execute(f'set -o pipefail; curl -fsSL {url} | bash')
+        assert result.status == 0, f'Failed to configure stage registry:\n{result.stderr}'
+        return result
+
     def create_custom_html_repo(self, rpm_url, repo_name=None, update=False, remove_rpm=None):
         """Creates a custom yum repository, that will be published on https
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2256,6 +2256,10 @@ class Capsule(ContentHost, CapsuleMixins):
             assert auth_result.status == 0, (
                 f'Container registry authentication failed:\n{auth_result.stderr}'
             )
+            # When authenticating to the stage registry, configure Podman to pull the
+            # stage images from the production registry so foremanctl deploy/pull uses stage images.
+            if registry_url == 'registry.stage.redhat.io':
+                self.configure_stage_registry_override()
         else:
             logger.warning(
                 'Container registry credentials not configured. '


### PR DESCRIPTION
### Problem Statement
foremanctl container deploys pull stage images through registry.redhat.io, but Podman rejects them with "A signature was required, but no signature exists" because stage images aren't signed under the production signature policy

### Solution
Add a configure_stage_registry_override() helper that runs Ohsnap's configure-stage-registry.sh to remap/redirect the stage registry to production and relax the signature policy, called from install_satellite_foremanctl() after authenticating to the stage registry

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Configure stage registry overrides during foremanctl installation so stage container images can be deployed successfully.

New Features:
- Add a helper to configure Podman stage registry overrides for container image pulls.

Bug Fixes:
- Fix stage image deployment failures caused by production signature policy enforcement.