### PR TITLE
[6.20.z] Foremanctl incremental backup/restore and refactor

### DIFF
--- a/tests/foreman/foremanctl/test_foremanctl_backup_restore.py
+++ b/tests/foreman/foremanctl/test_foremanctl_backup_restore.py
@@ -21,36 +21,76 @@ from robottelo.config import settings
 pytestmark = [pytest.mark.foremanctl]
 
 BACKUP_DIR = '/tmp/'
-BASIC_FILES = {'foremanctl-state.tar.gz', 'metadata.yml'}
+BACKUP_PREFIX = 'backup-'
+BASIC_FILES = {'foremanctl-state.tar.gz', 'metadata.yml', 'config.snar'}
 SAT_FILES = {'candlepin.dump', 'foreman.dump', 'pulp.dump'} | BASIC_FILES
-CONTENT_FILES = {'pulp-content.tar.gz'}
+CONTENT_FILES = {'pulp-content.tar.gz', 'pulp.snar'}
 
 
-def get_exp_files(module_target_sat, skip_pulp=False):
+@pytest.fixture(autouse=True, scope='module')
+def install_postgresql_client(module_target_sat):
+    """Ensure the PostgreSQL client (pg_dump/pg_restore) is available on the Satellite.
+
+    foremanctl backup/restore invokes ``pg_dump``/``pg_restore`` on the host, but the RPM does
+    not yet declare ``postgresql`` as a dependency. Until it does, install it here. Skip if
+    the client is already pre-installed.
+
+    TODO: drop this fixture once foremanctl declares postgresql as an RPM dependency.
+    """
+    if module_target_sat.execute('command -v pg_dump').status == 0:
+        return  # client already present
+
+    module_target_sat.register_to_cdn()
+    result = module_target_sat.execute('dnf -y install postgresql')
+    assert result.status == 0, (
+        f'Failed to install postgresql client:\n{result.stdout}\n{result.stderr}'
+    )
+
+
+@pytest.fixture(autouse=True)
+def cleanup_backup_dir(module_target_sat):
+    """Clean up backup directories before and after each test."""
+    module_target_sat.execute(f'rm -rf {BACKUP_DIR}{BACKUP_PREFIX}*')
+    yield
+    module_target_sat.execute(f'rm -rf {BACKUP_DIR}{BACKUP_PREFIX}*')
+
+
+def _assert_backup_files(server, backup_dir, skip_pulp=False):
+    """Verify that backup directory contains all expected files.
+
+    :param server: Satellite or Capsule server instance to execute commands on
+    :param backup_dir: Path to the backup directory
+    :param skip_pulp: Whether pulp content was skipped in the backup
+    """
     expected_files = SAT_FILES
     if not skip_pulp:
         expected_files = expected_files | CONTENT_FILES
-    return expected_files
+
+    ls_output = server.execute(f'ls -a {backup_dir}').stdout
+    files = ls_output.split('\n')
+    files = [i for i in files if not re.compile(r'^\.*$').search(i)]
+    assert set(files).issuperset(expected_files), (
+        f'Some required backup files are missing. Expected: {expected_files}, Found: {files}'
+    )
 
 
-def _create_backup(sat, subdir, skip_pulp=False):
+def _create_backup(server, subdir, skip_pulp=False, base_backup=None, wait_for_tasks=True):
     """Run foremanctl backup and return the timestamped backup subdirectory path."""
-    cmd = f'foremanctl backup {subdir} --wait-for-tasks'
+    cmd = f'foremanctl backup {subdir}'
     if skip_pulp:
         cmd += ' --skip-pulp-content'
-    result = sat.execute(cmd, timeout='30m')
+    if base_backup:
+        cmd += f' --base-backup {base_backup}'
+    if wait_for_tasks:
+        cmd += ' --wait-for-tasks'
+    result = server.execute(cmd, timeout='30m')
     assert result.status == 0, f'foremanctl backup failed:\n{result.stdout}\n{result.stderr}'
