### PR TITLE
[6.20.z] Update make_proxy() for foremanctl

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -29,6 +29,7 @@ from fauxfactory import (
 from robottelo import constants
 from robottelo.cli.proxy import CapsuleTunnelError
 from robottelo.config import settings
+from robottelo.enums import InstallMethod
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.host_helpers.repository_mixins import initiate_repo_helpers
 
@@ -501,8 +502,11 @@ class CLIFactory:
 
         if options is None or 'url' not in options:
             newport = self._satellite.available_capsule_port
+            proxy_port = (
+                8443 if self._satellite.install_method == InstallMethod.FOREMANCTL else 9090
+            )
             try:
-                with self._satellite.default_url_on_new_port(9090, newport) as url:
+                with self._satellite.default_url_on_new_port(proxy_port, newport) as url:
                     args['url'] = url
                     return create_object(self._satellite.cli.Proxy, args, options)
             except CapsuleTunnelError as err:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22659

### Problem Statement
`make_proxy()` fails on foremanctl Satellite deployments with `SSL_connect certificate verify failed (unable to get local issuer certificate).`

The method creates fake proxies by tunneling via ncat to port 9090, which on installer-based Satellite is the foreman-proxy.
On foremanctl, port 9090 is Cockpit (web console), not foreman-proxy.
Cockpit has its own self-signed certificate that Satellite doesn't trust, causing the SSL verification failure.

The foreman-proxy on foremanctl runs in a container on port 8443 (with network: host), using certificates signed by Foreman's own CA.

Verified directly on the live foremanctl instance — port 9090 responds with a Cockpit cert, while port 8443 responds with the proper proxy cert.

### Solution
Updated `make_proxy()` in `robottelo/host_helpers/cli_factory.py` to detect the install method and tunnel to the correct port:
- installer: port 9090 (foreman-proxy, unchanged)
- foremanctl: port 8443 (foreman-proxy container)

This directly fixes the failure of `test_positive_update_hostgroup`

### Related Issues


### PRT test Cases example
<img width="238" height="46" alt="image" src="https://github.com/user-attachments/assets/be00de60-8aa7-4ff7-ada7-c771542840ea" />

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_hostgroup.py::test_positive_update_hostgroup
deployment_type: container
```

## Summary by Sourcery

Bug Fixes:
- Use the correct foreman-proxy port when creating fake proxies for foremanctl deployments, preventing SSL verification failures caused by tunneling to Cockpit.