### PR TITLE
[6.20.z] Reduce Proton parameterization

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -14,6 +14,7 @@
 """
 
 import http
+import random
 
 from fauxfactory import gen_integer, gen_string
 from nailgun import client
@@ -23,25 +24,22 @@ from requests.exceptions import HTTPError
 from robottelo.config import get_credentials, user_nailgun_config
 from robottelo.constants import PRDS, REPOS, REPOSET
 from robottelo.utils.datafactory import (
-    filtered_datapoint,
     invalid_names_list,
-    parametrized,
     valid_data_list,
 )
 
 
-@filtered_datapoint
 def _good_max_hosts():
     """Return a list of valid ``max_hosts`` values."""
     return [gen_integer(*limits) for limits in ((1, 20), (10000, 20000))]
 
 
-@filtered_datapoint
 def _bad_max_hosts():
     """Return a list of invalid ``max_hosts`` values."""
     return [gen_integer(-100, -1), 0, gen_string('alpha')]
 
 
+@pytest.mark.migration_candidate
 def test_positive_create_unlimited_hosts(target_sat):
     """Create a plain vanilla activation key.
 
@@ -55,8 +53,8 @@ def test_positive_create_unlimited_hosts(target_sat):
     assert target_sat.api.ActivationKey().create().unlimited_hosts is True
 
 