-    result = sat.execute(f'test -d {subdir}')
-    assert result.status == 0, f'Backup directory {subdir} was not created'
-    backup_dir = re.findall(rf'{subdir}/foreman-backup-\S+', result.stdout)
-    if not backup_dir:
-        ls_result = sat.execute(f'ls -d {subdir}/foreman-backup-*')
-        assert ls_result.status == 0, f'No foreman-backup-* subdirectory found in {subdir}'
-        backup_dir = ls_result.stdout.strip().splitlines()
-    return backup_dir[0]
+    backup_dir = re.search(r'Location:\s*(\S+)', result.stdout)
+    assert backup_dir, f'Backup location not found in output:\n{result.stdout}'
+    return backup_dir.group(1)
 
 
-def test_positive_offline_backup(module_target_sat, setup_backup_tests):
+def test_positive_offline_backup(module_target_sat):
     """Verify foremanctl backup creates a backup successfully
 
     :id: e9eafa8a-4f1b-458c-b24b-c31d4bc04c4b
@@ -68,40 +108,18 @@ def test_positive_offline_backup(module_target_sat, setup_backup_tests):
 
     :Verifies: SAT-44895
     """
-    subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
+    subdir = f'{BACKUP_DIR}{BACKUP_PREFIX}{gen_string("alpha")}'
+    backup_dir = _create_backup(module_target_sat, subdir)
 
-    # Run backup with --wait-for-tasks to ensure no running tasks block it
-    result = module_target_sat.execute(
-        f'foremanctl backup {subdir} --wait-for-tasks',
-        timeout='30m',
-    )
-    assert result.status == 0, f'foremanctl backup failed:\n{result.stdout}\n{result.stderr}'
+    _assert_backup_files(module_target_sat, backup_dir)
 
-    # Verify backup directory was created
-    result = module_target_sat.execute(f'test -d {subdir}')
-    assert result.status == 0, f'Backup directory {subdir} was not created'
-
-    # Get list of files in backup directory
-    files = module_target_sat.execute(f'ls -a {subdir}/*').stdout.split('\n')
-    files = [i for i in files if not re.compile(r'^\.*$').search(i)]
-    expected_files = get_exp_files(module_target_sat)
-
-    # Verify all expected files are present
-    assert set(files).issuperset(expected_files), (
-        f'Some required backup files are missing. Expected: {expected_files}, Found: {files}'
-    )
-
-    # Verify foremanctl is still healthy after backup
     result = module_target_sat.execute('foremanctl health', timeout='5m')
     assert result.status == 0, f'foremanctl health check failed after backup:\n{result.stdout}'
 
 
-@pytest.mark.destructive
 @pytest.mark.e2e
 @pytest.mark.parametrize('skip_pulp', [False, True], ids=['include_pulp', 'skip_pulp'])
-def test_positive_backup_restore(
-    module_target_sat, setup_backup_tests, module_synced_repos, skip_pulp
-):
+def test_positive_backup_restore(module_target_sat, module_synced_repos, skip_pulp):
     """Verify foremanctl restore recovers a satellite to its original state from backup
 
     :id: cb8447fb-b25f-4ec7-b515-8fe7391bd867
@@ -130,15 +148,10 @@ def test_positive_backup_restore(
 
     :Verifies: SAT-44898
     """
-    subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
+    subdir = f'{BACKUP_DIR}{BACKUP_PREFIX}{gen_string("alpha")}'
     backup_dir = _create_backup(module_target_sat, subdir, skip_pulp=skip_pulp)
 
