### PR TITLE
Fix test_positive_list_hosts_thin_all for containerized Satellite

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1418,8 +1418,10 @@ def test_positive_list_hosts_thin_all(module_target_sat):
 
     :customerscenario: true
     """
+    # Create a host to ensure at least one host exists for thin listing
+    created_host = module_target_sat.api.Host().create()
     hosts = module_target_sat.api.Host().search(query={'thin': 'true', 'per_page': 'all'})
-    assert module_target_sat.hostname in [host.name for host in hosts]
+    assert created_host.name in [host.name for host in hosts]
     keys = dir(hosts[0])
     assert 'id' in keys
     assert 'name' in keys

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1407,7 +1407,7 @@ def test_positive_read_puppet_ca_proxy_name(
     assert session_puppet_enabled_proxy.name == host['puppet_ca_proxy_name']
 
 
-def test_positive_list_hosts_thin_all(module_target_sat):
+def test_positive_list_hosts_thin_all(module_target_sat, request):
     """List hosts with thin=true and per_page=all
 
     :id: 00b7e603-aed5-4b19-bfec-1a179fad6743
@@ -1420,6 +1420,7 @@ def test_positive_list_hosts_thin_all(module_target_sat):
     """
     # Create a host to ensure at least one host exists for thin listing
     created_host = module_target_sat.api.Host().create()
+    request.addfinalizer(created_host.delete)
     hosts = module_target_sat.api.Host().search(query={'thin': 'true', 'per_page': 'all'})
     assert created_host.name in [host.name for host in hosts]
     keys = dir(hosts[0])


### PR DESCRIPTION
### Problem Statement
The test `test_positive_list_hosts_thin_all` was failing on containerized Satellite deployments because it expected the Satellite instance to be registered as a host. With containerized Satellite, the Satellite doesn't register itself, causing the assertion `module_target_sat.hostname in [host.name for host in hosts]` to fail.

### Solution
Modified the test to create a host entry before performing the thin listing search. This ensures at least one host exists for validation, making the test compatible with both traditional and containerized Satellite deployments.

The test still validates the original intent:
- Hosts can be listed with `thin=true` and `per_page=all` without Internal Server Errors
- The thin representation contains minimal data (id, name) and excludes verbose fields (domain, ip, architecture)

### PRT Example
```bash
# Run the fixed test
pytest -sv tests/foreman/api/test_host.py::test_positive_list_hosts_thin_all

# Run with specific marker if needed
pytest tests/foreman/api/test_host.py::test_positive_list_hosts_thin_all -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure thin host listings are tested consistently across Satellite deployment types.

Bug Fixes:
- Make the thin host listing test reliable on containerized Satellite deployments by creating and cleaning up a host explicitly before validation.

Tests:
- Update host listing coverage to validate thin results against the explicitly created host while preserving checks for minimal fields.