### PR TITLE
[6.20.z] Update test_content_access_after_stopped_foreman for foremanctl

### DIFF
--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -16,6 +16,7 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE, FAKE_1_CUSTOM_PACKAGE
+from robottelo.enums import InstallMethod
 
 pytestmark = pytest.mark.destructive
 
@@ -50,9 +51,17 @@ def test_content_access_after_stopped_foreman(target_sat, rhel_contenthost):
     repos_collection.setup_virtual_machine(rhel_contenthost)
     result = rhel_contenthost.execute(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0
-    assert target_sat.cli.Service.stop(options={'only': 'foreman'}).status == 0
-    assert target_sat.cli.Service.status(options={'only': 'foreman'}).status == 1
+    if settings.server.install_method == InstallMethod.FOREMANCTL:
+        assert target_sat.execute('systemctl stop foreman.service').status == 0
+        assert target_sat.execute('systemctl is-active foreman.service').status != 0
+    else:
+        assert target_sat.cli.Service.stop(options={'only': 'foreman'}).status == 0
+        assert target_sat.cli.Service.status(options={'only': 'foreman'}).status == 1
     result = rhel_contenthost.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
     assert result.status == 0
-    assert target_sat.cli.Service.start(options={'only': 'foreman'}).status == 0
-    assert target_sat.cli.Service.status(options={'only': 'foreman'}).status == 0
+    if settings.server.install_method == InstallMethod.FOREMANCTL:
+        assert target_sat.execute('systemctl start foreman.service').status == 0
+        assert target_sat.execute('systemctl is-active foreman.service').status == 0
+    else:
+        assert target_sat.cli.Service.start(options={'only': 'foreman'}).status == 0
+        assert target_sat.cli.Service.status(options={'only': 'foreman'}).status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22691

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/destructive/test_contenthost.py::test_content_access_after_stopped_foreman
deployment_type: container
```

## Summary by Sourcery

Support foremanctl-specific service lifecycle checks in the content access test while preserving existing checks for other installation methods.

Bug Fixes:
- Update the content access test to correctly stop, verify, start, and verify Foreman when using the foremanctl installation method.

Tests:
- Adapt the destructive content host test to support both foremanctl and legacy service-management workflows.