-@pytest.mark.parametrize('max_host', **parametrized(_good_max_hosts()))
-def test_positive_create_limited_hosts(max_host, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_limited_hosts(target_sat):
     """Create an activation key with limited hosts.
 
     :id: 9bbba620-fd98-4139-a44b-af8ce330c7a4
@@ -65,16 +63,15 @@ def test_positive_create_limited_hosts(max_host, target_sat):
         number is limited
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    max_host = random.choice(_good_max_hosts())
     act_key = target_sat.api.ActivationKey(max_hosts=max_host, unlimited_hosts=False).create()
     assert act_key.max_hosts == max_host
     assert act_key.unlimited_hosts is False
 
 
-@pytest.mark.parametrize('key_name', **parametrized(valid_data_list()))
-def test_positive_create_with_name(key_name, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_name(target_sat):
     """Create an activation key providing the initial name.
 
     :id: 749e0d28-640e-41e5-89d6-b92411ce73a3
@@ -82,27 +79,26 @@ def test_positive_create_with_name(key_name, target_sat):
     :expectedresults: Activation key is created and contains provided name.
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    key_name = random.choice(list(valid_data_list().values()))
     act_key = target_sat.api.ActivationKey(name=key_name).create()
     assert key_name == act_key.name
 
 
-@pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-def test_positive_create_with_description(desc, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_description(target_sat):
     """Create an activation key and provide a description.
 
     :id: 64d93726-6f96-4a2e-ab29-eb5bfa2ff8ff
 
     :expectedresults: Created entity contains the provided description.
-
-    :parametrized: yes
     """
+    desc = random.choice(list(valid_data_list().values()))
     act_key = target_sat.api.ActivationKey(description=desc).create()
     assert desc == act_key.description
 
 
+@pytest.mark.migration_candidate
 def test_negative_create_with_no_host_limit(target_sat):
     """Create activation key without providing limitation for hosts number
 
@@ -116,8 +112,8 @@ def test_negative_create_with_no_host_limit(target_sat):
         target_sat.api.ActivationKey(unlimited_hosts=False).create()
 
 
-@pytest.mark.parametrize('max_host', **parametrized(_bad_max_hosts()))
-def test_negative_create_with_invalid_host_limit(max_host, target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_invalid_host_limit(target_sat):
     """Create activation key with invalid limit values for hosts number.
 
     :id: c018b177-2074-4f1a-a7e0-9f38d6c9a1a6
@@ -125,15 +121,14 @@ def test_negative_create_with_invalid_host_limit(max_host, target_sat):
     :expectedresults: Activation key is not created
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
+    max_host = random.choice(_bad_max_hosts())
     with pytest.raises(HTTPError):
         target_sat.api.ActivationKey(max_hosts=max_host, unlimited_hosts=False).create()
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-def test_negative_create_with_invalid_name(name, target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_invalid_name(target_sat):
     """Create activation key providing an invalid name.
 
     :id: 5f7051be-0320-4d37-9085-6904025ad909
@@ -141,23 +136,21 @@ def test_negative_create_with_invalid_name(name, target_sat):
     :expectedresults: Activation key is not created
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
+    name = random.choice(invalid_names_list())
     with pytest.raises(HTTPError):
         target_sat.api.ActivationKey(name=name).create()
 
 
-@pytest.mark.parametrize('max_host', **parametrized(_good_max_hosts()))
-def test_positive_update_limited_host(max_host, target_sat):
+@pytest.mark.migration_candidate
+def test_positive_update_limited_host(target_sat):
     """Create activation key then update it to limited hosts.
 
     :id: 34ca8303-8135-4694-9cf7-b20f8b4b0a1e
 
     :expectedresults: Activation key is created, updated to limited host
-
-    :parametrized: yes
     """
+    max_host = random.choice(_good_max_hosts())
     # unlimited_hosts defaults to True.
     act_key = target_sat.api.ActivationKey().create()
     want = {'max_hosts': max_host, 'unlimited_hosts': False}
@@ -168,8 +161,8 @@ def test_positive_update_limited_host(max_host, target_sat):
     assert want == actual
 
 
-@pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-def test_positive_update_name(new_name, target_sat, module_org):
+@pytest.mark.migration_candidate
+def test_positive_update_name(target_sat, module_org):
     """Create activation key providing the initial name, then update
     its name to another valid name.
 
@@ -177,9 +170,8 @@ def test_positive_update_name(new_name, target_sat, module_org):
 
     :expectedresults: Activation key is created, and its name can be
         updated.
-
-    :parametrized: yes
     """
+    new_name = random.choice(list(valid_data_list().values()))
     act_key = target_sat.api.ActivationKey(organization=module_org).create()
     updated = target_sat.api.ActivationKey(
         id=act_key.id, organization=module_org, name=new_name
@@ -187,8 +179,8 @@ def test_positive_update_name(new_name, target_sat, module_org):
     assert new_name == updated.name
 
 
-@pytest.mark.parametrize('max_host', **parametrized(_bad_max_hosts()))
-def test_negative_update_limit(max_host, target_sat):
+@pytest.mark.migration_candidate
+def test_negative_update_limit(target_sat):
     """Create activation key then update its limit to invalid value.
 
     :id: 0f857d2f-81ed-4b8b-b26e-34b4f294edbc
@@ -200,9 +192,8 @@ def test_negative_update_limit(max_host, target_sat):
         3. Record is not changed
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
+    max_host = random.choice(_bad_max_hosts())
     act_key = target_sat.api.ActivationKey().create()
     want = {'max_hosts': act_key.max_hosts, 'unlimited_hosts': act_key.unlimited_hosts}
     act_key.max_hosts = max_host
@@ -214,8 +205,8 @@ def test_negative_update_limit(max_host, target_sat):
     assert want == actual
 
 
-@pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
-def test_negative_update_name(new_name, target_sat, module_org):
+@pytest.mark.migration_candidate
+def test_negative_update_name(target_sat, module_org):
     """Create activation key then update its name to an invalid name.
 
     :id: da85a32c-942b-4ab8-a133-36b028208c4d
@@ -224,9 +215,8 @@ def test_negative_update_name(new_name, target_sat, module_org):
         updated.
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
+    new_name = random.choice(invalid_names_list())
     act_key = target_sat.api.ActivationKey(organization=module_org).create()
     with pytest.raises(HTTPError):
         target_sat.api.ActivationKey(id=act_key.id, organization=module_org, name=new_name).update(
@@ -237,6 +227,7 @@ def test_negative_update_name(new_name, target_sat, module_org):
     assert new_key.name == act_key.name
 
 
+@pytest.mark.migration_candidate
 def test_negative_update_max_hosts(target_sat, module_org):
     """Create an activation key with ``max_hosts == 1``, then update that
     field with a string value.
@@ -284,6 +275,7 @@ def test_positive_get_releases_content(target_sat):
     assert isinstance(response['results'], list)
 
 
+@pytest.mark.migration_candidate
 def test_positive_add_host_collections(module_org, module_target_sat):
     """Associate an activation key with several host collections.
 
@@ -351,8 +343,7 @@ def test_positive_remove_host_collection(module_org, module_target_sat):
 
 
 @pytest.mark.upgrade
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_delete(name, target_sat):
+def test_positive_delete(target_sat):
     """Create activation key and then delete it.
 
     :id: aa28d8fb-e07d-45fa-b43a-fc90c706d633
@@ -360,9 +351,8 @@ def test_positive_delete(name, target_sat):
     :expectedresults: Activation key is successfully deleted.
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    name = random.choice(list(valid_data_list().values()))
     act_key = target_sat.api.ActivationKey(name=name).create()
     act_key.delete()
     with pytest.raises(HTTPError):

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -12,17 +12,19 @@
 
 """
 
+import random
+
 from fauxfactory import gen_choice
 import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.utils.datafactory import (
     invalid_names_list,
-    parametrized,
     valid_data_list,
 )
 
 
+@pytest.mark.migration_candidate
 def test_positive_CRUD(default_os, target_sat):
     """Create a new Architecture with several attributes, update the name
     and delete the Architecture itself.
@@ -52,13 +54,11 @@ def test_positive_CRUD(default_os, target_sat):
         arch.read()
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-def test_negative_create_with_invalid_name(name, target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_invalid_name(target_sat):
     """Create architecture providing an invalid initial name.
 
     :id: 0fa6377d-063a-4e24-b606-b342e0d9108b
-
-    :parametrized: yes
 
     :expectedresults: Architecture is not created
 
@@ -66,22 +66,22 @@ def test_negative_create_with_invalid_name(name, target_sat):
 
     :BZ: 1401519
     """
+    name = random.choice(invalid_names_list())
     with pytest.raises(HTTPError):
         target_sat.api.Architecture(name=name).create()
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-def test_negative_update_with_invalid_name(name, module_architecture, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_update_with_invalid_name(module_architecture, module_target_sat):
     """Update architecture's name to an invalid name.
 
     :id: cb27b69b-14e0-42d0-9e44-e09d68324803
-
-    :parametrized: yes
 
     :expectedresults: Architecture's name is not updated.
 
     :CaseImportance: Medium
     """
+    name = random.choice(invalid_names_list())
     with pytest.raises(HTTPError):
         module_target_sat.api.Architecture(id=module_architecture.id, name=name).update(['name'])
     arch = module_target_sat.api.Architecture(id=module_architecture.id).read()

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -19,7 +19,6 @@ from requests.exceptions import HTTPError
 
 from robottelo.utils.datafactory import (
     invalid_values_list,
-    parametrized,
     valid_data_list,
 )
 
@@ -30,25 +29,25 @@ def fake_hosts(module_org, module_target_sat):
     return [module_target_sat.api.Host(organization=module_org).create() for _ in range(2)]
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_name(module_org, name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_name(module_org, module_target_sat):
     """Create host collections with different names.
 
     :id: 8f2b9223-f5be-4cb1-8316-01ea747cae14
-
-    :parametrized: yes
 
     :expectedresults: The host collection was successfully created and has
         appropriate name.
 
     :CaseImportance: Critical
     """
+    name = choice(list(valid_data_list().values()))
     host_collection = module_target_sat.api.HostCollection(
         name=name, organization=module_org
     ).create()
     assert host_collection.name == name
 
 
+@pytest.mark.migration_candidate
 def test_positive_list(module_org, module_target_sat):
     """Create new host collection and then retrieve list of all existing
     host collections
@@ -69,6 +68,7 @@ def test_positive_list(module_org, module_target_sat):
     assert len(hc_list) >= 1
 
 
+@pytest.mark.migration_candidate
 def test_positive_list_for_organization(target_sat):
     """Create host collection for specific organization. Retrieve list of
     host collections for that organization
@@ -87,25 +87,25 @@ def test_positive_list_for_organization(target_sat):
     assert hc_list[0].id == hc.id
 
 
-@pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-def test_positive_create_with_description(module_org, desc, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_create_with_description(module_org, module_target_sat):
     """Create host collections with different descriptions.
 
     :id: 9d13392f-8d9d-4ff1-8909-4233e4691055
-
-    :parametrized: yes
 
     :expectedresults: The host collection was successfully created and has
         appropriate description.
 
     :CaseImportance: Critical
     """
+    desc = choice(list(valid_data_list().values()))
     host_collection = module_target_sat.api.HostCollection(
         description=desc, organization=module_org
     ).create()
     assert host_collection.description == desc
 
 
+@pytest.mark.migration_candidate
 def test_positive_create_with_limit(module_org, module_target_sat):
     """Create host collections with different limits.
 
@@ -124,6 +124,7 @@ def test_positive_create_with_limit(module_org, module_target_sat):
         assert host_collection.max_hosts == limit
 
 
+@pytest.mark.migration_candidate
 @pytest.mark.parametrize("unlimited", [False, True])
 def test_positive_create_with_unlimited_hosts(module_org, unlimited, module_target_sat):
     """Create host collection with different values of 'unlimited hosts'
@@ -234,40 +235,39 @@ def test_positive_read_host_ids(module_org, fake_hosts, module_target_sat):
     )
 
 
-@pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-def test_positive_update_name(module_org, new_name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_update_name(module_org, module_target_sat):
     """Check if host collection name can be updated
 
     :id: b2dedb99-6dd7-41be-8aaa-74065c820ac6
-
-    :parametrized: yes
 
     :expectedresults: Host collection name was successfully updated
 
     :CaseImportance: Critical
     """
+    new_name = choice(list(valid_data_list().values()))
     host_collection = module_target_sat.api.HostCollection(organization=module_org).create()
     host_collection.name = new_name
     assert host_collection.update().name == new_name
 
 
-@pytest.mark.parametrize('new_desc', **parametrized(valid_data_list()))
-def test_positive_update_description(module_org, new_desc, module_target_sat):
+@pytest.mark.migration_candidate
+def test_positive_update_description(module_org, module_target_sat):
     """Check if host collection description can be updated
 
     :id: f8e9bd1c-1525-4b5f-a07c-eb6b6e7aa628
-
-    :parametrized: yes
 
     :expectedresults: Host collection description was updated
 
     :CaseImportance: Critical
     """
+    new_desc = choice(list(valid_data_list().values()))
     host_collection = module_target_sat.api.HostCollection(organization=module_org).create()
     host_collection.description = new_desc
     assert host_collection.update().description == new_desc
 
 
+@pytest.mark.migration_candidate
 def test_positive_update_limit(module_org, module_target_sat):
     """Check if host collection limit can be updated
 
@@ -285,6 +285,7 @@ def test_positive_update_limit(module_org, module_target_sat):
         assert host_collection.update().max_hosts == limit
 
 
+@pytest.mark.migration_candidate
 def test_positive_update_unlimited_hosts(module_org, module_target_sat):
     """Check if host collection 'unlimited hosts' parameter can be updated
 
@@ -308,6 +309,7 @@ def test_positive_update_unlimited_hosts(module_org, module_target_sat):
         assert host_collection.unlimited_hosts == unlimited
 
 
+@pytest.mark.migration_candidate
 def test_positive_update_host(module_org, fake_hosts, module_target_sat):
     """Update host collection's host.
 
@@ -361,17 +363,16 @@ def test_positive_delete(module_org, module_target_sat):
         host_collection.read()
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_invalid_name(module_org, name, module_target_sat):
+@pytest.mark.migration_candidate
+def test_negative_create_with_invalid_name(module_org, module_target_sat):
     """Try to create host collections with different invalid names
 
     :id: 38f67d04-a19d-4eab-a577-21b8d62c7389
-
-    :parametrized: yes
 
     :expectedresults: The host collection was not created
 
     :CaseImportance: Critical
     """
+    name = choice(invalid_values_list())
     with pytest.raises(HTTPError):
         module_target_sat.api.HostCollection(name=name, organization=module_org).create()

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -13,6 +13,7 @@
 """
 
 from copy import copy
+import random
 from random import randint
 
 from fauxfactory import gen_string
@@ -24,7 +25,6 @@ from robottelo.config import get_credentials
 from robottelo.constants import DEFAULT_ARCHITECTURE, REPOS
 from robottelo.utils.datafactory import (
     invalid_values_list,
-    parametrized,
     valid_hostgroups_list,
 )
 
@@ -191,23 +191,23 @@ class TestHostGroup:
             == 'Configuration successfully rebuilt.'
         )
 
-    @pytest.mark.parametrize('name', **parametrized(valid_hostgroups_list()))
-    def test_positive_create_with_name(self, name, module_org, module_location, module_target_sat):
+    @pytest.mark.migration_candidate
+    def test_positive_create_with_name(self, module_org, module_location, module_target_sat):
         """Create a hostgroup with different names
 
         :id: fd5d353c-fd0c-4752-8a83-8f399b4c3416
-
-        :parametrized: yes
 
         :expectedresults: A hostgroup is created with expected name
 
         :CaseImportance: Critical
         """
+        name = random.choice(valid_hostgroups_list())
         hostgroup = module_target_sat.api.HostGroup(
             location=[module_location], name=name, organization=[module_org]
         ).create()
         assert name == hostgroup.name
 
+    @pytest.mark.migration_candidate
     def test_positive_clone(self, hostgroup, target_sat):
         """Create a hostgroup by cloning an existing one
 
@@ -443,18 +443,17 @@ class TestHostGroup:
         hostgroup = target_sat.api.HostGroup(organization=orgs).create()
         assert {org.name for org in orgs}, {org.read().name for org in hostgroup.organization}
 
-    @pytest.mark.parametrize('name', **parametrized(valid_hostgroups_list()))
-    def test_positive_update_name(self, name, hostgroup):
+    @pytest.mark.migration_candidate
+    def test_positive_update_name(self, hostgroup):
         """Update a hostgroup with a new name
 
         :id: 8abb151f-a058-4f47-a1c1-f60a32cd7572
-
-        :parametrized: yes
 
         :expectedresults: A hostgroup is updated with expected name
 
         :CaseImportance: Critical
         """
+        name = random.choice(valid_hostgroups_list())
         hostgroup.name = name
         hostgroup = hostgroup.update(['name'])
         assert name == hostgroup.name
@@ -579,35 +578,33 @@ class TestHostGroup:
         hostgroup = hostgroup.update(['organization'])
         assert {org.name for org in new_orgs} == {org.read().name for org in hostgroup.organization}
 
-    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-    def test_negative_create_with_name(self, name, module_org, module_location, module_target_sat):
+    @pytest.mark.migration_candidate
+    def test_negative_create_with_name(self, module_org, module_location, module_target_sat):
         """Attempt to create a hostgroup with invalid names
 
         :id: 3f5aa17a-8db9-4fe9-b309-b8ec5e739da1
-
-        :parametrized: yes
 
         :expectedresults: A hostgroup is not created
 
         :CaseImportance: Critical
         """
+        name = random.choice(invalid_values_list())
         with pytest.raises(HTTPError):
             module_target_sat.api.HostGroup(
                 location=[module_location], name=name, organization=[module_org]
             ).create()
 
-    @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-    def test_negative_update_name(self, new_name, hostgroup):
+    @pytest.mark.migration_candidate
+    def test_negative_update_name(self, hostgroup):
         """Attempt to update a hostgroup with invalid names
 
         :id: 6d8c4738-a0c4-472b-9a71-27c8a3832335
-
-        :parametrized: yes
 
         :expectedresults: A hostgroup is not updated
 
         :CaseImportance: Critical
         """
+        new_name = random.choice(invalid_values_list())
         original_name = hostgroup.name
         hostgroup.name = new_name
         with pytest.raises(HTTPError):

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -120,21 +120,21 @@ class TestMedia:
         media = module_target_sat.api.Media(id=media.id, path_=new_url).update(['path_'])
         assert media.path_ == new_url
 
-    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-    def test_negative_create_with_invalid_name(self, name, target_sat):
+    @pytest.mark.migration_candidate
+    def test_negative_create_with_invalid_name(self, target_sat):
         """Try to create media entity providing an invalid name
 
         :id: 0934f4dc-f674-40fe-a639-035761139c83
-
-        :parametrized: yes
 
         :expectedresults: Media entity is not created
 
         :CaseImportance: Medium
         """
+        name = random.choice(invalid_values_list())
         with pytest.raises(HTTPError):
             target_sat.api.Media(name=name).create()
 
+    @pytest.mark.migration_candidate
     def test_negative_create_with_invalid_url(self, target_sat):
         """Try to create media entity providing an invalid URL
 
@@ -147,6 +147,7 @@ class TestMedia:
         with pytest.raises(HTTPError):
             target_sat.api.Media(path_='NON_EXISTENT_URL').create()
 
+    @pytest.mark.migration_candidate
     def test_negative_create_with_invalid_os_family(self, target_sat):
         """Try to create media entity providing an invalid OS family
 
@@ -159,22 +160,22 @@ class TestMedia:
         with pytest.raises(HTTPError):
             target_sat.api.Media(os_family='NON_EXISTENT_OS').create()
 
-    @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-    def test_negative_update_name(self, class_media, new_name, target_sat):
+    @pytest.mark.migration_candidate
+    def test_negative_update_name(self, class_media, target_sat):
         """Create media entity providing the initial name, then try to
         update its name to invalid one.
 
         :id: 1c7d3af1-8cef-454e-80b6-a8e95b5dfa8b
 
-        :parametrized: yes
-
         :expectedresults: Media entity is not updated
 
         :CaseImportance: Medium
         """
+        new_name = random.choice(invalid_values_list())
         with pytest.raises(HTTPError):
             target_sat.api.Media(id=class_media.id, name=new_name).update(['name'])
 
+    @pytest.mark.migration_candidate
     def test_negative_update_url(self, class_media, target_sat):
         """Try to update media with invalid url.
 
@@ -187,6 +188,7 @@ class TestMedia:
         with pytest.raises(HTTPError):
             target_sat.api.Media(id=class_media.id, path_='NON_EXISTENT_URL').update(['path_'])
 
+    @pytest.mark.migration_candidate
     def test_negative_update_os_family(self, class_media, target_sat):
         """Try to update media with invalid operation system.
 

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -34,15 +34,11 @@ from robottelo.utils.datafactory import (
 class TestPartitionTable:
     """Tests for the ``ptables`` path."""
 
-    @pytest.mark.parametrize(
-        'name', **parametrized(generate_strings_list(length=1, exclude_types='alphanumeric'))
-    )
-    def test_positive_create_with_one_character_name(self, target_sat, name):
+    @pytest.mark.migration_candidate
+    def test_positive_create_with_one_character_name(self, target_sat):
         """Create Partition table with 1 character in name
 
         :id: 71601d96-8ce8-4ecb-b053-af6f26a246ea
-
-        :parametrized: yes
 
         :expectedresults: Partition table was created
 
@@ -50,9 +46,11 @@ class TestPartitionTable:
 
         :CaseImportance: Low
         """
+        name = random.choice(generate_strings_list(length=1, exclude_types='alphanumeric'))
         ptable = target_sat.api.PartitionTable(name=name).create()
         assert ptable.name == name
 
+    @pytest.mark.migration_candidate
     @pytest.mark.parametrize(
         ('name', 'new_name'),
         **parametrized(
@@ -88,6 +86,7 @@ class TestPartitionTable:
         with pytest.raises(HTTPError):
             ptable.read()
 
+    @pytest.mark.migration_candidate
     @pytest.mark.parametrize(
         ('layout', 'new_layout'),
         **parametrized(list(zip(valid_data_list(), valid_data_list(), strict=True))),
@@ -110,6 +109,7 @@ class TestPartitionTable:
         ptable.layout = new_layout
         assert ptable.update(['layout']).layout == new_layout
 
+    @pytest.mark.migration_candidate
     def test_positive_create_with_layout_length(self, target_sat):
         """Create a Partition Table with layout length more than 4096 chars
 
@@ -124,6 +124,7 @@ class TestPartitionTable:
         ptable = target_sat.api.PartitionTable(layout=layout).create()
         assert ptable.layout == layout
 
+    @pytest.mark.migration_candidate
     def test_positive_create_update_with_os(self, target_sat):
         """Create new partition table with random operating system and update it with
             random operating system
@@ -141,6 +142,7 @@ class TestPartitionTable:
         ptable.os_family = new_os_family
         assert ptable.update(['os_family']).os_family == new_os_family
 
+    @pytest.mark.migration_candidate
     def test_positive_create_search_with_org(self, target_sat, module_org):
         """Create new partition table with organization and try to find it using its name and
             organization it assigned to
@@ -160,68 +162,65 @@ class TestPartitionTable:
         assert len(result) == 1
         assert result[0].read().organization[0].id == module_org.id
 
-    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-    def test_negative_create_with_invalid_name(self, target_sat, name):
+    @pytest.mark.migration_candidate
+    def test_negative_create_with_invalid_name(self, target_sat):
         """Try to create partition table using invalid names only
 
         :id: 02631917-2f7a-4cf7-bb2a-783349a04758
-
-        :parametrized: yes
 
         :expectedresults: Partition table was not created
 
         :CaseImportance: Medium
         """
+        name = random.choice(invalid_values_list())
         with pytest.raises(HTTPError):
             target_sat.api.PartitionTable(name=name).create()
 
-    @pytest.mark.parametrize('layout', **parametrized(('', ' ', None)))
-    def test_negative_create_with_empty_layout(self, target_sat, layout):
+    @pytest.mark.migration_candidate
+    def test_negative_create_with_empty_layout(self, target_sat):
         """Try to create partition table with empty layout
 
         :id: 03cb7a35-e4c3-4874-841b-0760c3b8d6af
 
-        :parametrized: yes
-
         :expectedresults: Partition table was not created
         """
+        layout = random.choice(('', ' ', None))
         with pytest.raises(HTTPError):
             target_sat.api.PartitionTable(layout=layout).create()
 
-    @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-    def test_negative_update_name(self, target_sat, new_name):
+    @pytest.mark.migration_candidate
+    def test_negative_update_name(self, target_sat):
         """Try to update partition table using invalid names only
 
         :id: 7e9face8-2c20-450e-890c-6def6de570ca
-
-        :parametrized: yes
 
         :expectedresults: Partition table was not updated
 
         :CaseImportance: Medium
         """
+        new_name = random.choice(invalid_values_list())
         ptable = target_sat.api.PartitionTable().create()
         ptable.name = new_name
         with pytest.raises(HTTPError):
             assert ptable.update(['name']).name != new_name
 
-    @pytest.mark.parametrize('new_layout', **parametrized(('', ' ', None)))
-    def test_negative_update_layout(self, target_sat, new_layout):
+    @pytest.mark.migration_candidate
+    def test_negative_update_layout(self, target_sat):
         """Try to update partition table with empty layout
 
         :id: 35c84c8f-b802-4076-89f2-4ec04cf43a31
-
-        :parametrized: yes
 
         :expectedresults: Partition table was not updated
 
         :CaseImportance: Medium
         """
+        new_layout = random.choice(('', ' ', None))
         ptable = target_sat.api.PartitionTable().create()
         ptable.layout = new_layout
         with pytest.raises(HTTPError):
             assert ptable.update(['layout']).layout != new_layout
 
+    @pytest.mark.migration_candidate
     def test_positive_clone_locked_ptable(self, target_sat, locked_partition_table):
         """Clone a locked partition table. Verify the cloned ptable is not locked.
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -12,6 +12,8 @@
 
 """
 
+import random
+
 from fauxfactory import gen_alphanumeric, gen_string
 import pytest
 
@@ -21,7 +23,6 @@ from robottelo.constants import DEFAULT_ARCHITECTURE, PRDS, REPOS, REPOSET
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.utils.datafactory import (
     invalid_values_list,
-    parametrized,
     valid_data_list,
 )
 
@@ -34,8 +35,7 @@ def get_default_env(module_org, module_target_sat):
     )
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_name(module_target_sat, module_sca_manifest_org, name):
+def test_positive_create_with_name(module_target_sat, module_sca_manifest_org):
     """Create Activation key for all variations of Activation key
     name
 
@@ -44,17 +44,15 @@ def test_positive_create_with_name(module_target_sat, module_sca_manifest_org, n
     :expectedresults: Activation key is created with chosen name
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    name = random.choice(list(valid_data_list().values()))
     new_ak = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_sca_manifest_org.id, 'name': name}
     )
     assert new_ak['name'] == name
 
 
-@pytest.mark.parametrize('desc', **parametrized(valid_data_list()))
-def test_positive_create_with_description(desc, module_org, module_target_sat):
+def test_positive_create_with_description(module_org, module_target_sat):
     """Create Activation key for all variations of Description
 
     :id: 5a5ca7f9-1449-4365-ac8a-978605620bf2
@@ -62,9 +60,8 @@ def test_positive_create_with_description(desc, module_org, module_target_sat):
     :expectedresults: Activation key is created with chosen description
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    desc = random.choice(list(valid_data_list().values()))
     new_ak = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id, 'description': desc}
     )
@@ -135,17 +132,15 @@ def test_positive_create_with_default_lce_by_name(
     assert new_ak_env.content_view_environments[0].name == lce['name']
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_cv(name, module_org, get_default_env, module_target_sat):
+def test_positive_create_with_cv(module_org, get_default_env, module_target_sat):
     """Create Activation key for all variations of Content Views
 
     :id: ec7b1af5-c3f4-40c3-b1df-c69c02a3b9a7
 
     :expectedresults: Activation key is created and has proper content view
         assigned
-
-    :parametrized: yes
     """
+    name = random.choice(list(valid_data_list().values()))
     new_cv = module_target_sat.cli_factory.make_content_view(
         {'name': name, 'organization-id': module_org.id}
     )
@@ -210,8 +205,7 @@ def test_positive_create_content_and_check_enabled(module_org, module_target_sat
     assert content[0]['default-enabled?'] == 'false'
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_invalid_name(name, module_org, module_target_sat):
+def test_negative_create_with_invalid_name(module_org, module_target_sat):
     """Create Activation key with invalid Name
 
     :id: d9b7e3a9-1d24-4e47-bd4a-dce75772d829
@@ -220,9 +214,8 @@ def test_negative_create_with_invalid_name(name, module_org, module_target_sat):
         shown.
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(CLIFactoryError) as raise_ctx:
         module_target_sat.cli_factory.make_activation_key(
             {'organization-id': module_org.id, 'name': name}
@@ -233,11 +226,7 @@ def test_negative_create_with_invalid_name(name, module_org, module_target_sat):
         assert 'Name is too long (maximum is 255 characters)' in str(raise_ctx)
 
 
-@pytest.mark.parametrize(
-    'limit',
-    **parametrized([value for value in invalid_values_list() if not value.isdigit()] + [0.5]),
-)
-def test_negative_create_with_usage_limit_with_not_integers(module_org, limit, module_target_sat):
+def test_negative_create_with_usage_limit_with_not_integers(module_org, module_target_sat):
     """Create Activation key with non integers Usage Limit
 
     :id: 247ebc2e-c80f-488b-aeaf-6bf5eba55375
@@ -246,12 +235,11 @@ def test_negative_create_with_usage_limit_with_not_integers(module_org, limit, m
         shown.
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
     # exclude numeric values from invalid values list
     # invalid_values = [value for value in invalid_values_list() if not value.isdigit()]
     # invalid_values.append(0.5)
+    limit = random.choice([value for value in invalid_values_list() if not value.isdigit()] + [0.5])
     with pytest.raises(CLIFactoryError) as raise_ctx:
         module_target_sat.cli_factory.make_activation_key(
             {'organization-id': module_org.id, 'max-hosts': limit}
@@ -262,10 +250,7 @@ def test_negative_create_with_usage_limit_with_not_integers(module_org, limit, m
         assert 'Numeric value is required.' in str(raise_ctx)
 
 
-@pytest.mark.parametrize('invalid_values', ['-1', '-500', 0])
-def test_negative_create_with_usage_limit_with_invalid_integers(
-    module_org, invalid_values, module_target_sat
-):
+def test_negative_create_with_usage_limit_with_invalid_integers(module_org, module_target_sat):
     """Create Activation key with invalid integers Usage Limit
 
     :id: 9089f756-fda8-4e28-855c-cf8273f7c6cd
@@ -274,9 +259,8 @@ def test_negative_create_with_usage_limit_with_invalid_integers(
         shown.
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
+    invalid_values = random.choice(['-1', '-500', 0])
     with pytest.raises(CLIFactoryError) as raise_ctx:
         module_target_sat.cli_factory.make_activation_key(
             {'organization-id': module_org.id, 'max-hosts': invalid_values}
@@ -284,8 +268,7 @@ def test_negative_create_with_usage_limit_with_invalid_integers(
     assert 'Failed to create ActivationKey with data:' in str(raise_ctx)
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_delete_by_name(name, module_org, module_target_sat):
+def test_positive_delete_by_name(module_org, module_target_sat):
     """Create Activation key and delete it for all variations of
     Activation key name
 
@@ -294,9 +277,8 @@ def test_positive_delete_by_name(name, module_org, module_target_sat):
     :expectedresults: Activation key is deleted
 
     :CaseImportance: High
-
-    :parametrized: yes
     """
+    name = random.choice(list(valid_data_list().values()))
     new_ak = module_target_sat.cli_factory.make_activation_key(
         {'name': name, 'organization-id': module_org.id}
     )
@@ -387,8 +369,7 @@ def test_positive_delete_with_lce(
         module_target_sat.cli.ActivationKey.info({'id': new_ak['id']})
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_update_name_by_id(module_org, name, module_target_sat):
+def test_positive_update_name_by_id(module_org, module_target_sat):
     """Update Activation Key Name in Activation key searching by ID
 
     :id: bc304894-fd9b-4622-96e3-57c2257e26ca
@@ -396,9 +377,8 @@ def test_positive_update_name_by_id(module_org, name, module_target_sat):
     :expectedresults: Activation key is updated
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    name = random.choice(list(valid_data_list().values()))
     activation_key = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id}
     )
@@ -430,8 +410,7 @@ def test_positive_update_name_by_name(module_org, module_target_sat):
     assert updated_ak['name'] == new_name
 
 
-@pytest.mark.parametrize('description', **parametrized(valid_data_list()))
-def test_positive_update_description(description, module_org, module_target_sat):
+def test_positive_update_description(module_org, module_target_sat):
     """Update Description in an Activation key
 
     :id: 60a4e860-d99c-431e-b70b-9b0fa90d839b
@@ -439,9 +418,8 @@ def test_positive_update_description(description, module_org, module_target_sat)
     :expectedresults: Activation key is updated
 
     :CaseImportance: High
-
-    :parametrized: yes
     """
+    description = random.choice(list(valid_data_list().values()))
     activation_key = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id}
     )
@@ -565,8 +543,7 @@ def test_positive_update_usage_limit_to_unlimited(module_org, module_target_sat)
     assert updated_ak['host-limit'] == '0 of Unlimited'
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_update_name(module_org, name, module_target_sat):
+def test_negative_update_name(module_org, module_target_sat):
     """Try to update Activation Key using invalid value for its name
 
     :id: b75e7c38-fde2-4110-ba65-4157319fc159
@@ -575,9 +552,8 @@ def test_negative_update_name(module_org, name, module_target_sat):
         shown.
 
     :CaseImportance: Low
-
-    :parametrized: yes
     """
+    name = random.choice(invalid_values_list())
     new_ak = module_target_sat.cli_factory.make_activation_key({'organization-id': module_org.id})
     with pytest.raises(CLIReturnCodeError) as raise_ctx:
         module_target_sat.cli.ActivationKey.update(
@@ -649,8 +625,7 @@ def test_positive_usage_limit(module_org, module_location, target_sat, content_h
     assert f"Max Hosts ({max_hosts}) reached for activation key '{new_ak.name}'" in result.stderr
 
 
-@pytest.mark.parametrize('host_col_name', **parametrized(valid_data_list()))
-def test_positive_update_host_collection(module_org, host_col_name, module_target_sat):
+def test_positive_update_host_collection(module_org, module_target_sat):
     """Test that host collections can be associated to Activation
     Keys
 
@@ -660,9 +635,8 @@ def test_positive_update_host_collection(module_org, host_col_name, module_targe
 
     :expectedresults: Host collections are successfully associated to
         Activation key
-
-    :parametrized: yes
     """
+    host_col_name = random.choice(list(valid_data_list().values()))
     activation_key = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id}
     )
@@ -871,8 +845,7 @@ def test_positive_update_aks_to_chost_in_one_command(module_org):
     """
 
 
-@pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_list_by_name(module_org, name, module_target_sat):
+def test_positive_list_by_name(module_org, module_target_sat):
     """List Activation key for all variations of Activation key name
 
     :id: 644b70d9-86c1-4e26-b38e-6aafab3efa34
@@ -880,9 +853,8 @@ def test_positive_list_by_name(module_org, name, module_target_sat):
     :expectedresults: Activation key is listed
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    name = random.choice(list(valid_data_list().values()))
     module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id, 'name': name}
     )
@@ -994,8 +966,7 @@ def test_positive_remove_host_collection_by_id(module_org, module_target_sat):
     )
 
 
-@pytest.mark.parametrize('host_col', **parametrized(valid_data_list()))
-def test_positive_remove_host_collection_by_name(module_org, host_col, module_target_sat):
+def test_positive_remove_host_collection_by_name(module_org, module_target_sat):
     """Test that hosts associated to Activation Keys can be removed
     using name of that host collection
 
@@ -1013,9 +984,8 @@ def test_positive_remove_host_collection_by_name(module_org, host_col, module_ta
         key
 
     :BZ: 1336716
-
-    :parametrized: yes
     """
+    host_col = random.choice(list(valid_data_list().values()))
     activation_key = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id}
     )
