### PR TITLE
Update column management related Hosts tests

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -222,22 +222,24 @@ def host_ui_default(target_sat):
 
 
 @pytest.fixture
-def ui_view_hosts_user(target_sat, current_sat_org, current_sat_location, expected_permissions):
+def ui_view_hosts_user(target_sat, expected_permissions):
     """User with View hosts role."""
-    role = target_sat.api.Role(organization=[current_sat_org]).create()
+    default_org = target_sat.api.Organization().search(query={'search': f'name="{DEFAULT_ORG}"'})[0]
+    default_loc = target_sat.api.Location().search(query={'search': f'name="{DEFAULT_LOC}"'})[0]
+    role = target_sat.api.Role(organization=[default_org]).create()
     target_sat.api_factory.create_role_permissions(
         role,
         {
             'Host': ['view_hosts'],
-            'Organization': expected_permissions['Organization'],
-            'Location': expected_permissions['Location'],
+            'Organization': ['view_organizations'],
+            'Location': ['view_locations'],
         },
     )
     password = gen_string('alphanumeric')
     user = target_sat.api.User(
         admin=False,
-        location=[current_sat_location],
-        organization=[current_sat_org],
+        organization=[default_org],
+        location=[default_loc],
         role=[role],
         password=password,
     ).create()
@@ -602,7 +604,7 @@ def test_positive_assign_taxonomies(
 @pytest.mark.skipif(
     (settings.ui.webdriver != 'chrome'), reason='Currently only chrome is supported'
 )
-def test_positive_export_selected_columns(request, target_sat, current_sat_location):
+def test_positive_export_selected_columns(request, target_sat):
     """Select certain columns in the hosts table and check that they are exported in the CSV file.
 
     :id: 2b65c1d6-0b94-11ef-a4b7-000c2989e153
@@ -652,8 +654,20 @@ def test_positive_export_selected_columns(request, target_sat, current_sat_locat
         Box(ui='Recommendations', csv='Recommendations', displayed=True),
     )
 
+    fake_host = target_sat.cli_factory.make_fake_host(
+        {
+            'organization': DEFAULT_ORG,
+            'location': DEFAULT_LOC,
+        }
+    )
+
+    @request.addfinalizer
+    def _cleanup():
+        target_sat.api.Host().search(query={"search": f'name={fake_host.name}'})[0].delete()
+
     with target_sat.ui_session() as session:
-        session.location.select(loc_name=current_sat_location.name)
+        session.organization.select(org_name=DEFAULT_ORG)
+        session.location.select(loc_name=DEFAULT_LOC)
         # Save original column settings
         original_headers = session.all_hosts.get_displayed_table_headers()
         original_columns = {header: True for header in original_headers if header is not None}
@@ -661,7 +675,8 @@ def test_positive_export_selected_columns(request, target_sat, current_sat_locat
         def restore_columns():
             """Restore original column settings after test"""
             with target_sat.ui_session() as restore_session:
-                restore_session.location.select(loc_name=current_sat_location.name)
+                session.organization.select(org_name=DEFAULT_ORG)
+                restore_session.location.select(loc_name=DEFAULT_LOC)
                 wait_for(lambda: restore_session.browser.refresh(), timeout=5)
                 all_possible_columns = {column.ui: False for column in columns}
                 all_possible_columns.update(original_columns)
@@ -1379,9 +1394,7 @@ def test_positive_read_details_page_from_new_ui(target_sat, host_ui_options):
         assert values['overview']['details']['details']['comment'] == 'Host with fake data'
 
 
-def test_positive_manage_table_columns(
-    target_sat, test_name, ui_hosts_columns_user, current_sat_org, current_sat_location
-):
+def test_positive_manage_table_columns(request, target_sat, test_name, ui_hosts_columns_user):
     """Set custom columns of the hosts table.
 
     :id: e5e18982-cc43-11ed-8562-000c2989e153
@@ -1414,11 +1427,22 @@ def test_positive_manage_table_columns(
         'Boot time': True,
         'Recommendations': False,
     }
+    fake_host = target_sat.cli_factory.make_fake_host(
+        {
+            'organization': DEFAULT_ORG,
+            'location': DEFAULT_LOC,
+        }
+    )
+
+    @request.addfinalizer
+    def _cleanup():
+        target_sat.api.Host().search(query={"search": f'name={fake_host.name}'})[0].delete()
+
     with target_sat.ui_session(
         test_name, ui_hosts_columns_user.login, ui_hosts_columns_user.password
     ) as session:
-        session.organization.select(org_name=current_sat_org.name)
-        session.location.select(loc_name=current_sat_location.name)
+        session.organization.select(DEFAULT_ORG)
+        session.location.select(DEFAULT_LOC)
         session.all_hosts.manage_table_columns(columns)
         displayed_columns = session.host.get_displayed_table_headers()
         for column, is_displayed in columns.items():

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -675,7 +675,7 @@ def test_positive_export_selected_columns(request, target_sat):
         def restore_columns():
             """Restore original column settings after test"""
             with target_sat.ui_session() as restore_session:
-                session.organization.select(org_name=DEFAULT_ORG)
+                restore_session.organization.select(org_name=DEFAULT_ORG)
                 restore_session.location.select(loc_name=DEFAULT_LOC)
                 wait_for(lambda: restore_session.browser.refresh(), timeout=5)
                 all_possible_columns = {column.ui: False for column in columns}


### PR DESCRIPTION
### Problem Statement
Tests were failing primarily because there is no satellite host itself in foremanctl

### Solution
This PR fixes it by creating fake hosts for the tests


### PRT test Cases example
<img width="270" height="71" alt="image" src="https://github.com/user-attachments/assets/6d3e8e47-3a0d-4f1a-826b-aede4e50effc" />
<img width="272" height="26" alt="image" src="https://github.com/user-attachments/assets/914f6755-509b-4fb8-8d12-cc4077d68748" />

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_positive_export_selected_columns or test_positive_manage_table_columns'
deployment_type: container
```

## Summary by Sourcery

Make Hosts column-management UI tests reliable by provisioning test hosts in the default context.

Bug Fixes:
- Fix Hosts column-management and CSV export tests by ensuring they operate against available fake hosts in the default organization and location.

Enhancements:
- Align the affected UI tests and test user permissions with the default organization and location context.

Tests:
- Update Hosts table column tests to create and clean up temporary fake hosts during execution.