### PR TITLE
Updated test case as per output from subscription-manager environments --list-enabled

### DIFF
--- a/pytest_fixtures/component/os.py
+++ b/pytest_fixtures/component/os.py
@@ -12,7 +12,8 @@ def default_os(
     session_target_sat,
 ):
     """Returns an Operating System entity read from searching for supportability.content_host.default_os_name"""
-    search_string = f'name="{settings.supportability.content_hosts.default_os_name}"'
+    # Use partial match (~) instead of exact match to handle OS names like "RedHat 9.4"
+    search_string = f'name ~ {settings.supportability.content_hosts.default_os_name}'
 
     try:
         os = (

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -4420,7 +4420,7 @@ def test_cv_env_order(module_target_sat, module_org, module_lce, module_cv_repo,
     # but put them in the same format as the name data from the sub-man CLI command.
     ui_env_list = [
         f'{ui_envs[0]["lce"]}',
-        f'{ui_envs[1]['lce']}/{ui_envs[1]["content_view"]}',
+        f'{ui_envs[1]["lce"]}/{ui_envs[1]["content_view"]}',
     ]
     assert sub_man_env_list == ui_env_list
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -4419,8 +4419,8 @@ def test_cv_env_order(module_target_sat, module_org, module_lce, module_cv_repo,
     # Extract the values from the host's CV env list from the UI. Maintain the display order
     # but put them in the same format as the name data from the sub-man CLI command.
     ui_env_list = [
-        f'{ui_envs[0]["lce"]}/{ui_envs[0]["content_view"]}',
-        ui_envs[1]['lce'],
+        f'{ui_envs[0]["lce"]}',
+        f'{ui_envs[1]['lce']}/{ui_envs[1]["content_view"]}',
     ]
     assert sub_man_env_list == ui_env_list
 


### PR DESCRIPTION
### Problem Statement
Test case test_cv_env_order was failing due to format mismatch in assert statement.

Format that we are getting in `subscription-manager environments --list-enabled ` command
```
ipdb> rhel_contenthost.execute('subscription-manager environments --list-enabled')
stdout:
+-------------------------------------------+
          Environments
+-------------------------------------------+
Name:        Library
Description: 

Name:        lblgNaokVLaf/WErudNHTUu
Description: 

```

### Solution
Updated format in assert statement.

### Related Issues


 ### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k test_cv_env_order
deployment_type: container
```


<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Align the host content view environment order test with the current subscription-manager output format.

Bug Fixes:
- Fix the content view environment order test to match the environment names returned by the subscription-manager command.

Tests:
- Update the expected environment list in the host content view environment order test.