@@ -1153,8 +1123,7 @@ def test_update_ak_with_syspurpose_values(module_sca_manifest_org, module_target
     assert updated_ak['system-purpose']['service-level'] == "Premium"
 
 
-@pytest.mark.parametrize('new_name', **parametrized(valid_data_list()))
-def test_positive_copy_by_parent_id(module_org, new_name, module_target_sat):
+def test_positive_copy_by_parent_id(module_org, module_target_sat):
     """Copy Activation key for all valid Activation Key name
     variations
 
@@ -1163,9 +1132,8 @@ def test_positive_copy_by_parent_id(module_org, new_name, module_target_sat):
     :expectedresults: Activation key is successfully copied
 
     :CaseImportance: Critical
-
-    :parametrized: yes
     """
+    new_name = random.choice(list(valid_data_list().values()))
     parent_ak = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id}
     )

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -12,6 +12,8 @@
 
 """
 
+import random
+
 from fauxfactory import gen_choice
 import pytest
 
@@ -19,7 +21,6 @@ from robottelo.exceptions import CLIReturnCodeError
 from robottelo.utils.datafactory import (
     invalid_id_list,
     invalid_values_list,
-    parametrized,
     valid_data_list,
 )
 
@@ -54,37 +55,31 @@ class TestArchitecture:
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Architecture.info({'id': architecture['id']})
 
-    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-    def test_negative_create_with_name(self, name, module_target_sat):
+    def test_negative_create_with_name(self, module_target_sat):
         """Don't create an Architecture with invalid data.
 
         :id: cfed972e-9b09-4852-bdd2-b5a8a8aed170
