### PR TITLE
Add cleanups for taxonomy and content-related fixtures

### DIFF
--- a/pytest_fixtures/component/contentview.py
+++ b/pytest_fixtures/component/contentview.py
@@ -1,27 +1,55 @@
 # Content View Fixtures
 from nailgun.entity_mixins import call_entity_method_with_timeout
 import pytest
+from requests.exceptions import HTTPError
 
 from robottelo.constants import DEFAULT_CV
+from robottelo.logging import logger
 
 
 @pytest.fixture(scope='module')
 def module_cv(module_org, module_target_sat):
-    return module_target_sat.api.ContentView(organization=module_org).create()
+    cv = module_target_sat.api.ContentView(organization=module_org).create()
+    yield cv
+    try:
+        cv = cv.read()
+        for version in cv.version:
+            version.delete()
+        cv.delete()
+    except HTTPError:
+        logger.exception('Exception while deleting module scope content view in teardown')
 
 
 @pytest.fixture(scope='module')
 def module_published_cv(module_org, module_target_sat):
-    content_view = module_target_sat.api.ContentView(organization=module_org).create()
-    content_view.publish()
-    return content_view.read()
+    cv = module_target_sat.api.ContentView(organization=module_org).create()
+    cv.publish()
+    cv = cv.read()
+    yield cv
+    try:
+        cv = cv.read()
+        for version in cv.version:
+            version.delete()
+        cv.delete()
+    except HTTPError:
+        logger.exception('Exception while deleting module scope published content view in teardown')
 
 
 @pytest.fixture
 def function_published_cv(function_org, target_sat):
-    content_view = target_sat.api.ContentView(organization=function_org).create()
-    content_view.publish()
-    return content_view.read()
+    cv = target_sat.api.ContentView(organization=function_org).create()
+    cv.publish()
+    cv = cv.read()
+    yield cv
+    try:
+        cv = cv.read()
+        for version in cv.version:
+            version.delete()
+        cv.delete()
+    except HTTPError:
+        logger.exception(
+            'Exception while deleting function scope published content view in teardown'
+        )
 
 
 @pytest.fixture(scope="module")

--- a/pytest_fixtures/component/lce.py
+++ b/pytest_fixtures/component/lce.py
@@ -1,7 +1,9 @@
 # Lifecycle Environment Fixtures
 import pytest
+from requests.exceptions import HTTPError
 
 from robottelo.constants import LIBRARY_LCE
+from robottelo.logging import logger
 
 
 @pytest.fixture(scope='session')
@@ -13,12 +15,24 @@ def default_lce(session_target_sat):
 
 @pytest.fixture(scope='module')
 def module_lce(module_org, module_target_sat):
-    return module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
+    lce = module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
+    yield lce
+    try:
+        lce.delete()
+    except HTTPError:
+        logger.exception('Exception while deleting module scope lifecycle environment in teardown')
 
 
 @pytest.fixture
 def function_lce(function_org, target_sat):
-    return target_sat.api.LifecycleEnvironment(organization=function_org).create()
+    lce = target_sat.api.LifecycleEnvironment(organization=function_org).create()
+    yield lce
+    try:
+        lce.delete()
+    except HTTPError:
+        logger.exception(
+            'Exception while deleting function scope lifecycle environment in teardown'
+        )
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -19,17 +19,23 @@ def module_repo_options(request, module_org, module_product):
 @pytest.fixture(scope='module')
 def module_repo(module_repo_options, module_target_sat):
     """Create a new repository."""
-    return module_target_sat.api.Repository(**module_repo_options).create()
+    repo = module_target_sat.api.Repository(**module_repo_options).create()
+    yield repo
+    repo.delete()
 
 
 @pytest.fixture
 def function_product(target_sat, function_org):
-    return target_sat.api.Product(organization=function_org).create()
+    product = target_sat.api.Product(organization=function_org).create()
+    yield product
+    product.delete()
 
 
 @pytest.fixture(scope='module')
 def module_product(module_org, module_target_sat):
-    return module_target_sat.api.Product(organization=module_org).create()
+    product = module_target_sat.api.Product(organization=module_org).create()
+    yield product
+    product.delete()
 
 
 @pytest.fixture(scope='module')
@@ -99,7 +105,8 @@ def setup_content(module_target_sat, module_org):
 def module_repository(os_path, module_product, module_target_sat):
     repo = module_target_sat.api.Repository(product=module_product, url=os_path).create()
     call_entity_method_with_timeout(module_target_sat.api.Repository(id=repo.id).sync, timeout=3600)
-    return repo
+    yield repo
+    repo.delete()
 
 
 @pytest.fixture

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -34,12 +34,16 @@ def current_sat_location(target_sat):
 
 @pytest.fixture
 def function_org(target_sat):
-    return target_sat.api.Organization().create()
+    org = target_sat.api.Organization().create()
+    yield org
+    org.delete()
 
 
 @pytest.fixture(scope='module')
 def module_org(module_target_sat):
-    return module_target_sat.api.Organization().create()
+    org = module_target_sat.api.Organization().create()
+    yield org
+    org.delete()
 
 
 @pytest.fixture(scope='class')
@@ -51,7 +55,9 @@ def class_org(class_target_sat):
 
 @pytest.fixture(scope='module')
 def module_location(module_target_sat, module_org):
-    return module_target_sat.api.Location(organization=[module_org]).create()
+    loc = module_target_sat.api.Location(organization=[module_org]).create()
+    yield loc
+    loc.delete()
 
 
 @pytest.fixture(scope='class')
@@ -63,7 +69,9 @@ def class_location(class_target_sat, class_org):
 
 @pytest.fixture
 def function_location(target_sat):
-    return target_sat.api.Location().create()
+    loc = target_sat.api.Location().create()
+    yield loc
+    loc.delete()
 
 
 @pytest.fixture


### PR DESCRIPTION
### Problem Statement

This is a first step to ensuring we have a proper cleanup for fixtures in order to make Satellite instances more re-usable, which should allow us a bit more aggressive parallelization to reduce the count of needed Satellites. 

### Solution

This is just a first step: add a few cleanups for org/loc fixtures and the dependants. I'd rather try to make smaller changes in incremental way instead of creating a huge PR.

### Related Issues

None so far.

## Summary by Sourcery

Enhancements:
- Add teardown cleanup for organization, location, lifecycle environment, content view, repository, and product fixtures to improve Satellite instance reuse.