### PR TITLE
[6.20.z] Add cloudbilling tests workaround for SAT-50249

### DIFF
--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -32,6 +32,7 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.utils.datafactory import gen_string
+from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(autouse=True)
@@ -342,6 +343,8 @@ def test_positive_cloud_billing_azure_columns(
         )
         with open(result_json) as json_file:
             data_json = json.load(json_file)
+            if is_open('SAT-50249') and isinstance(data_json, str):
+                data_json = json.loads(data_json)
 
         report_columns = data_json[0].keys()
 
@@ -407,6 +410,8 @@ def test_positive_cloud_billing_aws_columns(
         )
         with open(result_json) as json_file:
             data_json = json.load(json_file)
+            if is_open('SAT-50249') and isinstance(data_json, str):
+                data_json = json.loads(data_json)
 
         report_columns = data_json[0].keys()
 
@@ -476,6 +481,8 @@ def test_positive_cloud_billing_gcp_columns(
         )
         with open(result_json) as json_file:
             data_json = json.load(json_file)
+            if is_open('SAT-50249') and isinstance(data_json, str):
+                data_json = json.loads(data_json)
 
         report_columns = data_json[0].keys()
 
@@ -519,6 +526,8 @@ def test_positive_cloud_billing_inputs_default_false(
         )
         with open(result_json) as json_file:
             data_json = json.load(json_file)
+            if is_open('SAT-50249') and isinstance(data_json, str):
+                data_json = json.loads(data_json)
 
         report_columns = data_json[0].keys()
 
@@ -570,6 +579,8 @@ def test_negative_cloud_billing_azure_false_aws_gcp_true(
         )
         with open(result_json) as json_file:
             data_json = json.load(json_file)
+            if is_open('SAT-50249') and isinstance(data_json, str):
+                data_json = json.loads(data_json)
 
         report_columns = data_json[0].keys()
 
@@ -623,6 +634,8 @@ def test_negative_cloud_billing_aws_false_azure_gcp_true(
         )
         with open(result_json) as json_file:
             data_json = json.load(json_file)
+            if is_open('SAT-50249') and isinstance(data_json, str):
+                data_json = json.loads(data_json)
 
         report_columns = data_json[0].keys()
 
@@ -676,6 +689,8 @@ def test_negative_cloud_billing_gcp_false_azure_aws_true(
         )
         with open(result_json) as json_file:
             data_json = json.load(json_file)
+            if is_open('SAT-50249') and isinstance(data_json, str):
+                data_json = json.loads(data_json)
 
         report_columns = data_json[0].keys()
 
@@ -729,6 +744,8 @@ def test_positive_cloud_billing_multiple_providers_enabled(
         )
         with open(result_json) as json_file:
             data_json = json.load(json_file)
+            if is_open('SAT-50249') and isinstance(data_json, str):
+                data_json = json.loads(data_json)
 
         report_columns = data_json[0].keys()
 
@@ -781,6 +798,8 @@ def test_positive_installed_products_hardware_model_column(
         )
         with open(result_json) as json_file:
             data_json = json.load(json_file)
+            if is_open('SAT-50249') and isinstance(data_json, str):
+                data_json = json.loads(data_json)
 
         report_columns = data_json[0].keys()
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22681

### Problem Statement
Since snap 211, all report template JSON downloads via the UI are double-encoded (see SAT-50249 for more details). 
This causes issues in the tests in 
`report_columns = data_json[0].keys()` which fails with 
<img width="695" height="181" alt="image" src="https://github.com/user-attachments/assets/29190d67-2a53-428f-82f3-15f887365d09" />

### Solution
Add `is_open('SAT-50249')` workaround that decodes the double-encoded JSON when the upstream bug is open.



### PRT test Cases example
<img width="150" height="150" alt="Screenshot 2026-09-08 at 10 46 23" src="https://github.com/user-attachments/assets/10c2163d-5619-4237-adb6-6c2860fb1f20" />
<img width="190" height="150" alt="Screenshot 2026-09-08 at 10 54 29" src="https://github.com/user-attachments/assets/99516299-76bd-4595-9f0e-d7be9d9c60b1" />
<img width="411" height="65" alt="Screenshot 2026-09-08 at 10 58 48" src="https://github.com/user-attachments/assets/9f4608cb-1153-4bce-a0e9-17713aa06236" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_reporttemplates.py::test_positive_cloud_billing_azure_columns tests/foreman/ui/test_reporttemplates.py::test_positive_cloud_billing_aws_columns tests/foreman/ui/test_reporttemplates.py::test_positive_cloud_billing_gcp_columns tests/foreman/ui/test_reporttemplates.py::test_positive_cloud_billing_inputs_default_false tests/foreman/ui/test_reporttemplates.py::test_negative_cloud_billing_azure_false_aws_gcp_true tests/foreman/ui/test_reporttemplates.py::test_negative_cloud_billing_aws_false_azure_gcp_true tests/foreman/ui/test_reporttemplates.py::test_negative_cloud_billing_gcp_false_azure_aws_true tests/foreman/ui/test_reporttemplates.py::test_positive_cloud_billing_multiple_providers_enabled tests/foreman/ui/test_reporttemplates.py::test_positive_installed_products_hardware_model_column
deployment_type: container
```

## Summary by Sourcery

Work around SAT-50249 in report template UI tests by decoding affected JSON downloads when necessary.

Bug Fixes:
- Keep cloud billing and installed-products report template tests working while SAT-50249 causes UI-downloaded JSON to be double-encoded.

Enhancements:
- Conditionally normalize report template JSON downloads based on the upstream issue status.