-
-        :parametrized: yes
 
         :expectedresults: Architecture is not created.
 
         :CaseImportance: Medium
         """
-
+        name = random.choice(invalid_values_list())
         with pytest.raises(CLIReturnCodeError) as error:
             module_target_sat.cli.Architecture.create({'name': name})
 
         assert 'Could not create the architecture:' in error.value.message
 
-    @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-    def test_negative_update_name(self, class_architecture, new_name, module_target_sat):
+    def test_negative_update_name(self, class_architecture, module_target_sat):
         """Create Architecture then fail to update its name
 
         :id: 037c4892-5e62-46dd-a2ed-92243e870e40
-
-        :parametrized: yes
 
         :expectedresults: Architecture name is not updated
 
         :CaseImportance: Medium
         """
-
+        new_name = random.choice(invalid_values_list())
         with pytest.raises(CLIReturnCodeError) as error:
             module_target_sat.cli.Architecture.update(
                 {'id': class_architecture['id'], 'new-name': new_name}
@@ -95,18 +90,16 @@ class TestArchitecture:
         result = module_target_sat.cli.Architecture.info({'id': class_architecture['id']})
         assert class_architecture['name'] == result['name']
 
-    @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
-    def test_negative_delete_by_id(self, entity_id, module_target_sat):
+    def test_negative_delete_by_id(self, module_target_sat):
         """Delete architecture by invalid ID
 
         :id: 78bae664-6493-4c74-a587-94170f20746e
