### PR TITLE
Fix nailgun_capsule lookup for both containerized installs

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1706,7 +1706,13 @@ class Capsule(ContentHost, CapsuleMixins):
 
     @property
     def nailgun_capsule(self):
-        return self.satellite.api.Capsule().search(query={'search': f'name={self.hostname}'})[0]
+        # Containerized installs expose a dedicated content (pulp) capsule named
+        # '<hostname>-pulp', while traditional rpm installs use just '<hostname>'.
+        # Prefer the content capsule when present, otherwise fall back to the plain one.
+        for name in (f'{self.hostname}-pulp', self.hostname):
+            if results := self.satellite.api.Capsule().search(query={'search': f'name={name}'}):
+                return results[0]
+        raise ContentHostError(f'No Capsule found matching hostname {self.hostname}')
 
     @property
     def nailgun_smart_proxy(self):


### PR DESCRIPTION
### Problem Statement
Containerized installs expose the content capsule as '<hostname>-pulp', while rpm installs use plain '<hostname>'. 


### Solution
Prefer the pulp capsule when present and fall back to the plain one, raising a clear ContentHostError instead of an IndexError when neither exists.


### Related Issues
No issues


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k test_positive_on_demand_sync
```

## Summary by Sourcery

Fix nailgun capsule lookup across containerized and RPM installations.

Bug Fixes:
- Resolve the appropriate content capsule for both containerized and RPM installations, preferring the pulp capsule and falling back to the hostname capsule.
- Raise a clear ContentHostError when no matching capsule exists instead of exposing an IndexError.