### PR TITLE
Refactor firewall configuration and align foremanctl with containerized documentation

### DIFF
--- a/robottelo/host_helpers/capsule_mixins.py
+++ b/robottelo/host_helpers/capsule_mixins.py
@@ -245,3 +245,52 @@ class CapsuleInfo:
         ).stdout.strip()
         # assert that proxy has been used
         assert satellite_ip in diff
+
+    def configure_firewall(self, ports=None, services=None, verify=True):
+        """Wrapper method to call the configure_firewall function."""
+        return configure_firewall(self, ports=ports, services=services, verify=verify)
+
+
+def configure_firewall(host, ports=None, services=None, verify=True):
+    """
+    Configure firewall with specified ports and services.
+
+    Args:
+        host: Satellite or Capsule instance with execute() method
+        ports (list): List of port specifications (e.g., ['80/tcp', '443/tcp', '8000/tcp', '8443/tcp'])
+        services (list): List of firewall services (e.g., ['http', 'https', 'RH-Satellite-6'])
+        verify (bool): Whether to verify and log firewall configuration after setup
+
+    Returns:
+        bool: True if successful
+
+    """
+    # Install and enable firewalld
+    result = host.execute(
+        "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
+    )
+    assert result.status == 0, "firewalld is not present and can't be installed"
+
+    # Add ports if specified
+    if ports:
+        ports_str = ' '.join([f'--add-port="{port}"' for port in ports])
+        result = host.execute(f'firewall-cmd {ports_str}')
+        assert result.status == 0, f"Failed to add ports: {ports}"
+
+    # Add services if specified
+    if services:
+        services_str = ' '.join([f'--add-service={service}' for service in services])
+        result = host.execute(f'firewall-cmd {services_str}')
+        assert result.status == 0, f"Failed to add services: {services}"
+
+    # Make changes persistent
+    result = host.execute('firewall-cmd --runtime-to-permanent')
+    assert result.status == 0, "Failed to make firewall changes permanent"
+
+    # Verify configuration if requested
+    if verify:
+        firewall_status = host.execute('firewall-cmd --list-all')
+        assert firewall_status.status == 0, 'Failed to verify firewall configuration'
+        logger.info(f'Firewall configuration:\n{firewall_status.stdout}')
+
+    return True

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -73,6 +73,7 @@ from robottelo.host_helpers import (
     ContentHostMixins,
     SatelliteMixins,
 )
+from robottelo.host_helpers.capsule_mixins import configure_firewall
 from robottelo.logging import logger
 from robottelo.utils import validate_ssh_pub_key
 from robottelo.utils.datafactory import valid_emails_list
@@ -2061,14 +2062,12 @@ class Capsule(ContentHost, CapsuleMixins):
         # Update system, firewall services and check capsule is already installed from template
         # Setups firewall on Capsule
         self.execute('dnf -y update', timeout=0)
-        assert (
-            self.execute(
-                "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
-            ).status
-            == 0
-        ), "firewalld is not present and can't be installed"
-        self.execute('firewall-cmd --add-service RH-Satellite-6-capsule')
-        self.execute('firewall-cmd --runtime-to-permanent')
+        configure_firewall(
+            self,
+            ports=['8000/tcp', '8443/tcp'],
+            services=['http', 'https'],
+            verify=False,
+        )
 
         # Generate certificate, copy it to Capsule, run installer, check it succeeds
         if not capsule_cert_opts:
@@ -2280,17 +2279,11 @@ class Capsule(ContentHost, CapsuleMixins):
             assert self.is_fips_enabled()
 
         # Configure Satellite firewall to open communication