-
-        :parametrized: yes
 
         :expectedresults: Architecture is not deleted
 
         :CaseImportance: Medium
         """
+        entity_id = random.choice(invalid_id_list())
         with pytest.raises(CLIReturnCodeError) as error:
             module_target_sat.cli.Architecture.delete({'id': entity_id})
 

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -12,6 +12,8 @@
 
 """
 
+import random
+
 from fauxfactory import gen_string
 import pytest
 
@@ -20,7 +22,6 @@ from robottelo.constants import DEFAULT_CV, LIBRARY_LCE
 from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.utils.datafactory import (
     invalid_values_list,
-    parametrized,
     valid_data_list,
 )
 
@@ -168,19 +169,17 @@ def test_positive_update_to_unlimited_hosts(module_org, module_target_sat):
     assert result['limit'] == 'None'
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_name(module_org, name, module_target_sat):
+def test_negative_create_with_name(module_org, module_target_sat):
     """Attempt to create host collection with invalid name of different
     types
 
     :id: 92a9eff0-693f-4ab8-b2c4-de08e5f709a7
 
-    :parametrized: yes
-
     :expectedresults: Host collection is not created and error is raised
 
     :CaseImportance: Critical
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(CLIFactoryError):
         module_target_sat.cli_factory.make_host_collection(
             {'name': name, 'organization-id': module_org.id}

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -12,6 +12,8 @@
 
 """
 