-    files = module_target_sat.execute(f'ls {backup_dir}').stdout.split('\n')
-    files = [i for i in files if i.strip()]
-    expected_files = get_exp_files(module_target_sat, skip_pulp)
-    assert set(files).issuperset(expected_files), (
-        f'Some required backup files are missing. Expected: {expected_files}, Found: {files}'
-    )
+    _assert_backup_files(module_target_sat, backup_dir, skip_pulp=skip_pulp)
 
     post_backup_repo = module_target_sat.api.Repository(
         url=settings.repos.yum_3.url, product=module_synced_repos['custom'].product
@@ -200,7 +213,7 @@ def test_positive_backup_restore(
         ), 'Pulp artifacts should be repopulated after restore'
 
 
-def test_positive_restore_validate(module_target_sat, setup_backup_tests):
+def test_positive_restore_validate(module_target_sat):
     """Verify foremanctl restore --validate checks backup integrity without making changes
 
     :id: b4573263-ce88-4a89-9600-8e8b89aa3d63
@@ -219,7 +232,7 @@ def test_positive_restore_validate(module_target_sat, setup_backup_tests):
 
     :Verifies: SAT-44898
     """
-    subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
+    subdir = f'{BACKUP_DIR}{BACKUP_PREFIX}{gen_string("alpha")}'
     backup_dir = _create_backup(module_target_sat, subdir)
 
     health_before = module_target_sat.execute('foremanctl health', timeout='5m')
@@ -237,7 +250,7 @@ def test_positive_restore_validate(module_target_sat, setup_backup_tests):
     assert health_after.status == 0, f'Health check failed after validate:\n{health_after.stdout}'
 
 
-def test_negative_restore_baddir(module_target_sat, setup_backup_tests):
+def test_negative_restore_baddir(module_target_sat):
     """Verify foremanctl restore fails with a non-existing backup directory
 
     :id: a7b530e6-7496-45b6-ba14-198980dc3ca8
@@ -250,7 +263,7 @@ def test_negative_restore_baddir(module_target_sat, setup_backup_tests):
 
     :Verifies: SAT-44898
     """
-    bad_dir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
+    bad_dir = f'{BACKUP_DIR}{BACKUP_PREFIX}{gen_string("alpha")}'
 
     result = module_target_sat.execute(
         f'foremanctl restore {bad_dir} --force',
@@ -259,7 +272,7 @@ def test_negative_restore_baddir(module_target_sat, setup_backup_tests):
     assert result.status != 0, 'foremanctl restore should fail with non-existing backup directory'
 
 
-def test_negative_restore_no_force(module_target_sat, setup_backup_tests):
+def test_negative_restore_no_force(module_target_sat):
     """Verify foremanctl restore fails without --force on an existing deployment
 
     :id: ba844ee3-6837-4f8d-b856-3bd8cf5f1d2a
@@ -274,7 +287,7 @@ def test_negative_restore_no_force(module_target_sat, setup_backup_tests):
 
     :Verifies: SAT-44898
     """
-    subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
+    subdir = f'{BACKUP_DIR}{BACKUP_PREFIX}{gen_string("alpha")}'
     backup_dir = _create_backup(module_target_sat, subdir)
 
     result = module_target_sat.execute(
@@ -284,3 +297,124 @@ def test_negative_restore_no_force(module_target_sat, setup_backup_tests):
     assert result.status != 0, (
         'foremanctl restore should fail without --force on existing deployment'
     )
+
+
+@pytest.mark.e2e
+def test_positive_backup_restore_incremental(module_target_sat):
+    """Incremental backup/restore end-to-end test using foremanctl.
+
+    :id: 2fc57857-bba0-425e-a7f2-e70ff5cafaab
+
+    :steps:
+        1. Sync a custom repository
+        2. Take an initial backup with foremanctl
+        3. Create additional content (sync another repo)
+        4. Take an incremental backup referencing the initial one
+        5. Verify expected files are present in the incremental backup
+        6. Restore the initial backup and check system health
+        7. Verify the additional content is missing
+        8. Restore the incremental backup and check system health
+        9. Verify all content is restored
+
+    :expectedresults:
+        1. Initial and incremental backups succeed
+        2. Expected files are present in the incremental backup
+        3. Restore of both backups succeeds
+        4. System health checks pass after each restore
+        5. Content is present/absent as expected after each restore
+    """
+    product = module_target_sat.api.Product(
+        organization=module_target_sat.api.Organization().create()
+    ).create()
+
+    initial_repo = module_target_sat.api.Repository(
+        url=settings.repos.yum_1.url, product=product
+    ).create()
+    initial_repo.sync()
+    initial_repo = initial_repo.read()
+
+    subdir = f'{BACKUP_DIR}{BACKUP_PREFIX}{gen_string("alpha")}'
+    init_backup_dir = _create_backup(module_target_sat, subdir)
+
+    secondary_repo = module_target_sat.api.Repository(
+        url=settings.repos.yum_3.url, product=product
+    ).create()
+    secondary_repo.sync()
+    secondary_repo = secondary_repo.read()
+
+    inc_backup_dir = _create_backup(module_target_sat, subdir, base_backup=init_backup_dir)
+
+    _assert_backup_files(module_target_sat, inc_backup_dir)
+
+    result = module_target_sat.execute(
+        f'foremanctl restore {init_backup_dir} --force',
+        timeout='30m',
+    )
+    assert result.status == 0, f'Initial restore failed:\n{result.stdout}\n{result.stderr}'
+
+    result = module_target_sat.execute('foremanctl health', timeout='5m')
+    assert result.status == 0, f'Health check failed after initial restore:\n{result.stdout}'
+
+    result = module_target_sat.api.Repository().search(
+        query={'search': f'name="{secondary_repo.name}"'}
+    )
+    assert len(result) == 0, 'Secondary repo should not exist after restoring initial backup'
+
+    result = module_target_sat.execute(
+        f'foremanctl restore {inc_backup_dir} --force',
+        timeout='30m',
+    )
+    assert result.status == 0, f'Incremental restore failed:\n{result.stdout}\n{result.stderr}'
+
+    result = module_target_sat.execute('foremanctl health', timeout='5m')
+    assert result.status == 0, f'Health check failed after incremental restore:\n{result.stdout}'
+
+    repo = module_target_sat.api.Repository().search(
+        query={'search': f'name="{initial_repo.name}"'}
+    )[0]
+    assert repo.id == initial_repo.id
+
+    repo = module_target_sat.api.Repository().search(
+        query={'search': f'name="{secondary_repo.name}"'}
+    )[0]
+    assert repo.id == secondary_repo.id
+
+
+def test_negative_backup_incremental_nodir_baddir(module_target_sat):
+    """Try to take an incremental backup with missing or non-existing previous backup path.
+
+    :id: 715a0b22-6b9d-4f0b-b8c3-1ea0713ee68f
+
+    :steps:
+        1. Run foremanctl backup with --base-backup but no path argument
+        2. Run foremanctl backup with --base-backup pointing to a non-existing directory
+
+    :expectedresults:
+        1. Both commands fail with a non-zero exit code
+        2. The no-directory variant mentions expected one argument
+        3. The bad-directory variant mentions the directory does not exist
+        4. No backup directory was created on the filesystem
+    """
+    subdir = f'{BACKUP_DIR}{BACKUP_PREFIX}{gen_string("alpha")}'
+
+    # No directory: --base-backup without a path
+    result = module_target_sat.execute(f'foremanctl backup {subdir} --base-backup')
+    assert result.status != 0, (
+        f'Incremental backup without path should have failed:\n{result.stdout}'
+    )
+    assert '--base-backup: expected one argument' in result.stderr, (
+        f'Expected --base-backup argument error, got:\n{result.stderr}'
+    )
+
+    # Bad directory: --base-backup with a non-existing path
+    nonexistent = f'{BACKUP_DIR}{BACKUP_PREFIX}{gen_string("alpha")}'
+    result = module_target_sat.execute(f'foremanctl backup {subdir} --base-backup {nonexistent}')
+    assert result.status != 0, f'Incremental backup should have failed:\n{result.stdout}'
+    assert (
+        f'Previous backup directory does not exist or is not a valid foremanctl backup: {nonexistent}'
+        in result.stdout
+    ), f'Expected error referencing bad path {nonexistent}, got:\n{result.stdout}'
+
+    # Verify no backup was created
+    result = module_target_sat.execute(f'test -d {subdir}')
+    assert result.status != 0, f'Backup directory {subdir} should not exist after failed backups'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22383

### New test cases

- **`test_positive_backup_restore_incremental`** - End-to-end incremental backup/restore test. Creates initial content, takes a full backup, adds more content, takes an incremental backup, then restores each in sequence and verifies content presence/absence after each restore. Marked `destructive` since a failed restore would render the instance unusable.

- **`test_negative_backup_incremental_nodir_baddir`** - Verifies that `foremanctl backup --incremental` fails gracefully in two scenarios: when no path argument is provided at all (expects argument parsing error), and when the path points to a non-existing directory (expects a descriptive error referencing the bad path).

### Refactoring of existing code

- **`_create_backup` helper reworked** - Instead of shelling out to `test -d` and `ls` to find the backup directory, the helper now parses the `Location:` line from the `foremanctl backup` output. This is both simpler and validates that the command reports the correct path. Added `incremental` parameter so the helper can also handle incremental backups (used by the new incremental test).

- **`test_positive_offline_backup` uses `_create_backup`** - The test predates the helper, so it was doing everything manually. Now it delegates to the helper for consistency.

- **Replaced `setup_backup_tests` with `cleanup_backup_dir` autouse fixture** - The old fixture lived in `pytest_fixtures/component/maintain.py`, tying these `foremanctl` tests to the `foreman-maintain` fixture domain. A simple function-scoped autouse cleanup fixture keeps the tests self-contained. The cleanup is harmless for negative tests that produce no backup.

- **`get_exp_files` - dropped unused satellite parameter** - Inherited from the `foreman-maintain` implementation where it could receive either a Satellite or Capsule instance, but it was never actually used in the function body.

- **Added `.config.snar` and `.pulp.snar` to expected file sets** - These GNU tar snapshot files are essential for incremental backups to work and were missing from the assertions. Organized following the same grouping pattern as the original `foreman-maintain` tests: `.config.snar` in `BASIC_FILES`, `.pulp.snar` in `CONTENT_FILES`.

- **Unified file-listing pattern** - All tests now use `ls -a` with the dotfile-filtering regex, so the `.snar` files are actually visible to the assertions. Previously, one test used plain `ls` with a whitespace strip, which would have missed dotfiles.

- **Introduced `BACKUP_PREFIX` constant** - The `backup-` prefix was hardcoded both in per-test subdir paths and in the cleanup fixture's glob pattern, with no single source of truth. Now both derive from the same constant.


### Related Issues
[SAT-44903](https://redhat.atlassian.net/browse/SAT-44903)


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/foremanctl/test_foremanctl_backup_restore.py
deployment_type: container
theforeman:
  foremanctl: 609
```

## Summary by Sourcery

Add incremental backup and restore coverage while consolidating backup test setup, validation, and cleanup.

New Features:
- Add end-to-end coverage for restoring full and incremental backups in sequence, including verification of content state and system health.
- Add negative coverage for incremental backups with missing or invalid base-backup paths.

Enhancements:
- Refactor backup test helpers to validate reported backup locations, share backup-file assertions, and support incremental backup workflows.
- Make backup test cleanup self-contained and consistently manage backup naming and hidden snapshot files.
- Ensure the PostgreSQL client is available before running backup and restore tests.

Tests:
- Expand backup and restore assertions to include GNU tar snapshot files and consistently list hidden files.