### PR TITLE
[6.16.z] Extend Openvox Agent testing matrix by RHEL10 (#22633)

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -13,7 +13,6 @@ from robottelo import constants
 from robottelo.config import settings
 from robottelo.enums import NetworkType
 from robottelo.hosts import ContentHost
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -52,12 +51,7 @@ def module_provisioning_rhel_content(
         organization=module_sca_manifest_org, name=f'rhel{rhel_ver}_{gen_string("alpha")}'
     ).create()
     client_repos_urls = [settings.repos.SATCLIENT_REPO[f'rhel{rhel_ver}']]
-    if (
-        rhel_ver in (8, 9)  # only RHEL 8 and 9 openvox-agent repositories are available
-        or (
-            rhel_ver == 7 and not is_open('SAT-44580')
-        )  # openvox-agent for EL7 is still not delivered
-    ):
+    if rhel_ver > 6:
         client_repos_urls.append(settings.repos.OPENVOX_AGENT_REPO[f'rhel{rhel_ver}'])
     client_repos = [
         sat.api.Repository(


### PR DESCRIPTION
Manual cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/22633
(cherry picked from commit c4b86c9cbc9c6bd1435a229fd2aa58639ae595aa)

### Problem Statement
There is now produced OpenVox agent el10 build on nightly compose server.

### Solution
Extend Openvox Agent testing matrix by RHEL10
specifically for this CP: avoid testing Openvox Agent for RHEL6

### Related Issues
[SAT-45729](https://redhat.atlassian.net/browse/SAT-45729)
`satelliteqe/satellite-jenkins#2053` - CI is ready

Fixes #22724

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->