+import random
+
 from fauxfactory import gen_integer
 import pytest
 
@@ -20,7 +22,6 @@ from robottelo.exceptions import CLIFactoryError, CLIReturnCodeError
 from robottelo.utils.datafactory import (
     invalid_id_list,
     invalid_values_list,
-    parametrized,
     valid_hostgroups_list,
 )
 
@@ -83,16 +84,14 @@ def hostgroup(content_source, module_org, module_target_sat):
     )
 
 
-@pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_name(name, module_target_sat):
+def test_negative_create_with_name(module_target_sat):
     """Don't create an HostGroup with invalid data.
 
     :id: 853a6d43-129a-497b-94f0-08dc622862f8
 
-    :parametrized: yes
-
     :expectedresults: HostGroup is not created.
     """
+    name = random.choice(invalid_values_list())
     with pytest.raises(CLIReturnCodeError):
         module_target_sat.cli.HostGroup.create({'name': name})
 

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -12,11 +12,13 @@
 
 """
 
+import random
+
 from fauxfactory import gen_alphanumeric
 import pytest
 
 from robottelo.exceptions import CLIReturnCodeError
-from robottelo.utils.datafactory import parametrized, valid_data_list
+from robottelo.utils.datafactory import valid_data_list
 
 URL = "http://mirror.fakeos.org/%s/$major.$minor/os/$arch"
 OSES = ['Archlinux', 'Debian', 'Gentoo', 'Redhat', 'Solaris', 'Suse', 'Windows']
@@ -25,19 +27,17 @@ OSES = ['Archlinux', 'Debian', 'Gentoo', 'Redhat', 'Solaris', 'Suse', 'Windows']
 class TestMedium:
     """Test class for Medium CLI"""
 
-    @pytest.mark.parametrize('name', **parametrized(valid_data_list().values()))
-    def test_positive_crud_with_name(self, name, module_target_sat):
+    def test_positive_crud_with_name(self, module_target_sat):
         """Check if Medium can be created, updated, deleted
 
         :id: 66b749b2-0248-47a8-b78f-3366f3804b29