-        assert (
-            self.execute(
-                '(which firewall-cmd || dnf -y install firewalld) && systemctl enable --now firewalld'
-            ).status
-            == 0
-        ), 'firewalld is not present and can\'t be installed'
-        assert (
-            self.execute(
-                'firewall-cmd --permanent --add-service RH-Satellite-6 && firewall-cmd --reload'
-            ).status
-            == 0
+        configure_firewall(
+            self,
+            ports=['80/tcp', '443/tcp', '8000/tcp', '8443/tcp'],
+            services=['http', 'https'],
+            verify=True,
         )
 
         # Install Satellite and return result
@@ -2798,22 +2791,22 @@ class Satellite(Capsule, SatelliteMixins):
 
     def setup_firewall(self):
         # Setups firewall on Satellite
-        assert (
-            self.execute(
-                "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
-            ).status
-            == 0
-        ), "firewalld is not present and can't be installed"
-        assert (
-            self.execute(
-                command='firewall-cmd --add-port="53/udp" --add-port="53/tcp" --add-port="67/udp" '
-                '--add-port="69/udp" --add-port="80/tcp" --add-port="443/tcp" '
-                '--add-port="5647/tcp" --add-port="8000/tcp" --add-port="9090/tcp" '
-                '--add-port="8140/tcp"'
-            ).status
-            == 0
+        configure_firewall(
+            self,
+            ports=[
+                '53/udp',
+                '53/tcp',
+                '67/udp',
+                '69/udp',
+                '80/tcp',
+                '443/tcp',
+                '5647/tcp',
+                '8000/tcp',
+                '9090/tcp',
+                '8140/tcp',
+            ],
+            verify=False,
         )
-        assert self.execute(command='firewall-cmd --runtime-to-permanent').status == 0
 
     def capsule_certs_generate(self, capsule, cert_path=None, **extra_kwargs):
         """Generate capsule certs, returning the cert path, installer command stdout and args"""

--- a/tests/foreman/cli/test_rhcloud_iop.py
+++ b/tests/foreman/cli/test_rhcloud_iop.py
@@ -88,21 +88,21 @@ def test_positive_install_iop_custom_certs(
     satellite.install_satellite_or_capsule_package()
 
     # Set up firewall
-    result = satellite.execute(
-        "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
+    satellite.configure_firewall(
+        ports=[
+            '53/udp',
+            '53/tcp',
+            '67/udp',
+            '69/udp',
+            '80/tcp',
+            '443/tcp',
+            '5647/tcp',
+            '8000/tcp',
+            '9090/tcp',
+            '8140/tcp',
+        ],
+        verify=False,
     )
-    assert result.status == 0, "firewalld is not present and can't be installed"
-
-    result = satellite.execute(
-        'firewall-cmd --add-port="53/udp" --add-port="53/tcp" --add-port="67/udp" '
-        '--add-port="69/udp" --add-port="80/tcp" --add-port="443/tcp" '
-        '--add-port="5647/tcp" --add-port="8000/tcp" --add-port="9090/tcp" '
-        '--add-port="8140/tcp"'
-    )
-    assert result.status == 0
-
-    result = satellite.execute('firewall-cmd --runtime-to-permanent')
-    assert result.status == 0
 
     # Set IPv6 proxy for podman to pull images
     satellite.enable_ipv6_podman_proxy()

--- a/tests/foreman/foremanctl/test_install_foremanctl.py
+++ b/tests/foreman/foremanctl/test_install_foremanctl.py
@@ -140,14 +140,11 @@ def module_cap_ready_rhel(request):
         # Unregister capsule in case it's registered to CDN
         cap.unregister()
         # Setup firewall to allow Satellite-Capsule communication
-        assert (
-            cap.execute(
-                'which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld'
-            ).status
-            == 0
-        ), "firewalld is not present and can't be installed"
-        cap.execute('firewall-cmd --add-service RH-Satellite-6-capsule')
-        cap.execute('firewall-cmd --runtime-to-permanent')
+        cap.configure_firewall(
+            ports=['8000/tcp', '8443/tcp'],
+            services=['http', 'https'],
+            verify=False,
+        )
         yield cap
 
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -124,15 +124,7 @@ def install_satellite(satellite, installer_args, enable_fapolicyd=False):
         assert satellite.execute('rpm -q foreman-proxy-fapolicyd').status == 0
         assert satellite.execute('systemctl is-active fapolicyd').status == 0
     # Configure Satellite firewall to open communication
-    assert (
-        satellite.execute(
-            "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
-        ).status
-        == 0
-    ), "firewalld is not present and can't be installed"
-    satellite.execute(
-        'firewall-cmd --permanent --add-service RH-Satellite-6 && firewall-cmd --reload'
-    )
+    satellite.configure_firewall(services=['RH-Satellite-6'], verify=False)
     # Install Satellite and return result
     return satellite.execute(
         InstallerCommand(installer_args=installer_args).get_command(),
@@ -288,14 +280,7 @@ def test_capsule_installation(
     assert len(result.stdout) == 0
 
     # Enabling firewall
-    assert (
-        cap_ready_rhel.execute(
-            "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
-        ).status
-        == 0
-    ), "firewalld is not present and can't be installed"
-    cap_ready_rhel.execute('firewall-cmd --add-service RH-Satellite-6-capsule')
-    cap_ready_rhel.execute('firewall-cmd --runtime-to-permanent')
+    cap_ready_rhel.configure_firewall(services=['RH-Satellite-6-capsule'], verify=False)
 
     result = cap_ready_rhel.cli.Health.check()
     assert 'FAIL' not in result.stdout


### PR DESCRIPTION
### Problem Statement


The current firewall configuration for Satellite/Capsule installations doesn't align with the containerized Foreman documentation. The code uses the RH-Satellite-6-capsule firewall service, which is not referenced in the new containerized installation documentation. Additionally, firewall setup logic is duplicated across multiple locations in the codebase.

### Solution

- Created a centralized configure_firewall() function in robottelo/host_helpers/capsule_mixins.py to eliminate code duplication
- Updated foremanctl installation path to use explicit ports (8000/tcp, 8443/tcp) and services (http, https) as specified in the containerized Foreman documentation
- Preserved RH-Satellite-6-capsule service for installer-based installations to maintain backward compatibility
- Followed the documentation's recommended pattern: add firewall rules to runtime, then persist with --runtime-to-permanent
- Added conditional logic in Capsule.install() to apply appropriate firewall rules based on InstallMethod (FOREMANCTL vs INSTALLER)

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->

## Summary by Sourcery

Centralize firewall setup and apply installation-method-specific rules for containerized and installer-based Foreman deployments.

Enhancements:
- Centralize firewall configuration across Satellite and Capsule setup paths and tests.
- Align Foremanctl firewall rules with containerized Foreman documentation while retaining service-based rules for installer-based deployments.

Tests:
- Update firewall setup in installation and Foremanctl test fixtures to use the shared configuration helper.