### PR TITLE
[6.20.z] Mark installer-only tests with foreman_installer marker

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -194,6 +194,7 @@ def sat_non_default_install(module_sat_ready_rhels):
 @pytest.mark.e2e
 @pytest.mark.pit_server
 @pytest.mark.build_sanity
+@pytest.mark.foreman_installer
 def test_capsule_installation(
     pytestconfig, sat_fapolicyd_install, cap_ready_rhel, module_sca_manifest
 ):
@@ -302,6 +303,7 @@ def test_capsule_installation(
 
 
 @pytest.mark.e2e
+@pytest.mark.foreman_installer
 def test_foreman_rails_cache_store(sat_non_default_install):
     """Test foreman-rails-cache-store option
 
@@ -323,6 +325,7 @@ def test_foreman_rails_cache_store(sat_non_default_install):
 
 
 @pytest.mark.e2e
+@pytest.mark.foreman_installer
 def test_content_guarded_distributions_option(
     sat_default_install, sat_non_default_install, module_sca_manifest
 ):
@@ -381,6 +384,7 @@ def test_content_guarded_distributions_option(
 
 
 @pytest.mark.upgrade
+@pytest.mark.foreman_installer
 def test_positive_selinux_foreman_module(target_sat):
     """Check if SELinux foreman module is installed on Satellite
 
@@ -400,6 +404,7 @@ def test_positive_selinux_foreman_module(target_sat):
 
 
 @pytest.mark.upgrade
+@pytest.mark.foreman_installer
 @pytest.mark.parametrize('service', SATELLITE_SERVICES)
 def test_positive_check_installer_service_running(target_sat, service):
     """Check if a service is running
@@ -427,6 +432,7 @@ def test_positive_check_installer_service_running(target_sat, service):
 
 
 @pytest.mark.upgrade
+@pytest.mark.foreman_installer
 def test_positive_check_installer_hammer_ping(target_sat):
     """Check if hammer ping reports all services as ok
 
@@ -540,6 +546,7 @@ def test_installer_capsule_with_enabled_ansible(module_capsule_configured_ansibl
 @pytest.mark.build_sanity
 @pytest.mark.first_sanity
 @pytest.mark.pit_server
+@pytest.mark.foreman_installer
 def test_satellite_installation(pytestconfig, installer_satellite):
     """Run a basic Satellite installation
 
@@ -583,6 +590,7 @@ def test_satellite_installation(pytestconfig, installer_satellite):
 
 
 @pytest.mark.pit_server
+@pytest.mark.foreman_installer
 @pytest.mark.parametrize('package', ['nmap-ncat'])
 def test_weak_dependency(sat_non_default_install, package):
     """Check if Satellite and its (sub)components do not require certain (potentially insecure) packages. On an existing Satellite the package has to be either not installed or can be safely removed.


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22693

### Problem Statement
Most tests in `tests/foreman/installer/test_installer.py` were not marked with `@pytest.mark.foreman_installer`, so they were still collected during foremanctl runs, even though they duplicate foremanctl's own coverage or assert installer-specific artifacts that don't exist in a containerized foremanctl deployment.

### Solution
Marked the installer-only tests with `@pytest.mark.foreman_installer` so they are deselected on foremanctl runs. 
The dual-method test is left as-is since it's already parametrized per method; a module-level marker was avoided because it would wrongly deselect that test's foremanctl variant

### Related Issues

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Exclude installer-only coverage from foremanctl runs by applying the appropriate pytest marker to the relevant tests.

Bug Fixes:
- Prevent installer-specific tests from being collected during foremanctl test runs.

Tests:
- Mark installer-only installer test cases with the `foreman_installer` pytest marker while preserving tests that support both deployment methods.