-
-        :parametrized: yes
 
         :expectedresults: Medium is created
 
 
         :CaseImportance: Critical
         """
+        name = random.choice(list(valid_data_list().values()))
         medium = module_target_sat.cli_factory.make_medium({'name': name})
         assert medium['name'] == name
         new_name = gen_alphanumeric(6)

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -12,6 +12,8 @@
 
 """
 
+import random
+
 from fauxfactory import gen_string
 import pytest
 
@@ -72,49 +74,43 @@ class TestModel:
         model = module_target_sat.cli_factory.make_model({'vendor-class': vendor_class})
         assert model['vendor-class'] == vendor_class
 
-    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-    def test_negative_create_with_name(self, name, module_target_sat):
+    def test_negative_create_with_name(self, module_target_sat):
         """Don't create an Model with invalid data.
 
         :id: b2eade66-b612-47e7-bfcc-6e363023f498
-
-        :parametrized: yes
 
         :expectedresults: Model is not created.
 
         :CaseImportance: High
         """
+        name = random.choice(invalid_values_list())
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Model.create({'name': name})
 
-    @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-    def test_negative_update_name(self, class_model, new_name, module_target_sat):
+    def test_negative_update_name(self, class_model, module_target_sat):
         """Fail to update shared model name
 
         :id: 98020a4a-1789-4df3-929c-6c132b57f5a1
-
-        :parametrized: yes
 
         :expectedresults: Model name is not updated
 
         :CaseImportance: Medium
         """
+        new_name = random.choice(invalid_values_list())
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Model.update({'id': class_model['id'], 'new-name': new_name})
         result = module_target_sat.cli.Model.info({'id': class_model['id']})
         assert class_model['name'] == result['name']
 
-    @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
-    def test_negative_delete_by_id(self, entity_id, module_target_sat):
+    def test_negative_delete_by_id(self, module_target_sat):
         """Delete model by wrong ID
 
         :id: f8b0d428-1b3d-4fc9-9ca1-1eb30c8ac20a
-
-        :parametrized: yes
 
         :expectedresults: Model is not deleted
 
         :CaseImportance: High
         """
+        entity_id = random.choice(invalid_id_list())
         with pytest.raises(CLIReturnCodeError):
             module_target_sat.cli.Model.delete({'id': entity_id})

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -12,6 +12,7 @@
 
 """
 
+import random
 from random import randint
 
 from fauxfactory import gen_string
@@ -24,13 +25,10 @@ from robottelo.utils.datafactory import generate_strings_list, parametrized
 class TestPartitionTable:
     """Partition Table CLI tests."""
 
-    @pytest.mark.parametrize('name', **parametrized(generate_strings_list(length=1)))
-    def test_positive_create_with_one_character_name(self, name, target_sat):
+    def test_positive_create_with_one_character_name(self, target_sat):
         """Create Partition table with 1 character in name
 
         :id: cfec857c-ed6e-4472-93bb-70e1d4f39bae
-
-        :parametrized: yes
 
         :expectedresults: Partition table was created
 
@@ -38,6 +36,7 @@ class TestPartitionTable:
 
         :CaseImportance: Medium
         """
+        name = random.choice(generate_strings_list(length=1))
         ptable = target_sat.cli_factory.make_partition_table({'name': name})
         assert ptable['name'] == name
         target_sat.cli.PartitionTable.delete({'id': ptable['id']})

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -22,7 +22,7 @@ import pytest
 from robottelo import constants
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
-from robottelo.utils.datafactory import parametrized, valid_data_list
+from robottelo.utils.datafactory import valid_data_list
 
 
 @pytest.mark.e2e
@@ -112,16 +112,14 @@ def test_positive_end_to_end_register(
 
 
 @pytest.mark.upgrade
-@pytest.mark.parametrize('cv_name', **parametrized(valid_data_list('ui')))
-def test_positive_create_with_cv(session, module_org, cv_name, target_sat):
+def test_positive_create_with_cv(session, module_org, target_sat):
     """Create Activation key for all variations of Content Views
 
     :id: 2ad000f1-6c80-46aa-a61b-9ea62cefe91b
 
-    :parametrized: yes
-
     :expectedresults: Activation key is created
     """
+    cv_name = random.choice(list(valid_data_list('ui').values()))
     name = gen_string('alpha')
     env_name = gen_string('alpha')
     repo_id = target_sat.api_factory.create_sync_custom_repo(module_org.id)
@@ -383,13 +381,10 @@ def test_positive_update_env(session, module_org, target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.parametrize('cv2_name', **parametrized(valid_data_list('ui')))
-def test_positive_update_cv(session, module_org, cv2_name, target_sat):
+def test_positive_update_cv(session, module_org, target_sat):
     """Update Content View in an Activation key
 
     :id: 68880ca6-acb9-4a16-aaa0-ced680126732
-
-    :parametrized: yes
 
     :steps:
         1. Create Activation key
@@ -398,6 +393,7 @@ def test_positive_update_cv(session, module_org, cv2_name, target_sat):
 
     :expectedresults: Activation key is updated
     """
+    cv2_name = random.choice(list(valid_data_list('ui').values()))
     name = gen_string('alpha')
     env1_name = gen_string('alpha')
     env2_name = gen_string('alpha')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22636

### Problem Statement

See: https://github.com/SatelliteQE/robottelo/pull/22543#issue-5259511166

### Solution

See: https://github.com/SatelliteQE/robottelo/pull/22543#issue-5259511166

### Related Issues

See: https://github.com/SatelliteQE/robottelo/pull/22543#issue-5259511166

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Reduce Proton test parameterization and identify applicable tests as migration candidates.

Enhancements:
- Reduce test-case expansion by replacing broad pytest parameterization with one randomly selected data value per test run across Foreman API, CLI, and UI tests.
- Mark applicable API tests as migration candidates to support migration tracking.

Tests:
- Update affected tests to retain valid and invalid input coverage while running as single test cases instead of generating multiple parameterized cases.

Chores:
- Remove unnecessary parametrization utility imports and metadata from the updated tests.